### PR TITLE
add fd util & set `CLOEXEC`

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -105,7 +105,7 @@ fn EventLoop::run_forever(self : Self) -> Unit raise {
     self.poll.remove(fd, events=task.events) catch {
       err => abort("detach \{fd} from loop: \{err}")
     }
-    close_ffi(fd)
+    @fd_util.close(fd)
   }
   self.tasks.clear()
 }
@@ -194,11 +194,10 @@ pub fn close_fd(fd : Int) -> Unit {
       err => abort("detach \{fd} from loop: \{err}")
     }
   }
-  close_ffi(fd)
+  @fd_util.close(fd) catch {
+    _ => ()
+  }
 }
-
-///|
-extern "C" fn close_ffi(fd : Int) = "close"
 
 ///|
 pub async fn perform_job(job : @thread_pool.Job) -> Int raise {

--- a/src/internal/event_loop/moon.pkg.json
+++ b/src/internal/event_loop/moon.pkg.json
@@ -3,6 +3,7 @@
     "moonbitlang/async/os_error",
     "moonbitlang/async/internal/coroutine",
     "moonbitlang/async/internal/thread_pool",
+    "moonbitlang/async/internal/fd_util",
     "moonbitlang/async/internal/time"
   ],
   "native-stub": [ "poll.c" ]

--- a/src/internal/fd_util/fd_util.mbt
+++ b/src/internal/fd_util/fd_util.mbt
@@ -1,0 +1,69 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+extern "C" fn set_blocking_ffi(fd : Int) -> Int = "moonbitlang_async_set_blocking"
+
+///|
+pub fn set_blocking(fd : Int) -> Unit raise {
+  if set_blocking_ffi(fd) < 0 {
+    @os_error.check_errno()
+  }
+}
+
+///|
+extern "C" fn set_nonblocking_ffi(fd : Int) -> Int = "moonbitlang_async_set_nonblocking"
+
+///|
+pub fn set_nonblocking(fd : Int) -> Unit raise {
+  if set_nonblocking_ffi(fd) < 0 {
+    @os_error.check_errno()
+  }
+}
+
+///|
+extern "C" fn set_cloexec_ffi(fd : Int) -> Int = "moonbitlang_async_set_cloexec"
+
+///|
+pub fn set_cloexec(fd : Int) -> Unit raise {
+  if set_cloexec_ffi(fd) < 0 {
+    @os_error.check_errno()
+  }
+}
+
+///|
+#borrow(fds)
+extern "C" fn pipe_ffi(fds : FixedArray[Int]) -> Int = "moonbitlang_async_pipe"
+
+///|
+pub fn pipe() -> (Int, Int) raise {
+  let fds : FixedArray[Int] = [0, 0]
+  if 0 != pipe_ffi(fds) {
+    @os_error.check_errno()
+  }
+  guard fds is [r, w]
+  set_cloexec(r)
+  set_cloexec(w)
+  (r, w)
+}
+
+///|
+extern "C" fn close_ffi(fd : Int) -> Int = "close"
+
+///|
+pub fn close(fd : Int) -> Unit raise {
+  if close_ffi(fd) < 0 {
+    @os_error.check_errno()
+  }
+}

--- a/src/internal/fd_util/fd_util.mbti
+++ b/src/internal/fd_util/fd_util.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/async/internal/fd_util"
+
+// Values
+fn close(Int) -> Unit raise
+
+fn pipe() -> (Int, Int) raise
+
+fn set_blocking(Int) -> Unit raise
+
+fn set_cloexec(Int) -> Unit raise
+
+fn set_nonblocking(Int) -> Unit raise
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/internal/fd_util/moon.pkg.json
+++ b/src/internal/fd_util/moon.pkg.json
@@ -1,0 +1,4 @@
+{
+  "import": [ "moonbitlang/async/os_error" ],
+  "native-stub": [ "stub.c" ]
+}

--- a/src/internal/fd_util/stub.c
+++ b/src/internal/fd_util/stub.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unistd.h>
+#include <fcntl.h>
+
+int moonbitlang_async_set_blocking(int fd) {
+  int flags = fcntl(fd, F_GETFL);
+  if (flags < 0) return flags;
+
+  if (flags & O_NONBLOCK) {
+    if (fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) < 0)
+      return -1;
+  }
+
+  return 0;
+}
+
+int moonbitlang_async_set_nonblocking(int fd) {
+  int flags = fcntl(fd, F_GETFL);
+  if (flags < 0) return flags;
+
+  if (!(flags & O_NONBLOCK)) {
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0)
+      return -1;
+  }
+
+  return 0;
+}
+
+int moonbitlang_async_set_cloexec(int fd) {
+  int flags = fcntl(fd, F_GETFD);
+  if (flags < 0) return flags;
+
+  if (!(flags & FD_CLOEXEC)) {
+    if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) < 0)
+      return -1;
+  }
+
+  return 0;
+}
+
+int moonbitlang_async_pipe(int *fds) {
+  if (pipe(fds) < 0)
+    return -1;
+
+  for (int i = 0; i < 2; ++i) {
+    if (moonbitlang_async_set_cloexec(fds[i]) < 0)
+      return -1;
+  }
+
+  return 0;
+}

--- a/src/internal/thread_pool/moon.pkg.json
+++ b/src/internal/thread_pool/moon.pkg.json
@@ -1,4 +1,7 @@
 {
-  "import": [ "moonbitlang/async/os_error" ],
+  "import": [
+    "moonbitlang/async/os_error",
+    "moonbitlang/async/internal/fd_util"
+  ],
   "native-stub": [ "thread_pool.c" ]
 }

--- a/src/internal/thread_pool/thread_pool.mbt
+++ b/src/internal/thread_pool/thread_pool.mbt
@@ -13,15 +13,25 @@
 // limitations under the License.
 
 ///|
-extern "C" fn init_thread_pool_ffi() -> Int = "moonbitlang_async_init_thread_pool"
+extern "C" fn init_thread_pool_ffi(notify_recv : Int, notify_send : Int) -> Int = "moonbitlang_async_init_thread_pool"
 
 ///|
 pub fn init_thread_pool() -> Int raise {
-  let completion_fd = init_thread_pool_ffi()
-  if completion_fd < 0 {
+  let (notify_recv, notify_send) = @fd_util.pipe()
+  try {
+    @fd_util.set_nonblocking(notify_recv)
+    @fd_util.set_blocking(notify_send)
+  } catch {
+    err => {
+      @fd_util.close(notify_recv)
+      @fd_util.close(notify_send)
+      raise err
+    }
+  }
+  if init_thread_pool_ffi(notify_recv, notify_send) < 0 {
     @os_error.check_errno()
   }
-  completion_fd
+  notify_recv
 }
 
 ///|

--- a/src/pipe/ffi.mbt
+++ b/src/pipe/ffi.mbt
@@ -13,16 +13,7 @@
 // limitations under the License.
 
 ///|
-extern "C" fn pipe_ffi(out : FixedArray[Int]) -> Int = "moonbitlang_async_pipe"
-
-///|
 extern "C" fn get_blocking(fd : Int) -> Int = "moonbitlang_async_get_blocking"
-
-///|
-extern "C" fn set_nonblock(fd : Int) -> Int = "moonbitlang_async_set_nonblock"
-
-///|
-extern "C" fn set_blocking(fd : Int) -> Int = "moonbitlang_async_set_blocking"
 
 ///|
 extern "C" fn read_ffi(

--- a/src/pipe/moon.pkg.json
+++ b/src/pipe/moon.pkg.json
@@ -2,6 +2,7 @@
   "import": [
     "moonbitlang/async/os_error",
     "moonbitlang/async/internal/event_loop",
+    "moonbitlang/async/internal/fd_util",
     "moonbitlang/async"
   ],
   "native-stub": [ "stub.c" ]

--- a/src/pipe/pipe.mbt
+++ b/src/pipe/pipe.mbt
@@ -36,17 +36,9 @@ pub fn PipeWrite::fd(self : PipeWrite) -> Int {
 /// Create a pipe using `pipe(2)` system call.
 /// Return the read end and write end of the pipe.
 pub fn pipe() -> (PipeRead, PipeWrite) raise {
-  let fds : FixedArray[Int] = [0, 0]
-  if 0 != pipe_ffi(fds) {
-    @os_error.check_errno()
-  }
-  guard fds is [r, w]
-  if set_nonblock(r) < 0 {
-    @os_error.check_errno()
-  }
-  if set_nonblock(w) < 0 {
-    @os_error.check_errno()
-  }
+  let (r, w) = @fd_util.pipe()
+  @fd_util.set_nonblocking(r)
+  @fd_util.set_nonblocking(w)
   (PipeRead(r), PipeWrite(w))
 }
 
@@ -61,7 +53,9 @@ let stdio_need_reset : Array[Int] = []
 pub let stdin : PipeRead = {
   if get_blocking(0) > 0 {
     stdio_need_reset.push(0)
-    ignore(set_nonblock(0))
+    @fd_util.set_nonblocking(0) catch {
+      _ => ()
+    }
   }
   PipeRead(0)
 }
@@ -74,7 +68,9 @@ pub let stdin : PipeRead = {
 pub let stdout : PipeWrite = {
   if get_blocking(1) > 0 {
     stdio_need_reset.push(1)
-    ignore(set_nonblock(1))
+    @fd_util.set_nonblocking(1) catch {
+      _ => ()
+    }
   }
   PipeWrite(1)
 }
@@ -87,7 +83,9 @@ pub let stdout : PipeWrite = {
 pub let stderr : PipeWrite = {
   if get_blocking(2) > 0 {
     stdio_need_reset.push(2)
-    ignore(set_nonblock(2))
+    @fd_util.set_nonblocking(2) catch {
+      _ => ()
+    }
   }
   PipeWrite(2)
 }
@@ -98,7 +96,9 @@ pub let stderr : PipeWrite = {
 /// If stdio is already in non-blocking mode, this function does nothing.
 pub fn reset_stdio() -> Unit {
   for fd in stdio_need_reset {
-    ignore(set_blocking(fd))
+    @fd_util.set_blocking(fd) catch {
+      _ => ()
+    }
   }
 }
 

--- a/src/pipe/stub.c
+++ b/src/pipe/stub.c
@@ -17,58 +17,12 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-int moonbitlang_async_pipe(int *fds) {
-  if (pipe(fds) < 0)
-    return -1;
-
-  int flags = fcntl(fds[0], F_GETFD);
-  if (flags < 0) return flags;
-
-  if (!(flags & FD_CLOEXEC)) {
-    if (fcntl(fds[0], F_SETFD, flags | FD_CLOEXEC) < 0)
-      return -1;
-  }
-
-  flags = fcntl(fds[1], F_GETFD);
-  if (flags < 0) return flags;
-
-  if (!(flags & FD_CLOEXEC)) {
-    if (fcntl(fds[1], F_SETFD, flags | FD_CLOEXEC) < 0)
-      return -1;
-  }
-
-  return 0;
-}
-
 int moonbitlang_async_get_blocking(int fd) {
   int flags = fcntl(fd, F_GETFL);
   if (flags < 0)
     return flags;
 
   return (flags & O_NONBLOCK) > 0;
-}
-
-int moonbitlang_async_set_nonblock(int fd) {
-  int flags = fcntl(fd, F_GETFL);
-  if (flags < 0)
-    return flags;
-
-  if (flags & O_NONBLOCK)
-    return 0;
-
-  return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-}
-
-int moonbitlang_async_set_blocking(int fd) {
-  int flags = fcntl(fd, F_GETFL);
-  if (flags < 0)
-    return flags;
-
-  if (flags & O_NONBLOCK) {
-    return fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
-  }
-
-  return 0;
 }
 
 int moonbitlang_async_read(int fd, void *buf, int offset, int max_len) {

--- a/src/socket/moon.pkg.json
+++ b/src/socket/moon.pkg.json
@@ -2,6 +2,7 @@
   "import": [
     "moonbitlang/async/os_error",
     "moonbitlang/async/internal/event_loop",
+    "moonbitlang/async/internal/fd_util",
     "moonbitlang/async"
   ],
   "native-stub": [ "socket.c" ]

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -23,35 +23,11 @@
 #include <moonbit.h>
 
 int moonbitlang_async_make_tcp_socket() {
-  int sock = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
-  if (sock > 0) {
-    int flags = fcntl(sock, F_GETFL);
-    if (flags < 0)
-      return flags;
-
-    if (!(flags & O_NONBLOCK)) {
-      int status = fcntl(sock, F_SETFL, flags | O_NONBLOCK);
-      if (status < 0)
-        return status;
-    }
-  }
-  return sock;
+  return socket(AF_INET, SOCK_STREAM, 0);
 }
 
 int moonbitlang_async_make_udp_socket() {
-  int sock = socket(AF_INET, SOCK_DGRAM, 0);
-  if (sock > 0) {
-    int flags = fcntl(sock, F_GETFL);
-    if (flags < 0)
-      return flags;
-
-    if (!(flags & O_NONBLOCK)) {
-      int status = fcntl(sock, F_SETFL, flags | O_NONBLOCK);
-      if (status < 0)
-        return status;
-    }
-  }
-  return sock;
+  return socket(AF_INET, SOCK_DGRAM, 0);
 }
 
 int moonbitlang_async_bind(int sockfd, struct sockaddr_in *addr) {

--- a/src/socket/socket.mbti
+++ b/src/socket/socket.mbti
@@ -24,7 +24,7 @@ fn TCP::close(Self) -> Unit
 async fn TCP::connect(Self, Addr) -> Unit raise
 fn TCP::enable_keepalive(Self, idle_before_keep_alive~ : Int = .., keep_alive_count~ : Int = .., keep_alive_interval~ : Int = ..) -> Unit raise
 fn TCP::listen(Self) -> Unit raise
-fn TCP::new() -> Self
+fn TCP::new() -> Self raise
 async fn TCP::recv(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> Int raise
 async fn TCP::recv_exactly(Self, Int) -> Bytes raise
 async fn TCP::send(Self, Bytes, offset~ : Int = .., len? : Int) -> Unit raise
@@ -33,7 +33,7 @@ type UDP
 fn UDP::bind(Self, Addr) -> Unit raise
 fn UDP::close(Self) -> Unit
 fn UDP::connect(Self, Addr) -> Unit raise
-fn UDP::new() -> Self
+fn UDP::new() -> Self raise
 async fn UDP::recv(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> Int raise
 async fn UDP::recvfrom(Self, FixedArray[Byte], offset~ : Int = .., max_len? : Int) -> (Int, Addr) raise
 async fn UDP::send(Self, Bytes, offset~ : Int = .., len? : Int) -> Unit raise

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -19,8 +19,14 @@ type TCP Int
 ///|
 /// Create a new TCP socket using the `socket(2)` system call.
 /// The created socket always operate in non-blocking mode.
-pub fn TCP::new() -> TCP {
-  make_tcp_socket()
+pub fn TCP::new() -> TCP raise {
+  let sock = make_tcp_socket()
+  if sock < 0 {
+    @os_error.check_errno()
+  }
+  @fd_util.set_cloexec(sock)
+  @fd_util.set_nonblocking(sock)
+  TCP(sock)
 }
 
 ///|

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -19,8 +19,14 @@ type UDP Int
 ///|
 /// Create a new UDP socket using the `socket(2)` system call.
 /// The created socket always operate in non-blocking mode.
-pub fn UDP::new() -> UDP {
-  make_udp_socket()
+pub fn UDP::new() -> UDP raise {
+  let sock = make_udp_socket()
+  if sock < 0 {
+    @os_error.check_errno()
+  }
+  @fd_util.set_cloexec(sock)
+  @fd_util.set_nonblocking(sock)
+  UDP(sock)
 }
 
 ///|


### PR DESCRIPTION
- refactor: add a `@fd_util` package holding common utilities on file descriptors, and utilize to reduce duplicated code
- set `CLOEXEC` for everything we manage, in preparation of process manipulation
- [breaking] forgot to handle error in socket creation. Now `@socket.TCP::new` and `@socket.UDP::new` may raise