### PR TITLE
refactor process API, integrate with native task system & cancellation

### DIFF
--- a/src/process/basic_test.mbt
+++ b/src/process/basic_test.mbt
@@ -25,13 +25,15 @@ fn ascii_to_string(ascii : @bytes.View) -> String {
 ///|
 test "basic_ls" {
   let log = StringBuilder::new()
-  @async.with_event_loop(fn(_) {
+  @async.with_event_loop(fn(root) {
     let (r, w) = @pipe.pipe()
     defer r.close()
-    @process.spawn(b"ls\x00", [b"src\x00"], stdout=w, extra_env={
-      b"LANG": b"C",
+    root.spawn_bg(fn() {
+      @process.run(b"ls\x00", [b"src\x00"], stdout=w, extra_env={
+        b"LANG": b"C",
+      })
+      |> ignore
     })
-    |> ignore
     let buf = FixedArray::make(1024, b'0')
     while r.read(buf) is n && n > 0 {
       let data = buf.unsafe_reinterpret_as_bytes()[0:n]
@@ -79,8 +81,10 @@ test "basic_cat" {
   @async.with_event_loop(fn(root) {
     let (cat_read, we_write) = @pipe.pipe()
     let (we_read, cat_write) = @pipe.pipe()
-    @process.spawn(b"cat\x00", [b"-"], stdin=cat_read, stdout=cat_write)
-    |> ignore
+    root.spawn_bg(fn() {
+      @process.run(b"cat\x00", [b"-"], stdin=cat_read, stdout=cat_write)
+      |> ignore
+    })
     root.spawn_bg(fn() {
       defer we_write.close()
       we_write.write(b"abcd\n")

--- a/src/process/cancel_test.mbt
+++ b/src/process/cancel_test.mbt
@@ -1,0 +1,91 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "cancel process" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    let (r, w) = @pipe.pipe()
+    let task = root.spawn(allow_failure=true, fn() {
+      defer log.write_string("process terminates\n")
+      @process.run(
+        b"sh\x00",
+        [b"-c\x00", b"echo first; sleep 10; echo second\x00"],
+        stdout=w,
+      )
+    })
+    root.spawn_bg(fn() {
+      defer r.close()
+      let buf = FixedArray::make(1024, b'0')
+      while r.read(buf) is n && n > 0 {
+        let data = buf.unsafe_reinterpret_as_bytes()[0:n] |> ascii_to_string
+        log.write_string("from process: \{data}\n")
+      }
+    })
+    @async.sleep(50)
+    task.cancel()
+    log.write_string("cancelling task running process\n")
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|from process: first
+      #|
+      #|cancelling task running process
+      #|process terminates
+      #|
+    ),
+  )
+}
+
+///|
+test "orphan process" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    let (r, w) = @pipe.pipe()
+    let task = root.spawn(allow_failure=true, fn() {
+      defer log.write_string("process terminates\n")
+      @process.run(
+        b"sh\x00",
+        [b"-c\x00", b"echo first; sleep 1; echo second\x00"],
+        stdout=w,
+        orphan=true,
+      )
+    })
+    root.spawn_bg(fn() {
+      defer r.close()
+      let buf = FixedArray::make(1024, b'0')
+      while r.read(buf) is n && n > 0 {
+        let data = buf.unsafe_reinterpret_as_bytes()[0:n] |> ascii_to_string
+        log.write_string("from process: \{data}\n")
+      }
+    })
+    @async.sleep(50)
+    task.cancel()
+    log.write_string("cancelling task running process\n")
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|from process: first
+      #|
+      #|cancelling task running process
+      #|process terminates
+      #|from process: second
+      #|
+      #|
+    ),
+  )
+}

--- a/src/process/env_test.mbt
+++ b/src/process/env_test.mbt
@@ -16,13 +16,15 @@
 ///|
 test "set_env" {
   let log = StringBuilder::new()
-  @async.with_event_loop(fn(_) {
+  @async.with_event_loop(fn(root) {
     let (r, w) = @pipe.pipe()
     defer r.close()
-    @process.spawn(b"sh\x00", [b"-c\x00", b"echo $MAGIC_VAR\x00"], stdout=w, extra_env={
-      b"MAGIC_VAR": b"MAGIC_VALUE",
+    root.spawn_bg(fn() {
+      @process.run(b"sh\x00", [b"-c\x00", b"echo $MAGIC_VAR\x00"], stdout=w, extra_env={
+        b"MAGIC_VAR": b"MAGIC_VALUE",
+      })
+      |> ignore
     })
-    |> ignore
     let buf = FixedArray::make(1024, b'0')
     while r.read(buf) is n && n > 0 {
       let data = buf.unsafe_reinterpret_as_bytes()[0:n]
@@ -41,22 +43,24 @@ test "set_env" {
 ///|
 test "set_env no inherit" {
   let log = StringBuilder::new()
-  @async.with_event_loop(fn(_) {
+  @async.with_event_loop(fn(root) {
     let (r, w) = @pipe.pipe()
     defer r.close()
-    @process.spawn(
-      b"env\x00",
-      [],
-      stdout=w,
-      extra_env={
-        b"MAGIC_VAR_1": b"MAGIC_VALUE_1",
-        b"MAGIC_VAR_2": b"MAGIC_VALUE_2",
-        b"MAGIC_VAR_3": b"MAGIC_VALUE_3",
-        b"MAGIC_VAR_4": b"MAGIC_VALUE_4",
-      },
-      inherit_env=false,
-    )
-    |> ignore
+    root.spawn_bg(fn() {
+      @process.run(
+        b"env\x00",
+        [],
+        stdout=w,
+        extra_env={
+          b"MAGIC_VAR_1": b"MAGIC_VALUE_1",
+          b"MAGIC_VAR_2": b"MAGIC_VALUE_2",
+          b"MAGIC_VAR_3": b"MAGIC_VALUE_3",
+          b"MAGIC_VAR_4": b"MAGIC_VALUE_4",
+        },
+        inherit_env=false,
+      )
+      |> ignore
+    })
     let buf = FixedArray::make(1024, b'0')
     while r.read(buf) is n && n > 0 {
       let data = buf.unsafe_reinterpret_as_bytes()[0:n]

--- a/src/process/moon.pkg.json
+++ b/src/process/moon.pkg.json
@@ -2,6 +2,7 @@
   "import": [
     "moonbitlang/async/internal/event_loop",
     "moonbitlang/async/internal/thread_pool",
+    "moonbitlang/async/internal/coroutine",
     "moonbitlang/async/internal/fd_util",
     "moonbitlang/async/pipe"
   ],

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -13,21 +13,25 @@
 // limitations under the License.
 
 ///|
-struct Process {
-  pid : Int
-  mut exit_status : Int?
-}
-
-///|
 extern "C" fn get_curr_env() -> FixedArray[Bytes?] = "moonbitlang_async_get_curr_env"
 
 ///|
 let curr_env : FixedArray[Bytes?] = get_curr_env()
 
 ///|
-/// Spawn a new system process with command `cmd`,
+extern "C" fn terminate_process(pid : Int) = "moonbitlang_async_terminate_process"
+
+///|
+/// Execute a system process with command `cmd`,
 /// and provide `args` as extra arguments to `cmd.
 /// Both `cmd` and elements of `args` must be `'\0'` terminated.
+///
+/// `run` will block until the new process terminates,
+/// and returns the exit status of the process.
+/// If current task is cancelled while blocking,
+/// the spawned process will be terminated via `SIGTERM`,
+/// unless `orphan` is `true` (`false` by default).
+/// To run the process in background, use `@async.spawn` or `@async.spawn_bg`.
 ///
 /// If `inherit_env` is `true` (`true` by default),
 /// the new process will inherit environment variables of current process.
@@ -40,10 +44,7 @@ let curr_env : FixedArray[Bytes?] = get_curr_env()
 /// the corresponding channel of the new process will be redirected to the given pipe.
 /// The ownership of `stdin`, `stdout`, and `stderr` will be transferred to the `spawn`,
 /// current process MUST NOT read/write/close these pipes any more, even if `spawn` fails.
-///
-/// The new process will run in background, while current process can do other tasks.
-/// You can wait for the process using the handle returned by `spawn`.
-pub async fn spawn(
+pub async fn run(
   cmd : Bytes,
   args : Array[Bytes],
   extra_env~ : Map[Bytes, Bytes] = {},
@@ -51,7 +52,8 @@ pub async fn spawn(
   stdin? : @pipe.PipeRead,
   stdout? : @pipe.PipeWrite,
   stderr? : @pipe.PipeWrite,
-) -> Process raise {
+  orphan~ : Bool = false,
+) -> Int raise {
   let argv = FixedArray::make(args.length() + 2, None)
   argv[0] = Some(cmd)
   for i in 0..<args.length() {
@@ -112,17 +114,12 @@ pub async fn spawn(
     }
   }
   let job = @thread_pool.spawn_job(cmd, argv, env, stdin, stdout, stderr)
-  { pid: @event_loop.perform_job(job), exit_status: None }
-}
-
-///|
-/// Wait for a spawned process to terminate.
-/// Returns the exit code of the process.
-pub async fn Process::wait(self : Process) -> Int raise {
-  if self.exit_status is Some(status) {
-    return status
+  let pid = @event_loop.perform_job(job)
+  @event_loop.wait_pid(pid) catch {
+    err if !orphan && @coroutine.is_being_cancelled() => {
+      terminate_process(pid)
+      raise err
+    }
+    err => raise err
   }
-  let status = @event_loop.wait_pid(self.pid)
-  self.exit_status = Some(status)
-  status
 }

--- a/src/process/process.mbti
+++ b/src/process/process.mbti
@@ -6,13 +6,11 @@ import(
 )
 
 // Values
-async fn spawn(Bytes, Array[Bytes], extra_env? : Map[Bytes, Bytes], inherit_env? : Bool, stdin? : @pipe.PipeRead, stdout? : @pipe.PipeWrite, stderr? : @pipe.PipeWrite) -> Process raise
+async fn run(Bytes, Array[Bytes], extra_env? : Map[Bytes, Bytes], inherit_env? : Bool, stdin? : @pipe.PipeRead, stdout? : @pipe.PipeWrite, stderr? : @pipe.PipeWrite, orphan? : Bool) -> Int raise
 
 // Errors
 
 // Types and methods
-type Process
-async fn Process::wait(Self) -> Int raise
 
 // Type aliases
 

--- a/src/process/stub.c
+++ b/src/process/stub.c
@@ -15,7 +15,9 @@
  */
 
 #include <sys/wait.h>
+#include <sys/types.h>
 #include <string.h>
+#include <signal.h>
 #include <moonbit.h>
 
 extern char **environ;
@@ -36,4 +38,8 @@ moonbit_bytes_t *moonbitlang_async_get_curr_env() {
   result[len] = 0;
 
   return result;
+}
+
+void moonbitlang_async_terminate_process(pid_t pid) {
+  kill(pid, SIGTERM);
 }

--- a/src/process/wait_test.mbt
+++ b/src/process/wait_test.mbt
@@ -23,8 +23,8 @@ test "basic wait" {
         log.write_string("\{(i + 1) * 300}ms tick\n")
       }
     })
-    let proc = @process.spawn(b"sh\x00", [b"-c\x00", b"sleep 1\x00"])
-    log.write_string("process completed with \{proc.wait()}\n")
+    let result = @process.run(b"sh\x00", [b"-c\x00", b"sleep 1\x00"])
+    log.write_string("process completed with \{result}\n")
   })
   inspect(
     log.to_string(),
@@ -43,25 +43,8 @@ test "basic wait" {
 test "wait exitcode" {
   let log = StringBuilder::new()
   @async.with_event_loop(fn(_) {
-    let proc = @process.spawn(b"sh\x00", [b"-c\x00", b"exit 42\x00"])
-    log.write_string("process completed with \{proc.wait()}")
+    let result = @process.run(b"sh\x00", [b"-c\x00", b"exit 42\x00"])
+    log.write_string("process completed with \{result}")
   })
   inspect(log.to_string(), content="process completed with 42")
-}
-
-///|
-test "multiple wait" {
-  let log = StringBuilder::new()
-  @async.with_event_loop(fn(_) {
-    let proc = @process.spawn(b"sh\x00", [b"-c\x00", b"exit 42\x00"])
-    log.write_string("process completed with \{proc.wait()}\n")
-    log.write_string("wait again: \{proc.wait()}")
-  })
-  inspect(
-    log.to_string(),
-    content=(
-      #|process completed with 42
-      #|wait again: 42
-    ),
-  )
 }


### PR DESCRIPTION
This PR refactors the API of `@process`. Previously, the API is non-structural. The spawned process is orphan, and may leak if not properly waited. The previous API cannot integrate with structured concurrency as well.

This PR replaces `@process.spawn` with `@process.run`, Compared to `@process.spawn`, `@process.run` will wait until the spawned process completes. And if current task is cancelled, the spawned process will be terminated via `SIGTERM`, making process spawning structural.

Previous behavior can still be recovered partially:

- to run the process in background, just use `spawn` or `spawn_bg`
- to prevent the process from being killed, pass `orphan=true` to `@process.run`