### PR TITLE
fix async cleanup related bug

### DIFF
--- a/src/cancellation_test.mbt
+++ b/src/cancellation_test.mbt
@@ -168,10 +168,10 @@ test "recursive cancel" {
   inspect(
     buf.to_string(),
     content=(
+      #|main task exit
       #|first sleep cancelled with Cancelled
       #|second sleep cancelled with Cancelled
       #|task finished
-      #|main task exit
       #|Ok(())
     ),
   )
@@ -223,7 +223,7 @@ test "error in cancellation" {
     log.to_string(),
     content=(
       #|causing other error in cancellation handler
-      #|Err(Err)
+      #|Ok(())
     ),
   )
 }

--- a/src/cancellation_test.mbt
+++ b/src/cancellation_test.mbt
@@ -223,7 +223,7 @@ test "error in cancellation" {
     log.to_string(),
     content=(
       #|causing other error in cancellation handler
-      #|Ok(())
+      #|Err(Err)
     ),
   )
 }

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -99,10 +99,7 @@ pub async fn sleep(duration : Int) -> Unit raise {
 }
 
 ///|
-pub fn spawn(
-  f : async () -> Unit raise,
-  on_error? : (Error) -> Unit,
-) -> Coroutine {
+pub fn spawn(f : async () -> Unit raise) -> Coroutine {
   scheduler.coro_id += 1
   let coro = {
     state: Running,
@@ -127,9 +124,6 @@ pub fn spawn(
       coro.wake()
     }
     coro.downstream.clear()
-    if coro.state is Fail(err) && on_error is Some(on_error) {
-      on_error(err)
-    }
   })
   scheduler.curr_coro = last_coro
   coro

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -26,6 +26,7 @@ struct Coroutine {
   mut state : State
   mut shielded : Bool
   mut cancelled : Bool
+  mut ready : Bool
   downstream : Set[Coroutine]
 }
 
@@ -41,6 +42,7 @@ pub impl Hash for Coroutine with hash_combine(self, hasher) {
 
 ///|
 pub fn Coroutine::wake(self : Coroutine) -> Unit {
+  self.ready = true
   scheduler.run_later.push_back(self)
 }
 
@@ -55,13 +57,9 @@ pub(all) suberror Cancelled derive(Show)
 ///|
 pub fn Coroutine::cancel(self : Coroutine) -> Unit {
   self.cancelled = true
-  let last_coro = scheduler.curr_coro
-  scheduler.curr_coro = Some(self)
-  while not(self.shielded) && self.state is Suspend(ok_cont=_, err_cont~) {
-    self.state = Running
-    err_cont(Cancelled)
+  if not(self.shielded || self.ready) {
+    self.wake()
   }
-  scheduler.curr_coro = last_coro
 }
 
 ///|
@@ -70,6 +68,7 @@ pub async fn pause() -> Unit raise {
   async_suspend(fn(ok_cont, err_cont) {
     guard coro.state is Running
     coro.state = Suspend(ok_cont~, err_cont~)
+    coro.ready = true
     scheduler.run_later.push_back(coro)
   })
 }
@@ -107,6 +106,7 @@ pub fn spawn(
   scheduler.coro_id += 1
   let coro = {
     state: Running,
+    ready: false,
     shielded: false,
     downstream: Set::new(),
     coro_id: scheduler.coro_id,

--- a/src/internal/coroutine/coroutine.mbti
+++ b/src/internal/coroutine/coroutine.mbti
@@ -18,7 +18,7 @@ fn reschedule() -> Unit
 
 async fn sleep(Int) -> Unit raise
 
-fn spawn(async () -> Unit raise, on_error? : (Error) -> Unit) -> Coroutine
+fn spawn(async () -> Unit raise) -> Coroutine
 
 async fn suspend() -> Unit raise
 

--- a/src/internal/coroutine/scheduler.mbt
+++ b/src/internal/coroutine/scheduler.mbt
@@ -94,11 +94,16 @@ fn Scheduler::flush_timer(scheduler : Scheduler) -> Unit {
 pub fn reschedule() -> Unit {
   scheduler.flush_timer()
   while scheduler.run_later.pop_front() is Some(coro) {
-    guard coro.state is Suspend(ok_cont~, err_cont=_) else {  }
+    coro.ready = false
+    guard coro.state is Suspend(ok_cont~, err_cont~) else {  }
     coro.state = Running
     let last_coro = scheduler.curr_coro
     scheduler.curr_coro = Some(coro)
-    ok_cont(())
+    if coro.cancelled && not(coro.shielded) {
+      err_cont(Cancelled)
+    } else {
+      ok_cont(())
+    }
     scheduler.curr_coro = last_coro
     scheduler.flush_timer()
   }

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -309,3 +309,49 @@ test "cancel while scheduled" {
     ),
   )
 }
+
+///|
+test "error in async cancel" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    root.spawn_bg(fn() {
+      for _ in 0..<3 {
+        @async.sleep(20)
+        log.write_string("tick\n")
+      }
+    })
+    log.write_object(
+      try? @async.with_task_group(fn(group) {
+        group.spawn_bg(no_wait=true, allow_failure=true, fn() {
+          @async.sleep(1000) catch {
+            _ => {
+              log.write_string("performing async cleanup\n")
+              @async.protect_from_cancel(fn() {
+                @async.sleep(20)
+                log.write_string("raising error from async cleanup\n")
+                raise Err
+              })
+            }
+          }
+        })
+        @async.sleep(10)
+        log.write_string("main task of inner group done\n")
+      }),
+    )
+    log.write_string("\ngroup terminates\n")
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|main task of inner group done
+      #|performing async cleanup
+      #|tick
+      #|raising error from async cleanup
+      #|Ok(())
+      #|group terminates
+      #|tick
+      #|tick
+      #|
+    ),
+  )
+}

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -266,3 +266,46 @@ test "protect_from_cancel in cancellation handler" {
     ),
   )
 }
+
+///|
+test "cancel while scheduled" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    root.spawn_bg(fn() {
+      for _ in 0..<2 {
+        @async.sleep(20)
+        log.write_string("tick\n")
+      }
+    })
+    let task1 = root.spawn(allow_failure=true, fn() {
+      // after calling `pause`, current coroutine would be in `run_later`,
+      // and it will receive cancellation in this situation
+      @async.pause() catch {
+        err => {
+          log.write_string("`pause` cancelled with \{err}\n")
+          @async.protect_from_cancel(fn() {
+            // Now, due to `protect_from_cancel`,
+            // we are allowed to suspend inside cancellation handler.
+            // However, since current coroutine is still in `run_later`,
+            // the scheduler will wakeup current coroutine immediately,
+            // before the timer expires.
+            @async.sleep(30)
+            log.write_string("async cleanup finished\n")
+          })
+          raise err
+        }
+      }
+    })
+    root.spawn_bg(fn() { task1.cancel() })
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|`pause` cancelled with Cancelled
+      #|tick
+      #|async cleanup finished
+      #|tick
+      #|
+    ),
+  )
+}

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -32,9 +32,8 @@ priv enum TaskGroupState {
 /// The type parameter `X` in `TaskGroup[X]` is the result type of the group,
 /// see `with_task_group` for more detail.
 struct TaskGroup[X] {
-  children : Array[@coroutine.Coroutine]
+  children : Set[@coroutine.Coroutine]
   parent : @coroutine.Coroutine
-  mut unfinished : Int
   mut waiting : Int
   mut state : TaskGroupState
   mut result : X?
@@ -53,51 +52,46 @@ fn[X] TaskGroup::spawn_coroutine(
   if not(self.state is Running) {
     raise AlreadyTerminated
   }
-  self.unfinished += 1
   if not(no_wait) {
     self.waiting += 1
   }
-  fn on_completion() {
-    self.unfinished -= 1
-    if not(no_wait) {
-      self.waiting -= 1
-      if self.waiting == 0 && self.state is Running {
-        for child in self.children {
-          if child != @coroutine.current_coroutine() {
-            child.cancel()
-          }
-        }
-        self.state = Done
-      }
-    }
-    if self.unfinished == 0 {
-      self.parent.wake()
-    }
-  }
-
-  fn on_error(err) {
-    if not(allow_failure) {
-      if self.state is Running {
-        for child in self.children {
-          if child != @coroutine.current_coroutine() {
-            child.cancel()
-          }
-        }
-        self.state = Fail(err)
-      } else if not(err is @coroutine.Cancelled) {
-        self.state = Fail(err)
-      }
-    }
-    on_completion()
-  }
-
   async fn worker() raise {
-    f()
-    on_completion()
+    let coro = @coroutine.current_coroutine()
+    defer {
+      if not(no_wait) {
+        self.waiting -= 1
+        if self.waiting == 0 && self.state is Running {
+          for child in self.children {
+            child.cancel()
+          }
+          self.state = Done
+        }
+      }
+      if self.children.is_empty() {
+        self.parent.wake()
+      }
+    }
+    try {
+      defer self.children.remove(coro)
+      f()
+    } catch {
+      err if allow_failure => raise err
+      err => {
+        if self.state is Running {
+          for child in self.children {
+            child.cancel()
+          }
+          self.state = Fail(err)
+        } else if not(err is @coroutine.Cancelled) {
+          self.state = Fail(err)
+        }
+        raise err
+      }
+    }
   }
 
-  let coro = @coroutine.spawn(worker, on_error~)
-  self.children.push(coro)
+  let coro = @coroutine.spawn(worker)
+  self.children.add(coro)
   coro
 }
 
@@ -167,9 +161,8 @@ pub fn[G, X] TaskGroup::spawn(
 /// `with_task_group` will return the result of `f`.
 pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X raise) -> X raise {
   let tg = {
-    children: [],
+    children: Set::new(),
     parent: @coroutine.current_coroutine(),
-    unfinished: 0,
     waiting: 0,
     state: Running,
     result: None,
@@ -180,7 +173,7 @@ pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X raise) -> X raise 
       tg.result = Some(value)
     }
   })
-  if tg.unfinished > 0 {
+  if not(tg.children.is_empty()) {
     @coroutine.suspend() catch {
       err =>
         if tg.state is Running {
@@ -191,7 +184,7 @@ pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X raise) -> X raise 
         }
     }
   }
-  if tg.unfinished > 0 {
+  if not(tg.children.is_empty()) {
     protect_from_cancel(@coroutine.suspend) catch {
       _ => ()
     }

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -35,22 +35,9 @@ struct TaskGroup[X] {
   children : Array[@coroutine.Coroutine]
   parent : @coroutine.Coroutine
   mut unfinished : Int
+  mut waiting : Int
   mut state : TaskGroupState
   mut result : X?
-}
-
-///|
-fn[X] TaskGroup::cancel(self : TaskGroup[X], err : Error) -> Unit {
-  let old_state = self.state
-  match old_state {
-    Done(_) | Fail(_) if err is @coroutine.Cancelled => ()
-    _ => self.state = Fail(err)
-  }
-  if old_state is Running {
-    for child in self.children {
-      child.cancel()
-    }
-  }
 }
 
 ///|
@@ -66,21 +53,40 @@ fn[X] TaskGroup::spawn_coroutine(
   if not(self.state is Running) {
     raise AlreadyTerminated
   }
+  self.unfinished += 1
   if not(no_wait) {
-    self.unfinished += 1
+    self.waiting += 1
   }
   fn on_completion() {
+    self.unfinished -= 1
     if not(no_wait) {
-      self.unfinished -= 1
-      if self.unfinished == 0 {
-        self.parent.wake()
+      self.waiting -= 1
+      if self.waiting == 0 && self.state is Running {
+        for child in self.children {
+          if child != @coroutine.current_coroutine() {
+            child.cancel()
+          }
+        }
+        self.state = Done
       }
+    }
+    if self.unfinished == 0 {
+      self.parent.wake()
     }
   }
 
   fn on_error(err) {
     if not(allow_failure) {
-      self.cancel(err)
+      if self.state is Running {
+        for child in self.children {
+          if child != @coroutine.current_coroutine() {
+            child.cancel()
+          }
+        }
+        self.state = Fail(err)
+      } else if not(err is @coroutine.Cancelled) {
+        self.state = Fail(err)
+      }
     }
     on_completion()
   }
@@ -164,6 +170,7 @@ pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X raise) -> X raise 
     children: [],
     parent: @coroutine.current_coroutine(),
     unfinished: 0,
+    waiting: 0,
     state: Running,
     result: None,
   }
@@ -175,13 +182,18 @@ pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X raise) -> X raise 
   })
   if tg.unfinished > 0 {
     @coroutine.suspend() catch {
-      err => tg.cancel(err)
+      err =>
+        if tg.state is Running {
+          tg.state = Fail(err)
+          for child in tg.children {
+            child.cancel()
+          }
+        }
     }
   }
-  if tg.state is Running {
-    tg.state = Done
-    for child in tg.children {
-      child.cancel()
+  if tg.unfinished > 0 {
+    protect_from_cancel(@coroutine.suspend) catch {
+      _ => ()
     }
   }
   tg.children.clear()


### PR DESCRIPTION
`protect_from_cancel` can be used to perform asynchronous cleanup. However there are some bug related to this in the coroutine system:

- if a task is already in the `run_later` queue when being cancelled, and the task performs async cleanup, it will be mistakenly waken through the entry in `run_later`
- `with_task_group` does not wait for async cleanup

This PR fixes these two bugs, and perform some refactor on the code base. The major change is:

- execution of cancellation handler is now not immediate. Instead, cancelled task will be scheduled for run just like normal tasks in the queue
- a new flag `ready` is added to coroutines, indicating whether they are already in the `run_later` queue. On cancellation, already `ready` coroutine will not be scheduled, the current entry in `run_later` will be reused to perform cancellation, fixing the first bug
- `with_task_group` will now wait for all cancelled children to complete, even if they perform async cleanup
- use `Set` to store children of task group, and remove completed children. This saves space and can skip already completed children on cancellation