### PR TITLE
fix hang when coroutine is cancelled immediately after spawning

### DIFF
--- a/src/cancellation_test.mbt
+++ b/src/cancellation_test.mbt
@@ -236,3 +236,27 @@ test "error in cancellation" {
     ),
   )
 }
+
+///|
+test "immediately cancelled" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    let task = root.spawn(allow_failure=true, fn() {
+      defer log.write_string("task terminated\n")
+      log.write_string("task started\n")
+      @async.sleep(100)
+      log.write_string("task finished\n")
+    })
+    log.write_string("task spawned\n")
+    task.cancel()
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|task spawned
+      #|task started
+      #|task terminated
+      #|
+    ),
+  )
+}

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -109,29 +109,29 @@ pub fn spawn(f : async () -> Unit raise) -> Coroutine {
   scheduler.coro_id += 1
   let coro = {
     state: Running,
-    ready: false,
-    shielded: false,
+    ready: true,
+    shielded: true,
     downstream: Set::new(),
     coro_id: scheduler.coro_id,
     cancelled: false,
   }
-  let last_coro = scheduler.curr_coro
-  scheduler.curr_coro = Some(coro)
-  run_async(fn() {
-    try {
-      pause()
-      f()
-    } catch {
-      err => coro.state = Fail(err)
-    } noraise {
-      _ => coro.state = Done
-    }
-    for coro in coro.downstream {
-      coro.wake()
-    }
-    coro.downstream.clear()
-  })
-  scheduler.curr_coro = last_coro
+  fn run(_) {
+    run_async(fn() {
+      coro.shielded = false
+      try f() catch {
+        err => coro.state = Fail(err)
+      } noraise {
+        _ => coro.state = Done
+      }
+      for coro in coro.downstream {
+        coro.wake()
+      }
+      coro.downstream.clear()
+    })
+  }
+
+  coro.state = Suspend(ok_cont=run, err_cont=_ => ())
+  scheduler.run_later.push_back(coro)
   coro
 }
 


### PR DESCRIPTION
If a coroutine is cancelled immediately after being spawned, before the start of its execution, task group handling logic will not be triggered, causing task group hang. This PR now make sure all coroutines will get a chance to start their execution, even if immediately cancelled. In this case, cancellation will be deferred to the first suspension point.