### PR TITLE
add `spawn_loop` API

### DIFF
--- a/src/async.mbti
+++ b/src/async.mbti
@@ -17,6 +17,13 @@ async fn with_timeout(Int, async () -> Unit raise) -> Unit raise
 pub type! AlreadyTerminated
 impl Show for AlreadyTerminated
 
+pub(all) enum RetryMethod {
+  NoRetry
+  Immediate
+  FixedDelay(Int)
+  ExponentialDelay(initial~ : Int, factor~ : Double, maximum~ : Int)
+}
+
 type Task[X]
 fn[X] Task::cancel(Self[X]) -> Unit
 async fn[X] Task::wait(Self[X]) -> X raise
@@ -25,6 +32,7 @@ type TaskGroup[X]
 fn[X] TaskGroup::return_immediately(Self[X], X) -> Unit raise
 fn[G, X] TaskGroup::spawn(Self[G], async () -> X raise, no_wait~ : Bool = .., allow_failure~ : Bool = ..) -> Task[X] raise
 fn[X] TaskGroup::spawn_bg(Self[X], async () -> Unit raise, no_wait~ : Bool = .., allow_failure~ : Bool = ..) -> Unit raise
+fn[X] TaskGroup::spawn_loop(Self[X], async () -> IterResult raise, no_wait~ : Bool = .., allow_failure~ : Bool = .., retry~ : RetryMethod = ..) -> Unit raise
 
 // Type aliases
 pub typealias @moonbitlang/async/aqueue.Queue as Queue

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -45,6 +45,11 @@ pub fn Coroutine::wake(self : Coroutine) -> Unit {
 }
 
 ///|
+pub fn is_being_cancelled() -> Bool {
+  current_coroutine().cancelled
+}
+
+///|
 pub(all) suberror Cancelled derive(Show)
 
 ///|

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -21,17 +21,11 @@ priv enum State {
 }
 
 ///|
-priv enum CancellationShield {
-  NoShield
-  Shielded
-  ShieldedCancelled
-}
-
-///|
 struct Coroutine {
   coro_id : Int
   mut state : State
-  mut shield : CancellationShield
+  mut shielded : Bool
+  mut cancelled : Bool
   downstream : Set[Coroutine]
 }
 
@@ -55,17 +49,10 @@ pub(all) suberror Cancelled derive(Show)
 
 ///|
 pub fn Coroutine::cancel(self : Coroutine) -> Unit {
-  match self.shield {
-    NoShield => ()
-    Shielded => {
-      self.shield = ShieldedCancelled
-      return
-    }
-    ShieldedCancelled => return
-  }
+  self.cancelled = true
   let last_coro = scheduler.curr_coro
   scheduler.curr_coro = Some(self)
-  while self.state is Suspend(ok_cont=_, err_cont~) {
+  while not(self.shielded) && self.state is Suspend(ok_cont=_, err_cont~) {
     self.state = Running
     err_cont(Cancelled)
   }
@@ -122,9 +109,10 @@ pub fn spawn(
   scheduler.coro_id += 1
   let coro = {
     state: Running,
-    shield: NoShield,
+    shielded: false,
     downstream: Set::new(),
     coro_id: scheduler.coro_id,
+    cancelled: false,
   }
   let last_coro = scheduler.curr_coro
   scheduler.curr_coro = Some(coro)
@@ -181,31 +169,23 @@ pub async fn Coroutine::wait(target : Coroutine) -> Unit raise {
 ///|
 pub async fn protect_from_cancel(f : async () -> Unit raise) -> Unit raise {
   guard scheduler.curr_coro is Some(coro)
-  if coro.shield is NoShield {
-    coro.shield = Shielded
-    fn restore_state() raise {
-      match coro.shield {
-        Shielded => coro.shield = NoShield
-        ShieldedCancelled => {
-          let err = Cancelled
-          coro.shield = NoShield
-          coro.state = Fail(err)
-          raise err
-        }
-        NoShield => panic()
-      }
-    }
-
+  if coro.shielded {
+    // already in a shield, do nothing
+    f()
+  } else {
+    coro.shielded = true
     try f() catch {
       err => {
-        restore_state()
+        coro.shielded = false
         raise err
       }
     } noraise {
-      _ => restore_state()
+      _ => {
+        coro.shielded = false
+        if coro.cancelled {
+          raise Cancelled
+        }
+      }
     }
-  } else {
-    // already in a shield, do nothing
-    f()
   }
 }

--- a/src/internal/coroutine/coroutine.mbti
+++ b/src/internal/coroutine/coroutine.mbti
@@ -3,6 +3,8 @@ package "moonbitlang/async/internal/coroutine"
 // Values
 fn current_coroutine() -> Coroutine
 
+fn is_being_cancelled() -> Bool
+
 fn next_expire_time() -> Int64?
 
 fn no_more_work() -> Bool

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -159,7 +159,7 @@ test "protect_from_cancel fail" {
       #|100ms tick
       #|200ms tick
       #|critial job fail
-      #|Ok(())
+      #|Err(Err)
     ),
   )
 }
@@ -230,6 +230,38 @@ test "protect_from_cancel nested2" {
       #|200ms tick
       #|outer critial job finished
       #|`with_timeout` containing critical job finished
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "protect_from_cancel in cancellation handler" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.spawn_bg(no_wait=true, fn() {
+        @async.sleep(100) catch {
+          err => {
+            log.write_string("cancelled with error \{err}\n")
+            @async.protect_from_cancel(fn() {
+              @async.sleep(50)
+              log.write_string("critial cancellation handler terminated\n")
+            })
+            raise err
+          }
+        }
+      })
+      @async.sleep(50)
+      log.write_string("start cancellation\n")
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|start cancellation
+      #|cancelled with error Cancelled
+      #|critial cancellation handler terminated
       #|Ok(())
     ),
   )

--- a/src/spawn_loop_test.mbt
+++ b/src/spawn_loop_test.mbt
@@ -1,0 +1,236 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "spawn_loop basic" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      let mut i = 0
+      root.spawn_loop(fn() {
+        log.write_string("tick \{i}\n")
+        i = i + 1
+        if i < 3 {
+          IterContinue
+        } else {
+          IterEnd
+        }
+      })
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|tick 0
+      #|tick 1
+      #|tick 2
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "spawn_loop basic-error" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      let mut i = 0
+      root.spawn_loop(fn() {
+        log.write_string("tick \{i}\n")
+        i = i + 1
+        if i >= 3 {
+          raise Err
+        }
+        IterContinue
+      })
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|tick 0
+      #|tick 1
+      #|tick 2
+      #|Err(Err)
+    ),
+  )
+}
+
+///|
+test "spawn_loop retry-immediate" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      let mut i = 0
+      root.spawn_loop(retry=Immediate, fn() {
+        log.write_string("tick \{i}\n")
+        i = i + 1
+        if i < 3 {
+          raise Err
+        }
+        IterEnd
+      })
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|tick 0
+      #|tick 1
+      #|tick 2
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "spawn_loop retry-fixed" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.spawn_bg(fn() {
+        for i in 0..<3 {
+          @async.sleep(50)
+          log.write_string("tick \{i}\n")
+        }
+      })
+      @async.sleep(25)
+      let mut i = 0
+      root.spawn_loop(retry=FixedDelay(50), fn() {
+        log.write_string("loop \{i}\n")
+        i = i + 1
+        if i < 3 {
+          raise Err
+        }
+        IterEnd
+      })
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|loop 0
+      #|tick 0
+      #|loop 1
+      #|tick 1
+      #|loop 2
+      #|tick 2
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "spawn_loop retry-exponential" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.spawn_bg(fn() {
+        for i in 0..<9 {
+          @async.sleep(50)
+          log.write_string("tick \{i}\n")
+        }
+      })
+      @async.sleep(25)
+      let mut i = 0
+      root.spawn_loop(
+        retry=ExponentialDelay(initial=50, factor=2, maximum=150),
+        fn() {
+          log.write_string("loop \{i}\n")
+          i = i + 1
+          match i {
+            1 | 2 | 3 => raise Err
+            4 => IterContinue
+            5 | 6 => raise Err
+            _ => IterEnd
+          }
+        },
+      )
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|loop 0
+      #|tick 0
+      #|loop 1
+      #|tick 1
+      #|tick 2
+      #|loop 2
+      #|tick 3
+      #|tick 4
+      #|tick 5
+      #|loop 3
+      #|loop 4
+      #|tick 6
+      #|loop 5
+      #|tick 7
+      #|tick 8
+      #|loop 6
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "spawn_loop cancelled1" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      let mut i = 0
+      root.spawn_loop(no_wait=true, allow_failure=true, retry=Immediate, fn() {
+        @async.sleep(50)
+        log.write_string("loop \{i}\n")
+        i = i + 1
+        IterContinue
+      })
+      @async.sleep(125)
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|loop 0
+      #|loop 1
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "spawn_loop cancelled2" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      let mut i = 0
+      root.spawn_loop(no_wait=true, allow_failure=true, retry=FixedDelay(50), fn(
+
+      ) {
+        log.write_string("loop \{i}\n")
+        i = i + 1
+        raise Err
+      })
+      @async.sleep(125)
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|loop 0
+      #|loop 1
+      #|loop 2
+      #|Ok(())
+    ),
+  )
+}

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -214,3 +214,82 @@ pub fn[X] TaskGroup::return_immediately(
   }
   raise @coroutine.Cancelled
 }
+
+///|
+pub(all) enum RetryMethod {
+  NoRetry
+  Immediate
+  FixedDelay(Int)
+  ExponentialDelay(initial~ : Int, factor~ : Double, maximum~ : Int)
+}
+
+///|
+/// Similar to `spawn_bg`, but the spawn a loop,
+/// i.e. the spawned task will be restarted after it terminates.
+/// The spawned task can terminate the loop by returning `IterEnd`.
+///
+/// When the spawned task raises an error, the behavior is determined by `retry`.
+/// - If `retry` is `NoRetry` (the default),
+///   the loop will terminate immediately and propagate the error.
+/// - If `retry` is `Immediate`, the task will immediately be restarted.
+/// - If `retry` is `FixedDelay(t)`,
+///   the task will be restarted after sleeping for `t` milliseconds
+/// - If `retry` is `ExponentialDelay(initial~, factor~, maximum~)`,
+///   the task will be restarted with an exponentially growing delay.
+///   The initial delay is `initial`, and after every failure,
+///   the delay will be multiplied by `factor`, but will never exceed `maximum`.
+///   If the task succeed, the retry delay will be reset to `initial`.
+///
+/// The meaning of `no_wait` and `allow_failure` is the same as `spawn_bg`.
+pub fn[X] TaskGroup::spawn_loop(
+  self : TaskGroup[X],
+  f : async () -> IterResult raise,
+  no_wait~ : Bool = false,
+  allow_failure~ : Bool = false,
+  retry~ : RetryMethod = NoRetry
+) -> Unit raise {
+  self.spawn_bg(no_wait~, allow_failure~, fn() {
+    match retry {
+      NoRetry =>
+        for {
+          guard f() is IterContinue else { break }
+        }
+      Immediate =>
+        for {
+          try f() catch {
+            err if @coroutine.is_being_cancelled() => raise err
+            _ => ()
+          } noraise {
+            IterContinue => ()
+            IterEnd => break
+          }
+        }
+      FixedDelay(t) =>
+        for {
+          try f() catch {
+            err if @coroutine.is_being_cancelled() => raise err
+            _ => sleep(t)
+          } noraise {
+            IterContinue => ()
+            IterEnd => break
+          }
+        }
+      ExponentialDelay(initial~, factor~, maximum~) =>
+        for delay = initial {
+          try f() catch {
+            err if @coroutine.is_being_cancelled() => raise err
+            _ => {
+              sleep(delay)
+              continue @cmp.minimum(
+                  maximum,
+                  (delay.to_double() * factor).to_int(),
+                )
+            }
+          } noraise {
+            IterContinue => continue initial
+            IterEnd => break
+          }
+        }
+    }
+  })
+}


### PR DESCRIPTION
Add a convenient API for spawning a task that repeatedly do something.

Termination of the loop is similar to `Iter`: the spawned function return `IterContinue` to indicate continue of iteration, and `IterEnd` for loop termination.

As for error handling, four favors are provided:

- stop loop on error (default)
- retry immediately
- retry after a fixed delay
- retry with an exponentially growing delay. If the spawned task succeed, the timeout will be reset

One important thing is to ensure that even if auto retry is enabled, `spawn_loop` can be cancelled. To achieve this I added a property indicating whether current coroutine is being cancelled (i.e. running inside cancellation handler). This change also lead to simplification of code in `protect_from_cancel`, and fixes a bug (if the body of `protect_from_cancel` raises an error, and the task is cancelled mid-way, previously `Cancelled` will be raised, now the error raised by `protect_from_cancel` is favored)