### PR TITLE
make `@io.Writer::write` atomic

### DIFF
--- a/src/io/moon.pkg.json
+++ b/src/io/moon.pkg.json
@@ -1,4 +1,5 @@
 {
+  "import": [ "moonbitlang/async" ],
   "test-import": [
     "moonbitlang/async",
     "moonbitlang/async/pipe"

--- a/src/io/writer.mbt
+++ b/src/io/writer.mbt
@@ -24,10 +24,16 @@ impl Writer with write(self, view) {
   let start = view.start_offset()
   let len = view.length()
   let end = start + len
-  for offset = start; offset < end; {
-    let progress = self.write_once(view.data(), offset~, len=end - offset)
-    continue offset + progress
+  let offset = self.write_once(view.data(), offset=start, len~)
+  if offset == end {
+    return
   }
+  @async.protect_from_cancel(fn() {
+    for offset = start; offset < end; {
+      let progress = self.write_once(view.data(), offset~, len=end - offset)
+      continue offset + progress
+    }
+  })
 }
 
 ///|


### PR DESCRIPTION
make `@io.Writer::write` atomic: either no data is written at all, or the whole message will be written if no error occurs, even if the coroutine calling `write` is cancelled. This avoids corrupted data being written.