### PR TITLE
utilize new `defer` syntax

### DIFF
--- a/src/example/tcp_echo_server/main.mbt
+++ b/src/example/tcp_echo_server/main.mbt
@@ -16,25 +16,20 @@
 fn main_prog() -> Unit raise {
   @async.with_event_loop(fn(root) {
     let listen_sock = @socket.TCP::new()
-    try {
-      listen_sock..bind(@socket.Addr::parse("0.0.0.0:4200"))..listen()
-      for {
-        let (conn, addr) = listen_sock.accept()
-        println("received new connection from \{addr}")
-        root.spawn_bg(fn() {
-          let buf = FixedArray::make(1024, b'0')
-          while conn.recv(buf) is n && n > 0 {
-            let buf = buf.unsafe_reinterpret_as_bytes()
-            conn.send(buf[0:n].to_bytes())
-          }
-          println("connection closed")
-        })
-      }
-    } catch {
-      err => {
-        listen_sock.close()
-        raise err
-      }
+    defer listen_sock.close()
+    listen_sock..bind(@socket.Addr::parse("0.0.0.0:4200"))..listen()
+    for {
+      let (conn, addr) = listen_sock.accept()
+      println("received new connection from \{addr}")
+      root.spawn_bg(fn() {
+        defer conn.close()
+        let buf = FixedArray::make(1024, b'0')
+        while conn.recv(buf) is n && n > 0 {
+          let buf = buf.unsafe_reinterpret_as_bytes()
+          conn.send(buf[0:n].to_bytes())
+        }
+        println("connection closed")
+      })
     }
   })
 }

--- a/src/example/tcp_ping_pong/main.mbt
+++ b/src/example/tcp_ping_pong/main.mbt
@@ -25,40 +25,33 @@ pub(all) type Printer (String) -> Unit
 async fn server(println : Printer) -> Unit raise {
   @async.with_task_group(fn(group) {
     let listen_sock = @socket.TCP::new()
+    defer listen_sock.close()
     listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
     try {
       for {
         let (conn, _) = listen_sock.accept()
         println("received new connection")
         group.spawn_bg(fn() {
+          defer conn.close()
           let buf = FixedArray::make(1024, b'0')
-          try {
-            while conn.recv(buf) is n && n > 0 {
-              let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
-              println("server received: \{msg}")
-              let reply = b"pong"
-              conn.send(reply)
-              println("server sent: \{reply}")
-              if msg == b"exit" {
-                println("server initiate terminate")
-                raise ServerTerminate
-              }
-            } else {
-              println("server: connection closed by peer")
+          while conn.recv(buf) is n && n > 0 {
+            let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
+            println("server received: \{msg}")
+            let reply = b"pong"
+            conn.send(reply)
+            println("server sent: \{reply}")
+            if msg == b"exit" {
+              println("server initiate terminate")
+              raise ServerTerminate
             }
-            conn.close()
-          } catch {
-            err => {
-              conn.close()
-              raise err
-            }
+          } else {
+            println("server: connection closed by peer")
           }
         })
       }
     } catch {
       err => {
         println("server terminate: \{err}")
-        listen_sock.close()
         raise err
       }
     }
@@ -68,6 +61,7 @@ async fn server(println : Printer) -> Unit raise {
 ///|
 async fn client(println : Printer, id : Int, msg : Bytes) -> Unit raise {
   let conn = @socket.TCP::new()
+  defer conn.close()
   conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   // The sleep here is used to make test result stable and portable,
   // because this message is in race condition
@@ -77,20 +71,11 @@ async fn client(println : Printer, id : Int, msg : Bytes) -> Unit raise {
   conn.send(msg)
   println("client \{id} sent: \{msg}")
   let buf = FixedArray::make(1024, b'0')
-  try {
-    if conn.recv(buf) is n && n > 0 {
-      let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
-      println("client \{id} received: \{msg}")
-    } else {
-      println("client \{id}: connection closed by peer")
-    }
-  } catch {
-    err => {
-      conn.close()
-      raise err
-    }
-  } noraise {
-    _ => conn.close()
+  if conn.recv(buf) is n && n > 0 {
+    let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
+    println("client \{id} received: \{msg}")
+  } else {
+    println("client \{id}: connection closed by peer")
   }
 }
 

--- a/src/example/udp_echo_server/main.mbt
+++ b/src/example/udp_echo_server/main.mbt
@@ -14,8 +14,9 @@
 
 ///|
 fn main_prog() -> Unit raise {
-  let server = @socket.UDP::new()
   @async.with_event_loop(fn(root) {
+    let server = @socket.UDP::new()
+    defer server.close()
     server.bind(@socket.Addr::parse("0.0.0.0:4200"))
     for {
       let buf = FixedArray::make(1024, b'0')
@@ -25,12 +26,7 @@ fn main_prog() -> Unit raise {
         server.sendto(buf[0:n].to_bytes(), addr)
       })
     }
-  }) catch {
-    err => {
-      server.close()
-      raise err
-    }
-  }
+  })
 }
 
 ///|

--- a/src/example/udp_ping_pong/main.mbt
+++ b/src/example/udp_ping_pong/main.mbt
@@ -23,8 +23,9 @@ pub(all) type Printer (String) -> Unit
 
 ///|
 async fn server(println : Printer) -> Unit raise {
-  let server_sock = @socket.UDP::new()
   @async.with_task_group(fn(group) {
+    let server_sock = @socket.UDP::new()
+    defer server_sock.close()
     server_sock.bind(@socket.Addr::parse("0.0.0.0:\{port}"))
     let buf = FixedArray::make(1024, b'0')
     while server_sock.recvfrom(buf) is (n, addr) && n > 0 {
@@ -45,7 +46,6 @@ async fn server(println : Printer) -> Unit raise {
   }) catch {
     err => {
       println("server terminate: \{err}")
-      server_sock.close()
       raise err
     }
   }
@@ -54,25 +54,17 @@ async fn server(println : Printer) -> Unit raise {
 ///|
 async fn client(println : Printer, id : Int, msg : Bytes) -> Unit raise {
   let conn = @socket.UDP::new()
+  defer conn.close()
   conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   conn.send(msg)
   println("client \{id} sent: \{msg}")
   let buf = FixedArray::make(1024, b'0')
-  try {
-    if conn.recv(buf) is n && n > 0 {
-      let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
-      println("client \{id} received: \{msg}")
-      conn.close()
-    } else {
-      println("client \{id}: connection closed by peer")
-    }
-  } catch {
-    err => {
-      conn.close()
-      raise err
-    }
-  } noraise {
-    _ => conn.close()
+  if conn.recv(buf) is n && n > 0 {
+    let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
+    println("client \{id} received: \{msg}")
+    conn.close()
+  } else {
+    println("client \{id}: connection closed by peer")
   }
 }
 

--- a/src/fs/create_test.mbt
+++ b/src/fs/create_test.mbt
@@ -17,12 +17,16 @@ test "basic create" {
   let buf = FixedArray::make(4, b'0')
   @async.with_event_loop(fn(_) {
     let path = b"basic_create_test\x00"
-    let w = @fs.create(path, permission=0o644, sync=Full)
-    w.write(b"abcd\n")
-    w.close()
-    let r = @fs.open(path, mode=ReadOnly)
-    guard r.read(buf) == buf.length()
-    r.close()
+    {
+      let w = @fs.create(path, permission=0o644, sync=Full)
+      defer w.close()
+      w.write(b"abcd\n")
+    }
+    {
+      let r = @fs.open(path, mode=ReadOnly)
+      defer r.close()
+      guard r.read(buf) == buf.length()
+    }
     @fs.remove(path)
   })
   inspect(buf, content="[b'\\x61', b'\\x62', b'\\x63', b'\\x64']")

--- a/src/fs/eof_test.mbt
+++ b/src/fs/eof_test.mbt
@@ -17,12 +17,16 @@ test "read EOF" {
   let buf = FixedArray::make(16, b'0')
   @async.with_event_loop(fn(_) {
     let path = b"read_eof_test\x00"
-    let w = @fs.create(path, permission=0o644, sync=Full)
-    w.write(b"abcd")
-    w.close()
-    let r = @fs.open(path, mode=ReadOnly)
-    let n = r.read(buf)
-    r.close()
+    {
+      let w = @fs.create(path, permission=0o644, sync=Full)
+      defer w.close()
+      w.write(b"abcd")
+    }
+    let n = {
+      let r = @fs.open(path, mode=ReadOnly)
+      defer r.close()
+      r.read(buf)
+    }
     @fs.remove(path)
     assert_eq(n, 4)
     inspect(

--- a/src/fs/seek_test.mbt
+++ b/src/fs/seek_test.mbt
@@ -19,34 +19,42 @@ test "basic seek" {
   @async.with_event_loop(fn(_) {
     let path = b"basic_seek_test\x00"
     // initialize
-    let w = @fs.create(path, permission=0o644, sync=Full)
-    log.write_string("initial size: \{w.size()}\n")
-    w.write(b"abcdef")
-    log.write_string("size after write: \{w.size()}\n")
-    w.close()
+    {
+      let w = @fs.create(path, permission=0o644, sync=Full)
+      defer w.close()
+      log.write_string("initial size: \{w.size()}\n")
+      w.write(b"abcdef")
+      log.write_string("size after write: \{w.size()}\n")
+    }
     // first read
-    let r = @fs.open(path, mode=ReadOnly)
-    log.write_string("current size: \{r.size()}\n")
-    guard r.read(buf) == buf.length()
-    log.write_string("current content: \{buf}\n")
-    r.close()
+    {
+      let r = @fs.open(path, mode=ReadOnly)
+      defer r.close()
+      log.write_string("current size: \{r.size()}\n")
+      guard r.read(buf) == buf.length()
+      log.write_string("current content: \{buf}\n")
+    }
     // update content
-    let w = @fs.open(path, mode=WriteOnly)
-    ignore(w.seek(-2, mode=FromEnd))
-    log.write_string("writing at position \{w.curr_pos()}\n")
-    w.write(b"56")
-    ignore(w.seek(2, mode=FromStart))
-    log.write_string("writing at position \{w.curr_pos()}\n")
-    w.write(b"34")
-    ignore(w.seek(-4, mode=Relative))
-    log.write_string("writing at position \{w.curr_pos()}\n")
-    w.write(b"12")
-    w.close()
+    {
+      let w = @fs.open(path, mode=WriteOnly)
+      defer w.close()
+      ignore(w.seek(-2, mode=FromEnd))
+      log.write_string("writing at position \{w.curr_pos()}\n")
+      w.write(b"56")
+      ignore(w.seek(2, mode=FromStart))
+      log.write_string("writing at position \{w.curr_pos()}\n")
+      w.write(b"34")
+      ignore(w.seek(-4, mode=Relative))
+      log.write_string("writing at position \{w.curr_pos()}\n")
+      w.write(b"12")
+    }
     // read content
-    let r = @fs.open(path, mode=ReadOnly)
-    guard r.read(buf) == buf.length()
-    log.write_string("final content: \{buf}\n")
-    r.close()
+    {
+      let r = @fs.open(path, mode=ReadOnly)
+      defer r.close()
+      guard r.read(buf) == buf.length()
+      log.write_string("final content: \{buf}\n")
+    }
     @fs.remove(path)
   })
   inspect(

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -77,19 +77,12 @@ pub async fn pause() -> Unit raise {
 ///|
 pub async fn suspend() -> Unit raise {
   guard scheduler.curr_coro is Some(coro)
+  defer {
+    scheduler.blocking -= 1
+  }
   async_suspend(fn(ok_cont, err_cont) {
     guard coro.state is Running
-    fn wrapped_ok_cont(x) {
-      scheduler.blocking -= 1
-      ok_cont(x)
-    }
-
-    fn wrapped_err_cont(err) {
-      scheduler.blocking -= 1
-      err_cont(err)
-    }
-
-    coro.state = Suspend(ok_cont=wrapped_ok_cont, err_cont=wrapped_err_cont)
+    coro.state = Suspend(ok_cont~, err_cont~)
     scheduler.blocking += 1
   })
 }
@@ -179,18 +172,12 @@ pub async fn protect_from_cancel(f : async () -> Unit raise) -> Unit raise {
     f()
   } else {
     coro.shielded = true
-    try f() catch {
-      err => {
-        coro.shielded = false
-        raise err
-      }
-    } noraise {
-      _ => {
-        coro.shielded = false
-        if coro.cancelled {
-          raise Cancelled
-        }
-      }
+    defer {
+      coro.shielded = false
+    }
+    f()
+    if coro.cancelled {
+      raise Cancelled
     }
   }
 }

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -40,25 +40,27 @@ let curr_loop : Ref[EventLoop?] = @ref.new(None)
 pub fn with_event_loop(f : async () -> Unit raise) -> Unit raise {
   guard curr_loop.val is None
   let job_completion_pipe = @thread_pool.init_thread_pool()
+  defer @thread_pool.destroy_thread_pool()
   let evloop = {
     poll: Instance::new(),
     tasks: {},
     jobs: {},
     job_completion_pipe,
   }
+  defer evloop.poll.destroy()
   evloop.poll.register(
     job_completion_pipe,
     prev_events=NoEvent,
     new_events=Read,
   )
+  defer (evloop.poll.remove(job_completion_pipe, events=Read) catch { _ => () })
   curr_loop.val = Some(evloop)
+  defer {
+    curr_loop.val = None
+  }
   let main = @coroutine.spawn(f)
   @coroutine.reschedule()
   evloop.run_forever()
-  curr_loop.val = None
-  evloop.poll.remove(job_completion_pipe, events=Read)
-  evloop.poll.destroy()
-  @thread_pool.destroy_thread_pool()
   main.unwrap()
 }
 

--- a/src/pipe/read_exactly_test.mbt
+++ b/src/pipe/read_exactly_test.mbt
@@ -23,22 +23,22 @@ test "read_exactly" {
     let (r, w) = @pipe.pipe()
     // reader
     root.spawn_bg(fn() {
+      defer r.close()
       let msg1 = r.read_exactly(4)
       log("first message: \{msg1}")
       let msg2 = r.read_exactly(4)
       log("second message: \{msg2}")
       let msg3 = r.read_exactly(4)
       log("third message: \{msg3}")
-      r.close()
     })
     // writer
     root.spawn_bg(fn() {
+      defer w.close()
       w.write([1, 2, 3, 4, 5, 6])
       log("first message sent")
       @async.sleep(200)
       w.write([7, 8, 9, 10, 11, 12])
       log("second message sent")
-      w.close()
     })
   })
   inspect(
@@ -65,28 +65,20 @@ test "read_exactly failure" {
       let (r, w) = @pipe.pipe()
       // reader
       root.spawn_bg(fn() {
-        try {
-          let msg1 = r.read_exactly(4)
-          log("first message: \{msg1}")
-          let msg2 = r.read_exactly(4)
-          log("second message: \{msg2}")
-          let msg3 = r.read_exactly(4)
-          log("third message: \{msg3}")
-        } catch {
-          err => {
-            r.close()
-            raise err
-          }
-        } noraise {
-          _ => r.close()
-        }
+        defer r.close()
+        let msg1 = r.read_exactly(4)
+        log("first message: \{msg1}")
+        let msg2 = r.read_exactly(4)
+        log("second message: \{msg2}")
+        let msg3 = r.read_exactly(4)
+        log("third message: \{msg3}")
       })
       // writer
       root.spawn_bg(fn() {
+        defer w.close()
         w.write([1, 2, 3, 4, 5, 6])
         log("first message sent")
         @async.sleep(200)
-        w.close()
       })
     })
   log(result.to_string())

--- a/src/socket/connect_burst_test.mbt
+++ b/src/socket/connect_burst_test.mbt
@@ -25,37 +25,25 @@ async fn server() -> Int raise {
   try
     @async.with_task_group(fn(group) {
       listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
+      defer listen_sock.close()
       for {
         let (conn, _) = listen_sock.accept()
         num_connection += 1
         group.spawn_bg(fn() {
+          defer conn.close()
           let buf = FixedArray::make(1024, b'0')
-          try {
-            while conn.recv(buf) is n && n > 0 {
-              let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
-              if msg == b"exit" {
-                raise ServerTerminate
-              }
-            }
-            conn.close()
-          } catch {
-            err => {
-              conn.close()
-              raise err
+          while conn.recv(buf) is n && n > 0 {
+            let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
+            if msg == b"exit" {
+              raise ServerTerminate
             }
           }
         })
       }
     })
   catch {
-    ServerTerminate => {
-      listen_sock.close()
-      num_connection
-    }
-    err => {
-      listen_sock.close()
-      raise err
-    }
+    ServerTerminate => num_connection
+    err => raise err
   } noraise {
     (_ : Unit) => panic()
   }
@@ -64,9 +52,9 @@ async fn server() -> Int raise {
 ///|
 async fn client(msg : Bytes) -> Unit raise {
   let conn = @socket.TCP::new()
+  defer conn.close()
   conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   conn.send(msg)
-  conn.close()
 }
 
 ///|

--- a/src/socket/read_exactly_test.mbt
+++ b/src/socket/read_exactly_test.mbt
@@ -24,48 +24,30 @@ test "read_exactly" {
     // server
     root.spawn_bg(fn() {
       let listen_sock = @socket.TCP::new()
-      try {
-        listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
-        let (conn, _) = listen_sock.accept()
-        try {
-          let msg1 = conn.recv_exactly(4)
-          log("first message: \{msg1}")
-          let msg2 = conn.recv_exactly(4)
-          log("second message: \{msg2}")
-          let msg3 = conn.recv_exactly(4)
-          log("third message: \{msg3}")
-        } catch {
-          err => {
-            conn.close()
-            raise err
-          }
-        } noraise {
-          _ => {
-            // let the client close first to avoid socket entering `TIME_WAIT` state,
-            // occupying the address.
-            @async.sleep(50)
-            conn.close()
-          }
-        }
-      } catch {
-        err => {
-          listen_sock.close()
-          raise err
-        }
-      } noraise {
-        _ => listen_sock.close()
-      }
+      defer listen_sock.close()
+      listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
+      let (conn, _) = listen_sock.accept()
+      defer conn.close()
+      let msg1 = conn.recv_exactly(4)
+      log("first message: \{msg1}")
+      let msg2 = conn.recv_exactly(4)
+      log("second message: \{msg2}")
+      let msg3 = conn.recv_exactly(4)
+      log("third message: \{msg3}")
+      // let the client close first to avoid socket entering `TIME_WAIT` state,
+      // occupying the address.
+      @async.sleep(50)
     })
     // client
     root.spawn_bg(fn() {
       let conn = @socket.TCP::new()
+      defer conn.close()
       conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
       conn.send([1, 2, 3, 4, 5, 6])
       log("first message sent")
       @async.sleep(200)
       conn.send([7, 8, 9, 10, 11, 12])
       log("second message sent")
-      conn.close()
     })
   })
   inspect(
@@ -93,46 +75,28 @@ test "read_exactly failure" {
       // server
       root.spawn_bg(fn() {
         let listen_sock = @socket.TCP::new()
-        try {
-          listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
-          let (conn, _) = listen_sock.accept()
-          try {
-            let msg1 = conn.recv_exactly(4)
-            log("first message: \{msg1}")
-            let msg2 = conn.recv_exactly(4)
-            log("second message: \{msg2}")
-            let msg3 = conn.recv_exactly(4)
-            log("third message: \{msg3}")
-          } catch {
-            err => {
-              conn.close()
-              raise err
-            }
-          } noraise {
-            _ => {
-              // let the client close first to avoid socket entering `TIME_WAIT` state,
-              // occupying the address.
-              @async.sleep(50)
-              conn.close()
-            }
-          }
-        } catch {
-          err => {
-            listen_sock.close()
-            raise err
-          }
-        } noraise {
-          _ => listen_sock.close()
-        }
+        defer listen_sock.close()
+        listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
+        let (conn, _) = listen_sock.accept()
+        defer conn.close()
+        let msg1 = conn.recv_exactly(4)
+        log("first message: \{msg1}")
+        let msg2 = conn.recv_exactly(4)
+        log("second message: \{msg2}")
+        let msg3 = conn.recv_exactly(4)
+        log("third message: \{msg3}")
+        // let the client close first to avoid socket entering `TIME_WAIT` state,
+        // occupying the address.
+        @async.sleep(50)
       })
       // client
       root.spawn_bg(fn() {
         let conn = @socket.TCP::new()
+        defer conn.close()
         conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
         conn.send([1, 2, 3, 4, 5, 6])
         log("first message sent")
         @async.sleep(200)
-        conn.close()
       })
     })
   log(result.to_string())


### PR DESCRIPTION
The latest release of MoonBit introduces `defer` syntax for resource cleanup. This PR utilize the `defer` syntax in the code base and examples, to make resource cleanup more robust and concise