### PR TITLE
update to newest compiler version

### DIFF
--- a/src/aqueue/aqueue.mbti
+++ b/src/aqueue/aqueue.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/aqueue"
 
 // Values

--- a/src/async.mbti
+++ b/src/async.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async"
 
 // Values
@@ -14,7 +15,7 @@ async fn[X] with_task_group(async (TaskGroup[X]) -> X raise) -> X raise
 async fn with_timeout(Int, async () -> Unit raise) -> Unit raise
 
 // Types and methods
-pub type! AlreadyTerminated
+pub suberror AlreadyTerminated
 impl Show for AlreadyTerminated
 
 pub(all) enum RetryMethod {

--- a/src/example/tcp_echo_server/tcp_echo_server.mbti
+++ b/src/example/tcp_echo_server/tcp_echo_server.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/example/tcp_echo_server"
 
 // Values

--- a/src/example/tcp_ping_pong/tcp_ping_pong.mbti
+++ b/src/example/tcp_ping_pong/tcp_ping_pong.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/example/tcp_ping_pong"
 
 // Values

--- a/src/example/udp_echo_server/udp_echo_server.mbti
+++ b/src/example/udp_echo_server/udp_echo_server.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/example/udp_echo_server"
 
 // Values

--- a/src/example/udp_ping_pong/udp_ping_pong.mbti
+++ b/src/example/udp_ping_pong/udp_ping_pong.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/example/udp_ping_pong"
 
 // Values

--- a/src/fs/fs.mbt
+++ b/src/fs/fs.mbt
@@ -41,7 +41,7 @@ extern "C" fn make_open_flags(
   sync~ : SyncMode,
   append~ : Bool,
   create~ : Bool,
-  truncate~ : Bool
+  truncate~ : Bool,
 ) -> Int = "moonbitlang_async_make_open_flags"
 
 ///|
@@ -51,7 +51,7 @@ pub async fn open(
   sync~ : SyncMode = NoSync,
   append~ : Bool = false,
   create? : Int,
-  truncate~ : Bool = false
+  truncate~ : Bool = false,
 ) -> File raise {
   let (create, user_mode) = match create {
     None => (false, 0)
@@ -66,7 +66,7 @@ pub async fn open(
 pub async fn create(
   filename : Bytes,
   permission~ : Int,
-  sync~ : SyncMode = NoSync
+  sync~ : SyncMode = NoSync,
 ) -> File raise {
   open(filename, mode=WriteOnly, sync~, create=permission, truncate=true)
 }
@@ -75,7 +75,7 @@ pub async fn create(
 pub async fn File::read(
   self : File,
   buf : FixedArray[Byte],
-  len : Int
+  len : Int,
 ) -> Unit raise {
   let File(fd) = self
   let job = @thread_pool.read_job(fd, buf, len)

--- a/src/fs/fs.mbti
+++ b/src/fs/fs.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/fs"
 
 // Values

--- a/src/internal/coroutine/async_primitive.mbt
+++ b/src/internal/coroutine/async_primitive.mbt
@@ -14,7 +14,7 @@
 
 ///|
 async fn[T, E : Error] async_suspend(
-  cb : ((T) -> Unit, (E) -> Unit) -> Unit
+  cb : ((T) -> Unit, (E) -> Unit) -> Unit,
 ) -> T raise E = "%async.suspend"
 
 ///|

--- a/src/internal/coroutine/async_primitive.mbt
+++ b/src/internal/coroutine/async_primitive.mbt
@@ -18,4 +18,4 @@ async fn[T, E : Error] async_suspend(
 ) -> T raise E = "%async.suspend"
 
 ///|
-fn run_async(f : async () -> Unit) = "%async.run"
+fn run_async(f : async () -> Unit noraise) = "%async.run"

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -109,7 +109,7 @@ pub async fn sleep(duration : Int) -> Unit raise {
 ///|
 pub fn spawn(
   f : async () -> Unit raise,
-  on_error? : (Error) -> Unit
+  on_error? : (Error) -> Unit,
 ) -> Coroutine {
   scheduler.coro_id += 1
   let coro = {

--- a/src/internal/coroutine/coroutine.mbti
+++ b/src/internal/coroutine/coroutine.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/internal/coroutine"
 
 // Values
@@ -22,7 +23,7 @@ fn spawn(async () -> Unit raise, on_error? : (Error) -> Unit) -> Coroutine
 async fn suspend() -> Unit raise
 
 // Types and methods
-pub(all) type! Cancelled
+pub(all) suberror Cancelled
 impl Show for Cancelled
 
 type Coroutine

--- a/src/internal/event_loop/event_loop.mbti
+++ b/src/internal/event_loop/event_loop.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/internal/event_loop"
 
 import(

--- a/src/internal/event_loop/poll.mbt
+++ b/src/internal/event_loop/poll.mbt
@@ -36,7 +36,7 @@ extern "C" fn Instance::register_ffi(
   fd : Int,
   prev_events~ : Int,
   new_events~ : Int,
-  oneshot~ : Bool
+  oneshot~ : Bool,
 ) -> Int = "moonbitlang_async_poll_register"
 
 ///|
@@ -45,7 +45,7 @@ fn Instance::register(
   fd : Int,
   prev_events~ : Int,
   new_events~ : Int,
-  oneshot~ : Bool = false
+  oneshot~ : Bool = false,
 ) -> Unit raise {
   if 0 != self.register_ffi(fd, prev_events~, new_events~, oneshot~) {
     @os_error.check_errno()
@@ -56,7 +56,7 @@ fn Instance::register(
 extern "C" fn Instance::remove_ffi(
   self : Instance,
   fd : Int,
-  events~ : Int
+  events~ : Int,
 ) -> Int = "moonbitlang_async_poll_remove"
 
 ///|

--- a/src/internal/thread_pool/thread_pool.mbti
+++ b/src/internal/thread_pool/thread_pool.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/internal/thread_pool"
 
 // Values

--- a/src/internal/time/time.mbti
+++ b/src/internal/time/time.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/internal/time"
 
 // Values

--- a/src/os_error/os_error.mbti
+++ b/src/os_error/os_error.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/os_error"
 
 // Values

--- a/src/pipe/ffi.mbt
+++ b/src/pipe/ffi.mbt
@@ -29,7 +29,7 @@ extern "C" fn read_ffi(
   fd : Int,
   buf : FixedArray[Byte],
   offset : Int,
-  max_len : Int
+  max_len : Int,
 ) -> Int = "moonbitlang_async_read"
 
 ///|
@@ -37,5 +37,5 @@ extern "C" fn write_ffi(
   fd : Int,
   buf : Bytes,
   offset : Int,
-  max_len : Int
+  max_len : Int,
 ) -> Int = "moonbitlang_async_write"

--- a/src/pipe/pipe.mbt
+++ b/src/pipe/pipe.mbt
@@ -127,7 +127,7 @@ pub async fn PipeRead::read(
   self : PipeRead,
   buf : FixedArray[Byte],
   offset~ : Int = 0,
-  max_len? : Int
+  max_len? : Int,
 ) -> Int raise {
   let max_len = max_len.unwrap_or(buf.length() - offset)
   let PipeRead(fd) = self
@@ -179,7 +179,7 @@ pub async fn PipeWrite::write(
   self : PipeWrite,
   buf : Bytes,
   offset~ : Int = 0,
-  len? : Int
+  len? : Int,
 ) -> Unit raise {
   let len = len.unwrap_or(buf.length() - offset)
   let PipeWrite(fd) = self

--- a/src/pipe/pipe.mbti
+++ b/src/pipe/pipe.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/pipe"
 
 // Values
@@ -12,7 +13,7 @@ let stdin : PipeRead
 let stdout : PipeWrite
 
 // Types and methods
-pub type! PipeClosed
+pub suberror PipeClosed
 impl Show for PipeClosed
 
 type PipeRead

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -39,7 +39,7 @@ extern "C" fn recv_ffi(
   sock : Int,
   buf : FixedArray[Byte],
   offset : Int,
-  max_len : Int
+  max_len : Int,
 ) -> Int = "moonbitlang_async_recv"
 
 ///|
@@ -48,7 +48,7 @@ extern "C" fn send_ffi(
   sock : Int,
   buf : Bytes,
   offset : Int,
-  max_len : Int
+  max_len : Int,
 ) -> Int = "moonbitlang_async_send"
 
 ///|
@@ -69,7 +69,7 @@ extern "C" fn enable_keepalive_ffi(
   sock : Int,
   keep_idle : Int,
   keep_count : Int,
-  keep_intv : Int
+  keep_intv : Int,
 ) -> Int = "moonbitlang_async_enable_keepalive"
 
 ///|
@@ -79,7 +79,7 @@ extern "C" fn recvfrom_ffi(
   buf : FixedArray[Byte],
   offset : Int,
   max_len : Int,
-  addr_buf : Addr
+  addr_buf : Addr,
 ) -> Int = "moonbitlang_async_recvfrom"
 
 ///|
@@ -89,5 +89,5 @@ extern "C" fn sendto_ffi(
   buf : Bytes,
   offset : Int,
   max_len : Int,
-  addr_buf : Addr
+  addr_buf : Addr,
 ) -> Int = "moonbitlang_async_sendto"

--- a/src/socket/socket.mbti
+++ b/src/socket/socket.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/socket"
 
 // Values
@@ -10,10 +11,10 @@ fn Addr::parse(String) -> Self raise InvalidAddr
 fn Addr::port(Self) -> Int
 impl Show for Addr
 
-pub type! ConnectionClosed
+pub suberror ConnectionClosed
 impl Show for ConnectionClosed
 
-pub type! InvalidAddr
+pub suberror InvalidAddr
 impl Show for InvalidAddr
 
 type TCP

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -62,7 +62,7 @@ pub fn TCP::enable_keepalive(
   self : TCP,
   idle_before_keep_alive~ : Int = -1,
   keep_alive_count~ : Int = -1,
-  keep_alive_interval~ : Int = -1
+  keep_alive_interval~ : Int = -1,
 ) -> Unit raise {
   let TCP(sock) = self
   let ret = enable_keepalive_ffi(
@@ -122,7 +122,7 @@ pub async fn TCP::recv(
   self : TCP,
   buf : FixedArray[Byte],
   offset~ : Int = 0,
-  max_len? : Int
+  max_len? : Int,
 ) -> Int raise {
   let max_len = max_len.unwrap_or(buf.length() - offset)
   let TCP(sock) = self
@@ -174,7 +174,7 @@ pub async fn TCP::send(
   self : TCP,
   buf : Bytes,
   offset~ : Int = 0,
-  len? : Int
+  len? : Int,
 ) -> Unit raise {
   let len = len.unwrap_or(buf.length() - offset)
   let TCP(sock) = self

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -67,7 +67,7 @@ pub async fn UDP::recv(
   self : UDP,
   buf : FixedArray[Byte],
   offset~ : Int = 0,
-  max_len? : Int
+  max_len? : Int,
 ) -> Int raise {
   let max_len = max_len.unwrap_or(buf.length() - offset)
   let UDP(sock) = self
@@ -104,7 +104,7 @@ pub async fn UDP::recvfrom(
   self : UDP,
   buf : FixedArray[Byte],
   offset~ : Int = 0,
-  max_len? : Int
+  max_len? : Int,
 ) -> (Int, Addr) raise {
   let max_len = max_len.unwrap_or(buf.length() - offset)
   let UDP(sock) = self
@@ -136,7 +136,7 @@ pub async fn UDP::send(
   self : UDP,
   buf : Bytes,
   offset~ : Int = 0,
-  len? : Int
+  len? : Int,
 ) -> Unit raise {
   let len = len.unwrap_or(buf.length() - offset)
   let UDP(sock) = self
@@ -169,7 +169,7 @@ pub async fn UDP::sendto(
   buf : Bytes,
   addr : Addr,
   offset~ : Int = 0,
-  len? : Int
+  len? : Int,
 ) -> Unit raise {
   let len = len.unwrap_or(buf.length() - offset)
   let UDP(sock) = self

--- a/src/spawn_loop_test.mbt
+++ b/src/spawn_loop_test.mbt
@@ -214,9 +214,7 @@ test "spawn_loop cancelled2" {
   log.write_object(
     try? @async.with_event_loop(fn(root) {
       let mut i = 0
-      root.spawn_loop(no_wait=true, allow_failure=true, retry=FixedDelay(50), fn(
-
-      ) {
+      root.spawn_loop(no_wait=true, allow_failure=true, retry=FixedDelay(50), fn() {
         log.write_string("loop \{i}\n")
         i = i + 1
         raise Err

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -61,7 +61,7 @@ fn[X] TaskGroup::spawn_coroutine(
   self : TaskGroup[X],
   f : async () -> Unit raise,
   no_wait~ : Bool,
-  allow_failure~ : Bool
+  allow_failure~ : Bool,
 ) -> @coroutine.Coroutine raise {
   if not(self.state is Running) {
     raise AlreadyTerminated
@@ -114,7 +114,7 @@ pub fn[X] TaskGroup::spawn_bg(
   self : TaskGroup[X],
   f : async () -> Unit raise,
   no_wait~ : Bool = false,
-  allow_failure~ : Bool = false
+  allow_failure~ : Bool = false,
 ) -> Unit raise {
   ignore(self.spawn_coroutine(f, no_wait~, allow_failure~))
 }
@@ -140,7 +140,7 @@ pub fn[G, X] TaskGroup::spawn(
   self : TaskGroup[G],
   f : async () -> X raise,
   no_wait~ : Bool = false,
-  allow_failure~ : Bool = false
+  allow_failure~ : Bool = false,
 ) -> Task[X] raise {
   let value = @ref.new(None)
   let coro = self.spawn_coroutine(
@@ -198,7 +198,7 @@ pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X raise) -> X raise 
 /// will be cancelled.
 pub fn[X] TaskGroup::return_immediately(
   self : TaskGroup[X],
-  value : X
+  value : X,
 ) -> Unit raise {
   if self.result is None {
     self.result = Some(value)
@@ -246,7 +246,7 @@ pub fn[X] TaskGroup::spawn_loop(
   f : async () -> IterResult raise,
   no_wait~ : Bool = false,
   allow_failure~ : Bool = false,
-  retry~ : RetryMethod = NoRetry
+  retry~ : RetryMethod = NoRetry,
 ) -> Unit raise {
   self.spawn_bg(no_wait~, allow_failure~, fn() {
     match retry {


### PR DESCRIPTION
update code base to newest compiler release. Changes:

- improvements on `mbti` format
- improvements on `moon fmt`
- `async` function without error must now be explicitly marked with `noraise`. For this library, all public `async` function raise error due to cancellation, so this change only affect one internal primitive