### PR TITLE
add http file server example

### DIFF
--- a/src/examples/http_file_server/http.mbt
+++ b/src/examples/http_file_server/http.mbt
@@ -1,0 +1,102 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn to_lower_case(ident : @bytes.View) -> Bytes {
+  let result = FixedArray::make(ident.length(), b'0')
+  for i in 0..<ident.length() {
+    match ident[i] {
+      'A'..='Z' as b => result[i] = b - 'A' + 'a'
+      b => result[i] = b
+    }
+  }
+  result.unsafe_reinterpret_as_bytes()
+}
+
+///|
+enum Cmd {
+  Get
+} derive(Show)
+
+///|
+struct HttpHeader {
+  cmd : Cmd
+  path : Bytes
+  headers : Map[Bytes, Bytes]
+} derive(Show)
+
+///|
+suberror InvalidRequest {
+  UnsupportedMethod(String)
+  InvalidProtocol(String)
+  InvalidFormat
+} derive(Show)
+
+///|
+typealias @io.BufferedReader[@socket.TCP] as Input
+
+///|
+async fn parse_http_header(src : Input) -> HttpHeader raise {
+  // parse the request line
+  let cmd_len = src.find(b" ")
+  let cmd = match src[:cmd_len] {
+    b"GET" => Get
+    cmd => raise UnsupportedMethod(ascii_to_string(cmd))
+  }
+  src.drop(cmd_len + 1)
+  let uri_len = src.find(b" ")
+  let uri = src[:uri_len]
+  src.drop(uri_len + 1)
+  let request_line_end = src.find(b"\r\n")
+  let protocol = src[:request_line_end]
+  src.drop(request_line_end + 2)
+  guard protocol == b"HTTP/1.1" else {
+    raise InvalidProtocol(ascii_to_string(protocol))
+  }
+  // parse request headers
+  let headers = {}
+  for {
+    let line_end = src.find(b"\r\n")
+    if line_end == 0 {
+      // empty line indicates end of header
+      src.drop(line_end + 2)
+      break
+    }
+    let header_line = src[:line_end]
+    guard header_line[:].find_index(':') is Some(colon_index) else {
+      raise InvalidFormat
+    }
+    let key = to_lower_case(header_line[:colon_index])
+    guard colon_index + 1 < header_line.length() else { raise InvalidFormat }
+    let value_start = if header_line[colon_index + 1] == ' ' {
+      colon_index + 2
+    } else {
+      colon_index + 1
+    }
+    let value = header_line[value_start:].to_bytes()
+    headers[key] = value
+    src.drop(line_end + 2)
+  }
+  { cmd, path: uri, headers }
+}
+
+///|
+async fn parse_http_request(src : Input) -> (HttpHeader, Bytes) raise {
+  let header = parse_http_header(src)
+  let body = match header.headers.get(b"content-length") {
+    None => b""
+    Some(len) => src.read_exactly(@strconv.parse_int(ascii_to_string(len)))
+  }
+  (header, body)
+}

--- a/src/examples/http_file_server/http_file_server.mbti
+++ b/src/examples/http_file_server/http_file_server.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/async/examples/http_file_server"
+
+// Values
+
+// Errors
+type InvalidRequest
+impl Show for InvalidRequest
+
+// Types and methods
+type Cmd
+impl Show for Cmd
+
+type HttpHeader
+impl Show for HttpHeader
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/http_file_server/main.mbt
+++ b/src/examples/http_file_server/main.mbt
@@ -1,0 +1,153 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async fn serve_directory(
+  conn : @socket.TCP,
+  dir : @fs.Directory,
+  path~ : Bytes,
+) -> Unit raise {
+  let files = dir.read_all()
+  files.sort()
+  let content = @buffer.new()
+  content
+  ..write_bytes(b"<!DOCTYPE html><html><head></head><body>")
+  ..write_bytes(b"<h1>")
+  ..write_bytes(path)
+  ..write_bytes(b"</h1>\n")
+  ..write_bytes(b"<div style=\"margin: 1em; font-size: 15pt\">")
+  if path[:-1].rev_find_index('/') is Some(index) {
+    content
+    ..write_bytes(b"<a href=\"")
+    ..write_bytesview(if index == 0 { b"/" } else { path[:index] })
+    ..write_bytes(b"\">..</a><br/><br/>\n")
+  }
+  for file in files {
+    content..write_bytes(b"<a href=\"")..write_bytes(path)
+    if path[path.length() - 1] != '/' {
+      content.write_bytes(b"/")
+    }
+    content
+    ..write_bytes(file)
+    ..write_bytes(b"\">")
+    ..write_bytes(file)
+    ..write_bytes(b"</a><br/>\n")
+  }
+  content.write_bytes(b"</div></body></html>")
+  conn
+  ..send(b"HTTP/1.1 200 OK\r\n")
+  ..send(b"Content-Type: text/html\r\n")
+  ..send(b"Content-Length: ")
+  ..send(content.length().to_string().to_ascii())
+  ..send(b"\r\n\r\n")
+  ..send(content.to_bytes())
+}
+
+///|
+async fn serve_file(
+  conn : @socket.TCP,
+  file : @fs.File,
+  path~ : Bytes,
+) -> Unit raise {
+  let content_type : Bytes = match path.suffix() {
+    "png" => "image/png"
+    "jpg" | "jpeg" => "image/jpeg"
+    "html" => "text/html"
+    "css" => "text/css"
+    "js" => "text/javascript"
+    "mp4" => "video/mp4"
+    "mpv" => "video/mpv"
+    "mpeg" => "video/mpeg"
+    "mkv" => "video/x-matroska"
+    _ => "appliaction/octet-stream"
+  }
+  conn
+  ..send(b"HTTP/1.1 200 OK\r\n")
+  ..send(b"Transfer-Encoding: chunked\r\n")
+  ..send("Content-Type: ")
+  ..send(content_type)
+  ..send(b"\r\n\r\n")
+  let send_buf = FixedArray::make(1024, b'0')
+  while file.read(send_buf) is n && n > 0 {
+    conn
+    ..send(n.to_string(radix=16).to_ascii())
+    ..send("\r\n")
+    ..send(send_buf.unsafe_reinterpret_as_bytes(), len=n)
+    ..send("\r\n")
+  }
+  conn.send("0\r\n\r\n")
+}
+
+///|
+let page_for_404 : Bytes = b"<html><head></head><body>Page Not Found</body></html>"
+
+///|
+async fn serve_404(conn : @socket.TCP) -> Unit raise {
+  conn
+  ..send(b"HTTP/1.1 404 NotFound\r\n")
+  ..send(b"Content-Type: text/html\r\n")
+  ..send(b"Content-Length: ")
+  ..send(page_for_404.length().to_string().to_ascii())
+  ..send(b"\r\n\r\n")
+  ..send(page_for_404)
+}
+
+///|
+async fn server(
+  ctx : @async.TaskGroup[Unit],
+  path~ : Bytes,
+  port~ : Int,
+) -> Unit raise {
+  let base_path = path
+  let listen_sock = @socket.TCP::new()
+  defer listen_sock.close()
+  listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
+  for {
+    let (conn, addr) = listen_sock.accept()
+    println("received new connection from \{addr}")
+    ctx.spawn_bg(allow_failure=true, fn() {
+      defer {
+        println("closing connection from \{addr}")
+        conn.close()
+      }
+      let src = @io.BufferedReader::new(conn)
+      for {
+        let (header, _) = parse_http_request(src)
+        let path = header.path
+        println("serving \{ascii_to_string(path)}")
+        match header.cmd {
+          Get =>
+            try @fs.open(base_path + header.path, mode=ReadOnly) catch {
+              _ => serve_404(conn)
+            } noraise {
+              file if file.kind() is Directory =>
+                serve_directory(conn, file.as_dir(), path~)
+              file => serve_file(conn, file, path~)
+            }
+        }
+      }
+    })
+  }
+}
+
+///|
+fn main {
+  let path = match @env.args() {
+    [] | [_] => b"."
+    [_, path, ..] => path.to_ascii()
+  }
+  @async.with_event_loop(ctx => server(ctx, path~, port=8001)) catch {
+    err => println("server terminate due to \{err}")
+  }
+}

--- a/src/examples/http_file_server/moon.pkg.json
+++ b/src/examples/http_file_server/moon.pkg.json
@@ -1,0 +1,9 @@
+{
+  "import": [
+    "moonbitlang/async",
+    "moonbitlang/async/io",
+    "moonbitlang/async/socket",
+    "moonbitlang/async/fs"
+  ],
+  "is-main": true
+}

--- a/src/examples/http_file_server/utils.mbt
+++ b/src/examples/http_file_server/utils.mbt
@@ -1,0 +1,67 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn ascii_to_string(bytes : Bytes) -> String {
+  let builder = StringBuilder::new()
+  for b in bytes {
+    match b {
+      '\r' => builder.write_string("\\r")
+      '\n' => builder.write_string("\\n")
+      b => builder.write_char(b.to_int().unsafe_to_char())
+    }
+  }
+  builder.to_string()
+}
+
+///|
+fn String::to_ascii(str : String) -> Bytes {
+  let result = FixedArray::make(str.length(), b'0')
+  for i in 0..<str.length() {
+    let c = str.unsafe_charcode_at(i)
+    guard c < 256
+    result[i] = c.to_byte()
+  }
+  result.unsafe_reinterpret_as_bytes()
+}
+
+///|
+fn @bytes.View::find_index(self : @bytes.View, byte : Byte) -> Int? {
+  for i in 0..<self.length() {
+    if self[i] == byte {
+      break Some(i)
+    }
+  } else {
+    None
+  }
+}
+
+///|
+fn @bytes.View::rev_find_index(self : @bytes.View, byte : Byte) -> Int? {
+  for i = self.length() - 1; i >= 0; i = i - 1 {
+    if self[i] == byte {
+      break Some(i)
+    }
+  } else {
+    None
+  }
+}
+
+///|
+fn Bytes::suffix(self : Bytes) -> @bytes.View {
+  match self[:].rev_find_index(b'.') {
+    Some(i) if i + 1 < self.length() => self[i + 1:]
+    _ => ""
+  }
+}


### PR DESCRIPTION
add example for a simple HTTP file server, similar to the classic `python -m http.server`.