### PR TITLE
allow only one writer, document the behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,10 @@ may block the whole program as well
 
 - although internally `moonbitlang/async` may use OS threads to perform some IO job,
 user code can only utilize one hardware processor
+
+There are several other points to notice when using this library:
+
+- At most one task can read/write to socket etc. at anytime, to avoid race condition.
+If multiple reader/writer is desired,
+you should create a dedicated worker task for reading/writing
+and use `@async.Queue` to distribute/gather data

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -24,7 +24,7 @@ priv struct EventLoop {
 priv struct Task {
   mut events : Int
   mut read : @coroutine.Coroutine?
-  mut write : Set[@coroutine.Coroutine]
+  mut write : @coroutine.Coroutine?
 }
 
 ///|
@@ -91,11 +91,9 @@ fn EventLoop::run_forever(self : Self) -> Unit raise {
         task.read = None
         coro.wake()
       }
-      if (events & Write) != 0 {
-        for coro in task.write {
-          coro.wake()
-        }
-        task.write = Set::new()
+      if task.write is Some(coro) && (events & Write) != 0 {
+        task.write = None
+        coro.wake()
       }
     }
     @coroutine.reschedule()
@@ -115,7 +113,7 @@ pub fn prepare_fd_read(fd : Int) -> Unit raise {
   guard curr_loop.val is Some(evloop)
   let task = match evloop.tasks.get(fd) {
     None => {
-      let task = { read: None, write: Set::new(), events: NoEvent }
+      let task = { read: None, write: None, events: NoEvent }
       evloop.tasks[fd] = task
       task
     }
@@ -152,12 +150,13 @@ pub fn prepare_fd_write(fd : Int) -> Unit raise {
   guard curr_loop.val is Some(evloop)
   let task = match evloop.tasks.get(fd) {
     None => {
-      let task = { read: None, write: Set::new(), events: NoEvent }
+      let task = { read: None, write: None, events: NoEvent }
       evloop.tasks[fd] = task
       task
     }
     Some(task) => task
   }
+  guard task.write is None
   if (task.events & Write) == 0 {
     evloop.poll.register(
       fd,
@@ -175,10 +174,10 @@ pub async fn wait_fd_write(fd : Int) -> Unit raise {
   guard evloop.tasks.get(fd) is Some(task)
   guard (task.events & Write) != 0
   let coro = @coroutine.current_coroutine()
-  task.write.add(coro)
+  task.write = Some(coro)
   ignore(@coroutine.suspend()) catch {
     err => {
-      task.write.remove(coro)
+      task.write = None
       raise err
     }
   }

--- a/src/pipe/pipe.mbt
+++ b/src/pipe/pipe.mbt
@@ -119,6 +119,10 @@ pub fn PipeWrite::close(self : PipeWrite) -> Unit {
 /// For `pipe.read(buf, offset~, max_len~)`,
 /// at most `max_len` bytes of data will be written to `buf`, starting from `offset`.
 /// The number of read bytes will be returned.
+///
+/// At most one task can read from a pipe at any time.
+/// To allow multiple reader,
+/// use a worker task for reading and use `@async.Queue` to distribute the data.
 pub async fn PipeRead::read(
   self : PipeRead,
   buf : FixedArray[Byte],
@@ -148,6 +152,10 @@ pub suberror PipeClosed derive(Show)
 /// `pipe.read_exactly(n)` read exactly `n` bytes of data from a pipe.
 /// `read_exactly` will only return after all `n` bytes of data are read.
 /// If the pipe is closed before receiving all data, an error is raised.
+///
+/// At most one task can read from a pipe at any time.
+/// To allow multiple reader,
+/// use a worker task for reading and use `@async.Queue` to distribute the data.
 pub async fn PipeRead::read_exactly(self : PipeRead, len : Int) -> Bytes raise {
   let buf = FixedArray::make(len, (0 : Byte))
   for received = 0; received < len; {
@@ -163,6 +171,10 @@ pub async fn PipeRead::read_exactly(self : PipeRead, len : Int) -> Bytes raise {
 ///|
 /// Write data through the write end of a pipe using `write(2)` system call.
 /// This function will only return after all data have been successfully written.
+///
+/// At most one task can write to a pipe at any time.
+/// To allow multiple writers,
+/// use a worker task for writing and use `@async.Queue` to gather data.
 pub async fn PipeWrite::write(
   self : PipeWrite,
   buf : Bytes,

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -89,6 +89,10 @@ pub async fn TCP::connect(self : TCP, addr : Addr) -> Unit raise {
 /// For `tcp.recv(buf, offset~, max_len~)`,
 /// at most `max_len` bytes of data will be written to `buf`, starting from `offset`.
 /// The number of received bytes will be returned.
+///
+/// At most one task can read from a TCP socket at any time.
+/// To allow multiple reader,
+/// use a worker task for reading and use `@async.Queue` to distribute the data.
 pub async fn TCP::recv(
   self : TCP,
   buf : FixedArray[Byte],
@@ -118,6 +122,10 @@ pub suberror ConnectionClosed derive(Show)
 /// `conn.recv_exactly(n)` receives exactly `n` bytes of data from a TCP connection.
 /// `recv_exactly` will only return after all `n` bytes of data are received.
 /// If the connection is closed before receiving all data, an error is raised.
+///
+/// At most one task can read from a TCP socket at any time.
+/// To allow multiple reader,
+/// use a worker task for reading and use `@async.Queue` to distribute the data.
 pub async fn TCP::recv_exactly(self : TCP, len : Int) -> Bytes raise {
   let buf = FixedArray::make(len, (0 : Byte))
   for received = 0; received < len; {
@@ -133,6 +141,10 @@ pub async fn TCP::recv_exactly(self : TCP, len : Int) -> Bytes raise {
 ///|
 /// Send data through a TCP connection using `send(2)` system call.
 /// This function will only return after all data have been successfully sent.
+///
+/// At most one task can write to a TCP socket at any time.
+/// To allow multiple writers,
+/// use a worker task for writing and use `@async.Queue` to gather data.
 pub async fn TCP::send(
   self : TCP,
   buf : Bytes,

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -59,6 +59,10 @@ pub fn UDP::connect(self : UDP, addr : Addr) -> Unit raise {
 /// and `recv` will always receive exactly one UDP packet.
 /// If the buffer is smaller than the received packet,
 /// the rest of the packet will be lost.
+///
+/// At most one task can read from a UDP socket at any time.
+/// To allow multiple reader,
+/// use a worker task for reading and use `@async.Queue` to distribute the data.
 pub async fn UDP::recv(
   self : UDP,
   buf : FixedArray[Byte],
@@ -83,6 +87,19 @@ pub async fn UDP::recv(
 
 ///|
 /// Same as `UDP::recv`, but also return the address of sender.
+/// Receive packet from a UDP socket  using `recvfrom(2)` system call.
+/// For `udp.recv(buf, offset~, max_len~)`,
+/// at most `max_len` bytes of data will be written to `buf`, starting from `offset`.
+/// The number of received bytes and the source address of the packet will be returned.
+///
+/// UDP is a datagram based protocol,
+/// and `recv` will always receive exactly one UDP packet.
+/// If the buffer is smaller than the received packet,
+/// the rest of the packet will be lost.
+///
+/// At most one task can read from a UDP socket at any time.
+/// To allow multiple reader,
+/// use a worker task for reading and use `@async.Queue` to distribute the data.
 pub async fn UDP::recvfrom(
   self : UDP,
   buf : FixedArray[Byte],
@@ -111,6 +128,10 @@ pub async fn UDP::recvfrom(
 /// The address of the remote peer is determined by `bind` or `connect`.
 ///
 /// UDP is a datagram based protocol, every call of `send` will send exactly one packet.
+///
+/// At most one task can write to a UDP socket at any time.
+/// To allow multiple writers,
+/// use a worker task for reading and use `@async.Queue` to gather the data.
 pub async fn UDP::send(
   self : UDP,
   buf : Bytes,
@@ -135,6 +156,14 @@ pub async fn UDP::send(
 
 ///|
 /// Same as `send`, but the address to send is explicitly passed as argument.
+/// Send data through a UDP socket using `sendto(2)` system call.
+/// The address of the remote peer is determined by `bind` or `connect`.
+///
+/// UDP is a datagram based protocol, every call of `send` will send exactly one packet.
+///
+/// At most one task can write to a UDP socket at any time.
+/// To allow multiple writers,
+/// use a worker task for reading and use `@async.Queue` to gather the data.
 pub async fn UDP::sendto(
   self : UDP,
   buf : Bytes,


### PR DESCRIPTION
This PR refines the semantic of sockets and pipes. Previously, sockets and pipes can have only one reader, but may have multiple writers. This PR deprecates this behavior, as multiple reader/writer both easily lead to race conditions. With the introduction of async queue in #5, multiple reader/write scenario can now be covered by a dedicated reader/writer task and async queue. So this PR now enforces one-writer property for sockets and pipes, and document the behavior.

TODO: also detect race condition for stuff in thread pool, such as regular file.