### PR TITLE
add group-scoped `defer` block

### DIFF
--- a/src/async.mbti
+++ b/src/async.mbti
@@ -30,6 +30,7 @@ fn[X] Task::cancel(Self[X]) -> Unit
 async fn[X] Task::wait(Self[X]) -> X raise
 
 type TaskGroup[X]
+fn[X] TaskGroup::add_defer(Self[X], async () -> Unit raise) -> Unit raise
 fn[X] TaskGroup::return_immediately(Self[X], X) -> Unit raise
 fn[G, X] TaskGroup::spawn(Self[G], async () -> X raise, no_wait~ : Bool = .., allow_failure~ : Bool = ..) -> Task[X] raise
 fn[X] TaskGroup::spawn_bg(Self[X], async () -> Unit raise, no_wait~ : Bool = .., allow_failure~ : Bool = ..) -> Unit raise

--- a/src/group_defer_test.mbt
+++ b/src/group_defer_test.mbt
@@ -1,0 +1,145 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "group defer basic" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    root.add_defer(() => log.write_string("first group defer\n"))
+    root.spawn_bg(fn() {
+      defer log.write_string("defer for first task\n")
+      @async.sleep(20)
+      root.add_defer(() => log.write_string("third group defer\n"))
+      @async.sleep(20)
+      log.write_string("first task finished\n")
+    })
+    root.spawn_bg(fn() {
+      defer log.write_string("defer for second task\n")
+      @async.sleep(10)
+      root.add_defer(() => log.write_string("second group defer\n"))
+      @async.sleep(20)
+      log.write_string("second task finished\n")
+    })
+    root.spawn_bg(no_wait=true, fn() {
+      defer log.write_string("defer for cancelled task\n")
+      @async.sleep(1000)
+    })
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|second task finished
+      #|defer for second task
+      #|first task finished
+      #|defer for first task
+      #|defer for cancelled task
+      #|third group defer
+      #|second group defer
+      #|first group defer
+      #|
+    ),
+  )
+}
+
+///|
+test "group defer error" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.add_defer(() => log.write_string("first group defer\n"))
+      root.spawn_bg(fn() {
+        defer log.write_string("defer for first task\n")
+        @async.sleep(20)
+        root.add_defer(() => log.write_string("third group defer\n"))
+        @async.sleep(20)
+        log.write_string("first task finished\n")
+      })
+      root.spawn_bg(fn() {
+        defer log.write_string("defer for second task\n")
+        @async.sleep(10)
+        root.add_defer(() => log.write_string("second group defer\n"))
+        @async.sleep(20)
+        log.write_string("second task raise error\n")
+        raise Err
+      })
+      root.spawn_bg(no_wait=true, fn() {
+        defer log.write_string("defer for cancelled task\n")
+        @async.sleep(1000)
+      })
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|second task raise error
+      #|defer for second task
+      #|defer for first task
+      #|defer for cancelled task
+      #|third group defer
+      #|second group defer
+      #|first group defer
+      #|Err(Err)
+    ),
+  )
+}
+
+///|
+test "group defer cancelled" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    root.spawn_bg(fn() {
+      for _ in 0..<4 {
+        @async.sleep(50)
+        log.write_string("tick\n")
+      }
+    })
+    @async.with_timeout(125, fn() {
+      @async.with_task_group(fn(group) {
+        group.add_defer(fn() {
+          @async.protect_from_cancel(fn() {
+            @async.sleep(50)
+            log.write_string("protected async defer completed\n")
+          })
+        })
+        group.add_defer(fn() {
+          try @async.sleep(50) catch {
+            err => {
+              log.write_string("normal async defer cancelled with \{err}\n")
+              raise err
+            }
+          } noraise {
+            _ => log.write_string("normal async defer completed\n")
+          }
+        })
+        defer log.write_string("start group termination\n")
+        @async.sleep(1000)
+      })
+    })
+    log.write_string("group terminated\n")
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|tick
+      #|tick
+      #|start group termination
+      #|normal async defer cancelled with Cancelled
+      #|tick
+      #|protected async defer completed
+      #|group terminated
+      #|tick
+      #|
+    ),
+  )
+}

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -37,6 +37,7 @@ struct TaskGroup[X] {
   mut waiting : Int
   mut state : TaskGroupState
   mut result : X?
+  group_defer : Array[async () -> Unit raise]
 }
 
 ///|
@@ -152,6 +153,27 @@ pub fn[G, X] TaskGroup::spawn(
 }
 
 ///|
+/// Attach a defer block, represented as a cleanup function, to a task group.
+/// The clenaup function will be invoked when the group terminates.
+/// Group scoped defer blocks are executed in FILO order, just like normal `defer`.
+/// `with_task_group` will only exit after all group defer blocks terminate.
+///
+/// Note that if the whole task group is cancelled,
+/// async operations in group defer block will be cancelled immediately too.
+/// Users can use `protect_from_cancel` to prevent async tasks from being cancelled.
+/// It is highly recommended to add a hard timeout to async defer block in this case,
+/// to avoid infinite hanging due to blocked operation.
+pub fn[X] TaskGroup::add_defer(
+  self : TaskGroup[X],
+  block : async () -> Unit raise,
+) -> Unit raise {
+  if not(self.state is Running) {
+    raise AlreadyTerminated
+  }
+  self.group_defer.push(block)
+}
+
+///|
 /// `with_task_group(f)` creates a new task group and run `f` with the new group.
 /// `f` itself will be run in a child task of the new group.
 /// `with_task_group` exits after all the whole group terminates,
@@ -166,6 +188,7 @@ pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X raise) -> X raise 
     waiting: 0,
     state: Running,
     result: None,
+    group_defer: [],
   }
   tg.spawn_bg(fn() {
     let value = f(tg)
@@ -190,6 +213,11 @@ pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X raise) -> X raise 
     }
   }
   tg.children.clear()
+  while tg.group_defer.pop() is Some(defer_block) {
+    defer_block() catch {
+      err => if tg.state is Done { tg.state = Fail(err) }
+    }
+  }
   match tg.state {
     Done => tg.result.unwrap()
     Fail(err) => raise err


### PR DESCRIPTION
This PR introduces group scoped `defer` block. These `defer` block will be executed after the whole group terminates.

Group scoped `defer` are executed sequentially in FILO order, just like normal `defer`. The group will wait for all group-scoped `defer` to complete before exit.