### PR TITLE
Basic DNS support

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -105,7 +105,7 @@ pub fn with_event_loop(f : async () -> Unit raise) -> Unit raise {
 
 ///|
 fn EventLoop::run_forever(self : Self) -> Unit raise {
-  while not(@coroutine.no_more_work()) {
+  while not(@coroutine.no_more_work() && self.running_workers.is_empty()) {
     let timeout = match @coroutine.next_expire_time() {
       Some(t) => @cmp.maximum(0, (t - @time.ms_since_epoch()).to_int())
       None => -1
@@ -141,9 +141,10 @@ fn EventLoop::run_forever(self : Self) -> Unit raise {
               wake_worker(worker.id)
             }
           }
-          guard self.jobs.get(job_id) is Some(coro)
-          self.jobs.remove(job_id)
-          coro.wake()
+          if self.jobs.get(job_id) is Some(coro) {
+            self.jobs.remove(job_id)
+            coro.wake()
+          }
         } else {
           if not(@os_error.is_nonblocking_io_error()) {
             @os_error.check_errno()
@@ -313,7 +314,10 @@ pub fn close_fd(fd : Int) -> Unit {
 }
 
 ///|
-async fn perform_job_in_worker(job : JobForWorker) -> Int raise {
+async fn perform_job_in_worker(
+  job : JobForWorker,
+  allow_cancel~ : Bool = false,
+) -> Int raise {
   guard curr_loop.val is Some(evloop)
   match evloop.idle_workers.pop_front() {
     None if evloop.running_workers.size() > evloop.max_worker_count =>
@@ -330,7 +334,16 @@ async fn perform_job_in_worker(job : JobForWorker) -> Int raise {
     }
   }
   evloop.jobs[job.id()] = @coroutine.current_coroutine()
-  @coroutine.protect_from_cancel(@coroutine.suspend)
+  if allow_cancel {
+    @coroutine.suspend() catch {
+      err => {
+        evloop.jobs.remove(job.id())
+        raise err
+      }
+    }
+  } else {
+    @coroutine.protect_from_cancel(@coroutine.suspend)
+  }
   if job.err() > 0 {
     raise @os_error.OSError(job.err())
   } else {
@@ -422,7 +435,10 @@ pub async fn perform_job(job : Job) -> Int raise {
     }
     WaitProcess(pid) => wait_pid(pid)
     GetAddrInfo(host~, out~) =>
-      perform_job_in_worker(JobForWorker::getaddrinfo(host, out))
+      perform_job_in_worker(
+        JobForWorker::getaddrinfo(host, out),
+        allow_cancel=true,
+      )
   }
 }
 

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -421,6 +421,8 @@ pub async fn perform_job(job : Job) -> Int raise {
       }
     }
     WaitProcess(pid) => wait_pid(pid)
+    GetAddrInfo(host~, out~) =>
+      perform_job_in_worker(JobForWorker::getaddrinfo(host, out))
   }
 }
 

--- a/src/internal/event_loop/event_loop.mbti
+++ b/src/internal/event_loop/event_loop.mbti
@@ -11,6 +11,8 @@ fn with_event_loop(async () -> Unit raise) -> Unit raise
 // Errors
 
 // Types and methods
+type AddrInfo
+
 type Directory
 
 type DirectoryEntry
@@ -28,6 +30,7 @@ pub(all) enum Job {
   Connect(sock~ : Int, addr~ : Bytes)
   Accept(sock~ : Int, addr~ : Bytes)
   WaitProcess(Int)
+  GetAddrInfo(host~ : Bytes, out~ : Ref[AddrInfo])
 }
 
 // Type aliases

--- a/src/internal/event_loop/job.mbt
+++ b/src/internal/event_loop/job.mbt
@@ -97,6 +97,16 @@ extern "C" fn JobForWorker::sendto(
 ) -> JobForWorker = "moonbitlang_async_make_sendto_job"
 
 ///|
+#external
+type AddrInfo
+
+///|
+extern "C" fn JobForWorker::getaddrinfo(
+  host : Bytes,
+  out : Ref[AddrInfo],
+) -> JobForWorker = "moonbitlang_async_make_getaddrinfo_job"
+
+///|
 pub(all) enum Job {
   Sleep(Int)
   Read(fd~ : Int, buf~ : FixedArray[Byte], offset~ : Int, len~ : Int)
@@ -123,4 +133,5 @@ pub(all) enum Job {
   Connect(sock~ : Int, addr~ : Bytes)
   Accept(sock~ : Int, addr~ : Bytes)
   WaitProcess(Int)
+  GetAddrInfo(host~ : Bytes, out~ : Ref[AddrInfo])
 }

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -70,3 +70,31 @@ pub fn Addr::parse(src : String) -> Addr raise InvalidAddr {
   guard 0 <= port && port < 65536 else { raise InvalidAddr }
   Addr::new(ip, port)
 }
+
+///|
+typealias @event_loop.AddrInfo
+
+///|
+extern "C" fn AddrInfo::null() -> AddrInfo = "moonbitlang_async_null_addrinfo"
+
+///|
+extern "C" fn AddrInfo::ip(self : AddrInfo) -> UInt = "moonbitlang_async_addrinfo_get_ip"
+
+///|
+extern "C" fn AddrInfo::free(self : AddrInfo) = "freeaddrinfo"
+
+///|
+pub suberror ResolveHostnameError Int derive(Show)
+
+///|
+/// Resolve a IPv4 address by hostname
+pub async fn Addr::resolve(host : Bytes, port~ : Int) -> Addr raise {
+  let info = @ref.new(AddrInfo::null())
+  let ret = @event_loop.perform_job(GetAddrInfo(host~, out=info))
+  if ret > 0 {
+    raise ResolveHostnameError(ret)
+  }
+  let ip = info.val.ip()
+  info.val.free()
+  Addr::new(ip, port)
+}

--- a/src/socket/moon.pkg.json
+++ b/src/socket/moon.pkg.json
@@ -6,7 +6,8 @@
     "moonbitlang/async/io"
   ],
   "test-import": [
-    "moonbitlang/async"
+    "moonbitlang/async",
+    "moonbitlang/async/aqueue"
   ],
   "native-stub": [ "socket.c" ]
 }

--- a/src/socket/resolve_host_test.mbt
+++ b/src/socket/resolve_host_test.mbt
@@ -31,3 +31,25 @@ test "resolve mooncakes.io" {
   })
   inspect(log.to_string(), content="54.188.190.230:443")
 }
+
+///|
+test "resolve cancel" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    let channel = @async.Queue::new()
+    let task = root.spawn(allow_failure=true, fn() {
+      channel.put(())
+      log.write_object(@socket.Addr::resolve("localhost", port=443))
+    })
+    channel.get() // make sure the task already started
+    task.cancel()
+    log.write_string("host resolution cancelled\n")
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|host resolution cancelled
+      #|
+    ),
+  )
+}

--- a/src/socket/resolve_host_test.mbt
+++ b/src/socket/resolve_host_test.mbt
@@ -1,0 +1,33 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "resolve localhost" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(_) {
+    let addr = @socket.Addr::resolve("localhost", port=4200)
+    log.write_object(addr)
+  })
+  inspect(log.to_string(), content="127.0.0.1:4200")
+}
+
+///|
+test "resolve mooncakes.io" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(_) {
+    let addr = @socket.Addr::resolve("mooncakes.io", port=443)
+    log.write_object(addr)
+  })
+  inspect(log.to_string(), content="54.188.190.230:443")
+}

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -18,6 +18,7 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
+#include <netdb.h>
 #include <stdio.h>
 #include <fcntl.h>
 #include <moonbit.h>
@@ -96,4 +97,12 @@ uint32_t moonbitlang_async_ip_addr_get_ip(struct sockaddr_in *addr) {
 
 uint32_t moonbitlang_async_ip_addr_get_port(struct sockaddr_in *addr) {
   return ntohs(addr->sin_port);
+}
+
+struct addrinfo *moonbitlang_async_null_addrinfo() {
+  return 0;
+}
+
+uint32_t moonbitlang_async_addrinfo_get_ip(struct addrinfo *addrinfo) {
+  return ntohl(((struct sockaddr_in*)(addrinfo->ai_addr))->sin_addr.s_addr);
 }

--- a/src/socket/socket.mbti
+++ b/src/socket/socket.mbti
@@ -7,12 +7,16 @@ package "moonbitlang/async/socket"
 pub suberror InvalidAddr
 impl Show for InvalidAddr
 
+pub suberror ResolveHostnameError Int
+impl Show for ResolveHostnameError
+
 // Types and methods
 type Addr
 fn Addr::ip(Self) -> UInt
 fn Addr::new(UInt, Int) -> Self
 fn Addr::parse(String) -> Self raise InvalidAddr
 fn Addr::port(Self) -> Int
+async fn Addr::resolve(Bytes, port~ : Int) -> Self raise
 impl Compare for Addr
 impl Eq for Addr
 impl Hash for Addr


### PR DESCRIPTION
This PR implements basic DNS support using libc `getaddrinfo`. `getaddrinfo` will be invoked in a worker thread to avoid blocking. Currently only IPv4 is supported.

In the future we may wish to implement our own DNS resolver, to better utilize polling, and better cancellation support.