### PR TITLE
feat: Add IPv6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 .mooncakes/
 .DS_Store
+.vscode/
+.idea/

--- a/src/example/tcp_echo_server/main.mbt
+++ b/src/example/tcp_echo_server/main.mbt
@@ -17,7 +17,7 @@ fn main_prog() -> Unit raise {
   @async.with_event_loop(fn(root) {
     let listen_sock = @socket.TCP::new()
     try {
-      listen_sock..bind(@socket.Addr::parse("0.0.0.0:4200"))..listen()
+      listen_sock..bind(@socket.SocketAddr::parse("0.0.0.0:4200"))..listen()
       for {
         let (conn, addr) = listen_sock.accept()
         println("received new connection from \{addr}")

--- a/src/example/tcp_ping_pong/main.mbt
+++ b/src/example/tcp_ping_pong/main.mbt
@@ -25,7 +25,7 @@ pub(all) type Printer (String) -> Unit
 async fn server(println : Printer) -> Unit raise {
   @async.with_task_group(fn(group) {
     let listen_sock = @socket.TCP::new()
-    listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
+    listen_sock..bind(@socket.SocketAddr::parse("0.0.0.0:\{port}"))..listen()
     try {
       for {
         let (conn, _) = listen_sock.accept()
@@ -68,7 +68,7 @@ async fn server(println : Printer) -> Unit raise {
 ///|
 async fn client(println : Printer, id : Int, msg : Bytes) -> Unit raise {
   let conn = @socket.TCP::new()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+  conn.connect(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
   // The sleep here is used to make test result stable and portable,
   // because this message is in race condition
   // with server side "received connection" message

--- a/src/example/udp_echo_server/main.mbt
+++ b/src/example/udp_echo_server/main.mbt
@@ -16,7 +16,7 @@
 fn main_prog() -> Unit raise {
   let server = @socket.UDP::new()
   @async.with_event_loop(fn(root) {
-    server.bind(@socket.Addr::parse("0.0.0.0:4200"))
+    server.bind(@socket.SocketAddr::parse("0.0.0.0:4200"))
     for {
       let buf = FixedArray::make(1024, b'0')
       let (n, addr) = server.recvfrom(buf)

--- a/src/example/udp_ping_pong/main.mbt
+++ b/src/example/udp_ping_pong/main.mbt
@@ -25,7 +25,7 @@ pub(all) type Printer (String) -> Unit
 async fn server(println : Printer) -> Unit raise {
   let server_sock = @socket.UDP::new()
   @async.with_task_group(fn(group) {
-    server_sock.bind(@socket.Addr::parse("0.0.0.0:\{port}"))
+    server_sock.bind(@socket.SocketAddr::parse("0.0.0.0:\{port}"))
     let buf = FixedArray::make(1024, b'0')
     while server_sock.recvfrom(buf) is (n, addr) && n > 0 {
       group.spawn_bg(fn() {
@@ -54,7 +54,7 @@ async fn server(println : Printer) -> Unit raise {
 ///|
 async fn client(println : Printer, id : Int, msg : Bytes) -> Unit raise {
   let conn = @socket.UDP::new()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+  conn.connect(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
   conn.send(msg)
   println("client \{id} sent: \{msg}")
   let buf = FixedArray::make(1024, b'0')

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -13,22 +13,86 @@
 // limitations under the License.
 
 ///|
-/// IPv4 address + port number
-type Addr Bytes
+type Ipv4Addr Bytes
 
 ///|
-pub extern "C" fn Addr::new(ip : UInt, port : Int) -> Addr = "moonbitlang_async_make_ip_addr"
+type Ipv6Addr Bytes
+
+///|
+priv type IpAddr Bytes
+
+///|
+pub(all) enum SocketAddr {
+  V4(Ipv4Addr) // IPv4 address and port
+  V6(Ipv6Addr) // IPv6 address and port
+} derive(Show)
+
+///|
+#deprecated("Use @socket.SocketAddr instead, it will be removed after 0.2.0")
+pub typealias SocketAddr as Addr
+
+///|
+fn SocketAddr::to_ipaddr(self : SocketAddr) -> IpAddr {
+  match self {
+    SocketAddr::V4(addr) => addr.to_ipaddr()
+    SocketAddr::V6(addr) => addr.to_ipaddr()
+  }
+}
+
+///|
+pub fn SocketAddr::is_ipv4(self : SocketAddr) -> Bool {
+  match self {
+    SocketAddr::V4(_) => true
+    SocketAddr::V6(_) => false
+  }
+}
+
+///|
+pub fn SocketAddr::is_ipv6(self : SocketAddr) -> Bool {
+  match self {
+    SocketAddr::V4(_) => false
+    SocketAddr::V6(_) => true
+  }
+}
+
+///|
+pub extern "C" fn Ipv4Addr::new(ip : UInt, port : Int) -> Ipv4Addr = "moonbitlang_async_make_ip_addr"
 
 ///|
 #borrow(addr)
-pub extern "C" fn Addr::ip(addr : Addr) -> UInt = "moonbitlang_async_ip_addr_get_ip"
+pub extern "C" fn Ipv4Addr::ip(addr : Ipv4Addr) -> UInt = "moonbitlang_async_ip_addr_get_ip"
 
 ///|
 #borrow(addr)
-pub extern "C" fn Addr::port(addr : Addr) -> Int = "moonbitlang_async_ip_addr_get_port"
+pub extern "C" fn Ipv4Addr::port(addr : Ipv4Addr) -> Int = "moonbitlang_async_ip_addr_get_port"
 
 ///|
-pub impl Show for Addr with output(self, logger) {
+pub extern "C" fn Ipv6Addr::new(
+  ip : FixedArray[Byte],
+  port : Int,
+  flowinfo : Int,
+  scope_id : Int
+) -> Ipv6Addr = "moonbitlang_async_make_ipv6_addr"
+
+///|
+#borrow(addr, buf)
+extern "C" fn Ipv6Addr::_ip(addr : Ipv6Addr, buf : FixedArray[Byte]) -> Unit = "moonbitlang_async_ipv6_addr_get_ip"
+
+///|
+#borrow(addr)
+pub extern "C" fn Ipv6Addr::port(addr : Ipv6Addr) -> Int = "moonbitlang_async_ipv6_addr_get_port"
+
+///|
+pub fn Ipv6Addr::ip(self : Ipv6Addr) -> FixedArray[Byte] {
+  let buf = FixedArray::make(16, Byte::default())
+  self._ip(buf)
+  buf
+}
+
+///|
+pub impl Show for Ipv4Addr with output(self, logger) {
+  // May be faster than using `ip_name` for logging
+  // It will reduce the memory allocation
   let ip = self.ip()
   let port = self.port()
   logger
@@ -44,29 +108,70 @@ pub impl Show for Addr with output(self, logger) {
 }
 
 ///|
+pub impl Show for Ipv6Addr with output(self, logger) {
+  let ip_str = self.ip_name() catch {
+    _ => abort("Unknown error to get IPv6 address")
+  }
+  logger.write_char('[')
+  logger.write_string(ip_str)
+  logger.write_char(']')
+  logger.write_char(':')
+  logger.write_object(self.port())
+}
+
+///|
 pub suberror InvalidAddr derive(Show)
 
 ///|
 /// Parse a string into IPv4 address, format should be `ip:port` (no space)
-// TODO: faster implementation
-pub fn Addr::parse(src : String) -> Addr raise InvalidAddr {
-  guard src.split(":").collect() is [ip, port] else { raise InvalidAddr }
-  guard ip.split(".").collect() is [a, b, c, d] else { raise InvalidAddr }
-  fn parse_octal(x : @string.View) raise InvalidAddr {
-    let value = @strconv.parse_uint(x.to_string()) catch {
-      _ => raise InvalidAddr
-    }
-    guard value < 256 else { raise InvalidAddr }
-    value
-  }
+pub fn Ipv4Addr::parse(src : String) -> Ipv4Addr raise InvalidAddr {
+  let (ip, port) = try_parse_ipv4(src) catch { _ => raise InvalidAddr }
+  Ipv4Addr::new(ip, port)
+}
 
-  let ip = (parse_octal(a) << 24) |
-    (parse_octal(b) << 16) |
-    (parse_octal(c) << 8) |
-    parse_octal(d)
-  let port = @strconv.parse_int(port.to_string()) catch {
+///|
+pub fn Ipv6Addr::parse(src : String) -> Ipv6Addr raise InvalidAddr {
+  let (ip_bytes, port, flowinfo, scope_id) = try_parse_ipv6(src)
+  let ip_bytes = ip_bytes.map(x => x.to_byte())
+  Ipv6Addr::new(ip_bytes, port, flowinfo, scope_id)
+}
+
+///|
+pub fn SocketAddr::parse(src : String) -> SocketAddr raise InvalidAddr {
+  parse_address(src) catch {
     _ => raise InvalidAddr
   }
-  guard 0 <= port && port < 65536 else { raise InvalidAddr }
-  Addr::new(ip, port)
+}
+
+///|
+pub fn SocketAddr::ip(self : SocketAddr) -> String {
+  match self {
+    SocketAddr::V4(addr) =>
+      addr.ip_name() catch {
+        _ => abort("Unknown error to get IPv4 address")
+      }
+    SocketAddr::V6(addr) =>
+      addr.ip_name() catch {
+        _ => abort("Unknown error to get IPv6 address")
+      }
+  }
+}
+
+///|
+pub fn SocketAddr::port(self : SocketAddr) -> Int {
+  match self {
+    SocketAddr::V4(addr) => addr.port()
+    SocketAddr::V6(addr) => addr.port()
+  }
+}
+
+///|
+fn parse_address(src : String) -> SocketAddr raise {
+  // Try to parse IPv6 format [addr]:port
+  if src.has_prefix("[") {
+    let addr = Ipv6Addr::parse(src)
+    return SocketAddr::V6(addr)
+  }
+  let addr = Ipv4Addr::parse(src)
+  SocketAddr::V4(addr)
 }

--- a/src/socket/addr_test.mbt
+++ b/src/socket/addr_test.mbt
@@ -1,0 +1,93 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "Parse IPv4 address" {
+  assert_eq(
+    @socket.Ipv4Addr::parse("127.0.0.1:8080").to_string(),
+    "127.0.0.1:8080",
+  )
+  assert_eq(@socket.Ipv4Addr::parse("0.0.0.0:8080").to_string(), "0.0.0.0:8080")
+  assert_eq(
+    @socket.Ipv4Addr::parse("255.255.255.255:8080").to_string(),
+    "255.255.255.255:8080",
+  )
+  assert_eq(
+    @socket.Ipv4Addr::parse("172.31.254.253:8080").to_string(),
+    "172.31.254.253:8080",
+  )
+}
+
+///|
+test "Parse invalid IPv4 address" {
+  // Too short
+  let v = try? @socket.Ipv4Addr::parse("127.0.0.1")
+  assert_true(v is Err(_))
+
+  // Too long
+  let v = try? @socket.Ipv4Addr::parse("127.0.0.1:8080:8080")
+  assert_true(v is Err(_))
+
+  // Invalid IP, out of range
+  let v = try? @socket.Ipv4Addr::parse("256.0.0.1:8080")
+  assert_true(v is Err(_))
+}
+
+///|
+test "Parse IPv6 address" {
+  let addr = @socket.Ipv6Addr::parse("[2a02:6b8::11:11]:8080")
+  assert_eq(addr.to_string(), "[2a02:6b8::11:11]:8080")
+  assert_eq(
+    @socket.Ipv6Addr::parse("[0:0:0:0:0:0:0:0]:8080").to_string(),
+    "[::]:8080",
+  )
+  assert_eq(
+    @socket.Ipv6Addr::parse("[0:0:0:0:0:0:0:1]:8080").to_string(),
+    "[::1]:8080",
+  )
+  assert_eq(@socket.Ipv6Addr::parse("[::1]:8080").to_string(), "[::1]:8080")
+}
+
+///|
+test "Parse invalid IPv6 address" {
+  // Too short
+  let v = try? @socket.Ipv6Addr::parse("[1:2:3:4:5:6:7:8080]")
+  assert_true(v is Err(_))
+
+  // Too long
+  let v = try? @socket.Ipv6Addr::parse("[1:2:3:4:5:6:7:8:9:8080]")
+  assert_true(v is Err(_))
+
+  // triple colon
+  let v = try? @socket.Ipv6Addr::parse("[1:2:::6:7:8]:8080]")
+  assert_true(v is Err(_))
+
+  // two double colons
+  let v = try? @socket.Ipv6Addr::parse("[1:2::6::8]:8080]")
+  assert_true(v is Err(_))
+}
+
+///|
+test "Parse IPv6 address with ipv4" {
+  let addr = @socket.Ipv6Addr::parse("[::ffff:192.0.2.33]:8080")
+  assert_eq(addr.to_string(), "[::ffff:192.0.2.33]:8080")
+  let addr = @socket.Ipv6Addr::parse("[::FFFF:192.0.2.33]:8080")
+  assert_eq(addr.to_string(), "[::ffff:192.0.2.33]:8080")
+  // Not enough groups
+  let v = try? @socket.Ipv6Addr::parse("[1:2:3:4:5:127.0.0.1]:8080")
+  assert_true(v is Err(_))
+  // Too many groups
+  let v = try? @socket.Ipv6Addr::parse("[1:2:3:4:5:6:7:127.0.0.1]:8080")
+  assert_true(v is Err(_))
+}

--- a/src/socket/addr_utils.mbt
+++ b/src/socket/addr_utils.mbt
@@ -1,0 +1,263 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn try_parse_ipv6(
+  input : String
+) -> (FixedArray[UInt], Int, Int, Int) raise InvalidAddr {
+  // Make sure the format is [addr]:port
+  guard input.has_prefix("[") else {
+    // IPv6 address must start with '['
+    raise InvalidAddr
+  }
+
+  // Find the closing bracket
+  guard input.rev_find("]") is Some(bracket_end) else {
+    // IPv6 address missing closing ']'
+    raise InvalidAddr
+  }
+
+  // Check the part after the closing bracket, it must be ":port"
+  let remaining = input.substring(start=bracket_end + 1)
+  guard remaining.has_prefix(":") else {
+    // Missing port after IPv6 address
+    raise InvalidAddr
+  }
+
+  // Parse the IPv6 address and port
+  let ip_str = input.substring(start=1, end=bracket_end)
+  let port_str = remaining.substring(start=1)
+
+  // Parse the IPv6 address into a byte array
+  let ip_bytes = parse_ipv6_to_bytes(ip_str)
+  let port = parse_port(port_str)
+  (ip_bytes, port, 0, 0)
+}
+
+///|
+fn parse_ipv6_to_bytes(ip_str : String) -> FixedArray[UInt] raise InvalidAddr {
+  // Handle the case where the IPv6 address is "::"
+  if ip_str == "::" {
+    return FixedArray::make(16, 0)
+  }
+
+  // Check for "::" compression
+  let compression_count = count_substring_occurrences(ip_str, "::")
+  guard compression_count <= 1 else {
+    // IPv6 address can only have one '::' compression
+    raise InvalidAddr
+  }
+  if compression_count == 1 {
+    return parse_compressed_ipv6_to_bytes(ip_str)
+  } else {
+    return parse_full_ipv6_to_bytes(ip_str)
+  }
+}
+
+///|
+fn parse_compressed_ipv6_to_bytes(
+  ip_str : String
+) -> FixedArray[UInt] raise InvalidAddr {
+  let parts = ip_str.split("::").collect()
+  let left_part = parts[0]
+  let right_part = if parts.length() > 1 { parts[1] } else { "" }
+  let left_groups = if left_part.is_empty() {
+    []
+  } else {
+    left_part.split(":").collect()
+  }
+
+  // Parse the right part, which may contain IPv4 address
+  let right_groups = if right_part.is_empty() {
+    []
+  } else {
+    right_part.split(":").collect()
+  }
+
+  // Check if the last group is an IPv4 address
+  let (right_groups_final, ipv4_bytes) = if !right_groups.is_empty() &&
+    right_groups[right_groups.length() - 1].contains(".") {
+    let ipv4_str = right_groups[right_groups.length() - 1]
+    let (a, b, c, d) = parse_ipv4_to_bytes(ipv4_str)
+    // Remove the IPv4 part from the right groups
+    let new_right = Array::new()
+    for i in 0..<(right_groups.length() - 1) {
+      new_right.push(right_groups[i])
+    }
+    (new_right, Some((a, b, c, d)))
+  } else {
+    (right_groups, None)
+  }
+
+  // Calculate the number of groups of compression
+  let ipv4_group_count = if ipv4_bytes.is_empty() { 0 } else { 2 }
+  let total_explicit_groups = left_groups.length() +
+    right_groups_final.length() +
+    ipv4_group_count
+  guard total_explicit_groups < 8 else {
+    // IPv6 address can have at most less than 8 explicit groups if "::" is used
+    raise InvalidAddr
+  }
+  let compression_groups = 8 - total_explicit_groups
+
+  // Build a 16-byte array initialized to zero
+  let result : FixedArray[UInt] = FixedArray::make(16, 0)
+  let mut byte_index = 0
+
+  // Add left side groups
+  for group_str in left_groups {
+    let group_value = parse_ipv6_group(group_str.to_string())
+    result[byte_index] = (group_value >> 8) & 0xFF
+    result[byte_index + 1] = group_value & 0xFF
+    byte_index += 2
+  }
+
+  // Add compression groups (zero groups)
+  for _ in 0..<compression_groups {
+    result[byte_index] = 0
+    result[byte_index + 1] = 0
+    byte_index += 2
+  }
+
+  // Add right side groups
+  for group_str in right_groups_final {
+    let group_value = parse_ipv6_group(group_str.to_string())
+    result[byte_index] = (group_value >> 8) & 0xFF
+    result[byte_index + 1] = group_value & 0xFF
+    byte_index += 2
+  }
+
+  // Add IPv4 bytes if they were parsed
+  if ipv4_bytes is Some((a, b, c, d)) {
+    result[byte_index + 0] = a
+    result[byte_index + 1] = b
+    result[byte_index + 2] = c
+    result[byte_index + 3] = d
+  }
+  result
+}
+
+///|
+fn parse_full_ipv6_to_bytes(
+  ip_str : String
+) -> FixedArray[UInt] raise InvalidAddr {
+  let parts = ip_str.split(":").collect()
+  let result : FixedArray[UInt] = FixedArray::make(16, 0)
+  let mut byte_index = 0
+  // Check if the last part contains a dot, indicating an embedded IPv4 address
+  if !parts.is_empty() && parts[parts.length() - 1].contains(".") {
+    guard parts.length() == 7 else {
+      // IPv6 address with embedded IPv4 must have 7 parts
+      raise InvalidAddr
+    }
+
+    // Parse the last part as an IPv4 address
+    let ipv4_str = parts[parts.length() - 1]
+    let (a, b, c, d) = parse_ipv4_to_bytes(ipv4_str)
+
+    // Build a 16-byte array initialized to zero
+    let mut byte_index = 0
+
+    // Add the first 6 IPv6 groups
+    for i in 0..<6 {
+      let group_value = parse_ipv6_group(parts[i].to_string())
+      result[byte_index] = (group_value >> 8) & 0xFF
+      result[byte_index + 1] = group_value & 0xFF
+      byte_index += 2
+    }
+    result[byte_index + 0] = a
+    result[byte_index + 1] = b
+    result[byte_index + 2] = c
+    result[byte_index + 3] = d
+    result
+  } else {
+    // The pure IPv6 address should have 8 groups
+    guard parts.length() == 8 else {
+      // Full IPv6 address must have 8 groups
+      raise InvalidAddr
+    }
+    for group_str in parts {
+      let group_value = parse_ipv6_group(group_str.to_string())
+      result[byte_index] = (group_value >> 8) & 0xFF
+      result[byte_index + 1] = group_value & 0xFF
+      byte_index += 2
+    }
+    result
+  }
+}
+
+///|
+fn parse_ipv6_group(group : String) -> UInt raise InvalidAddr {
+  guard !group.is_empty() && group.length() <= 4 else { raise InvalidAddr }
+  @strconv.parse_uint(group, base=16) catch {
+    _ => raise InvalidAddr
+  }
+}
+
+///|
+fn parse_ipv4_to_bytes(
+  ip_str : @string.View
+) -> (UInt, UInt, UInt, UInt) raise InvalidAddr {
+  let parts = ip_str.split(".").collect()
+  guard parts.length() == 4 else { raise InvalidAddr }
+  fn parse_octal(x : @string.View) raise InvalidAddr {
+    let value = @strconv.parse_uint(x.to_string()) catch {
+      _ => raise InvalidAddr
+    }
+    guard value < 256 else { raise InvalidAddr }
+    value
+  }
+
+  return (
+    parse_octal(parts[0]),
+    parse_octal(parts[1]),
+    parse_octal(parts[2]),
+    parse_octal(parts[3]),
+  )
+}
+
+///|
+fn try_parse_ipv4(input : String) -> (UInt, Int) raise InvalidAddr {
+  // Find the last colon to separate IP and port
+  guard input.rev_find(":") is Some(last_colon) else { raise InvalidAddr }
+  let ip_str = input.substring(end=last_colon)
+  let port_str = input.substring(start=last_colon + 1)
+  let port = @strconv.parse_int(port_str.to_string()) catch {
+    _ => raise InvalidAddr
+  }
+  guard 0 <= port && port < 65536 else { raise InvalidAddr }
+  // Parse the IP address
+  let (a, b, c, d) = parse_ipv4_to_bytes(ip_str.view())
+  let ip = (a << 24) | (b << 16) | (c << 8) | d
+  (ip, port)
+}
+
+///|
+fn parse_port(port_str : String) -> Int raise InvalidAddr {
+  guard !port_str.is_empty() else { raise InvalidAddr }
+  let port = @strconv.parse_int(port_str) catch { _ => raise InvalidAddr }
+  guard 0 <= port && port < 65536 else { raise InvalidAddr }
+  port
+}
+
+///|
+fn count_substring_occurrences(text : String, pattern : String) -> Int {
+  let mut count = 0
+  let mut start = 0
+  while text.substring(start~).find(pattern) is Some(pos) {
+    count += 1
+    start += pos + pattern.length()
+  }
+  count
+}

--- a/src/socket/connect_burst_test.mbt
+++ b/src/socket/connect_burst_test.mbt
@@ -19,12 +19,14 @@ suberror ServerTerminate
 let port = 4205
 
 ///|
-async fn server() -> Int raise {
-  let listen_sock = @socket.TCP::new()
+async fn server(ip : String) -> Int raise {
   let mut num_connection = 0
+  let addr = @socket.SocketAddr::parse("\{ip}:\{port}")
+  let domain = Domain::from_address(addr)
+  let listen_sock = @socket.TCP::new(domain~)
   try
     @async.with_task_group(fn(group) {
-      listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
+      listen_sock..bind(addr)..listen()
       for {
         let (conn, _) = listen_sock.accept()
         num_connection += 1
@@ -62,9 +64,11 @@ async fn server() -> Int raise {
 }
 
 ///|
-async fn client(msg : Bytes) -> Unit raise {
-  let conn = @socket.TCP::new()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+async fn client(ip : String, msg : Bytes) -> Unit raise {
+  let addr = @socket.SocketAddr::parse("\{ip}:\{port}")
+  let domain = Domain::from_address(addr)
+  let conn = @socket.TCP::new(domain~)
+  conn.connect(addr)
   conn.send(msg)
   conn.close()
 }
@@ -73,16 +77,46 @@ async fn client(msg : Bytes) -> Unit raise {
 test "connection burst" {
   let log = StringBuilder::new()
   let mut result = 0
+  let ip = "127.0.0.1"
   log.write_object(
     try? @async.with_event_loop(fn(root) {
-      root.spawn_bg(() => result = server())
+      root.spawn_bg(() => result = server(ip))
       root.spawn_bg(fn() {
         @async.with_task_group(fn(ctx) {
           for _ in 0..<6 {
-            ctx.spawn_bg(() => client(b"ping"))
+            ctx.spawn_bg(() => client(ip, b"ping"))
           }
         })
-        root.spawn_bg(() => client(b"exit"))
+        root.spawn_bg(() => client(ip, b"exit"))
+      })
+    }),
+  )
+  log.write_string("\n")
+  log.write_object(result)
+  inspect(
+    log.to_string(),
+    content=(
+      #|Ok(())
+      #|7
+    ),
+  )
+}
+
+///|
+test "connection burst with ipv6" {
+  let log = StringBuilder::new()
+  let mut result = 0
+  let ip = "[::1]"
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.spawn_bg(() => result = server(ip))
+      root.spawn_bg(fn() {
+        @async.with_task_group(fn(ctx) {
+          for _ in 0..<6 {
+            ctx.spawn_bg(() => client(ip, b"ping"))
+          }
+        })
+        root.spawn_bg(() => client(ip, b"exit"))
       })
     }),
   )

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -13,25 +13,22 @@
 // limitations under the License.
 
 ///|
-extern "C" fn make_tcp_socket() -> Int = "moonbitlang_async_make_tcp_socket"
-
-///|
-extern "C" fn make_udp_socket() -> Int = "moonbitlang_async_make_udp_socket"
+extern "C" fn make_socket(domain : Int, ty : Int, protocol : Int) -> Int = "moonbitlang_async_make_socket"
 
 ///|
 #borrow(addr)
-extern "C" fn bind_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_bind"
+extern "C" fn bind_ffi(sock : Int, addr : IpAddr) -> Int = "moonbitlang_async_bind"
 
 ///|
 extern "C" fn listen_ffi(sock : Int) -> Int = "moonbitlang_async_listen"
 
 ///|
 #borrow(addr_buf)
-extern "C" fn accept_ffi(sock : Int, addr_buf : Addr) -> Int = "moonbitlang_async_accept"
+extern "C" fn accept_ffi(sock : Int, addr_buf : IpAddr) -> Int = "moonbitlang_async_accept"
 
 ///|
 #borrow(addr)
-extern "C" fn connect_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_connect"
+extern "C" fn connect_ffi(sock : Int, addr : IpAddr) -> Int = "moonbitlang_async_connect"
 
 ///|
 #borrow(buf)
@@ -79,7 +76,7 @@ extern "C" fn recvfrom_ffi(
   buf : FixedArray[Byte],
   offset : Int,
   max_len : Int,
-  addr_buf : Addr
+  addr_buf : IpAddr
 ) -> Int = "moonbitlang_async_recvfrom"
 
 ///|
@@ -89,5 +86,5 @@ extern "C" fn sendto_ffi(
   buf : Bytes,
   offset : Int,
   max_len : Int,
-  addr_buf : Addr
+  addr_buf : IpAddr
 ) -> Int = "moonbitlang_async_sendto"

--- a/src/socket/ip.c
+++ b/src/socket/ip.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <arpa/inet.h>
+#include <string.h>
+#include <netdb.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
+#include <moonbit.h>
+
+static inline void empty_function(void *self)
+{
+    // no-op: empty function
+}
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_ipv4_addrlen(void)
+{
+    return INET_ADDRSTRLEN;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_ipv6_addrlen(void)
+{
+    return INET6_ADDRSTRLEN;
+}
+
+typedef struct moonbit_get_ip_name_port_cb_s
+{
+    int32_t (*code)(
+        struct moonbit_get_ip_name_port_cb_s *,
+        int32_t ai_family,
+        int32_t port,
+        int32_t flowinfo,
+        int32_t scope_id);
+} moonbit_get_ip_name_port_cb_t;
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_get_ip_addr_detail(
+    const struct sockaddr *src,
+    moonbit_get_ip_name_port_cb_t *cb)
+{
+    if (src == NULL || cb == NULL)
+    {
+        return -1;
+    }
+
+    // Now ip_str not passed as a parameter
+    char ip_str[INET6_ADDRSTRLEN];
+    int flowinfo = 0;
+    int scope_id = 0;
+    int port = 0;
+    if (src->sa_family == AF_INET)
+    {
+        const struct sockaddr_in *sa4 = (const struct sockaddr_in *)src;
+        if (inet_ntop(AF_INET, &sa4->sin_addr, ip_str, sizeof(ip_str)) == NULL)
+        {
+            return -1;
+        }
+        port = ntohs(sa4->sin_port);
+    }
+    else if (src->sa_family == AF_INET6)
+    {
+        const struct sockaddr_in6 *sa6 = (const struct sockaddr_in6 *)src;
+        if (inet_ntop(AF_INET6, &sa6->sin6_addr, ip_str, sizeof(ip_str)) == NULL)
+        {
+            return -1;
+        }
+        flowinfo = sa6->sin6_flowinfo;
+        scope_id = sa6->sin6_scope_id;
+        port = ntohs(sa6->sin6_port);
+    }
+    else
+    {
+        return -1;
+    }
+    moonbit_incref(cb);
+    cb->code(
+        cb, src->sa_family, port, flowinfo, scope_id);
+    return 0;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_get_ipv4_name(const struct sockaddr_in *src, moonbit_bytes_t dst)
+{
+    if (src == NULL || dst == NULL)
+    {
+        return -1;
+    }
+    char ip_str[INET_ADDRSTRLEN];
+    if (inet_ntop(AF_INET, &src->sin_addr, ip_str, sizeof(ip_str)) == NULL)
+    {
+        return -1;
+    }
+    int len = strlen(ip_str);
+    memcpy(dst, ip_str, len);
+    dst[len] = '\0';
+    return len;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t
+moonbitlang_get_ipv6_name(const struct sockaddr_in6 *src, moonbit_bytes_t dst)
+{
+    if (src == NULL || dst == NULL)
+    {
+        return -1;
+    }
+    char ip_str[INET6_ADDRSTRLEN];
+    if (inet_ntop(AF_INET6, &src->sin6_addr, ip_str, sizeof(ip_str)) == NULL)
+    {
+        return -1;
+    }
+    int len = strlen(ip_str);
+    memcpy(dst, ip_str, len);
+    dst[len] = '\0';
+    return len;
+}
+
+MOONBIT_FFI_EXPORT struct sockaddr_storage *moonbitlang_create_sockaddr_storage()
+{
+    struct sockaddr_storage *addr =
+        moonbit_make_external_object(empty_function, sizeof(struct sockaddr_storage));
+    memset(addr, 0, sizeof(struct sockaddr_storage));
+    addr->ss_family = AF_INET; // Default to IPv4
+    return addr;
+}
+
+
+// Constants for socket domains
+MOONBIT_FFI_EXPORT int32_t moonbitlang_AF_INET(void) { return AF_INET; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_AF_INET6(void) { return AF_INET6; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_AF_UNIX(void) {
+#if defined(_WIN32)
+    #include <ws2def.h>
+    #ifndef AF_UNIX
+        #define AF_UNIX AF_LOCAL
+    #endif
+    return AF_UNIX;
+#else
+    return AF_UNIX;
+#endif
+}
+MOONBIT_FFI_EXPORT int32_t moonbitlang_AF_UNSPEC(void) { return AF_UNSPEC; }
+
+
+// Constants for socket types
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SOCK_STREAM(void) { return SOCK_STREAM; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SOCK_DGRAM(void) { return SOCK_DGRAM; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_SOCK_RAW(void) { return SOCK_RAW; }
+
+// Constants for socket protocols
+MOONBIT_FFI_EXPORT int32_t moonbitlang_IPPROTO_IP(void) { return IPPROTO_IP; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_IPPROTO_TCP(void) { return IPPROTO_TCP; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_IPPROTO_UDP(void) { return IPPROTO_UDP; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_IPPROTO_ICMP(void) { return IPPROTO_ICMP; }
+MOONBIT_FFI_EXPORT int32_t moonbitlang_IPPROTO_ICMPV6(void) { return IPPROTO_ICMPV6; }

--- a/src/socket/ip.mbt
+++ b/src/socket/ip.mbt
@@ -1,0 +1,238 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+
+///|
+extern "C" fn _af_inet_ffi() -> Int = "moonbitlang_AF_INET"
+
+///|
+extern "C" fn _af_inet6_ffi() -> Int = "moonbitlang_AF_INET6"
+
+///|
+extern "C" fn _af_unix_ffi() -> Int = "moonbitlang_AF_UNIX"
+
+///|
+extern "C" fn _af_unspec_ffi() -> Int = "moonbitlang_AF_UNSPEC"
+
+///|
+extern "C" fn _sock_stream_ffi() -> Int = "moonbitlang_SOCK_STREAM"
+
+///|
+extern "C" fn _sock_dgram_ffi() -> Int = "moonbitlang_SOCK_DGRAM"
+
+///|
+extern "C" fn _sock_raw_ffi() -> Int = "moonbitlang_SOCK_RAW"
+
+///|
+extern "C" fn _ipproto_tcp_ffi() -> Int = "moonbitlang_IPPROTO_TCP"
+
+///|
+extern "C" fn _ipproto_udp_ffi() -> Int = "moonbitlang_IPPROTO_UDP"
+
+///|
+extern "C" fn _ipproto_icmp_ffi() -> Int = "moonbitlang_IPPROTO_ICMP"
+
+///|
+extern "C" fn _ipproto_icmpv6_ffi() -> Int = "moonbitlang_IPPROTO_ICMPV6"
+
+///|
+let _AF_INET : Int = _af_inet_ffi()
+
+///|
+let _AF_INET6 : Int = _af_inet6_ffi()
+
+///|
+let _AF_UNIX : Int = _af_unix_ffi()
+
+///|
+let _AF_UNSPEC : Int = _af_unspec_ffi()
+
+///|
+let _SOCK_STREAM : Int = _sock_stream_ffi()
+
+///|
+let _SOCK_DGRAM : Int = _sock_dgram_ffi()
+
+///|
+let _SOCK_RAW : Int = _sock_raw_ffi()
+
+///|
+let _IPPROTO_TCP : Int = _ipproto_tcp_ffi()
+
+///|
+let _IPPROTO_UDP : Int = _ipproto_udp_ffi()
+
+///|
+let _IPPROTO_ICMP : Int = _ipproto_icmp_ffi()
+
+///|
+let _IPPROTO_ICMPV6 : Int = _ipproto_icmpv6_ffi()
+
+///|
+priv trait ToIpAddr {
+  ip_name(self : Self) -> String raise
+  to_socket_addr(self : Self) -> SocketAddr raise
+  to_ipaddr(self : Self) -> IpAddr
+}
+
+///|
+impl ToIpAddr for IpAddr with to_ipaddr(self : IpAddr) -> IpAddr = "%identity"
+
+///|
+impl ToIpAddr for Ipv4Addr with to_ipaddr(self : Ipv4Addr) -> IpAddr = "%identity"
+
+///|
+impl ToIpAddr for Ipv6Addr with to_ipaddr(self : Ipv6Addr) -> IpAddr = "%identity"
+
+///|
+fn IpAddr::to_ipv4addr(self : IpAddr) -> Ipv4Addr = "%identity"
+
+///|
+fn IpAddr::to_ipv6addr(self : IpAddr) -> Ipv6Addr = "%identity"
+
+///|
+extern "C" fn ipv4_addrlen_ffi() -> Int = "moonbitlang_ipv4_addrlen"
+
+///|
+extern "C" fn ipv6_addrlen_ffi() -> Int = "moonbitlang_ipv6_addrlen"
+
+///|
+#borrow(addr)
+extern "C" fn get_ipaddr_detail_ffi(
+  addr : IpAddr,
+  cb : (Int, Int, Int, Int) -> Bool
+) -> Int = "moonbitlang_get_ip_addr_detail"
+
+///|
+#borrow(addr, bytes)
+extern "C" fn get_ipv4_name_ffi(addr : Ipv4Addr, bytes : Bytes) -> Int = "moonbitlang_get_ipv4_name"
+
+///|
+#borrow(addr, bytes)
+extern "C" fn get_ipv6_name_ffi(addr : Ipv6Addr, bytes : Bytes) -> Int = "moonbitlang_get_ipv6_name"
+
+///|
+extern "C" fn create_sockaddr_storage_ffi() -> IpAddr = "moonbitlang_create_sockaddr_storage"
+
+///|
+let _IP_V4_ADDRLEN : Int = ipv4_addrlen_ffi()
+
+///|
+let _IP_V6_ADDRLEN : Int = ipv6_addrlen_ffi()
+
+///|
+pub(all) enum Domain {
+  IPv4
+  IPv6
+  // TODO: support Unix domain socket
+  // Unix
+} derive(Show)
+
+///|
+priv enum Type {
+  Stream // SOCK_STREAM
+  Datagram // SOCK_DGRAM
+  // Raw // SOCK_RAW
+}
+
+///|
+pub fn Domain::from_address(addr : SocketAddr) -> Domain {
+  match addr {
+    V4(_) => IPv4
+    V6(_) => IPv6
+  }
+}
+
+///|
+fn Domain::inner(self : Domain) -> Int {
+  match self {
+    IPv4 => _AF_INET
+    IPv6 => _AF_INET6
+    // Unix => _AF_UNIX
+  }
+}
+
+///|
+fn Type::inner(self : Type) -> Int {
+  match self {
+    Stream => _SOCK_STREAM
+    Datagram => _SOCK_DGRAM
+    // Raw => _SOCK_RAW
+  }
+}
+
+///|
+impl ToIpAddr for IpAddr with to_socket_addr(self : IpAddr) -> SocketAddr raise {
+  let mut family : Int = -1
+  let status = get_ipaddr_detail_ffi(self, fn(
+    family_val : Int,
+    _port_val : Int,
+    _flowinfo_val : Int,
+    _scope_id_val : Int
+  ) {
+    family = family_val
+    return true
+  })
+  guard status >= 0 else { raise InvalidAddr }
+  if family == _AF_INET6 {
+    return SocketAddr::V6(self.to_ipv6addr())
+  } else if family == _AF_INET {
+    return SocketAddr::V4(self.to_ipv4addr())
+  } else {
+    raise InvalidAddr
+  }
+}
+
+///|
+impl ToIpAddr for IpAddr with ip_name(self : IpAddr) -> String raise {
+  match self.to_socket_addr() {
+    V4(addr) => addr.ip_name()
+    V6(addr) => addr.ip_name()
+  }
+}
+
+///|
+impl ToIpAddr for Ipv4Addr with to_socket_addr(self : Ipv4Addr) -> SocketAddr raise {
+  SocketAddr::V4(self)
+}
+
+///|
+impl ToIpAddr for Ipv4Addr with ip_name(self : Ipv4Addr) -> String raise {
+  let bytes = Bytes::make(_IP_V4_ADDRLEN, 0)
+  let status = get_ipv4_name_ffi(self, bytes)
+  guard status >= 0 else { raise InvalidAddr }
+  let buffer = @buffer.new()
+  for i = 0; bytes[i] != 0; i = i + 1 {
+    buffer.write_byte(bytes[i])
+  }
+  return utf8_bytes_to_mbt_string(buffer.contents())
+}
+
+///|
+impl ToIpAddr for Ipv6Addr with to_socket_addr(self : Ipv6Addr) -> SocketAddr raise {
+  SocketAddr::V6(self)
+}
+
+///|
+impl ToIpAddr for Ipv6Addr with ip_name(self : Ipv6Addr) -> String raise {
+  let bytes = Bytes::make(_IP_V6_ADDRLEN, 0)
+  let status = get_ipv6_name_ffi(self, bytes)
+  guard status >= 0 else { raise InvalidAddr }
+  let buffer = @buffer.new()
+  for i = 0; bytes[i] != 0; i = i + 1 {
+    buffer.write_byte(bytes[i])
+  }
+  return utf8_bytes_to_mbt_string(buffer.contents())
+}

--- a/src/socket/moon.pkg.json
+++ b/src/socket/moon.pkg.json
@@ -4,5 +4,5 @@
     "moonbitlang/async/internal/event_loop"
   ],
   "test-import": [ "moonbitlang/async" ],
-  "native-stub": [ "socket.c" ]
+  "native-stub": [ "socket.c", "ip.c" ]
 }

--- a/src/socket/read_exactly_test.mbt
+++ b/src/socket/read_exactly_test.mbt
@@ -25,7 +25,9 @@ test "read_exactly" {
     root.spawn_bg(fn() {
       let listen_sock = @socket.TCP::new()
       try {
-        listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
+        listen_sock
+        ..bind(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
+        ..listen()
         let (conn, _) = listen_sock.accept()
         try {
           let msg1 = conn.recv_exactly(4)
@@ -59,7 +61,7 @@ test "read_exactly" {
     // client
     root.spawn_bg(fn() {
       let conn = @socket.TCP::new()
-      conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+      conn.connect(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
       conn.send([1, 2, 3, 4, 5, 6])
       log("first message sent")
       @async.sleep(200)
@@ -94,7 +96,9 @@ test "read_exactly failure" {
       root.spawn_bg(fn() {
         let listen_sock = @socket.TCP::new()
         try {
-          listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
+          listen_sock
+          ..bind(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
+          ..listen()
           let (conn, _) = listen_sock.accept()
           try {
             let msg1 = conn.recv_exactly(4)
@@ -128,7 +132,7 @@ test "read_exactly failure" {
       // client
       root.spawn_bg(fn() {
         let conn = @socket.TCP::new()
-        conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+        conn.connect(@socket.SocketAddr::parse("127.0.0.1:\{port}"))
         conn.send([1, 2, 3, 4, 5, 6])
         log("first message sent")
         @async.sleep(200)

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
@@ -22,8 +23,8 @@
 #include <fcntl.h>
 #include <moonbit.h>
 
-int moonbitlang_async_make_tcp_socket() {
-  int sock = socket(AF_INET, SOCK_STREAM, 0);
+int moonbitlang_async_make_socket(int domain, int type, int protocol) {
+  int sock = socket(domain, type, protocol);
   if (sock > 0) {
     int flags = fcntl(sock, F_GETFL);
     if (flags < 0)
@@ -38,32 +39,21 @@ int moonbitlang_async_make_tcp_socket() {
   return sock;
 }
 
-int moonbitlang_async_make_udp_socket() {
-  int sock = socket(AF_INET, SOCK_DGRAM, 0);
-  if (sock > 0) {
-    int flags = fcntl(sock, F_GETFL);
-    if (flags < 0)
-      return flags;
 
-    if (!(flags & O_NONBLOCK)) {
-      int status = fcntl(sock, F_SETFL, flags | O_NONBLOCK);
-      if (status < 0)
-        return status;
-    }
-  }
-  return sock;
-}
-
-int moonbitlang_async_bind(int sockfd, struct sockaddr_in *addr) {
-  return bind(sockfd, (struct sockaddr*)addr, sizeof(struct sockaddr_in));
+int moonbitlang_async_bind(int sockfd, struct sockaddr_storage *addr) {
+  socklen_t socklen = (addr->ss_family == AF_INET6) ? 
+    sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+  return bind(sockfd, (struct sockaddr*)addr, socklen);
 }
 
 int moonbitlang_async_listen(int sockfd) {
   return listen(sockfd, SOMAXCONN);
 }
 
-int moonbitlang_async_accept(int sockfd, struct sockaddr_in *addr_buf) {
-  socklen_t socklen = sizeof(struct sockaddr_in);
+
+int moonbitlang_async_accept(int sockfd, struct sockaddr_storage *addr_buf) {
+  socklen_t socklen = (addr_buf->ss_family == AF_INET6) ? 
+    sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
   int conn = accept(sockfd, (struct sockaddr*)addr_buf, &socklen);
   if (conn > 0) {
     int flags = fcntl(conn, F_GETFL);
@@ -79,8 +69,8 @@ int moonbitlang_async_accept(int sockfd, struct sockaddr_in *addr_buf) {
   return conn;
 }
 
-int moonbitlang_async_connect(int sockfd, struct sockaddr_in *addr) {
-  return connect(sockfd, (struct sockaddr*)addr, sizeof(struct sockaddr_in));
+int moonbitlang_async_connect(int sockfd, struct sockaddr_storage *addr) {
+  return connect(sockfd, (struct sockaddr*)addr, sizeof(struct sockaddr_storage));
 }
 
 int moonbitlang_async_recv(int sockfd, void *buf, int offset, int max_len) {
@@ -152,10 +142,33 @@ uint32_t moonbitlang_async_ip_addr_get_port(struct sockaddr_in *addr) {
 }
 
 int moonbitlang_async_recvfrom(int sockfd, void *buf, int offset, int max_len, void *addr_buf) {
-  socklen_t addr_size = sizeof(struct sockaddr_in);
+  socklen_t addr_size = sizeof(struct sockaddr_storage);
   return recvfrom(sockfd, buf + offset, max_len, 0, addr_buf, &addr_size);
 }
 
-int moonbitlang_async_sendto(int sockfd, void *buf, int offset, int max_len, void *addr) {
-  return sendto(sockfd, buf + offset, max_len, 0, addr, sizeof(struct sockaddr_in));
+int moonbitlang_async_sendto(int sockfd, void *buf, int offset, int max_len, struct sockaddr_storage *addr) {
+  socklen_t addr_len = (addr->ss_family == AF_INET6) ? 
+      sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+  return sendto(sockfd, buf + offset, max_len, 0, (void *)addr, addr_len);
+}
+
+void *moonbitlang_async_make_ipv6_addr(uint8_t *ip, int port, uint32_t flowinfo, uint32_t scope_id) {
+  struct sockaddr_in6 *addr = (struct sockaddr_in6*)moonbit_make_bytes(
+    sizeof(struct sockaddr_in6),
+    0
+  );
+  addr->sin6_family = AF_INET6;
+  addr->sin6_port = htons(port);
+  addr->sin6_flowinfo = flowinfo;
+  addr->sin6_scope_id = scope_id;
+  memcpy(&addr->sin6_addr, ip, 16);
+  return addr;
+}
+
+void moonbitlang_async_ipv6_addr_get_ip(struct sockaddr_in6 *addr, uint8_t *dst) {
+    memcpy(dst, &addr->sin6_addr, 16);
+}
+
+uint32_t moonbitlang_async_ipv6_addr_get_port(struct sockaddr_in6 *addr) {
+  return ntohs(addr->sin6_port);
 }

--- a/src/socket/socket.mbti
+++ b/src/socket/socket.mbti
@@ -3,42 +3,68 @@ package "moonbitlang/async/socket"
 // Values
 
 // Types and methods
-type Addr
-fn Addr::ip(Self) -> UInt
-fn Addr::new(UInt, Int) -> Self
-fn Addr::parse(String) -> Self raise InvalidAddr
-fn Addr::port(Self) -> Int
-impl Show for Addr
-
 pub type! ConnectionClosed
 impl Show for ConnectionClosed
+
+pub(all) enum Domain {
+  IPv4
+  IPv6
+}
+fn Domain::from_address(SocketAddr) -> Self
+impl Show for Domain
 
 pub type! InvalidAddr
 impl Show for InvalidAddr
 
+type Ipv4Addr
+fn Ipv4Addr::ip(Self) -> UInt
+fn Ipv4Addr::new(UInt, Int) -> Self
+fn Ipv4Addr::parse(String) -> Self raise InvalidAddr
+fn Ipv4Addr::port(Self) -> Int
+impl Show for Ipv4Addr
+
+type Ipv6Addr
+fn Ipv6Addr::ip(Self) -> FixedArray[Byte]
+fn Ipv6Addr::new(FixedArray[Byte], Int, Int, Int) -> Self
+fn Ipv6Addr::parse(String) -> Self raise InvalidAddr
+fn Ipv6Addr::port(Self) -> Int
+impl Show for Ipv6Addr
+
+pub(all) enum SocketAddr {
+  V4(Ipv4Addr)
+  V6(Ipv6Addr)
+}
+fn SocketAddr::ip(Self) -> String
+fn SocketAddr::is_ipv4(Self) -> Bool
+fn SocketAddr::is_ipv6(Self) -> Bool
+fn SocketAddr::parse(String) -> Self raise InvalidAddr
+fn SocketAddr::port(Self) -> Int
+impl Show for SocketAddr
+
 type TCP
-async fn TCP::accept(Self) -> (Self, Addr) raise
-fn TCP::bind(Self, Addr) -> Unit raise
+async fn TCP::accept(Self) -> (Self, SocketAddr) raise
+fn TCP::bind(Self, SocketAddr) -> Unit raise
 fn TCP::close(Self) -> Unit
-async fn TCP::connect(Self, Addr) -> Unit raise
+async fn TCP::connect(Self, SocketAddr) -> Unit raise
 fn TCP::enable_keepalive(Self, idle_before_keep_alive~ : Int = .., keep_alive_count~ : Int = .., keep_alive_interval~ : Int = ..) -> Unit raise
 fn TCP::listen(Self) -> Unit raise
-fn TCP::new() -> Self
+fn TCP::new(domain? : Domain) -> Self
 async fn TCP::recv(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> Int raise
 async fn TCP::recv_exactly(Self, Int) -> Bytes raise
 async fn TCP::send(Self, Bytes, offset~ : Int = .., len? : Int) -> Unit raise
 
 type UDP
-fn UDP::bind(Self, Addr) -> Unit raise
+fn UDP::bind(Self, SocketAddr) -> Unit raise
 fn UDP::close(Self) -> Unit
-fn UDP::connect(Self, Addr) -> Unit raise
-fn UDP::new() -> Self
+fn UDP::connect(Self, SocketAddr) -> Unit raise
+fn UDP::new(domain? : Domain) -> Self
 async fn UDP::recv(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> Int raise
-async fn UDP::recvfrom(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> (Int, Addr) raise
+async fn UDP::recvfrom(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> (Int, SocketAddr) raise
 async fn UDP::send(Self, Bytes, offset~ : Int = .., len? : Int) -> Unit raise
-async fn UDP::sendto(Self, Bytes, Addr, offset~ : Int = .., len? : Int) -> Unit raise
+async fn UDP::sendto(Self, Bytes, SocketAddr, offset~ : Int = .., len? : Int) -> Unit raise
 
 // Type aliases
+pub typealias SocketAddr as Addr
 
 // Traits
 

--- a/src/socket/string_convert.mbt
+++ b/src/socket/string_convert.mbt
@@ -1,0 +1,57 @@
+// Copyright 2024 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Adapted from https://github.com/moonbitlang/x/blob/main/internal/ffi/string_convert.mbt
+fn utf8_bytes_to_mbt_string(bytes : Bytes) -> String {
+  let res : Array[Char] = []
+  let len = bytes.length()
+  let mut i = 0
+  while i < len {
+    let mut c = bytes[i].to_int()
+    if c < 0x80 {
+      res.push(Int::unsafe_to_char(c))
+      i += 1
+    } else if c < 0xE0 {
+      if i + 1 >= len {
+        break
+      }
+      c = ((c & 0x1F) << 6) | (bytes[i + 1].to_int() & 0x3F)
+      res.push(Int::unsafe_to_char(c))
+      i += 2
+    } else if c < 0xF0 {
+      if i + 2 >= len {
+        break
+      }
+      c = ((c & 0x0F) << 12) |
+        ((bytes[i + 1].to_int() & 0x3F) << 6) |
+        (bytes[i + 2].to_int() & 0x3F)
+      res.push(Int::unsafe_to_char(c))
+      i += 3
+    } else {
+      if i + 3 >= len {
+        break
+      }
+      c = ((c & 0x07) << 18) |
+        ((bytes[i + 1].to_int() & 0x3F) << 12) |
+        ((bytes[i + 2].to_int() & 0x3F) << 6) |
+        (bytes[i + 3].to_int() & 0x3F)
+      c -= 0x10000
+      res.push(Int::unsafe_to_char((c >> 10) + 0xD800))
+      res.push(Int::unsafe_to_char((c & 0x3FF) + 0xDC00))
+      i += 4
+    }
+  }
+  String::from_array(res)
+}

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -19,8 +19,9 @@ type TCP Int
 ///|
 /// Create a new TCP socket using the `socket(2)` system call.
 /// The created socket always operate in non-blocking mode.
-pub fn TCP::new() -> TCP {
-  make_tcp_socket()
+pub fn TCP::new(domain? : Domain) -> TCP {
+  let domain = domain.unwrap_or(Domain::IPv4)
+  make_socket(domain.inner(), Type::Stream.inner(), 0)
 }
 
 ///|
@@ -31,9 +32,9 @@ pub fn TCP::close(self : TCP) -> Unit {
 
 ///|
 /// Bind the socket to an address using the `bind(2)` system call.
-pub fn TCP::bind(self : TCP, addr : Addr) -> Unit raise {
+pub fn TCP::bind(self : TCP, addr : SocketAddr) -> Unit raise {
   let TCP(sock) = self
-  if 0 != bind_ffi(sock, addr) {
+  if 0 != bind_ffi(sock, addr.to_ipaddr()) {
     @os_error.check_errno()
   }
 }
@@ -77,14 +78,14 @@ pub fn TCP::enable_keepalive(
 /// Accept a new connection on a listening socket using `accept(2)` system call.
 /// A new socket representing the accepted connection
 /// will be returned together with the address of peer.
-pub async fn TCP::accept(self : TCP) -> (TCP, Addr) raise {
+pub async fn TCP::accept(self : TCP) -> (TCP, SocketAddr) raise {
   let TCP(listen_sock) = self
   @event_loop.prepare_fd_read(listen_sock)
-  let addr = Addr::new(0, 0)
+  let addr = create_sockaddr_storage_ffi()
   for {
     let conn_sock = accept_ffi(listen_sock, addr)
     if conn_sock > 0 {
-      return (TCP(conn_sock), addr)
+      return (TCP(conn_sock), addr.to_socket_addr())
     } else if @os_error.is_nonblocking_io_error() {
       @event_loop.wait_fd_read(listen_sock)
     } else {
@@ -95,10 +96,10 @@ pub async fn TCP::accept(self : TCP) -> (TCP, Addr) raise {
 
 ///|
 /// Make connection to a remote address using `connect(2)` system call.
-pub async fn TCP::connect(self : TCP, addr : Addr) -> Unit raise {
+pub async fn TCP::connect(self : TCP, addr : SocketAddr) -> Unit raise {
   let TCP(sock) = self
   @event_loop.prepare_fd_write(sock)
-  if 0 == connect_ffi(sock, addr) {
+  if 0 == connect_ffi(sock, addr.to_ipaddr()) {
     return
   }
   if @os_error.is_nonblocking_io_error() {

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -19,8 +19,9 @@ type UDP Int
 ///|
 /// Create a new UDP socket using the `socket(2)` system call.
 /// The created socket always operate in non-blocking mode.
-pub fn UDP::new() -> UDP {
-  make_udp_socket()
+pub fn UDP::new(domain? : Domain) -> UDP {
+  let domain = domain.unwrap_or(Domain::IPv4)
+  make_socket(domain.inner(), Type::Datagram.inner(), 0)
 }
 
 ///|
@@ -32,9 +33,9 @@ pub fn UDP::close(self : UDP) -> Unit {
 ///|
 /// Bind the socket to an address using the `bind(2)` system call,
 /// so that the socket can be used to receive packets from the address.
-pub fn UDP::bind(self : UDP, addr : Addr) -> Unit raise {
+pub fn UDP::bind(self : UDP, addr : SocketAddr) -> Unit raise {
   let UDP(sock) = self
-  if 0 != bind_ffi(sock, addr) {
+  if 0 != bind_ffi(sock, addr.to_ipaddr()) {
     @os_error.check_errno()
   }
 }
@@ -42,9 +43,9 @@ pub fn UDP::bind(self : UDP, addr : Addr) -> Unit raise {
 ///|
 /// "connect" the socket to remote address using `connect(2)` system call.
 /// For UDP socket, connect means setting the default address for `send`.
-pub fn UDP::connect(self : UDP, addr : Addr) -> Unit raise {
+pub fn UDP::connect(self : UDP, addr : SocketAddr) -> Unit raise {
   let UDP(sock) = self
-  if 0 != connect_ffi(sock, addr) {
+  if 0 != connect_ffi(sock, addr.to_ipaddr()) {
     @os_error.check_errno()
   }
 }
@@ -105,11 +106,11 @@ pub async fn UDP::recvfrom(
   buf : FixedArray[Byte],
   offset~ : Int = 0,
   max_len? : Int
-) -> (Int, Addr) raise {
+) -> (Int, SocketAddr) raise {
   let max_len = max_len.unwrap_or(buf.length() - offset)
   let UDP(sock) = self
   @event_loop.prepare_fd_read(sock)
-  let addr = Addr::new(0, 0)
+  let addr = create_sockaddr_storage_ffi()
   let n_read = recvfrom_ffi(sock, buf, offset, max_len, addr)
   let n_read = if n_read < 0 && @os_error.is_nonblocking_io_error() {
     @event_loop.wait_fd_read(sock)
@@ -120,7 +121,7 @@ pub async fn UDP::recvfrom(
   if n_read < 0 {
     @os_error.check_errno()
   }
-  (n_read, addr)
+  (n_read, addr.to_socket_addr())
 }
 
 ///|
@@ -167,7 +168,7 @@ pub async fn UDP::send(
 pub async fn UDP::sendto(
   self : UDP,
   buf : Bytes,
-  addr : Addr,
+  addr : SocketAddr,
   offset~ : Int = 0,
   len? : Int
 ) -> Unit raise {
@@ -175,7 +176,7 @@ pub async fn UDP::sendto(
   let UDP(sock) = self
   @event_loop.prepare_fd_write(sock)
   for {
-    let n_sent = sendto_ffi(sock, buf, offset, len, addr)
+    let n_sent = sendto_ffi(sock, buf, offset, len, addr.to_ipaddr())
     if n_sent > 0 {
       return
     }


### PR DESCRIPTION
1. Support IPv6 protocol
2. Maintain compatibility with the previous API version (Recommended to replace @socket.Addr with @socket.SocketAddr)