### PR TITLE
no longer need manual zero padding

### DIFF
--- a/src/fs/create_test.mbt
+++ b/src/fs/create_test.mbt
@@ -16,7 +16,7 @@
 test "basic create" {
   let buf = FixedArray::make(4, b'0')
   @async.with_event_loop(fn(_) {
-    let path = b"basic_create_test\x00"
+    let path = b"basic_create_test"
     {
       let w = @fs.create(path, permission=0o644, sync=Full)
       defer w.close()

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -32,7 +32,7 @@ extern "C" fn opendir_ffi(path : Bytes) -> Directory = "opendir"
 extern "C" fn Directory::is_null(dir : Directory) -> Bool = "moonbitlang_async_dir_is_null"
 
 ///|
-/// Open the directory at `path`. `path` should be a `'\0'` terminated byte string.
+/// Open the directory at `path`. `path` must not contain `'\0'`.
 /// If `path` is not a directory, an error will be raised
 pub fn opendir(path : Bytes) -> Directory raise {
   let dir = opendir_ffi(path)

--- a/src/fs/dir_test.mbt
+++ b/src/fs/dir_test.mbt
@@ -25,7 +25,7 @@ fn ascii_to_string(ascii : Bytes) -> String {
 test "read_all" {
   let log = StringBuilder::new()
   @async.with_event_loop(fn(_) {
-    let dir = @fs.opendir("src\x00")
+    let dir = @fs.opendir("src")
     defer dir.close()
     let list = dir.read_all().map(ascii_to_string)
     list.sort()
@@ -43,14 +43,14 @@ test "read_all" {
 test "as_dir" {
   let log = StringBuilder::new()
   @async.with_event_loop(fn(_) {
-    let dir_file = @fs.open("src\x00", mode=ReadOnly)
+    let dir_file = @fs.open("src", mode=ReadOnly)
     defer dir_file.close()
     guard dir_file.kind() is Directory
     let dir = dir_file.as_dir()
     let list = dir.read_all()
     list.sort()
     for file in list {
-      let kind = @fs.open(b"src/" + file + b"\x00", mode=ReadOnly).kind()
+      let kind = @fs.open(b"src/" + file, mode=ReadOnly).kind()
       log.write_string("\{ascii_to_string(file)}: \{kind}\n")
     }
   })

--- a/src/fs/eof_test.mbt
+++ b/src/fs/eof_test.mbt
@@ -16,7 +16,7 @@
 test "read EOF" {
   let buf = FixedArray::make(16, b'0')
   @async.with_event_loop(fn(_) {
-    let path = b"read_eof_test\x00"
+    let path = b"read_eof_test"
     {
       let w = @fs.create(path, permission=0o644, sync=Full)
       defer w.close()

--- a/src/fs/fs.mbt
+++ b/src/fs/fs.mbt
@@ -57,7 +57,7 @@ extern "C" fn make_open_flags(
 ) -> Int = "moonbitlang_async_make_open_flags"
 
 ///|
-/// Open a file. `filename` should be a byte string terminated with `'\0'`.
+/// Open a file. `filename` should be a byte string and must not contain `'\0'`.
 ///
 /// - `mode` determines what operations (read/write) are permitted for the file.
 ///

--- a/src/fs/seek_test.mbt
+++ b/src/fs/seek_test.mbt
@@ -17,7 +17,7 @@ test "basic seek" {
   let log = StringBuilder::new()
   let buf = FixedArray::make(6, b'0')
   @async.with_event_loop(fn(_) {
-    let path = b"basic_seek_test\x00"
+    let path = b"basic_seek_test"
     // initialize
     {
       let w = @fs.create(path, permission=0o644, sync=Full)

--- a/src/process/basic_test.mbt
+++ b/src/process/basic_test.mbt
@@ -29,9 +29,7 @@ test "basic_ls" {
     let (r, w) = @pipe.pipe()
     defer r.close()
     root.spawn_bg(fn() {
-      @process.run(b"ls\x00", [b"src\x00"], stdout=w, extra_env={
-        b"LANG": b"C",
-      })
+      @process.run(b"ls", [b"src"], stdout=w, extra_env={ b"LANG": b"C" })
       |> ignore
     })
     let buf = FixedArray::make(1024, b'0')
@@ -82,8 +80,7 @@ test "basic_cat" {
     let (cat_read, we_write) = @pipe.pipe()
     let (we_read, cat_write) = @pipe.pipe()
     root.spawn_bg(fn() {
-      @process.run(b"cat\x00", [b"-"], stdin=cat_read, stdout=cat_write)
-      |> ignore
+      @process.run(b"cat", [b"-"], stdin=cat_read, stdout=cat_write) |> ignore
     })
     root.spawn_bg(fn() {
       defer we_write.close()

--- a/src/process/cancel_test.mbt
+++ b/src/process/cancel_test.mbt
@@ -21,8 +21,8 @@ test "cancel process" {
     let task = root.spawn(allow_failure=true, fn() {
       defer log.write_string("process terminates\n")
       @process.run(
-        b"sh\x00",
-        [b"-c\x00", b"echo first; sleep 10; echo second\x00"],
+        b"sh",
+        [b"-c", b"echo first; sleep 10; echo second"],
         stdout=w,
       )
     })
@@ -58,8 +58,8 @@ test "orphan process" {
     let task = root.spawn(allow_failure=true, fn() {
       defer log.write_string("process terminates\n")
       @process.run(
-        b"sh\x00",
-        [b"-c\x00", b"echo first; sleep 1; echo second\x00"],
+        b"sh",
+        [b"-c", b"echo first; sleep 1; echo second"],
         stdout=w,
         orphan=true,
       )

--- a/src/process/env_test.mbt
+++ b/src/process/env_test.mbt
@@ -20,7 +20,7 @@ test "set_env" {
     let (r, w) = @pipe.pipe()
     defer r.close()
     root.spawn_bg(fn() {
-      @process.run(b"sh\x00", [b"-c\x00", b"echo $MAGIC_VAR\x00"], stdout=w, extra_env={
+      @process.run(b"sh", [b"-c", b"echo $MAGIC_VAR"], stdout=w, extra_env={
         b"MAGIC_VAR": b"MAGIC_VALUE",
       })
       |> ignore
@@ -48,7 +48,7 @@ test "set_env no inherit" {
     defer r.close()
     root.spawn_bg(fn() {
       @process.run(
-        b"env\x00",
+        b"env",
         [],
         stdout=w,
         extra_env={

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -24,7 +24,7 @@ extern "C" fn terminate_process(pid : Int) = "moonbitlang_async_terminate_proces
 ///|
 /// Execute a system process with command `cmd`,
 /// and provide `args` as extra arguments to `cmd.
-/// Both `cmd` and elements of `args` must be `'\0'` terminated.
+/// Both `cmd` and elements of `args` must not contain `'\0'`.
 ///
 /// `run` will block until the new process terminates,
 /// and returns the exit status of the process.
@@ -38,7 +38,7 @@ extern "C" fn terminate_process(pid : Int) = "moonbitlang_async_terminate_proces
 ///
 /// `extra_env`, if present, will set extra environment variables for the new process
 /// (in addition to those inherited ones, if `inherit_env` is `true`).
-/// Keys and values of `extra_env` MUST NOT contain `'\0'`.
+/// Keys and values of `extra_env` must not contain `'\0'`.
 ///
 /// `stdin`, `stdout` and `stderr`, if set,
 /// the corresponding channel of the new process will be redirected to the given pipe.
@@ -106,7 +106,7 @@ pub async fn run(
       let envp = FixedArray::make(n + curr_env.length(), None)
       let mut i = 0
       for k, v in extra_env {
-        envp[i] = Some(k + b"=" + v + "\x00")
+        envp[i] = Some(k + b"=" + v)
         i = i + 1
       }
       curr_env.blit_to(envp, src_offset=0, dst_offset=i, len=curr_env.length())

--- a/src/process/wait_test.mbt
+++ b/src/process/wait_test.mbt
@@ -23,7 +23,7 @@ test "basic wait" {
         log.write_string("\{(i + 1) * 300}ms tick\n")
       }
     })
-    let result = @process.run(b"sh\x00", [b"-c\x00", b"sleep 1\x00"])
+    let result = @process.run(b"sh", [b"-c", b"sleep 1"])
     log.write_string("process completed with \{result}\n")
   })
   inspect(
@@ -43,7 +43,7 @@ test "basic wait" {
 test "wait exitcode" {
   let log = StringBuilder::new()
   @async.with_event_loop(fn(_) {
-    let result = @process.run(b"sh\x00", [b"-c\x00", b"exit 42\x00"])
+    let result = @process.run(b"sh", [b"-c", b"exit 42"])
     log.write_string("process completed with \{result}")
   })
   inspect(log.to_string(), content="process completed with 42")


### PR DESCRIPTION
with latest compiler release, MoonBit's native backend will now add zero padding for all `Bytes` and `String` value, so there is no need to manually add zero padding when dealing with C FFI. This PR simplifies tests utilizing this feature.