### PR TITLE
add asynchronous queue

### DIFF
--- a/src/aqueue/aqueue.mbt
+++ b/src/aqueue/aqueue.mbt
@@ -1,0 +1,68 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// An asynchronous queue, where reader can wait for data to arrive
+/// in a non-blocking manner.
+/// The internal buffer size of this queue is unlimited,
+/// and writing to the queue will never block.
+struct Queue[X] {
+  readers : @deque.T[Ref[@coroutine.Coroutine?]]
+  buffer : @deque.T[X]
+}
+
+///|
+/// Create an empty queue.
+pub fn[X] Queue::new() -> Queue[X] {
+  { readers: @deque.new(), buffer: @deque.new() }
+}
+
+///|
+/// Put a new element into a queue. This function neven blocks.
+/// If the queue is currently empty and there are readers blocked on this thread,
+/// one reader will be woken to process the data.
+pub fn[X] Queue::put(self : Queue[X], data : X) -> Unit {
+  self.buffer.push_back(data)
+  loop self.readers.pop_front() {
+    None => ()
+    Some({ val: None }) => continue self.readers.pop_front()
+    Some({ val: Some(reader) }) => reader.wake()
+  }
+}
+
+///|
+/// Fetch an element from the queue.
+/// If the queue is currently empty, `get` will block and wait until data arrive.
+/// If there are multiple readers blocked on `get`,
+/// new data will be delivered in a first-come-first-serve manner.
+///
+/// `get` itself never fail, and will wait indefinitely.
+/// However, since `get` is a blocking point, the task running `get` may be cancelled,
+/// in this case, an cancellation will be raised from `get`.
+pub async fn[X] Queue::get(self : Queue[X]) -> X raise {
+  loop self.buffer.pop_front() {
+    Some(data) => data
+    None => {
+      let reader = @ref.new(Some(@coroutine.current_coroutine()))
+      self.readers.push_back(reader)
+      @coroutine.suspend() catch {
+        err => {
+          reader.val = None
+          raise err
+        }
+      }
+      continue self.buffer.pop_front()
+    }
+  }
+}

--- a/src/aqueue/aqueue.mbti
+++ b/src/aqueue/aqueue.mbti
@@ -1,0 +1,14 @@
+package "moonbitlang/async/aqueue"
+
+// Values
+
+// Types and methods
+type Queue[X]
+async fn[X] Queue::get(Self[X]) -> X raise
+fn[X] Queue::new() -> Self[X]
+fn[X] Queue::put(Self[X], X) -> Unit
+
+// Type aliases
+
+// Traits
+

--- a/src/aqueue/aqueue_test.mbt
+++ b/src/aqueue/aqueue_test.mbt
@@ -1,0 +1,122 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "aqueue basic" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    let queue = @aqueue.Queue::new()
+    root.spawn_bg(fn() {
+      for _ in 0..<6 {
+        log.write_string("get => \{queue.get()}\n")
+      }
+    })
+    root.spawn_bg(fn() {
+      for x in 0..<6 {
+        @async.sleep(20)
+        queue.put(x)
+        log.write_string("put(\{x})\n")
+      }
+    })
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|put(0)
+      #|get => 0
+      #|put(1)
+      #|get => 1
+      #|put(2)
+      #|get => 2
+      #|put(3)
+      #|get => 3
+      #|put(4)
+      #|get => 4
+      #|put(5)
+      #|get => 5
+      #|
+    ),
+  )
+}
+
+///|
+test "aqueue multi-reader" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    let queue = @aqueue.Queue::new()
+    root.spawn_bg(fn() {
+      @async.sleep(20)
+      let x = queue.get()
+      log.write_string("task 1: get => \{x}\n")
+    })
+    root.spawn_bg(fn() {
+      let x = queue.get()
+      log.write_string("task 2: get => \{x}\n")
+    })
+    @async.sleep(50)
+    queue.put(1)
+    queue.put(2)
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|task 2: get => 1
+      #|task 1: get => 2
+      #|
+    ),
+  )
+}
+
+///|
+test "aqueue cancellation" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    let queue = @aqueue.Queue::new()
+    root.spawn_bg(fn() {
+      for x in 0..<6 {
+        @async.sleep(50)
+        log.write_string("put(\{x})\n")
+        queue.put(x)
+      }
+    })
+    @async.with_timeout(250, fn() {
+      for {
+        let x = queue.get() catch {
+          err => {
+            log.write_string("`queue.get()` cancelled with \{err}\n")
+            raise err
+          }
+        }
+        log.write_string("get => \{x}\n")
+      }
+    })
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|put(0)
+      #|get => 0
+      #|put(1)
+      #|get => 1
+      #|put(2)
+      #|get => 2
+      #|put(3)
+      #|get => 3
+      #|`queue.get()` cancelled with Cancelled
+      #|put(4)
+      #|put(5)
+      #|
+    ),
+  )
+}

--- a/src/aqueue/moon.pkg.json
+++ b/src/aqueue/moon.pkg.json
@@ -1,0 +1,4 @@
+{
+  "import": [ "moonbitlang/async/internal/coroutine" ],
+  "test-import": [ "moonbitlang/async" ]
+}

--- a/src/async.mbt
+++ b/src/async.mbt
@@ -64,3 +64,6 @@ pub async fn with_timeout(time : Int, f : async () -> Unit raise) -> Unit raise 
 /// because it will break other abstraction such as `with_timeout`.
 /// A common scenario is avoiding corrupted state due to partial write to file etc.
 pub fnalias @coroutine.protect_from_cancel
+
+///|
+pub typealias @aqueue.Queue

--- a/src/async.mbti
+++ b/src/async.mbti
@@ -27,6 +27,7 @@ fn[G, X] TaskGroup::spawn(Self[G], async () -> X raise, no_wait~ : Bool = .., al
 fn[X] TaskGroup::spawn_bg(Self[X], async () -> Unit raise, no_wait~ : Bool = .., allow_failure~ : Bool = ..) -> Unit raise
 
 // Type aliases
+pub typealias @moonbitlang/async/aqueue.Queue as Queue
 
 // Traits
 

--- a/src/moon.pkg.json
+++ b/src/moon.pkg.json
@@ -1,7 +1,8 @@
 {
   "import": [
     "moonbitlang/async/internal/coroutine",
-    "moonbitlang/async/internal/event_loop"
+    "moonbitlang/async/internal/event_loop",
+    "moonbitlang/async/aqueue"
   ],
   "test-import": [
     "moonbitlang/async/pipe",


### PR DESCRIPTION
This PR add an asynchronous queue implementation. Readers of the queue can wait indefinitely until data arrive.

For writer, the implementation in this PR employs the "infinite internal buffer, writer never block" style. There are alternatives too:

- fixed internal buffer size, writer block when buffer is full (useful for creating back-pressure)
- fixed internal buffer size, overwrite oldest record when buffer is full (ring buffer)

These variants are left for future work.