### PR TITLE
use condition variable for thread wakeup on MacOS

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -13,12 +13,6 @@
 // limitations under the License.
 
 ///|
-priv struct Worker {
-  id : Int64
-  job_slot : Ref[JobForWorker]
-}
-
-///|
 priv struct EventLoop {
   poll : Instance
   fds : Map[Int, FdHandle]
@@ -136,10 +130,7 @@ fn EventLoop::run_forever(self : Self) -> Unit raise {
           self.running_workers.remove(job_id)
           match self.job_queue.pop_front() {
             None => self.idle_workers.push_back(worker)
-            Some(job) => {
-              worker.job_slot.val = job
-              wake_worker(worker.id)
-            }
+            Some(job) => wake_worker(worker, job)
           }
           if self.jobs.get(job_id) is Some(coro) {
             self.jobs.remove(job_id)
@@ -325,14 +316,12 @@ async fn perform_job_in_worker(
     None if evloop.running_workers.size() > evloop.max_worker_count =>
       evloop.job_queue.push_back(job)
     None => {
-      let job_slot = @ref.new(job)
-      let id = spawn_worker(job_slot)
-      evloop.running_workers[job.id()] = { id, job_slot }
+      let worker = spawn_worker(job)
+      evloop.running_workers[job.id()] = worker
     }
     Some(worker) => {
-      worker.job_slot.val = job
       evloop.running_workers[job.id()] = worker
-      wake_worker(worker.id)
+      wake_worker(worker, job)
     }
   }
   evloop.jobs[job.id()] = @coroutine.current_coroutine()

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -13,17 +13,19 @@
 // limitations under the License.
 
 ///|
+priv type Worker
+
+///|
 extern "C" fn init_thread_pool_ffi(notify_send : Int) = "moonbitlang_async_init_thread_pool"
 
 ///|
 extern "C" fn destroy_thread_pool() = "moonbitlang_async_destroy_thread_pool"
 
 ///|
-#borrow(job_slot)
-extern "C" fn spawn_worker(job_slot : Ref[JobForWorker]) -> Int64 = "moonbitlang_async_spawn_worker"
+extern "C" fn spawn_worker(init_job : JobForWorker) -> Worker = "moonbitlang_async_spawn_worker"
 
 ///|
-extern "C" fn wake_worker(worker_id : Int64) = "moonbitlang_async_wake_worker"
+extern "C" fn wake_worker(worker : Worker, job : JobForWorker) = "moonbitlang_async_wake_worker"
 
 ///|
 extern "C" fn fetch_completion_ffi(notify_recv : Int) -> Int = "moonbitlang_async_fetch_completion"


### PR DESCRIPTION
It seems that the signal implementation of MacOS kernel [has a bug](https://stackoverflow.com/questions/79738262/pthread-kill-randomly-send-signal-to-the-wrong-thread-on-macos/79738415#79738415), resulting in recent random failure of MacOS CI. This PR uses condition variable instead of signal for thread wakeup on MacOS to work around the issue