### PR TITLE
enrich `with_timeout` & `retry` API

### DIFF
--- a/src/async.mbt
+++ b/src/async.mbt
@@ -38,17 +38,52 @@ pub fnalias @coroutine.pause
 
 ///|
 /// `with_timeout(timeout, f)` run the async function `f`.
-/// If `f` return or fail before `timeout`,
-/// `with_timeout` return immediately with the same result.
-/// If `f` is still running after `timeout` milliseconds,
-/// `with_timeout` will also return immediately, and `f` will be cancelled.
-pub async fn with_timeout(time : Int, f : async () -> Unit raise) -> Unit raise {
+///
+/// - If `f` return before `timeout`, `with_timeout` will immediately stop.
+///
+/// - If `f` fail before `timeout`, `with_timeout` will also fail immediately.
+///
+/// - If `f` is still running after `timeout` milliseconds, `f` will be cancelled.
+///   In this case, by default, `with_timeout` will return normally.
+///   However, if the optional argument `error` is explicitly set,
+///   `with_timeout` will raise the given error in this case.
+pub async fn with_timeout(
+  time : Int,
+  f : async () -> Unit raise,
+  error? : Error,
+) -> Unit raise {
   with_task_group(fn(group) {
     group.spawn_bg(no_wait=true, fn() {
       sleep(time)
-      group.return_immediately(())
+      match error {
+        Some(err) => raise err
+        None => group.return_immediately(())
+      }
     })
     f()
+  })
+}
+
+///|
+/// `with_timeout_opt(timeout, f)` run the async function `f`.
+///
+/// - If `f` return `value` before `timeout`,
+///   `with_timeout_opt` will return `Some(value)` immediately.
+///
+/// - If `f` fail before `timeout`, `with_timeout_opt` will fail immediately.
+///
+/// - If `f` is still running after `timeout` milliseconds,
+/// ` with_timeout_opt` will return `None` immediately, and `f` will be cancelled.
+pub async fn[X] with_timeout_opt(
+  time : Int,
+  f : async () -> X raise,
+) -> X? raise {
+  with_task_group(fn(group) {
+    group.spawn_bg(no_wait=true, fn() {
+      sleep(time)
+      group.return_immediately(None)
+    })
+    Some(f())
   })
 }
 

--- a/src/async.mbt
+++ b/src/async.mbt
@@ -102,3 +102,77 @@ pub fnalias @coroutine.protect_from_cancel
 
 ///|
 pub typealias @aqueue.Queue
+
+///|
+/// `RetryMethod` describes different retry strategies used by various APIs:
+///
+/// - `Immediate`: failed task will immediately be restarted.
+///
+/// - `FixedDelay(t)`,
+///   failed task will be restarted after sleeping for `t` milliseconds
+///
+/// - `ExponentialDelay(initial~, factor~, maximum~)`:
+///   failed task will be restarted with an exponentially growing delay.
+///   The initial delay is `initial`, and after every failure,
+///   the delay will be multiplied by `factor`, but will never exceed `maximum`.
+pub(all) enum RetryMethod {
+  Immediate
+  FixedDelay(Int)
+  ExponentialDelay(initial~ : Int, factor~ : Double, maximum~ : Int)
+}
+
+///|
+/// `retry(strategy, f)` will keep retrying some async operation until success.
+/// If `f` returns `value` normally, `retry` will immediately return `value`.
+/// If `f` fails with error, `retry` will restart `f` again.
+/// The restart strategy is determined by `strategy`,
+/// see the `RetryMethod` type for more details.
+///
+/// If current task is cancelled, `retry` will be cancelled too.
+///
+/// By default, the number of retry attempt is unbounded.
+/// However, if `max_retry` is set,
+/// the number of retry attempts will not exceed the value of `max_retry`.
+/// If retry attempts reaches limit, `retry` will raise the error from `f`'s last attempt.
+pub async fn[X] retry(
+  strategy : RetryMethod,
+  max_retry? : Int,
+  f : async () -> X raise,
+) -> X raise {
+  match strategy {
+    Immediate =>
+      for i = 0; ; i = i + 1 {
+        try f() catch {
+          err if @coroutine.is_being_cancelled() => raise err
+          err if max_retry is Some(max) && i >= max => raise err
+          _ => ()
+        } noraise {
+          result => return result
+        }
+      }
+    FixedDelay(t) =>
+      for i = 0; ; i = i + 1 {
+        try f() catch {
+          err if @coroutine.is_being_cancelled() => raise err
+          err if max_retry is Some(max) && i >= max => raise err
+          _ => sleep(t)
+        } noraise {
+          result => return result
+        }
+      }
+    ExponentialDelay(initial~, factor~, maximum~) =>
+      for i = 0, timeout = initial; ; i = i + 1 {
+        try f() catch {
+          err if @coroutine.is_being_cancelled() => raise err
+          err if max_retry is Some(max) && i >= max => raise err
+          _ => {
+            sleep(timeout)
+            continue i + 1,
+              @cmp.minimum(maximum, (timeout.to_double() * factor).to_int())
+          }
+        } noraise {
+          result => return result
+        }
+      }
+  }
+}

--- a/src/async.mbti
+++ b/src/async.mbti
@@ -6,6 +6,8 @@ async fn pause() -> Unit raise
 
 async fn protect_from_cancel(async () -> Unit raise) -> Unit raise
 
+async fn[X] retry(RetryMethod, max_retry? : Int, async () -> X raise) -> X raise
+
 async fn sleep(Int) -> Unit raise
 
 fn with_event_loop(async (TaskGroup[Unit]) -> Unit raise) -> Unit raise
@@ -22,7 +24,6 @@ impl Show for AlreadyTerminated
 
 // Types and methods
 pub(all) enum RetryMethod {
-  NoRetry
   Immediate
   FixedDelay(Int)
   ExponentialDelay(initial~ : Int, factor~ : Double, maximum~ : Int)
@@ -37,7 +38,7 @@ fn[X] TaskGroup::add_defer(Self[X], async () -> Unit raise) -> Unit raise
 fn[X] TaskGroup::return_immediately(Self[X], X) -> Unit raise
 fn[G, X] TaskGroup::spawn(Self[G], async () -> X raise, no_wait? : Bool, allow_failure? : Bool) -> Task[X] raise
 fn[X] TaskGroup::spawn_bg(Self[X], async () -> Unit raise, no_wait? : Bool, allow_failure? : Bool) -> Unit raise
-fn[X] TaskGroup::spawn_loop(Self[X], async () -> IterResult raise, no_wait? : Bool, allow_failure? : Bool, retry? : RetryMethod) -> Unit raise
+fn[X] TaskGroup::spawn_loop(Self[X], async () -> IterResult raise, no_wait? : Bool, allow_failure? : Bool, retry? : RetryMethod, max_retry? : Int) -> Unit raise
 
 // Type aliases
 pub typealias @moonbitlang/async/aqueue.Queue as Queue

--- a/src/async.mbti
+++ b/src/async.mbti
@@ -12,7 +12,9 @@ fn with_event_loop(async (TaskGroup[Unit]) -> Unit raise) -> Unit raise
 
 async fn[X] with_task_group(async (TaskGroup[X]) -> X raise) -> X raise
 
-async fn with_timeout(Int, async () -> Unit raise) -> Unit raise
+async fn with_timeout(Int, async () -> Unit raise, error? : Error) -> Unit raise
+
+async fn[X] with_timeout_opt(Int, async () -> X raise) -> X? raise
 
 // Errors
 pub suberror AlreadyTerminated

--- a/src/fs/dir_test.mbt
+++ b/src/fs/dir_test.mbt
@@ -34,7 +34,7 @@ test "read_all" {
   inspect(
     log.to_string(),
     content=(
-      #|["fs", "pipe", "aqueue", "socket", "process", "examples", "internal", "os_error", "task.mbt", "async.mbt", "async.mbti", "moon.pkg.json", "wait_test.mbt", "pause_test.mbt", "spawn_test.mbt", "task_group.mbt", "timer_test.mbt", "worker_test.mbt", "no_wait_test.mbt", "spawn_loop_test.mbt", "group_defer_test.mbt", "cancellation_test.mbt", "with_timeout_test.mbt", "allow_failure_test.mbt", "missing_close_test.mbt", "return_immediately_test.mbt", "protect_from_cancel_test.mbt"]
+      #|["fs", "pipe", "aqueue", "socket", "process", "examples", "internal", "os_error", "task.mbt", "async.mbt", "async.mbti", "moon.pkg.json", "wait_test.mbt", "pause_test.mbt", "retry_test.mbt", "spawn_test.mbt", "task_group.mbt", "timer_test.mbt", "worker_test.mbt", "no_wait_test.mbt", "spawn_loop_test.mbt", "group_defer_test.mbt", "cancellation_test.mbt", "with_timeout_test.mbt", "allow_failure_test.mbt", "missing_close_test.mbt", "return_immediately_test.mbt", "protect_from_cancel_test.mbt"]
     ),
   )
 }
@@ -71,6 +71,7 @@ test "as_dir" {
       #|moon.pkg.json: Regular
       #|wait_test.mbt: Regular
       #|pause_test.mbt: Regular
+      #|retry_test.mbt: Regular
       #|spawn_test.mbt: Regular
       #|task_group.mbt: Regular
       #|timer_test.mbt: Regular

--- a/src/process/basic_test.mbt
+++ b/src/process/basic_test.mbt
@@ -58,6 +58,7 @@ test "basic_ls" {
       #|pipe
       #|process
       #|protect_from_cancel_test.mbt
+      #|retry_test.mbt
       #|return_immediately_test.mbt
       #|socket
       #|spawn_loop_test.mbt

--- a/src/retry_test.mbt
+++ b/src/retry_test.mbt
@@ -13,18 +13,16 @@
 // limitations under the License.
 
 ///|
-test "spawn_loop basic" {
+test "retry immediate" {
   let log = StringBuilder::new()
   log.write_object(
-    try? @async.with_event_loop(fn(root) {
+    try? @async.with_event_loop(fn(_) {
       let mut i = 0
-      root.spawn_loop(fn() {
+      retry(Immediate, fn() {
         log.write_string("tick \{i}\n")
         i = i + 1
         if i < 3 {
-          IterContinue
-        } else {
-          IterEnd
+          raise Err
         }
       })
     }),
@@ -41,58 +39,62 @@ test "spawn_loop basic" {
 }
 
 ///|
-test "spawn_loop basic-error" {
-  let log = StringBuilder::new()
-  log.write_object(
-    try? @async.with_event_loop(fn(root) {
-      let mut i = 0
-      root.spawn_loop(fn() {
-        log.write_string("tick \{i}\n")
-        i = i + 1
-        if i >= 3 {
-          raise Err
-        }
-        IterContinue
-      })
-    }),
-  )
-  inspect(
-    log.to_string(),
-    content=(
-      #|tick 0
-      #|tick 1
-      #|tick 2
-      #|Err(Err)
-    ),
-  )
-}
-
-///|
-test "spawn_loop retry-exponential" {
+test "retry fixed" {
   let log = StringBuilder::new()
   log.write_object(
     try? @async.with_event_loop(fn(root) {
       root.spawn_bg(fn() {
-        for i in 0..<9 {
+        for i in 0..<3 {
           @async.sleep(50)
           log.write_string("tick \{i}\n")
         }
       })
       @async.sleep(25)
       let mut i = 0
-      root.spawn_loop(
-        retry=ExponentialDelay(initial=50, factor=2, maximum=150),
-        fn() {
-          log.write_string("loop \{i}\n")
-          i = i + 1
-          match i {
-            1 | 2 | 3 => raise Err
-            4 => IterContinue
-            5 | 6 => raise Err
-            _ => IterEnd
-          }
-        },
-      )
+      retry(FixedDelay(50), fn() {
+        log.write_string("loop \{i}\n")
+        i = i + 1
+        if i < 3 {
+          raise Err
+        }
+      })
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|loop 0
+      #|tick 0
+      #|loop 1
+      #|tick 1
+      #|loop 2
+      #|tick 2
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "retry exponential" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.spawn_bg(fn() {
+        for i in 0..<7 {
+          @async.sleep(50)
+          log.write_string("tick \{i}\n")
+        }
+      })
+      @async.sleep(25)
+      let mut i = 0
+      retry(ExponentialDelay(initial=50, factor=2, maximum=150), fn() {
+        log.write_string("loop \{i}\n")
+        i = i + 1
+        if i < 4 {
+          raise Err
+        }
+      })
+      log.write_string("retry completed\n")
     }),
   )
   inspect(
@@ -108,12 +110,60 @@ test "spawn_loop retry-exponential" {
       #|tick 4
       #|tick 5
       #|loop 3
-      #|loop 4
+      #|retry completed
       #|tick 6
-      #|loop 5
-      #|tick 7
-      #|tick 8
-      #|loop 6
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "retry cancelled1" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(_) {
+      let mut i = 0
+      @async.with_timeout(125, fn() {
+        @async.retry(Immediate, fn() {
+          @async.sleep(50)
+          log.write_string("loop \{i}\n")
+          i = i + 1
+          raise Err
+        })
+      })
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|loop 0
+      #|loop 1
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "retry cancelled2" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(_) {
+      let mut i = 0
+      @async.with_timeout(125, fn() {
+        retry(FixedDelay(50), fn() {
+          log.write_string("loop \{i}\n")
+          i = i + 1
+          raise Err
+        })
+      })
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|loop 0
+      #|loop 1
+      #|loop 2
       #|Ok(())
     ),
   )

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -249,29 +249,18 @@ pub fn[X] TaskGroup::return_immediately(
 }
 
 ///|
-pub(all) enum RetryMethod {
-  NoRetry
-  Immediate
-  FixedDelay(Int)
-  ExponentialDelay(initial~ : Int, factor~ : Double, maximum~ : Int)
-}
+fnalias retry as moonbitlang_async_retry
 
 ///|
 /// Similar to `spawn_bg`, but the spawn a loop,
 /// i.e. the spawned task will be restarted after it terminates.
 /// The spawned task can terminate the loop by returning `IterEnd`.
 ///
-/// When the spawned task raises an error, the behavior is determined by `retry`.
-/// - If `retry` is `NoRetry` (the default),
-///   the loop will terminate immediately and propagate the error.
-/// - If `retry` is `Immediate`, the task will immediately be restarted.
-/// - If `retry` is `FixedDelay(t)`,
-///   the task will be restarted after sleeping for `t` milliseconds
-/// - If `retry` is `ExponentialDelay(initial~, factor~, maximum~)`,
-///   the task will be restarted with an exponentially growing delay.
-///   The initial delay is `initial`, and after every failure,
-///   the delay will be multiplied by `factor`, but will never exceed `maximum`.
-///   If the task succeed, the retry delay will be reset to `initial`.
+/// If `retry_method` is set, within each loop,
+/// the spawned task will be automatically restarted on failure.
+/// The restart strategy is determined by the value of `retry_method`.
+/// `max_retry` will be passed as-is to `retry`.
+/// See `retry` and `RetryMethod` for more details.
 ///
 /// The meaning of `no_wait` and `allow_failure` is the same as `spawn_bg`.
 pub fn[X] TaskGroup::spawn_loop(
@@ -279,50 +268,16 @@ pub fn[X] TaskGroup::spawn_loop(
   f : async () -> IterResult raise,
   no_wait~ : Bool = false,
   allow_failure~ : Bool = false,
-  retry~ : RetryMethod = NoRetry,
+  retry? : RetryMethod,
+  max_retry? : Int,
 ) -> Unit raise {
   self.spawn_bg(no_wait~, allow_failure~, fn() {
-    match retry {
-      NoRetry =>
-        for {
-          guard f() is IterContinue else { break }
-        }
-      Immediate =>
-        for {
-          try f() catch {
-            err if @coroutine.is_being_cancelled() => raise err
-            _ => ()
-          } noraise {
-            IterContinue => ()
-            IterEnd => break
-          }
-        }
-      FixedDelay(t) =>
-        for {
-          try f() catch {
-            err if @coroutine.is_being_cancelled() => raise err
-            _ => sleep(t)
-          } noraise {
-            IterContinue => ()
-            IterEnd => break
-          }
-        }
-      ExponentialDelay(initial~, factor~, maximum~) =>
-        for delay = initial {
-          try f() catch {
-            err if @coroutine.is_being_cancelled() => raise err
-            _ => {
-              sleep(delay)
-              continue @cmp.minimum(
-                  maximum,
-                  (delay.to_double() * factor).to_int(),
-                )
-            }
-          } noraise {
-            IterContinue => continue initial
-            IterEnd => break
-          }
-        }
+    for {
+      let result = match retry {
+        None => f()
+        Some(strategy) => moonbitlang_async_retry(strategy, f, max_retry?)
+      }
+      guard result is IterContinue else { break }
     }
   })
 }

--- a/src/with_timeout_test.mbt
+++ b/src/with_timeout_test.mbt
@@ -203,3 +203,131 @@ test "with_timeout error_on_cancel" {
     ),
   )
 }
+
+///|
+test "with_timeout error-on-timeout" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.spawn_bg(fn() {
+        @async.sleep(50)
+        log.write_string("50ms tick\n")
+      })
+      defer log.write_string("main task terminates\n")
+      @async.with_timeout(25, error=Err, fn() {
+        @async.sleep(2000) catch {
+          err => {
+            log.write_string("task cancelled\n")
+            raise err
+          }
+        }
+        log.write_string("task finished after 2s\n")
+      })
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|task cancelled
+      #|main task terminates
+      #|Err(Err)
+    ),
+  )
+}
+
+///|
+test "with_timeout_opt normal exit" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.spawn_bg(fn() {
+        @async.sleep(50)
+        log.write_string("50ms tick\n")
+      })
+      log.write_object(
+        @async.with_timeout_opt(1000, fn() {
+          @async.sleep(25)
+          log.write_string("task finished after 25ms\n")
+          42
+        }),
+      )
+      log.write_char('\n')
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|task finished after 25ms
+      #|Some(42)
+      #|50ms tick
+      #|Ok(())
+    ),
+  )
+}
+
+///|
+test "with_timeout_opt failure" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.spawn_bg(fn() {
+        @async.sleep(50)
+        log.write_string("50ms tick\n")
+      })
+      @async.with_timeout(1000, fn() {
+        @async.sleep(25)
+        raise Err
+      }) catch {
+        err => {
+          log.write_string("main task fail with \{err}\n")
+          raise err
+        }
+      }
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|main task fail with Err
+      #|Err(Err)
+    ),
+  )
+}
+
+///|
+test "with_timeout_opt timeout" {
+  let log = StringBuilder::new()
+  log.write_object(
+    try? @async.with_event_loop(fn(root) {
+      root.spawn_bg(fn() {
+        @async.sleep(50)
+        log.write_string("50ms tick\n")
+      })
+      log.write_object(
+        @async.with_timeout_opt(25, fn() {
+          try @async.sleep(2000) catch {
+            err => {
+              log.write_string("task cancelled\n")
+              raise err
+            }
+          } noraise {
+            _ => {
+              log.write_string("task finished after 2s\n")
+              42
+            }
+          }
+        }),
+      )
+      log.write_char('\n')
+    }),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|task cancelled
+      #|None
+      #|50ms tick
+      #|Ok(())
+    ),
+  )
+}


### PR DESCRIPTION
This PR performs some API refinement and enrichment:

- `with_timeout` now accepts an extra optional argument `error`. If set, `with_timeout` will raise the supplied error instead of silently return in the timeout case
- introduced a new API `with_timeout_opt`, which returns `Some(value)` when the callback returns `value` before timeout, or returns `None` in the timeout case
- the retry logic of `spawn_loop` is extracted to a separated function `retry`, with additional support for max retry attempt limit
- `spawn_loop` now internally calls `retry` directly, and also supports `max_retry`