### PR TITLE
introduce `@io.Writer`

### DIFF
--- a/src/examples/cat/cat.mbti
+++ b/src/examples/cat/cat.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/async/examples/cat"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/cat/main.mbt
+++ b/src/examples/cat/main.mbt
@@ -1,0 +1,44 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn String::to_ascii(str : String) -> Bytes {
+  Bytes::makei(str.length(), i => str.unsafe_charcode_at(i).to_byte())
+}
+
+///|
+fn main {
+  defer @pipe.reset_stdio()
+  @async.with_event_loop(fn(_) {
+    try {
+      let args = @env.args()
+      match args {
+        [] | [_] => @pipe.stdout.write_reader(@pipe.stdin)
+        [_, .. files] =>
+          for file in files {
+            if file == "-" {
+              @pipe.stdout.write_reader(@pipe.stdin)
+            } else {
+              let file = @fs.open(file.to_ascii(), mode=ReadOnly)
+              @pipe.stdout.write_reader(file)
+            }
+          }
+      }
+    } catch {
+      err => @pipe.stderr.write(err.to_string().to_ascii())
+    }
+  }) catch {
+    _ => ()
+  }
+}

--- a/src/examples/cat/moon.pkg.json
+++ b/src/examples/cat/moon.pkg.json
@@ -1,0 +1,9 @@
+{
+  "import": [
+    "moonbitlang/async",
+    "moonbitlang/async/io",
+    "moonbitlang/async/fs",
+    "moonbitlang/async/pipe"
+  ],
+  "is-main": true
+}

--- a/src/examples/http_file_server/main.mbt
+++ b/src/examples/http_file_server/main.mbt
@@ -83,7 +83,7 @@ async fn serve_file(
     conn
     ..send(n.to_string(radix=16).to_ascii())
     ..send("\r\n")
-    ..send(send_buf.unsafe_reinterpret_as_bytes(), len=n)
+    ..send(send_buf.unsafe_reinterpret_as_bytes()[:n])
     ..send("\r\n")
   }
   conn.send("0\r\n\r\n")

--- a/src/fs/fs.mbt
+++ b/src/fs/fs.mbt
@@ -181,21 +181,10 @@ pub impl @io.Reader for File with read_all(self) {
 }
 
 ///|
-/// `file.write(buf, offset~, len~)` write content of `buf[offset:offset+len]`
-/// to the file `file`.
-/// By default, `offset` is `0` and `len` is `buf.length() - offset`.
-///
-/// `write` will ensure all data is succesfully written,
-/// Unless an error occurred while writing.
-pub async fn File::write(
-  self : File,
-  buf : Bytes,
-  offset~ : Int = 0,
-  len~ : Int = buf.length() - offset,
-) -> Unit raise {
+pub impl @io.Writer for File with write_once(self, buf, offset~, len~) {
   let can_poll = self.kind.can_poll()
   let job = @event_loop.Write(fd=self.fd, buf~, offset~, len~, can_poll~)
-  ignore(@event_loop.perform_job(job))
+  @event_loop.perform_job(job)
 }
 
 ///|

--- a/src/fs/fs.mbti
+++ b/src/fs/fs.mbti
@@ -25,8 +25,8 @@ fn File::kind(Self) -> FileKind
 async fn File::read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int raise
 fn File::seek(Self, Int64, mode~ : SeekMode) -> Int64 raise
 fn File::size(Self) -> Int64 raise
-async fn File::write(Self, Bytes, offset? : Int, len? : Int) -> Unit raise
 impl @moonbitlang/async/io.Reader for File
+impl @moonbitlang/async/io.Writer for File
 
 pub(all) enum FileKind {
   Unknown

--- a/src/io/io.mbti
+++ b/src/io/io.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/io"
 
+import(
+  "moonbitlang/core/bytes"
+)
+
 // Values
 
 // Errors
@@ -24,5 +28,11 @@ pub(open) trait Reader {
   async read(Self, FixedArray[Byte], offset~ : Int, max_len~ : Int) -> Int raise
   async read_exactly(Self, Int) -> Bytes raise = _
   async read_all(Self) -> Bytes raise = _
+}
+
+pub(open) trait Writer {
+  async write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int raise
+  async write(Self, @bytes.View) -> Unit raise = _
+  async write_reader(Self, &Reader) -> Unit raise = _
 }
 

--- a/src/io/writer.mbt
+++ b/src/io/writer.mbt
@@ -1,0 +1,46 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub(open) trait Writer {
+  async write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int raise
+  async write(Self, @bytes.View) -> Unit raise = _
+  async write_reader(Self, &Reader) -> Unit raise = _
+}
+
+///|
+impl Writer with write(self, view) {
+  let start = view.start_offset()
+  let len = view.length()
+  let end = start + len
+  for offset = start; offset < end; {
+    let progress = self.write_once(view.data(), offset~, len=end - offset)
+    continue offset + progress
+  }
+}
+
+///|
+impl Writer with write_reader(self, reader) {
+  let buf = FixedArray::make(1024, b'0')
+  while reader.read(buf, offset=0, max_len=1024) is n && n > 0 {
+    for offset = 0; offset < n; {
+      let progress = self.write_once(
+        buf.unsafe_reinterpret_as_bytes(),
+        offset~,
+        len=n - offset,
+      )
+      continue offset + progress
+    }
+  }
+}

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -1,0 +1,73 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "write large data" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    let (r, w) = @pipe.pipe()
+    root.spawn_bg(fn() {
+      defer w.close()
+      let data = Bytes::make(1024 * 16, 0)
+      w.write(data)
+    })
+    root.spawn_bg(fn() { log.write_object(r.read_all().length()) })
+  })
+  inspect(log.to_string(), content="16384")
+}
+
+///|
+test "write reader" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    let (r1, w1) = @pipe.pipe()
+    let (r2, w2) = @pipe.pipe()
+    root.spawn_bg(fn() {
+      defer r2.close()
+      defer w1.close()
+      w1.write_reader(r2)
+    })
+    root.spawn_bg(fn() {
+      defer r1.close()
+      let buf = FixedArray::make(1024, b'0')
+      while r1.read(buf) is n && n > 0 {
+        @async.sleep(10)
+        log.write_string("received \{buf.unsafe_reinterpret_as_bytes()[:n]}\n")
+      }
+    })
+    root.spawn_bg(fn() {
+      defer w2.close()
+      w2.write(b"abcd")
+      log.write_string("sending 4 bytes\n")
+      @async.sleep(20)
+      w2.write(b"efgh")
+      log.write_string("sending 4 bytes\n")
+      @async.sleep(20)
+      w2.write(b"ijkl")
+      log.write_string("sending 4 bytes\n")
+    })
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|sending 4 bytes
+      #|received b"\x61\x62\x63\x64"
+      #|sending 4 bytes
+      #|received b"\x65\x66\x67\x68"
+      #|sending 4 bytes
+      #|received b"\x69\x6a\x6b\x6c"
+      #|
+    ),
+  )
+}

--- a/src/pipe/pipe.mbt
+++ b/src/pipe/pipe.mbt
@@ -151,23 +151,7 @@ pub async fn PipeRead::read_exactly(self : PipeRead, len : Int) -> Bytes raise {
 }
 
 ///|
-/// Write data through the write end of a pipe using `write(2)` system call.
-/// This function will only return after all data have been successfully written.
-///
-/// At most one task can write to a pipe at any time.
-/// To allow multiple writers,
-/// use a worker task for writing and use `@async.Queue` to gather data.
-pub async fn PipeWrite::write(
-  self : PipeWrite,
-  buf : Bytes,
-  offset~ : Int = 0,
-  len~ : Int = buf.length() - offset,
-) -> Unit raise {
+pub impl @io.Writer for PipeWrite with write_once(self, buf, offset~, len~) {
   let PipeWrite(fd) = self
-  for sent = 0; sent < len; {
-    let new_sent = @event_loop.perform_job(
-      Write(fd~, buf~, offset=offset + sent, len=len - sent, can_poll=true),
-    )
-    continue sent + new_sent
-  }
+  @event_loop.perform_job(Write(fd~, buf~, offset~, len~, can_poll=true))
 }

--- a/src/pipe/pipe.mbti
+++ b/src/pipe/pipe.mbti
@@ -25,7 +25,7 @@ impl @moonbitlang/async/io.Reader for PipeRead
 type PipeWrite
 fn PipeWrite::close(Self) -> Unit
 fn PipeWrite::fd(Self) -> Int
-async fn PipeWrite::write(Self, Bytes, offset? : Int, len? : Int) -> Unit raise
+impl @moonbitlang/async/io.Writer for PipeWrite
 
 // Type aliases
 

--- a/src/socket/socket.mbti
+++ b/src/socket/socket.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/socket"
 
+import(
+  "moonbitlang/core/bytes"
+)
+
 // Values
 
 // Errors
@@ -32,8 +36,9 @@ fn TCP::listen(Self) -> Unit raise
 fn TCP::new() -> Self raise
 async fn TCP::recv(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int raise
 async fn TCP::recv_exactly(Self, Int) -> Bytes raise
-async fn TCP::send(Self, Bytes, offset? : Int, len? : Int) -> Unit raise
+async fn TCP::send(Self, @bytes.View) -> Unit raise
 impl @moonbitlang/async/io.Reader for TCP
+impl @moonbitlang/async/io.Writer for TCP
 
 type UDP
 fn UDP::bind(Self, Addr) -> Unit raise

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -137,23 +137,18 @@ pub async fn TCP::recv_exactly(self : TCP, len : Int) -> Bytes raise {
 }
 
 ///|
-/// Send data through a TCP connection using `send(2)` system call.
+pub impl @io.Writer for TCP with write_once(self, buf, offset~, len~) {
+  let TCP(sock) = self
+  @event_loop.perform_job(Write(fd=sock, buf~, offset~, len~, can_poll=true))
+}
+
+///|
+/// Send data through a TCP connection.
 /// This function will only return after all data have been successfully sent.
 ///
 /// At most one task can write to a TCP socket at any time.
 /// To allow multiple writers,
 /// use a worker task for writing and use `@async.Queue` to gather data.
-pub async fn TCP::send(
-  self : TCP,
-  buf : Bytes,
-  offset~ : Int = 0,
-  len~ : Int = buf.length() - offset,
-) -> Unit raise {
-  let TCP(sock) = self
-  for sent = 0; sent < len; {
-    let new_sent = @event_loop.perform_job(
-      Write(fd=sock, buf~, offset=offset - sent, len=len - sent, can_poll=true),
-    )
-    continue sent + new_sent
-  }
+pub async fn TCP::send(self : TCP, data : @bytes.View) -> Unit raise {
+  @io.Writer::write(self, data)
 }


### PR DESCRIPTION
This PR introduces a new trait `@io.Writer` for general stream based writer abstraction. `@pipe.PipeWrite`, `@socket.TCP` and `@fs.File` both implement this trait. `@io.Writer` also provides generic functionalities such as ensuring all data written, connecting a reader to a writer directly.

This PR introduces a breaking change: the `.write` and `.send` methods of the implementers of `@io.Writer` now migrates to using a `@bytes.View` as input, instead of explicit `Bytes` + offset + length.

To demonstrate the new abstraction, an example of the classic `cat` program is added.