### PR TITLE
Add support for IPv6 addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 .mooncakes/
 .DS_Store
+.vscode/
+.idea/

--- a/src/example/tcp_echo_server/main.mbt
+++ b/src/example/tcp_echo_server/main.mbt
@@ -17,7 +17,7 @@ fn main_prog() -> Unit raise {
   @async.with_event_loop(fn(root) {
     let listen_sock = @socket.TCP::new()
     try {
-      listen_sock..bind(@socket.Addr::parse("0.0.0.0:4200"))..listen()
+      listen_sock..bind(@socket.SocketAddr::parse("0.0.0.0:4200"))..listen()
       for {
         let (conn, addr) = listen_sock.accept()
         println("received new connection from \{addr}")

--- a/src/example/tcp_ping_pong/main.mbt
+++ b/src/example/tcp_ping_pong/main.mbt
@@ -25,7 +25,7 @@ pub(all) type Printer (String) -> Unit
 async fn server(println : Printer) -> Unit raise {
   @async.with_task_group(fn(group) {
     let listen_sock = @socket.TCP::new()
-    listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
+    listen_sock..bind(@socket.SocketAddr::parse("0.0.0.0:\{port}"))..listen()
     try {
       for {
         let (conn, _) = listen_sock.accept()
@@ -68,7 +68,7 @@ async fn server(println : Printer) -> Unit raise {
 ///|
 async fn client(println : Printer, id : Int, msg : Bytes) -> Unit raise {
   let conn = @socket.TCP::new()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+  conn.connect(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
   // The sleep here is used to make test result stable and portable,
   // because this message is in race condition
   // with server side "received connection" message

--- a/src/example/udp_ping_pong/main.mbt
+++ b/src/example/udp_ping_pong/main.mbt
@@ -25,7 +25,7 @@ pub(all) type Printer (String) -> Unit
 async fn server(println : Printer) -> Unit raise {
   let server_sock = @socket.UDP::new()
   @async.with_task_group(fn(group) {
-    server_sock.bind(@socket.Addr::parse("0.0.0.0:\{port}"))
+    server_sock.bind(@socket.SocketAddr::parse("0.0.0.0:\{port}"))
     let buf = FixedArray::make(1024, b'0')
     while server_sock.recvfrom(buf) is (n, addr) && n > 0 {
       group.spawn_bg(fn() {
@@ -54,7 +54,7 @@ async fn server(println : Printer) -> Unit raise {
 ///|
 async fn client(println : Printer, id : Int, msg : Bytes) -> Unit raise {
   let conn = @socket.UDP::new()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+  conn.connect(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
   conn.send(msg)
   println("client \{id} sent: \{msg}")
   let buf = FixedArray::make(1024, b'0')

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -13,22 +13,63 @@
 // limitations under the License.
 
 ///|
-/// IPv4 address + port number
-type Addr Bytes
+type Ipv4Addr Bytes
 
 ///|
 type Ipv6Addr Bytes
 
 ///|
-pub extern "C" fn Addr::new(ip : UInt, port : Int) -> Addr = "moonbitlang_async_make_ip_addr"
+type IpAddr Bytes
+
+///|
+pub(all) enum SocketAddr {
+  V4(Ipv4Addr) // IPv4 address and port
+  V6(Ipv6Addr) // IPv6 address and port
+} derive(Show)
+
+///|
+#deprecated("Use @socket.SocketAddr instead")
+pub typealias SocketAddr as Addr
+
+///|
+pub(open) trait ToSocketAddrs {
+  to_socket_addr(self : Self) -> Iter[SocketAddr] raise InvalidAddr
+}
+
+///|
+pub fn SocketAddr::to_ipaddr(self : SocketAddr) -> IpAddr {
+  match self {
+    SocketAddr::V4(addr) => addr.to_ipaddr()
+    SocketAddr::V6(addr) => addr.to_ipaddr()
+  }
+}
+
+///|
+pub fn SocketAddr::is_ipv4(self : SocketAddr) -> Bool {
+  match self {
+    SocketAddr::V4(_) => true
+    SocketAddr::V6(_) => false
+  }
+}
+
+///|
+pub fn SocketAddr::is_ipv6(self : SocketAddr) -> Bool {
+  match self {
+    SocketAddr::V4(_) => false
+    SocketAddr::V6(_) => true
+  }
+}
+
+///|
+pub extern "C" fn Ipv4Addr::new(ip : UInt, port : Int) -> Ipv4Addr = "moonbitlang_async_make_ip_addr"
 
 ///|
 #borrow(addr)
-pub extern "C" fn Addr::ip(addr : Addr) -> UInt = "moonbitlang_async_ip_addr_get_ip"
+pub extern "C" fn Ipv4Addr::ip(addr : Ipv4Addr) -> UInt = "moonbitlang_async_ip_addr_get_ip"
 
 ///|
 #borrow(addr)
-pub extern "C" fn Addr::port(addr : Addr) -> Int = "moonbitlang_async_ip_addr_get_port"
+pub extern "C" fn Ipv4Addr::port(addr : Ipv4Addr) -> Int = "moonbitlang_async_ip_addr_get_port"
 
 ///|
 pub extern "C" fn Ipv6Addr::new(
@@ -39,7 +80,7 @@ pub extern "C" fn Ipv6Addr::new(
 ) -> Ipv6Addr = "moonbitlang_async_make_ipv6_addr"
 
 ///|
-#borrow(addr)
+#borrow(addr, buf)
 pub extern "C" fn Ipv6Addr::ip(addr : Ipv6Addr, buf : Bytes) -> Int = "moonbitlang_async_ipv6_addr_get_ip"
 
 ///|
@@ -47,7 +88,7 @@ pub extern "C" fn Ipv6Addr::ip(addr : Ipv6Addr, buf : Bytes) -> Int = "moonbitla
 pub extern "C" fn Ipv6Addr::port(addr : Ipv6Addr) -> Int = "moonbitlang_async_ipv6_addr_get_port"
 
 ///|
-pub impl Show for Addr with output(self, logger) {
+pub impl Show for Ipv4Addr with output(self, logger) {
   let ip = self.ip()
   let port = self.port()
   logger
@@ -64,7 +105,7 @@ pub impl Show for Addr with output(self, logger) {
 
 ///|
 pub impl Show for Ipv6Addr with output(self, logger) {
-  let ip_buf = Bytes::make(47, Byte::default())
+  let ip_buf = Bytes::make(_IP_V6_ADDRLEN, Byte::default())
   let len = self.ip(ip_buf)
   let ip_str = utf8_bytes_to_mbt_string(ip_buf[0:len].to_bytes())
   logger.write_char('[')
@@ -80,9 +121,9 @@ pub suberror InvalidAddr derive(Show)
 ///|
 /// Parse a string into IPv4 address, format should be `ip:port` (no space)
 // TODO: faster implementation
-pub fn Addr::parse(src : String) -> Addr raise InvalidAddr {
+pub fn Ipv4Addr::parse(src : String) -> Ipv4Addr raise InvalidAddr {
   let (ip, port) = try_parse_ipv4(src) catch { _ => raise InvalidAddr }
-  Addr::new(ip, port)
+  Ipv4Addr::new(ip, port)
 }
 
 ///|
@@ -90,4 +131,22 @@ pub fn Ipv6Addr::parse(src : String) -> Ipv6Addr raise InvalidAddr {
   let (ip_bytes, port, flowinfo, scope_id) = try_parse_ipv6(src)
   let ip_bytes = ip_bytes.map(x => x.to_byte())
   Ipv6Addr::new(ip_bytes, port, flowinfo, scope_id)
+}
+
+///|
+pub fn SocketAddr::parse(src : String) -> SocketAddr raise InvalidAddr {
+  parse_address(src) catch {
+    _ => raise InvalidAddr
+  }
+}
+
+///|
+fn parse_address(src : String) -> SocketAddr raise {
+  // Try to parse IPv6 format [addr]:port
+  if src.has_prefix("[") {
+    let addr = Ipv6Addr::parse(src)
+    return SocketAddr::V6(addr)
+  }
+  let addr = Ipv4Addr::parse(src)
+  SocketAddr::V4(addr)
 }

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -81,11 +81,18 @@ pub extern "C" fn Ipv6Addr::new(
 
 ///|
 #borrow(addr, buf)
-pub extern "C" fn Ipv6Addr::ip(addr : Ipv6Addr, buf : Bytes) -> Int = "moonbitlang_async_ipv6_addr_get_ip"
+extern "C" fn Ipv6Addr::_ip(addr : Ipv6Addr, buf : FixedArray[Byte]) -> Unit = "moonbitlang_async_ipv6_addr_get_ip"
 
 ///|
 #borrow(addr)
 pub extern "C" fn Ipv6Addr::port(addr : Ipv6Addr) -> Int = "moonbitlang_async_ipv6_addr_get_port"
+
+///|
+pub fn Ipv6Addr::ip(self : Ipv6Addr) -> FixedArray[Byte] {
+  let buf = FixedArray::make(16, Byte::default())
+  self._ip(buf)
+  buf
+}
 
 ///|
 pub impl Show for Ipv4Addr with output(self, logger) {
@@ -105,9 +112,9 @@ pub impl Show for Ipv4Addr with output(self, logger) {
 
 ///|
 pub impl Show for Ipv6Addr with output(self, logger) {
-  let ip_buf = Bytes::make(_IP_V6_ADDRLEN, Byte::default())
-  let len = self.ip(ip_buf)
-  let ip_str = utf8_bytes_to_mbt_string(ip_buf[0:len].to_bytes())
+  let ip_str = self.ip_name() catch {
+    _ => abort("Unknown error to get IPv6 address")
+  }
   logger.write_char('[')
   logger.write_string(ip_str)
   logger.write_char(']')
@@ -137,6 +144,28 @@ pub fn Ipv6Addr::parse(src : String) -> Ipv6Addr raise InvalidAddr {
 pub fn SocketAddr::parse(src : String) -> SocketAddr raise InvalidAddr {
   parse_address(src) catch {
     _ => raise InvalidAddr
+  }
+}
+
+///|
+pub fn SocketAddr::ip(self : SocketAddr) -> String {
+  match self {
+    SocketAddr::V4(addr) =>
+      addr.ip_name() catch {
+        _ => abort("Unknown error to get IPv4 address")
+      }
+    SocketAddr::V6(addr) =>
+      addr.ip_name() catch {
+        _ => abort("Unknown error to get IPv6 address")
+      }
+  }
+}
+
+///|
+pub fn SocketAddr::port(self : SocketAddr) -> Int {
+  match self {
+    SocketAddr::V4(addr) => addr.port()
+    SocketAddr::V6(addr) => addr.port()
   }
 }
 

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -17,6 +17,9 @@
 type Addr Bytes
 
 ///|
+type Ipv6Addr Bytes
+
+///|
 pub extern "C" fn Addr::new(ip : UInt, port : Int) -> Addr = "moonbitlang_async_make_ip_addr"
 
 ///|
@@ -26,6 +29,22 @@ pub extern "C" fn Addr::ip(addr : Addr) -> UInt = "moonbitlang_async_ip_addr_get
 ///|
 #borrow(addr)
 pub extern "C" fn Addr::port(addr : Addr) -> Int = "moonbitlang_async_ip_addr_get_port"
+
+///|
+pub extern "C" fn Ipv6Addr::new(
+  ip : FixedArray[Byte],
+  port : Int,
+  flowinfo : Int,
+  scope_id : Int
+) -> Ipv6Addr = "moonbitlang_async_make_ipv6_addr"
+
+///|
+#borrow(addr)
+pub extern "C" fn Ipv6Addr::ip(addr : Ipv6Addr, buf : Bytes) -> Int = "moonbitlang_async_ipv6_addr_get_ip"
+
+///|
+#borrow(addr)
+pub extern "C" fn Ipv6Addr::port(addr : Ipv6Addr) -> Int = "moonbitlang_async_ipv6_addr_get_port"
 
 ///|
 pub impl Show for Addr with output(self, logger) {
@@ -44,29 +63,31 @@ pub impl Show for Addr with output(self, logger) {
 }
 
 ///|
+pub impl Show for Ipv6Addr with output(self, logger) {
+  let ip_buf = Bytes::make(47, Byte::default())
+  let len = self.ip(ip_buf)
+  let ip_str = utf8_bytes_to_mbt_string(ip_buf[0:len].to_bytes())
+  logger.write_char('[')
+  logger.write_string(ip_str)
+  logger.write_char(']')
+  logger.write_char(':')
+  logger.write_object(self.port())
+}
+
+///|
 pub suberror InvalidAddr derive(Show)
 
 ///|
 /// Parse a string into IPv4 address, format should be `ip:port` (no space)
 // TODO: faster implementation
 pub fn Addr::parse(src : String) -> Addr raise InvalidAddr {
-  guard src.split(":").collect() is [ip, port] else { raise InvalidAddr }
-  guard ip.split(".").collect() is [a, b, c, d] else { raise InvalidAddr }
-  fn parse_octal(x : @string.View) raise InvalidAddr {
-    let value = @strconv.parse_uint(x.to_string()) catch {
-      _ => raise InvalidAddr
-    }
-    guard value < 256 else { raise InvalidAddr }
-    value
-  }
-
-  let ip = (parse_octal(a) << 24) |
-    (parse_octal(b) << 16) |
-    (parse_octal(c) << 8) |
-    parse_octal(d)
-  let port = @strconv.parse_int(port.to_string()) catch {
-    _ => raise InvalidAddr
-  }
-  guard 0 <= port && port < 65536 else { raise InvalidAddr }
+  let (ip, port) = try_parse_ipv4(src) catch { _ => raise InvalidAddr }
   Addr::new(ip, port)
+}
+
+///|
+pub fn Ipv6Addr::parse(src : String) -> Ipv6Addr raise InvalidAddr {
+  let (ip_bytes, port, flowinfo, scope_id) = try_parse_ipv6(src)
+  let ip_bytes = ip_bytes.map(x => x.to_byte())
+  Ipv6Addr::new(ip_bytes, port, flowinfo, scope_id)
 }

--- a/src/socket/addr_test.mbt
+++ b/src/socket/addr_test.mbt
@@ -14,14 +14,17 @@
 
 ///|
 test "Parse IPv4 address" {
-  assert_eq(@socket.Addr::parse("127.0.0.1:8080").to_string(), "127.0.0.1:8080")
-  assert_eq(@socket.Addr::parse("0.0.0.0:8080").to_string(), "0.0.0.0:8080")
   assert_eq(
-    @socket.Addr::parse("255.255.255.255:8080").to_string(),
+    @socket.Ipv4Addr::parse("127.0.0.1:8080").to_string(),
+    "127.0.0.1:8080",
+  )
+  assert_eq(@socket.Ipv4Addr::parse("0.0.0.0:8080").to_string(), "0.0.0.0:8080")
+  assert_eq(
+    @socket.Ipv4Addr::parse("255.255.255.255:8080").to_string(),
     "255.255.255.255:8080",
   )
   assert_eq(
-    @socket.Addr::parse("172.31.254.253:8080").to_string(),
+    @socket.Ipv4Addr::parse("172.31.254.253:8080").to_string(),
     "172.31.254.253:8080",
   )
 }
@@ -29,15 +32,15 @@ test "Parse IPv4 address" {
 ///|
 test "Parse invalid IPv4 address" {
   // Too short
-  let v = try? @socket.Addr::parse("127.0.0.1")
+  let v = try? @socket.Ipv4Addr::parse("127.0.0.1")
   assert_true(v is Err(_))
 
   // Too long
-  let v = try? @socket.Addr::parse("127.0.0.1:8080:8080")
+  let v = try? @socket.Ipv4Addr::parse("127.0.0.1:8080:8080")
   assert_true(v is Err(_))
 
   // Invalid IP, out of range
-  let v = try? @socket.Addr::parse("256.0.0.1:8080")
+  let v = try? @socket.Ipv4Addr::parse("256.0.0.1:8080")
   assert_true(v is Err(_))
 }
 

--- a/src/socket/addr_test.mbt
+++ b/src/socket/addr_test.mbt
@@ -1,0 +1,90 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "Parse IPv4 address" {
+  assert_eq(@socket.Addr::parse("127.0.0.1:8080").to_string(), "127.0.0.1:8080")
+  assert_eq(@socket.Addr::parse("0.0.0.0:8080").to_string(), "0.0.0.0:8080")
+  assert_eq(
+    @socket.Addr::parse("255.255.255.255:8080").to_string(),
+    "255.255.255.255:8080",
+  )
+  assert_eq(
+    @socket.Addr::parse("172.31.254.253:8080").to_string(),
+    "172.31.254.253:8080",
+  )
+}
+
+///|
+test "Parse invalid IPv4 address" {
+  // Too short
+  let v = try? @socket.Addr::parse("127.0.0.1")
+  assert_true(v is Err(_))
+
+  // Too long
+  let v = try? @socket.Addr::parse("127.0.0.1:8080:8080")
+  assert_true(v is Err(_))
+
+  // Invalid IP, out of range
+  let v = try? @socket.Addr::parse("256.0.0.1:8080")
+  assert_true(v is Err(_))
+}
+
+///|
+test "Parse IPv6 address" {
+  let addr = @socket.Ipv6Addr::parse("[2a02:6b8::11:11]:8080")
+  assert_eq(addr.to_string(), "[2a02:6b8::11:11]:8080")
+  assert_eq(
+    @socket.Ipv6Addr::parse("[0:0:0:0:0:0:0:0]:8080").to_string(),
+    "[::]:8080",
+  )
+  assert_eq(
+    @socket.Ipv6Addr::parse("[0:0:0:0:0:0:0:1]:8080").to_string(),
+    "[::1]:8080",
+  )
+  assert_eq(@socket.Ipv6Addr::parse("[::1]:8080").to_string(), "[::1]:8080")
+}
+
+///|
+test "Parse invalid IPv6 address" {
+  // Too short
+  let v = try? @socket.Ipv6Addr::parse("[1:2:3:4:5:6:7:8080]")
+  assert_true(v is Err(_))
+
+  // Too long
+  let v = try? @socket.Ipv6Addr::parse("[1:2:3:4:5:6:7:8:9:8080]")
+  assert_true(v is Err(_))
+
+  // triple colon
+  let v = try? @socket.Ipv6Addr::parse("[1:2:::6:7:8]:8080]")
+  assert_true(v is Err(_))
+
+  // two double colons
+  let v = try? @socket.Ipv6Addr::parse("[1:2::6::8]:8080]")
+  assert_true(v is Err(_))
+}
+
+///|
+test "Parse IPv6 address with ipv4" {
+  let addr = @socket.Ipv6Addr::parse("[::ffff:192.0.2.33]:8080")
+  assert_eq(addr.to_string(), "[::ffff:192.0.2.33]:8080")
+  let addr = @socket.Ipv6Addr::parse("[::FFFF:192.0.2.33]:8080")
+  assert_eq(addr.to_string(), "[::ffff:192.0.2.33]:8080")
+  // Not enough groups
+  let v = try? @socket.Ipv6Addr::parse("[1:2:3:4:5:127.0.0.1]:8080")
+  assert_true(v is Err(_))
+  // Too many groups
+  let v = try? @socket.Ipv6Addr::parse("[1:2:3:4:5:6:7:127.0.0.1]:8080")
+  assert_true(v is Err(_))
+}

--- a/src/socket/addr_utils.mbt
+++ b/src/socket/addr_utils.mbt
@@ -1,0 +1,263 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn try_parse_ipv6(
+  input : String
+) -> (FixedArray[UInt], Int, Int, Int) raise InvalidAddr {
+  // Make sure the format is [addr]:port
+  guard input.has_prefix("[") else {
+    // IPv6 address must start with '['
+    raise InvalidAddr
+  }
+
+  // Find the closing bracket
+  guard input.rev_find("]") is Some(bracket_end) else {
+    // IPv6 address missing closing ']'
+    raise InvalidAddr
+  }
+
+  // Check the part after the closing bracket, it must be ":port"
+  let remaining = input.substring(start=bracket_end + 1)
+  guard remaining.has_prefix(":") else {
+    // Missing port after IPv6 address
+    raise InvalidAddr
+  }
+
+  // Parse the IPv6 address and port
+  let ip_str = input.substring(start=1, end=bracket_end)
+  let port_str = remaining.substring(start=1)
+
+  // Parse the IPv6 address into a byte array
+  let ip_bytes = parse_ipv6_to_bytes(ip_str)
+  let port = parse_port(port_str)
+  (ip_bytes, port, 0, 0)
+}
+
+///|
+fn parse_ipv6_to_bytes(ip_str : String) -> FixedArray[UInt] raise InvalidAddr {
+  // Handle the case where the IPv6 address is "::"
+  if ip_str == "::" {
+    return FixedArray::make(16, 0)
+  }
+
+  // Check for "::" compression
+  let compression_count = count_substring_occurrences(ip_str, "::")
+  guard compression_count <= 1 else {
+    // IPv6 address can only have one '::' compression
+    raise InvalidAddr
+  }
+  if compression_count == 1 {
+    return parse_compressed_ipv6_to_bytes(ip_str)
+  } else {
+    return parse_full_ipv6_to_bytes(ip_str)
+  }
+}
+
+///|
+fn parse_compressed_ipv6_to_bytes(
+  ip_str : String
+) -> FixedArray[UInt] raise InvalidAddr {
+  let parts = ip_str.split("::").collect()
+  let left_part = parts[0]
+  let right_part = if parts.length() > 1 { parts[1] } else { "" }
+  let left_groups = if left_part.is_empty() {
+    []
+  } else {
+    left_part.split(":").collect()
+  }
+
+  // Parse the right part, which may contain IPv4 address
+  let right_groups = if right_part.is_empty() {
+    []
+  } else {
+    right_part.split(":").collect()
+  }
+
+  // Check if the last group is an IPv4 address
+  let (right_groups_final, ipv4_bytes) = if !right_groups.is_empty() &&
+    right_groups[right_groups.length() - 1].contains(".") {
+    let ipv4_str = right_groups[right_groups.length() - 1]
+    let (a, b, c, d) = parse_ipv4_to_bytes(ipv4_str)
+    // Remove the IPv4 part from the right groups
+    let new_right = Array::new()
+    for i in 0..<(right_groups.length() - 1) {
+      new_right.push(right_groups[i])
+    }
+    (new_right, Some((a, b, c, d)))
+  } else {
+    (right_groups, None)
+  }
+
+  // Calculate the number of groups of compression
+  let ipv4_group_count = if ipv4_bytes.is_empty() { 0 } else { 2 }
+  let total_explicit_groups = left_groups.length() +
+    right_groups_final.length() +
+    ipv4_group_count
+  guard total_explicit_groups < 8 else {
+    // IPv6 address can have at most less than 8 explicit groups if "::" is used
+    raise InvalidAddr
+  }
+  let compression_groups = 8 - total_explicit_groups
+
+  // Build a 16-byte array initialized to zero
+  let result : FixedArray[UInt] = FixedArray::make(16, 0)
+  let mut byte_index = 0
+
+  // Add left side groups
+  for group_str in left_groups {
+    let group_value = parse_ipv6_group(group_str.to_string())
+    result[byte_index] = (group_value >> 8) & 0xFF
+    result[byte_index + 1] = group_value & 0xFF
+    byte_index += 2
+  }
+
+  // Add compression groups (zero groups)
+  for _ in 0..<compression_groups {
+    result[byte_index] = 0
+    result[byte_index + 1] = 0
+    byte_index += 2
+  }
+
+  // Add right side groups
+  for group_str in right_groups_final {
+    let group_value = parse_ipv6_group(group_str.to_string())
+    result[byte_index] = (group_value >> 8) & 0xFF
+    result[byte_index + 1] = group_value & 0xFF
+    byte_index += 2
+  }
+
+  // Add IPv4 bytes if they were parsed
+  if ipv4_bytes is Some((a, b, c, d)) {
+    result[byte_index + 0] = a
+    result[byte_index + 1] = b
+    result[byte_index + 2] = c
+    result[byte_index + 3] = d
+  }
+  result
+}
+
+///|
+fn parse_full_ipv6_to_bytes(
+  ip_str : String
+) -> FixedArray[UInt] raise InvalidAddr {
+  let parts = ip_str.split(":").collect()
+  let result : FixedArray[UInt] = FixedArray::make(16, 0)
+  let mut byte_index = 0
+  // Check if the last part contains a dot, indicating an embedded IPv4 address
+  if !parts.is_empty() && parts[parts.length() - 1].contains(".") {
+    guard parts.length() == 7 else {
+      // IPv6 address with embedded IPv4 must have 7 parts
+      raise InvalidAddr
+    }
+
+    // Parse the last part as an IPv4 address
+    let ipv4_str = parts[parts.length() - 1]
+    let (a, b, c, d) = parse_ipv4_to_bytes(ipv4_str)
+
+    // Build a 16-byte array initialized to zero
+    let mut byte_index = 0
+
+    // Add the first 6 IPv6 groups
+    for i in 0..<6 {
+      let group_value = parse_ipv6_group(parts[i].to_string())
+      result[byte_index] = (group_value >> 8) & 0xFF
+      result[byte_index + 1] = group_value & 0xFF
+      byte_index += 2
+    }
+    result[byte_index + 0] = a
+    result[byte_index + 1] = b
+    result[byte_index + 2] = c
+    result[byte_index + 3] = d
+    result
+  } else {
+    // The pure IPv6 address should have 8 groups
+    guard parts.length() == 8 else {
+      // Full IPv6 address must have 8 groups
+      raise InvalidAddr
+    }
+    for group_str in parts {
+      let group_value = parse_ipv6_group(group_str.to_string())
+      result[byte_index] = (group_value >> 8) & 0xFF
+      result[byte_index + 1] = group_value & 0xFF
+      byte_index += 2
+    }
+    result
+  }
+}
+
+///|
+fn parse_ipv6_group(group : String) -> UInt raise InvalidAddr {
+  guard !group.is_empty() && group.length() <= 4 else { raise InvalidAddr }
+  @strconv.parse_uint(group, base=16) catch {
+    _ => raise InvalidAddr
+  }
+}
+
+///|
+fn parse_ipv4_to_bytes(
+  ip_str : @string.View
+) -> (UInt, UInt, UInt, UInt) raise InvalidAddr {
+  let parts = ip_str.split(".").collect()
+  guard parts.length() == 4 else { raise InvalidAddr }
+  fn parse_octal(x : @string.View) raise InvalidAddr {
+    let value = @strconv.parse_uint(x.to_string()) catch {
+      _ => raise InvalidAddr
+    }
+    guard value < 256 else { raise InvalidAddr }
+    value
+  }
+
+  return (
+    parse_octal(parts[0]),
+    parse_octal(parts[1]),
+    parse_octal(parts[2]),
+    parse_octal(parts[3]),
+  )
+}
+
+///|
+fn try_parse_ipv4(input : String) -> (UInt, Int) raise InvalidAddr {
+  // Find the last colon to separate IP and port
+  guard input.rev_find(":") is Some(last_colon) else { raise InvalidAddr }
+  let ip_str = input.substring(end=last_colon)
+  let port_str = input.substring(start=last_colon + 1)
+  let port = @strconv.parse_int(port_str.to_string()) catch {
+    _ => raise InvalidAddr
+  }
+  guard 0 <= port && port < 65536 else { raise InvalidAddr }
+  // Parse the IP address
+  let (a, b, c, d) = parse_ipv4_to_bytes(ip_str.view())
+  let ip = (a << 24) | (b << 16) | (c << 8) | d
+  (ip, port)
+}
+
+///|
+fn parse_port(port_str : String) -> Int raise InvalidAddr {
+  guard !port_str.is_empty() else { raise InvalidAddr }
+  let port = @strconv.parse_int(port_str) catch { _ => raise InvalidAddr }
+  guard 0 <= port && port < 65536 else { raise InvalidAddr }
+  port
+}
+
+///|
+fn count_substring_occurrences(text : String, pattern : String) -> Int {
+  let mut count = 0
+  let mut start = 0
+  while text.substring(start~).find(pattern) is Some(pos) {
+    count += 1
+    start += pos + pattern.length()
+  }
+  count
+}

--- a/src/socket/connect_burst_test.mbt
+++ b/src/socket/connect_burst_test.mbt
@@ -24,7 +24,7 @@ async fn server() -> Int raise {
   let mut num_connection = 0
   try
     @async.with_task_group(fn(group) {
-      listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
+      listen_sock..bind(@socket.SocketAddr::parse("0.0.0.0:\{port}"))..listen()
       for {
         let (conn, _) = listen_sock.accept()
         num_connection += 1
@@ -64,7 +64,7 @@ async fn server() -> Int raise {
 ///|
 async fn client(msg : Bytes) -> Unit raise {
   let conn = @socket.TCP::new()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+  conn.connect(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
   conn.send(msg)
   conn.close()
 }

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -20,18 +20,18 @@ extern "C" fn make_udp_socket() -> Int = "moonbitlang_async_make_udp_socket"
 
 ///|
 #borrow(addr)
-extern "C" fn bind_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_bind"
+extern "C" fn bind_ffi(sock : Int, addr : IpAddr) -> Int = "moonbitlang_async_bind"
 
 ///|
 extern "C" fn listen_ffi(sock : Int) -> Int = "moonbitlang_async_listen"
 
 ///|
 #borrow(addr_buf)
-extern "C" fn accept_ffi(sock : Int, addr_buf : Addr) -> Int = "moonbitlang_async_accept"
+extern "C" fn accept_ffi(sock : Int, addr_buf : IpAddr) -> Int = "moonbitlang_async_accept"
 
 ///|
 #borrow(addr)
-extern "C" fn connect_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_connect"
+extern "C" fn connect_ffi(sock : Int, addr : IpAddr) -> Int = "moonbitlang_async_connect"
 
 ///|
 #borrow(buf)
@@ -68,7 +68,7 @@ extern "C" fn recvfrom_ffi(
   buf : FixedArray[Byte],
   offset : Int,
   max_len : Int,
-  addr_buf : Addr
+  addr_buf : IpAddr
 ) -> Int = "moonbitlang_async_recvfrom"
 
 ///|
@@ -78,5 +78,5 @@ extern "C" fn sendto_ffi(
   buf : Bytes,
   offset : Int,
   max_len : Int,
-  addr_buf : Addr
+  addr_buf : IpAddr
 ) -> Int = "moonbitlang_async_sendto"

--- a/src/socket/ip.c
+++ b/src/socket/ip.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/socket.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netinet/udp.h>
+#include <netinet/tcp.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <moonbit.h>
+
+typedef struct moonbit_getaddrinfo_s
+{
+    struct addrinfo *addr;
+} moonbit_getaddrinfo_t;
+
+static inline void empty_function(void *self)
+{
+    // no-op: empty function
+}
+
+static inline void
+moonbit_getaddrinfo_finalize(void *object)
+{
+    moonbit_getaddrinfo_t *addr_info = object;
+    if (addr_info && addr_info->addr)
+    {
+        freeaddrinfo(addr_info->addr);
+        addr_info->addr = NULL;
+    }
+}
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_is_null_pointer(void *ptr)
+{
+    return ptr == NULL;
+}
+
+MOONBIT_FFI_EXPORT
+moonbit_getaddrinfo_t *
+moonbitlang_getaddrinfo_make_ffi(
+    moonbit_bytes_t hostname,
+    moonbit_bytes_t service,
+    int ai_flags,
+    int ai_family,
+    int ai_socktype,
+    int ai_protocol)
+{
+    struct addrinfo hints, *result;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_flags = ai_flags;
+    // hints.ai_family = ai_family;
+    hints.ai_family = AF_UNSPEC;   // IPv4 or IPv6
+    hints.ai_socktype = ai_socktype;
+    hints.ai_protocol = ai_protocol;
+    int status = getaddrinfo(
+        (const char *)hostname,
+        (const char *)service,
+        // NULL,
+        &hints,
+        &result);
+    if (status != 0)
+    {
+        return NULL; // Error handling
+    }
+
+    moonbit_getaddrinfo_t *addr =
+        (moonbit_getaddrinfo_t *)moonbit_make_external_object(
+            moonbit_getaddrinfo_finalize, sizeof(moonbit_getaddrinfo_t));
+    memset(addr, 0, sizeof(moonbit_getaddrinfo_t));
+    addr->addr = result;
+    return addr;
+}
+
+typedef struct moonbit_addrinfo_results_iterate_cb_s
+{
+    int32_t (*code)(
+        struct moonbit_addrinfo_results_iterate_cb_s *,
+        int32_t ai_flags,
+        int32_t ai_family,
+        int32_t ai_socktype,
+        int32_t ai_protocol,
+        moonbit_bytes_t ai_addr);
+} moonbit_addrinfo_results_iterate_cb_t;
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_addrinfo_results_iterate_ffi(
+    moonbit_getaddrinfo_t *addrinfo,
+    moonbit_addrinfo_results_iterate_cb_t *cb)
+{
+    int32_t terminated = 0;
+    for (struct addrinfo *ai = addrinfo->addr; ai != NULL; ai = ai->ai_next)
+    {
+        moonbit_bytes_t sockaddr = moonbit_make_bytes(ai->ai_addrlen, 0);
+        memcpy((void *)sockaddr, ai->ai_addr, ai->ai_addrlen);
+        moonbit_incref(cb);
+        terminated = cb->code(
+            cb, ai->ai_flags, ai->ai_family, ai->ai_socktype, ai->ai_protocol,
+            sockaddr);
+        if (terminated)
+        {
+            break;
+        }
+    }
+    return terminated;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_ipv4_addrlen_ffi(void)
+{
+    return INET_ADDRSTRLEN;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_ipv6_addrlen_ffi(void)
+{
+    return INET6_ADDRSTRLEN;
+}
+
+typedef struct moonbit_get_ip_name_port_cb_s
+{
+    int32_t (*code)(
+        struct moonbit_get_ip_name_port_cb_s *,
+        int32_t ai_family,
+        int32_t port,
+        int32_t flowinfo,
+        int32_t scope_id);
+} moonbit_get_ip_name_port_cb_t;
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_get_ip_name_ffi(
+    const struct sockaddr *src,
+    moonbit_get_ip_name_port_cb_t *cb)
+{
+    if (src == NULL || cb == NULL)
+    {
+        return -1;
+    }
+
+    char ip_str[INET6_ADDRSTRLEN];
+    int flowinfo = 0;
+    int scope_id = 0;
+    int port = 0;
+    if (src->sa_family == AF_INET)
+    {
+        const struct sockaddr_in *sa4 = (const struct sockaddr_in *)src;
+        if (inet_ntop(AF_INET, &sa4->sin_addr, ip_str, sizeof(ip_str)) == NULL)
+        {
+            return -1;
+        }
+        port = ntohs(sa4->sin_port);
+    }
+    else if (src->sa_family == AF_INET6)
+    {
+        const struct sockaddr_in6 *sa6 = (const struct sockaddr_in6 *)src;
+        if (inet_ntop(AF_INET6, &sa6->sin6_addr, ip_str, sizeof(ip_str)) == NULL)
+        {
+            return -1;
+        }
+        flowinfo = sa6->sin6_flowinfo;
+        scope_id = sa6->sin6_scope_id;
+        port = ntohs(sa6->sin6_port);
+    }
+    else
+    {
+        return -1;
+    }
+    moonbit_incref(cb);
+    cb->code(
+        cb, src->sa_family, port, flowinfo, scope_id);
+    return 0;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_get_ipv4_name_ffi(const struct sockaddr_in *src, moonbit_bytes_t dst)
+{
+    if (src == NULL || dst == NULL)
+    {
+        return -1;
+    }
+    char ip_str[INET_ADDRSTRLEN];
+    if (inet_ntop(AF_INET, &src->sin_addr, ip_str, sizeof(ip_str)) == NULL)
+    {
+        return -1;
+    }
+    int len = strlen(ip_str);
+    memcpy(dst, ip_str, len);
+    dst[len] = '\0';
+    return len;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_get_ipv6_name_ffi(const struct sockaddr_in6 *src, moonbit_bytes_t dst)
+{
+    if (src == NULL || dst == NULL)
+    {
+        return -1;
+    }
+    char ip_str[INET6_ADDRSTRLEN];
+    if (inet_ntop(AF_INET6, &src->sin6_addr, ip_str, sizeof(ip_str)) == NULL)
+    {
+        return -1;
+    }
+    int len = strlen(ip_str);
+    memcpy(dst, ip_str, len);
+    dst[len] = '\0';
+    return len;
+}
+
+MOONBIT_FFI_EXPORT struct sockaddr_storage *moonbitlang_create_sockaddr_storage_ffi()
+{
+    struct sockaddr_storage *addr =
+        moonbit_make_external_object(empty_function, sizeof(struct sockaddr_storage));
+    memset(addr, 0, sizeof(struct sockaddr_storage));
+    addr->ss_family = AF_INET; // Default to IPv4
+    return addr;
+}
+
+// Constants for socket domains
+MOONBIT_FFI_EXPORT int32_t moonbitlang_AF_INET_ffi(void) { return AF_INET; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_AF_INET6_ffi(void) { return AF_INET6; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_AF_UNIX_ffi(void) { return AF_UNIX; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_AF_UNSPEC_ffi(void) { return AF_UNSPEC; }
+
+// Constants for socket types
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SOCK_STREAM_ffi(void) { return SOCK_STREAM; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SOCK_DGRAM_ffi(void) { return SOCK_DGRAM; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SOCK_RAW_ffi(void) { return SOCK_RAW; }
+
+// Constants for socket protocols
+MOONBIT_FFI_EXPORT int32_t moonbitlang_IPPROTO_TCP_ffi(void) { return IPPROTO_TCP; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_IPPROTO_UDP_ffi(void) { return IPPROTO_UDP; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_IPPROTO_ICMP_ffi(void) { return IPPROTO_ICMP; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_IPPROTO_ICMPV6_ffi(void) { return IPPROTO_ICMPV6; }
+
+// Constants for socket options
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SOL_SOCKET_ffi(void) { return SOL_SOCKET; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SO_REUSEADDR_ffi(void) { return SO_REUSEADDR; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SO_KEEPALIVE_ffi(void) { return SO_KEEPALIVE; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SO_RCVBUF_ffi(void) { return SO_RCVBUF; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SO_SNDBUF_ffi(void) { return SO_SNDBUF; }
+
+// Constants for socket shutdown modes
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SHUT_RD_ffi(void) { return SHUT_RD; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SHUT_WR_ffi(void) { return SHUT_WR; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SHUT_RDWR_ffi(void) { return SHUT_RDWR; }
+
+// Constants for getaddrinfo flags
+MOONBIT_FFI_EXPORT int32_t moonbitlang_FLAG_AI_PASSIVE_ffi(void) { return AI_PASSIVE; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_FLAG_AI_CANONNAME_ffi(void) { return AI_CANONNAME; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_FLAG_AI_ALL_ffi(void) { return AI_ALL; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_FLAG_AI_NUMERICHOST_ffi(void) { return AI_NUMERICHOST; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_FLAG_AI_NUMERICSERV_ffi(void) { return AI_NUMERICSERV; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_FLAG_AI_ADDRCONFIG_ffi(void) { return AI_ADDRCONFIG; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_FLAG_AI_V4MAPPED_ffi(void) { return AI_V4MAPPED; }
+
+/// Constants for setsockopt

--- a/src/socket/ip.mbt
+++ b/src/socket/ip.mbt
@@ -1,0 +1,541 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#external
+type AddrInfoResults
+
+///|
+extern "C" fn _af_inet_ffi() -> Int = "moonbitlang_AF_INET_ffi"
+
+///|
+extern "C" fn _af_inet6_ffi() -> Int = "moonbitlang_AF_INET6_ffi"
+
+///|
+extern "C" fn _af_unix_ffi() -> Int = "moonbitlang_AF_UNIX_ffi"
+
+///|
+extern "C" fn _af_unspec_ffi() -> Int = "moonbitlang_AF_UNSPEC_ffi"
+
+///|
+extern "C" fn _sock_stream_ffi() -> Int = "moonbitlang_SOCK_STREAM_ffi"
+
+///|
+extern "C" fn _sock_dgram_ffi() -> Int = "moonbitlang_SOCK_DGRAM_ffi"
+
+///|
+extern "C" fn _sock_raw_ffi() -> Int = "moonbitlang_SOCK_RAW_ffi"
+
+///|
+extern "C" fn _ipproto_tcp_ffi() -> Int = "moonbitlang_IPPROTO_TCP_ffi"
+
+///|
+extern "C" fn _ipproto_udp_ffi() -> Int = "moonbitlang_IPPROTO_UDP_ffi"
+
+///|
+extern "C" fn _ipproto_icmp_ffi() -> Int = "moonbitlang_IPPROTO_ICMP_ffi"
+
+///|
+extern "C" fn _ipproto_icmpv6_ffi() -> Int = "moonbitlang_IPPROTO_ICMPV6_ffi"
+
+///|
+extern "C" fn _sol_socket_ffi() -> Int = "moonbitlang_SOL_SOCKET_ffi"
+
+///|
+extern "C" fn _so_reuseaddr_ffi() -> Int = "moonbitlang_SO_REUSEADDR_ffi"
+
+///|
+extern "C" fn _so_keepalive_ffi() -> Int = "moonbitlang_SO_KEEPALIVE_ffi"
+
+///|
+extern "C" fn _so_rcvbuf_ffi() -> Int = "moonbitlang_SO_RCVBUF_ffi"
+
+///|
+extern "C" fn _so_sndbuf_ffi() -> Int = "moonbitlang_SO_SNDBUF_ffi"
+
+///|
+extern "C" fn _shut_rd_ffi() -> Int = "moonbitlang_SHUT_RD_ffi"
+
+///|
+extern "C" fn _shut_wr_ffi() -> Int = "moonbitlang_SHUT_WR_ffi"
+
+///|
+extern "C" fn _shut_rdwr_ffi() -> Int = "moonbitlang_SHUT_RDWR_ffi"
+
+///|
+extern "C" fn _ai_flag_ai_passive_ffi() -> Int = "moonbitlang_FLAG_AI_PASSIVE_ffi"
+
+///|
+extern "C" fn _ai_flag_ai_canonname_ffi() -> Int = "moonbitlang_FLAG_AI_CANONNAME_ffi"
+
+///|
+extern "C" fn _ai_flag_ai_all_ffi() -> Int = "moonbitlang_FLAG_AI_ALL_ffi"
+
+///|
+extern "C" fn _ai_flag_ai_numerichost_ffi() -> Int = "moonbitlang_FLAG_AI_NUMERICHOST_ffi"
+
+///|
+extern "C" fn _ai_flag_ai_numericserv_ffi() -> Int = "moonbitlang_FLAG_AI_NUMERICSERV_ffi"
+
+///|
+extern "C" fn _ai_flag_ai_addrconfig_ffi() -> Int = "moonbitlang_FLAG_AI_ADDRCONFIG_ffi"
+
+///|
+extern "C" fn _ai_flag_ai_v4mapped_ffi() -> Int = "moonbitlang_FLAG_AI_V4MAPPED_ffi"
+
+///|
+extern "C" fn _socket_opt_level_sol_socket_ffi() -> Int = "moonbitlang_SOCKOPT_LEVEL_SOL_SOCKET_ffi"
+
+///|
+extern "C" fn _socket_opt_level_ipproto_ip_ffi() -> Int = "moonbitlang_SOCKOPT_LEVEL_IPPROTO_IP_ffi"
+
+///|
+extern "C" fn _socket_opt_level_ipproto_tcp_ffi() -> Int = "moonbitlang_SOCKOPT_LEVEL_IPPROTO_TCP_ffi"
+
+///|
+extern "C" fn _socket_opt_level_ipproto_udp_ffi() -> Int = "moonbitlang_SOCKOPT_LEVEL_IPPROTO_UDP_ffi"
+
+///|
+extern "C" fn _socket_opt_level_ipproto_icmp_ffi() -> Int = "moonbitlang_SOCKOPT_LEVEL_IPPROTO_ICMP_ffi"
+
+///|
+extern "C" fn _socket_opt_level_ipproto_icmpv6_ffi() -> Int = "moonbitlang_SOCKOPT_LEVEL_IPPROTO_ICMPV6_ffi"
+
+///|
+let _AF_INET : Int = _af_inet_ffi()
+
+///|
+let _AF_INET6 : Int = _af_inet6_ffi()
+
+///|
+let _AF_UNIX : Int = _af_unix_ffi()
+
+///|
+let _AF_UNSPEC : Int = _af_unspec_ffi()
+
+///|
+let _SOCK_STREAM : Int = _sock_stream_ffi()
+
+///|
+let _SOCK_DGRAM : Int = _sock_dgram_ffi()
+
+///|
+let _SOCK_RAW : Int = _sock_raw_ffi()
+
+///|
+let _IPPROTO_TCP : Int = _ipproto_tcp_ffi()
+
+///|
+let _IPPROTO_UDP : Int = _ipproto_udp_ffi()
+
+///|
+let _IPPROTO_ICMP : Int = _ipproto_icmp_ffi()
+
+///|
+let _IPPROTO_ICMPV6 : Int = _ipproto_icmpv6_ffi()
+
+///|
+let _SOL_SOCKET : Int = _sol_socket_ffi()
+
+///|
+let _SO_REUSEADDR : Int = _so_reuseaddr_ffi()
+
+///|
+let _SO_KEEPALIVE : Int = _so_keepalive_ffi()
+
+///|
+let _SO_RCVBUF : Int = _so_rcvbuf_ffi()
+
+///|
+let _SO_SNDBUF : Int = _so_sndbuf_ffi()
+
+///|
+let _SHUT_RD : Int = _shut_rd_ffi()
+
+///|
+let _SHUT_WR : Int = _shut_wr_ffi()
+
+///|
+let _SHUT_RDWR : Int = _shut_rdwr_ffi()
+
+///|
+let _AI_FLAG_PASSIVE : Int = _ai_flag_ai_passive_ffi()
+
+///|
+let _AI_FLAG_CANONNAME : Int = _ai_flag_ai_canonname_ffi()
+
+///|
+let _AI_FLAG_ALL : Int = _ai_flag_ai_all_ffi()
+
+///|
+let _AI_FLAG_NUMERICHOST : Int = _ai_flag_ai_numerichost_ffi()
+
+///|
+let _AI_FLAG_NUMERICSERV : Int = _ai_flag_ai_numericserv_ffi()
+
+///|
+let _AI_FLAG_ADDRCONFIG : Int = _ai_flag_ai_addrconfig_ffi()
+
+///|
+let _AI_FLAG_V4MAPPED : Int = _ai_flag_ai_v4mapped_ffi()
+
+///|
+let _SOCKOPT_LEVEL_SOL_SOCKET : Int = _socket_opt_level_sol_socket_ffi()
+
+///|
+let _SOCKOPT_LEVEL_IPPROTO_IP : Int = _socket_opt_level_ipproto_ip_ffi()
+
+///|
+let _SOCKOPT_LEVEL_IPPROTO_TCP : Int = _socket_opt_level_ipproto_tcp_ffi()
+
+///|
+let _SOCKOPT_LEVEL_IPPROTO_UDP : Int = _socket_opt_level_ipproto_udp_ffi()
+
+///|
+let _SOCKOPT_LEVEL_IPPROTO_ICMP : Int = _socket_opt_level_ipproto_icmp_ffi()
+
+///|
+let _SOCKOPT_LEVEL_IPPROTO_ICMPV6 : Int = _socket_opt_level_ipproto_icmpv6_ffi()
+
+///|
+pub struct AddrInfo {
+  family : Int
+  socktype : Int
+  protocol : Int
+  addr : IpAddr
+  canonname : String?
+}
+
+///|
+pub(open) trait ToIpAddr {
+  ip_name(self : Self) -> String raise
+  to_socket_addr(self : Self) -> SocketAddr raise
+  to_ipaddr(self : Self) -> IpAddr
+}
+
+///|
+priv trait RawPointer {
+  is_null(self : Self) -> Bool
+}
+
+///|
+pub(open) trait ToCString {
+  to_cstring(self : Self) -> Bytes
+}
+
+///|
+pub impl ToIpAddr for IpAddr with to_ipaddr(self : IpAddr) -> IpAddr = "%identity"
+
+///|
+pub impl ToIpAddr for Ipv4Addr with to_ipaddr(self : Ipv4Addr) -> IpAddr = "%identity"
+
+///|
+pub impl ToIpAddr for Ipv6Addr with to_ipaddr(self : Ipv6Addr) -> IpAddr = "%identity"
+
+///|
+fn IpAddr::to_ipv4addr(self : IpAddr) -> Ipv4Addr = "%identity"
+
+///|
+fn IpAddr::to_ipv6addr(self : IpAddr) -> Ipv6Addr = "%identity"
+
+///|
+#borrow(ptr)
+extern "C" fn addrinfo_is_null_pointer_ffi(ptr : AddrInfoResults) -> Bool = "moonbitlang_is_null_pointer"
+
+///|
+extern "C" fn ipv4_addrlen_ffi() -> Int = "moonbitlang_ipv4_addrlen_ffi"
+
+///|
+extern "C" fn ipv6_addrlen_ffi() -> Int = "moonbitlang_ipv6_addrlen_ffi"
+
+///|
+#borrow(addr)
+extern "C" fn get_ip_name_ffi(
+  addr : IpAddr,
+  cb : (Int, Int, Int, Int) -> Bool
+) -> Int = "moonbitlang_get_ip_name_ffi"
+
+///|
+#borrow(addr, bytes)
+extern "C" fn get_ipv4_name_ffi(addr : Ipv4Addr, bytes : Bytes) -> Int = "moonbitlang_get_ipv4_name_ffi"
+
+///|
+#borrow(addr, bytes)
+extern "C" fn get_ipv6_name_ffi(addr : Ipv6Addr, bytes : Bytes) -> Int = "moonbitlang_get_ipv6_name_ffi"
+
+///|
+extern "C" fn create_sockaddr_storage_ffi() -> IpAddr = "moonbitlang_create_sockaddr_storage_ffi"
+
+///|
+let _IP_V4_ADDRLEN : Int = ipv4_addrlen_ffi()
+
+///|
+let _IP_V6_ADDRLEN : Int = ipv6_addrlen_ffi()
+
+///|
+pub(all) enum Domain {
+  IPv4
+  IPv6
+  Unix
+} derive(Show)
+
+///|
+pub fn Domain::from_address(addr : SocketAddr) -> Domain {
+  match addr {
+    V4(_) => IPv4
+    V6(_) => IPv6
+  }
+}
+
+///|
+pub(all) enum Type {
+  Stream // SOCK_STREAM
+  Datagram // SOCK_DGRAM
+  Raw // SOCK_RAW
+} derive(Show)
+
+///|
+pub(open) trait ToType {
+  to_type(self : Self) -> Type raise
+}
+
+///|
+pub impl ToType for Type with to_type(self : Type) -> Type {
+  self
+}
+
+///|
+pub(all) enum Protocol {
+  TCP // IPPROTO_TCP
+  UDP // IPPROTO_UDP
+  ICMPV4 // IPPROTO_ICMP
+  ICMPV6 // IPPROTO_ICMPV6
+} derive(Show)
+
+///|
+pub(all) enum Shutdown {
+  Read // SHUT_RD
+  Write // SHUT_WR
+  Both // SHUT_RDWR
+} derive(Show)
+
+///|
+pub fn Domain::inner(self : Domain) -> Int {
+  match self {
+    IPv4 => _AF_INET
+    IPv6 => _AF_INET6
+    Unix => _AF_UNIX
+  }
+}
+
+///|
+pub fn Type::inner(self : Type) -> Int {
+  match self {
+    Stream => _SOCK_STREAM
+    Datagram => _SOCK_DGRAM
+    Raw => _SOCK_RAW
+  }
+}
+
+///|
+pub fn Protocol::inner(self : Protocol) -> Int {
+  match self {
+    TCP => _IPPROTO_TCP
+    UDP => _IPPROTO_UDP
+    ICMPV4 => _IPPROTO_ICMP
+    ICMPV6 => _IPPROTO_ICMPV6
+  }
+}
+
+///|
+pub fn Shutdown::inner(self : Shutdown) -> Int {
+  match self {
+    Read => _SHUT_RD // SHUT_RD
+    Write => _SHUT_WR // SHUT_WR
+    Both => _SHUT_RDWR // SHUT_RDWR
+  }
+}
+
+///|
+pub impl ToSocketAddrs for String with to_socket_addr(self : String) -> Iter[
+  SocketAddr,
+] raise {
+  if (try? parse_address(self)) is Ok(addr) {
+    return [addr].iter()
+  }
+  let (host, port) = match self.rev_find(":") {
+    Some(last_colon) if last_colon < self.length() => {
+      let ip_str = self.substring(end=last_colon)
+      let port_str = self.substring(start=last_colon + 1)
+      (ip_str, parse_port(port_str))
+    }
+    None => (self, 80) // No port specified, default to 80
+    _ => raise InvalidAddr
+  }
+  getaddrinfo(
+    host,
+    port.to_string(),
+    0,
+    Domain::Unix,
+    Type::Stream,
+    Protocol::TCP,
+  )
+  .iter()
+  .map(fn(info : AddrInfo) {
+    if info.family == _AF_INET6 {
+      Some(SocketAddr::V6(info.addr.to_ipv6addr()))
+    } else {
+      Some(SocketAddr::V4(info.addr.to_ipv4addr()))
+    }
+  })
+  .filter(r => !r.is_empty())
+  .map(r => r.unwrap())
+}
+
+///|
+impl RawPointer for AddrInfoResults with is_null(self : AddrInfoResults) -> Bool {
+  return addrinfo_is_null_pointer_ffi(self)
+}
+
+///|
+pub impl ToCString for String with to_cstring(self : String) -> Bytes {
+  mbt_string_to_utf8_bytes(self, true)
+}
+
+///|
+pub impl ToIpAddr for IpAddr with to_socket_addr(self : IpAddr) -> SocketAddr raise {
+  let mut family : Int = -1
+  let status = get_ip_name_ffi(self, fn(
+    family_val : Int,
+    _port_val : Int,
+    _flowinfo_val : Int,
+    _scope_id_val : Int
+  ) {
+    family = family_val
+    return true
+  })
+  guard status >= 0 else { raise InvalidAddr }
+  if family == _AF_INET6 {
+    return SocketAddr::V6(self.to_ipv6addr())
+  } else if family == _AF_INET {
+    return SocketAddr::V4(self.to_ipv4addr())
+  } else {
+    println("Unsupported address family: \{family}")
+    raise InvalidAddr
+  }
+}
+
+///|
+pub impl ToIpAddr for IpAddr with ip_name(self : IpAddr) -> String raise {
+  match self.to_socket_addr() {
+    V4(addr) => addr.ip_name()
+    V6(addr) => addr.ip_name()
+  }
+}
+
+///|
+pub impl ToIpAddr for Ipv4Addr with to_socket_addr(self : Ipv4Addr) -> SocketAddr raise {
+  SocketAddr::V4(self)
+}
+
+///|
+pub impl ToIpAddr for Ipv4Addr with ip_name(self : Ipv4Addr) -> String raise {
+  let bytes = Bytes::make(_IP_V4_ADDRLEN, 0)
+  let status = get_ipv4_name_ffi(self, bytes)
+  guard status >= 0 else { raise InvalidAddr }
+  let buffer = @buffer.new()
+  for i = 0; bytes[i] != 0; i = i + 1 {
+    buffer.write_byte(bytes[i])
+  }
+  return utf8_bytes_to_mbt_string(buffer.contents())
+}
+
+///|
+pub impl ToIpAddr for Ipv6Addr with to_socket_addr(self : Ipv6Addr) -> SocketAddr raise {
+  SocketAddr::V6(self)
+}
+
+///|
+pub impl ToIpAddr for Ipv6Addr with ip_name(self : Ipv6Addr) -> String raise {
+  let bytes = Bytes::make(_IP_V6_ADDRLEN, 0)
+  let status = get_ipv6_name_ffi(self, bytes)
+  guard status >= 0 else { raise InvalidAddr }
+  let buffer = @buffer.new()
+  for i = 0; bytes[i] != 0; i = i + 1 {
+    buffer.write_byte(bytes[i])
+  }
+  return utf8_bytes_to_mbt_string(buffer.contents())
+}
+
+///|
+extern "C" fn getaddrinfo_make_ffi(
+  hostname : Bytes,
+  service : Bytes,
+  ai_flags : Int,
+  ai_family : Int,
+  ai_socktype : Int,
+  ai_protocol : Int
+) -> AddrInfoResults = "moonbitlang_getaddrinfo_make_ffi"
+
+///|
+extern "C" fn addrinfo_results_iterate_ffi(
+  addr_info : AddrInfoResults,
+  cb : (Int, Int, Int, Int, IpAddr) -> Bool
+) -> Bool = "moonbitlang_addrinfo_results_iterate_ffi"
+
+///|
+pub fn AddrInfoResults::iter(self : AddrInfoResults) -> Iter[AddrInfo] {
+  Iter::new(fn(yield_ : (AddrInfo) -> IterResult) {
+    if addrinfo_results_iterate_ffi(self, fn(
+        _,
+        family : Int,
+        socktype : Int,
+        protocol : Int,
+        addr : IpAddr
+      ) {
+        match yield_({ family, socktype, protocol, addr, canonname: None }) {
+          IterEnd => true
+          IterContinue => false
+        }
+      }) {
+      return IterEnd
+    } else {
+      return IterContinue
+    }
+  })
+}
+
+///|
+pub fn[H : ToCString, S : ToCString] getaddrinfo(
+  hostname : H,
+  service : S,
+  ai_flags : Int,
+  ai_family : Domain,
+  ai_socktype : Type,
+  ai_protocol : Protocol
+) -> AddrInfoResults raise InvalidAddr {
+  let service = service.to_cstring()
+  let addr_info = getaddrinfo_make_ffi(
+    hostname.to_cstring(),
+    service,
+    ai_flags,
+    ai_family.inner(),
+    ai_socktype.inner(),
+    ai_protocol.inner(),
+  )
+  if addr_info.is_null() {
+    raise InvalidAddr
+  }
+  return addr_info
+}

--- a/src/socket/ip_test.mbt
+++ b/src/socket/ip_test.mbt
@@ -13,29 +13,15 @@
 // limitations under the License.
 
 ///|
-fn main_prog() -> Unit raise {
-  let server = @socket.UDP::new()
-  @async.with_event_loop(fn(root) {
-    server.bind(@socket.SocketAddr::parse("0.0.0.0:4200"))
-    for {
-      let buf = FixedArray::make(1024, b'0')
-      let (n, addr) = server.recvfrom(buf)
-      root.spawn_bg(fn() {
-        let buf = buf.unsafe_reinterpret_as_bytes()
-        server.sendto(buf[0:n].to_bytes(), addr)
-      })
+test "Resolve IPv4 hostname" {
+  let addrs = ToSocketAddrs::to_socket_addr("localhost").collect()
+  assert_true(addrs.length() > 0)
+  assert_true(addrs[0].is_ipv4())
+  match addrs[0] {
+    SocketAddr::V4(addr) => {
+      assert_eq(addr.ip_name(), "127.0.0.1")
+      assert_eq(addr.port(), 80)
     }
-  }) catch {
-    err => {
-      server.close()
-      raise err
-    }
-  }
-}
-
-///|
-fn main {
-  main_prog() catch {
-    err => println("server exit with error \{err}")
+    _ => fail("Expected IPv4 address")
   }
 }

--- a/src/socket/moon.pkg.json
+++ b/src/socket/moon.pkg.json
@@ -4,5 +4,5 @@
     "moonbitlang/async/internal/event_loop"
   ],
   "test-import": [ "moonbitlang/async" ],
-  "native-stub": [ "socket.c" ]
+  "native-stub": [ "socket.c", "ip.c" ]
 }

--- a/src/socket/read_exactly_test.mbt
+++ b/src/socket/read_exactly_test.mbt
@@ -25,7 +25,9 @@ test "read_exactly" {
     root.spawn_bg(fn() {
       let listen_sock = @socket.TCP::new()
       try {
-        listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
+        listen_sock
+        ..bind(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
+        ..listen()
         let (conn, _) = listen_sock.accept()
         try {
           let msg1 = conn.recv_exactly(4)
@@ -59,7 +61,7 @@ test "read_exactly" {
     // client
     root.spawn_bg(fn() {
       let conn = @socket.TCP::new()
-      conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+      conn.connect(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
       conn.send([1, 2, 3, 4, 5, 6])
       log("first message sent")
       @async.sleep(200)
@@ -94,7 +96,9 @@ test "read_exactly failure" {
       root.spawn_bg(fn() {
         let listen_sock = @socket.TCP::new()
         try {
-          listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
+          listen_sock
+          ..bind(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
+          ..listen()
           let (conn, _) = listen_sock.accept()
           try {
             let msg1 = conn.recv_exactly(4)
@@ -128,7 +132,7 @@ test "read_exactly failure" {
       // client
       root.spawn_bg(fn() {
         let conn = @socket.TCP::new()
-        conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+        conn.connect(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
         conn.send([1, 2, 3, 4, 5, 6])
         log("first message sent")
         @async.sleep(200)

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <stdio.h>
@@ -124,4 +125,32 @@ int moonbitlang_async_recvfrom(int sockfd, void *buf, int offset, int max_len, v
 
 int moonbitlang_async_sendto(int sockfd, void *buf, int offset, int max_len, void *addr) {
   return sendto(sockfd, buf + offset, max_len, 0, addr, sizeof(struct sockaddr_in));
+}
+
+
+void *moonbitlang_async_make_ipv6_addr(uint8_t *ip, int port, uint32_t flowinfo, uint32_t scope_id) {
+  struct sockaddr_in6 *addr = (struct sockaddr_in6*)moonbit_make_bytes(
+    sizeof(struct sockaddr_in6),
+    0
+  );
+  addr->sin6_family = AF_INET6;
+  addr->sin6_port = htons(port);
+  addr->sin6_flowinfo = flowinfo;
+  addr->sin6_scope_id = scope_id;
+  memcpy(&addr->sin6_addr, ip, 16);
+  return addr;
+}
+
+int32_t moonbitlang_async_ipv6_addr_get_ip(struct sockaddr_in6 *addr, uint8_t *dst) {
+  char ip_str[INET6_ADDRSTRLEN];
+  if (inet_ntop(AF_INET6, &addr->sin6_addr, ip_str, sizeof(ip_str)) == NULL) {
+      return -1;
+  }
+  int len = strlen(ip_str);
+  memcpy(dst, ip_str, len);
+  dst[len] = '\0';
+  return len;
+}
+uint32_t moonbitlang_async_ipv6_addr_get_port(struct sockaddr_in6 *addr) {
+  return ntohs(addr->sin6_port);
 }

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -146,16 +146,10 @@ void *moonbitlang_async_make_ipv6_addr(uint8_t *ip, int port, uint32_t flowinfo,
   return addr;
 }
 
-int32_t moonbitlang_async_ipv6_addr_get_ip(struct sockaddr_in6 *addr, uint8_t *dst) {
-  char ip_str[INET6_ADDRSTRLEN];
-  if (inet_ntop(AF_INET6, &addr->sin6_addr, ip_str, sizeof(ip_str)) == NULL) {
-      return -1;
-  }
-  int len = strlen(ip_str);
-  memcpy(dst, ip_str, len);
-  dst[len] = '\0';
-  return len;
+void moonbitlang_async_ipv6_addr_get_ip(struct sockaddr_in6 *addr, uint8_t *dst) {
+    memcpy(dst, &addr->sin6_addr, 16);
 }
+
 uint32_t moonbitlang_async_ipv6_addr_get_port(struct sockaddr_in6 *addr) {
   return ntohs(addr->sin6_port);
 }

--- a/src/socket/socket.mbti
+++ b/src/socket/socket.mbti
@@ -3,12 +3,11 @@ package "moonbitlang/async/socket"
 // Values
 
 // Types and methods
-type Addr
-fn Addr::ip(Self) -> UInt
-fn Addr::new(UInt, Int) -> Self
-fn Addr::parse(String) -> Self raise InvalidAddr
-fn Addr::port(Self) -> Int
-impl Show for Addr
+type SocketAddr
+fn SocketAddr::ip(Self) -> String
+fn SocketAddr::parse(String) -> Self raise InvalidAddr
+fn SocketAddr::port(Self) -> Int
+impl Show for SocketAddr
 
 pub type! ConnectionClosed
 impl Show for ConnectionClosed
@@ -17,10 +16,10 @@ pub type! InvalidAddr
 impl Show for InvalidAddr
 
 type TCP
-async fn TCP::accept(Self) -> (Self, Addr) raise
-fn TCP::bind(Self, Addr) -> Unit raise
+async fn TCP::accept(Self) -> (Self, SocketAddr) raise
+fn TCP::bind(Self, SocketAddr) -> Unit raise
 fn TCP::close(Self) -> Unit
-async fn TCP::connect(Self, Addr) -> Unit raise
+async fn TCP::connect(Self, SocketAddr) -> Unit raise
 fn TCP::listen(Self) -> Unit raise
 fn TCP::new() -> Self
 async fn TCP::recv(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> Int raise
@@ -28,14 +27,14 @@ async fn TCP::recv_exactly(Self, Int) -> Bytes raise
 async fn TCP::send(Self, Bytes, offset~ : Int = .., len? : Int) -> Unit raise
 
 type UDP
-fn UDP::bind(Self, Addr) -> Unit raise
+fn UDP::bind(Self, SocketAddr) -> Unit raise
 fn UDP::close(Self) -> Unit
-fn UDP::connect(Self, Addr) -> Unit raise
+fn UDP::connect(Self, SocketAddr) -> Unit raise
 fn UDP::new() -> Self
 async fn UDP::recv(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> Int raise
-async fn UDP::recvfrom(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> (Int, Addr) raise
+async fn UDP::recvfrom(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> (Int, SocketAddr) raise
 async fn UDP::send(Self, Bytes, offset~ : Int = .., len? : Int) -> Unit raise
-async fn UDP::sendto(Self, Bytes, Addr, offset~ : Int = .., len? : Int) -> Unit raise
+async fn UDP::sendto(Self, Bytes, SocketAddr, offset~ : Int = .., len? : Int) -> Unit raise
 
 // Type aliases
 

--- a/src/socket/string_convert.mbt
+++ b/src/socket/string_convert.mbt
@@ -1,0 +1,57 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Adapted from https://github.com/moonbitlang/x/blob/main/internal/ffi/string_convert.mbt
+fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
+  let res : Array[Char] = []
+  let len = bytes.length()
+  let mut i = 0
+  while i < len {
+    let mut c = bytes[i].to_int()
+    if c < 0x80 {
+      res.push(Int::unsafe_to_char(c))
+      i += 1
+    } else if c < 0xE0 {
+      if i + 1 >= len {
+        break
+      }
+      c = ((c & 0x1F) << 6) | (bytes[i + 1].to_int() & 0x3F)
+      res.push(Int::unsafe_to_char(c))
+      i += 2
+    } else if c < 0xF0 {
+      if i + 2 >= len {
+        break
+      }
+      c = ((c & 0x0F) << 12) |
+        ((bytes[i + 1].to_int() & 0x3F) << 6) |
+        (bytes[i + 2].to_int() & 0x3F)
+      res.push(Int::unsafe_to_char(c))
+      i += 3
+    } else {
+      if i + 3 >= len {
+        break
+      }
+      c = ((c & 0x07) << 18) |
+        ((bytes[i + 1].to_int() & 0x3F) << 12) |
+        ((bytes[i + 2].to_int() & 0x3F) << 6) |
+        (bytes[i + 3].to_int() & 0x3F)
+      c -= 0x10000
+      res.push(Int::unsafe_to_char((c >> 10) + 0xD800))
+      res.push(Int::unsafe_to_char((c & 0x3FF) + 0xDC00))
+      i += 4
+    }
+  }
+  String::from_array(res)
+}

--- a/src/socket/string_convert.mbt
+++ b/src/socket/string_convert.mbt
@@ -14,6 +14,44 @@
 
 ///|
 /// Adapted from https://github.com/moonbitlang/x/blob/main/internal/ffi/string_convert.mbt
+pub fn mbt_string_to_utf8_bytes(str : String, is_filename : Bool) -> Bytes {
+  let res : Array[Byte] = []
+  let len = str.length()
+  let mut i = 0
+  while i < len {
+    let mut c = str.charcode_at(i)
+    if 0xD800 <= c && c <= 0xDBFF {
+      c -= 0xD800
+      i = i + 1
+      let l = str.charcode_at(i) - 0xDC00
+      c = (c << 10) + l + 0x10000
+    }
+
+    // stdout accepts UTF-8, so convert the stream to UTF-8 first
+    if c < 0x80 {
+      res.push(c.to_byte())
+    } else if c < 0x800 {
+      res.push((0xc0 + (c >> 6)).to_byte())
+      res.push((0x80 + (c & 0x3f)).to_byte())
+    } else if c < 0x10000 {
+      res.push((0xe0 + (c >> 12)).to_byte())
+      res.push((0x80 + ((c >> 6) & 0x3f)).to_byte())
+      res.push((0x80 + (c & 0x3f)).to_byte())
+    } else {
+      res.push((0xf0 + (c >> 18)).to_byte())
+      res.push((0x80 + ((c >> 12) & 0x3f)).to_byte())
+      res.push((0x80 + ((c >> 6) & 0x3f)).to_byte())
+      res.push((0x80 + (c & 0x3f)).to_byte())
+    }
+    i = i + 1
+  }
+  if is_filename {
+    res.push((0).to_byte())
+  }
+  Bytes::from_array(res)
+}
+
+///|
 fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
   let res : Array[Char] = []
   let len = bytes.length()

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -31,9 +31,9 @@ pub fn TCP::close(self : TCP) -> Unit {
 
 ///|
 /// Bind the socket to an address using the `bind(2)` system call.
-pub fn TCP::bind(self : TCP, addr : Addr) -> Unit raise {
+pub fn TCP::bind(self : TCP, addr : SocketAddr) -> Unit raise {
   let TCP(sock) = self
-  if 0 != bind_ffi(sock, addr) {
+  if 0 != bind_ffi(sock, addr.to_ipaddr()) {
     @os_error.check_errno()
   }
 }
@@ -52,14 +52,14 @@ pub fn TCP::listen(self : TCP) -> Unit raise {
 /// Accept a new connection on a listening socket using `accept(2)` system call.
 /// A new socket representing the accepted connection
 /// will be returned together with the address of peer.
-pub async fn TCP::accept(self : TCP) -> (TCP, Addr) raise {
+pub async fn TCP::accept(self : TCP) -> (TCP, SocketAddr) raise {
   let TCP(listen_sock) = self
   @event_loop.prepare_fd_read(listen_sock)
-  let addr = Addr::new(0, 0)
+  let addr = create_sockaddr_storage_ffi()
   for {
     let conn_sock = accept_ffi(listen_sock, addr)
     if conn_sock > 0 {
-      return (TCP(conn_sock), addr)
+      return (TCP(conn_sock), addr.to_socket_addr())
     } else if @os_error.is_nonblocking_io_error() {
       @event_loop.wait_fd_read(listen_sock)
     } else {
@@ -70,10 +70,10 @@ pub async fn TCP::accept(self : TCP) -> (TCP, Addr) raise {
 
 ///|
 /// Make connection to a remote address using `connect(2)` system call.
-pub async fn TCP::connect(self : TCP, addr : Addr) -> Unit raise {
+pub async fn TCP::connect(self : TCP, addr : SocketAddr) -> Unit raise {
   let TCP(sock) = self
   @event_loop.prepare_fd_write(sock)
-  if 0 == connect_ffi(sock, addr) {
+  if 0 == connect_ffi(sock, addr.to_ipaddr()) {
     return
   }
   if @os_error.is_nonblocking_io_error() {

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -32,9 +32,9 @@ pub fn UDP::close(self : UDP) -> Unit {
 ///|
 /// Bind the socket to an address using the `bind(2)` system call,
 /// so that the socket can be used to receive packets from the address.
-pub fn UDP::bind(self : UDP, addr : Addr) -> Unit raise {
+pub fn UDP::bind(self : UDP, addr : SocketAddr) -> Unit raise {
   let UDP(sock) = self
-  if 0 != bind_ffi(sock, addr) {
+  if 0 != bind_ffi(sock, addr.to_ipaddr()) {
     @os_error.check_errno()
   }
 }
@@ -42,9 +42,9 @@ pub fn UDP::bind(self : UDP, addr : Addr) -> Unit raise {
 ///|
 /// "connect" the socket to remote address using `connect(2)` system call.
 /// For UDP socket, connect means setting the default address for `send`.
-pub fn UDP::connect(self : UDP, addr : Addr) -> Unit raise {
+pub fn UDP::connect(self : UDP, addr : SocketAddr) -> Unit raise {
   let UDP(sock) = self
-  if 0 != connect_ffi(sock, addr) {
+  if 0 != connect_ffi(sock, addr.to_ipaddr()) {
     @os_error.check_errno()
   }
 }
@@ -88,11 +88,11 @@ pub async fn UDP::recvfrom(
   buf : FixedArray[Byte],
   offset~ : Int = 0,
   max_len? : Int
-) -> (Int, Addr) raise {
+) -> (Int, SocketAddr) raise {
   let max_len = max_len.unwrap_or(buf.length() - offset)
   let UDP(sock) = self
   @event_loop.prepare_fd_read(sock)
-  let addr = Addr::new(0, 0)
+  let addr = create_sockaddr_storage_ffi()
   let n_read = recvfrom_ffi(sock, buf, offset, max_len, addr)
   let n_read = if n_read < 0 && @os_error.is_nonblocking_io_error() {
     @event_loop.wait_fd_read(sock)
@@ -103,7 +103,7 @@ pub async fn UDP::recvfrom(
   if n_read < 0 {
     @os_error.check_errno()
   }
-  (n_read, addr)
+  (n_read, addr.to_socket_addr())
 }
 
 ///|
@@ -138,7 +138,7 @@ pub async fn UDP::send(
 pub async fn UDP::sendto(
   self : UDP,
   buf : Bytes,
-  addr : Addr,
+  addr : SocketAddr,
   offset~ : Int = 0,
   len? : Int
 ) -> Unit raise {
@@ -146,7 +146,7 @@ pub async fn UDP::sendto(
   let UDP(sock) = self
   @event_loop.prepare_fd_write(sock)
   for {
-    let n_sent = sendto_ffi(sock, buf, offset, len, addr)
+    let n_sent = sendto_ffi(sock, buf, offset, len, addr.to_ipaddr())
     if n_sent > 0 {
       return
     }


### PR DESCRIPTION
1. **Support IPv6 protocol**  
2. **Support DNS domain resolution**  
3. **Maintain compatibility with the previous API version**  
   (Recommended to replace `@socket.Addr` with `@socket.SocketAddr`)  