### PR TITLE
`@process.run`: support setting working directory

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -394,9 +394,9 @@ pub async fn perform_job(job : Job) -> Int raise {
     Remove(path~) => perform_job_in_worker(JobForWorker::remove(path))
     Readdir(dir~, out~) =>
       perform_job_in_worker(JobForWorker::readdir(dir, out))
-    Spawn(path~, args~, env~, stdin~, stdout~, stderr~) =>
+    Spawn(path~, args~, env~, stdin~, stdout~, stderr~, cwd~) =>
       perform_job_in_worker(
-        JobForWorker::spawn(path, args, env, stdin, stdout, stderr),
+        JobForWorker::spawn(path, args, env, stdin, stdout, stderr, cwd),
       )
     Recvfrom(sock~, buf~, offset~, len~, addr~) =>
       perform_read_job(

--- a/src/internal/event_loop/event_loop.mbti
+++ b/src/internal/event_loop/event_loop.mbti
@@ -24,7 +24,7 @@ pub(all) enum Job {
   Open(path~ : Bytes, flags~ : Int, mode~ : Int)
   Remove(path~ : Bytes)
   Readdir(dir~ : Directory, out~ : Ref[DirectoryEntry])
-  Spawn(path~ : Bytes, args~ : FixedArray[Bytes?], env~ : FixedArray[Bytes?], stdin~ : Int, stdout~ : Int, stderr~ : Int)
+  Spawn(path~ : Bytes, args~ : FixedArray[Bytes?], env~ : FixedArray[Bytes?], stdin~ : Int, stdout~ : Int, stderr~ : Int, cwd~ : Bytes?)
   Recvfrom(sock~ : Int, buf~ : FixedArray[Byte], offset~ : Int, len~ : Int, addr~ : Bytes)
   Sendto(sock~ : Int, buf~ : Bytes, offset~ : Int, len~ : Int, addr~ : Bytes)
   Connect(sock~ : Int, addr~ : Bytes)

--- a/src/internal/event_loop/job.mbt
+++ b/src/internal/event_loop/job.mbt
@@ -75,6 +75,7 @@ extern "C" fn JobForWorker::spawn(
   stdin : Int,
   stdout : Int,
   stderr : Int,
+  cwd : Bytes?,
 ) -> JobForWorker = "moonbitlang_async_make_spawn_job"
 
 ///|
@@ -125,7 +126,8 @@ pub(all) enum Job {
     env~ : FixedArray[Bytes?],
     stdin~ : Int,
     stdout~ : Int,
-    stderr~ : Int
+    stderr~ : Int,
+    cwd~ : Bytes?
   )
   Recvfrom(
     sock~ : Int,

--- a/src/process/cwd_test.mbt
+++ b/src/process/cwd_test.mbt
@@ -1,0 +1,51 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "set cwd" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(root) {
+    guard @env.current_dir() is Some(prev_cwd)
+    let (r, w) = @pipe.pipe()
+    defer r.close()
+    root.spawn_bg(fn() {
+      let _ = @process.run(b"ls", [], stdout=w, cwd="src/process", extra_env={
+        b"LANG": b"en_US.UTF-8",
+      })
+      guard @env.current_dir() is Some(new_cwd)
+      guard prev_cwd == new_cwd
+    })
+    let buf = FixedArray::make(1024, b'0')
+    while r.read(buf) is n && n > 0 {
+      let data = buf.unsafe_reinterpret_as_bytes()[0:n]
+      log.write_string(ascii_to_string(data))
+    }
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|basic_test.mbt
+      #|cancel_test.mbt
+      #|cwd_test.mbt
+      #|env_test.mbt
+      #|moon.pkg.json
+      #|process.mbt
+      #|process.mbti
+      #|stub.c
+      #|wait_test.mbt
+      #|
+    ),
+  )
+}

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -44,6 +44,9 @@ extern "C" fn terminate_process(pid : Int) = "moonbitlang_async_terminate_proces
 /// the corresponding channel of the new process will be redirected to the given pipe.
 /// The ownership of `stdin`, `stdout`, and `stderr` will be transferred to the `spawn`,
 /// current process MUST NOT read/write/close these pipes any more, even if `spawn` fails.
+///
+/// If `cwd` is present, the spawned command will be executed
+/// in the directory specified by `cwd`.
 pub async fn run(
   cmd : Bytes,
   args : Array[Bytes],
@@ -52,6 +55,7 @@ pub async fn run(
   stdin? : @pipe.PipeRead,
   stdout? : @pipe.PipeWrite,
   stderr? : @pipe.PipeWrite,
+  cwd? : Bytes,
   orphan~ : Bool = false,
 ) -> Int raise {
   let argv = FixedArray::make(args.length() + 2, None)
@@ -120,6 +124,7 @@ pub async fn run(
     stdin~,
     stdout~,
     stderr~,
+    cwd~,
   )
   let pid = @event_loop.perform_job(job)
   @event_loop.perform_job(WaitProcess(pid)) catch {

--- a/src/process/process.mbti
+++ b/src/process/process.mbti
@@ -6,7 +6,7 @@ import(
 )
 
 // Values
-async fn run(Bytes, Array[Bytes], extra_env? : Map[Bytes, Bytes], inherit_env? : Bool, stdin? : @pipe.PipeRead, stdout? : @pipe.PipeWrite, stderr? : @pipe.PipeWrite, orphan? : Bool) -> Int raise
+async fn run(Bytes, Array[Bytes], extra_env? : Map[Bytes, Bytes], inherit_env? : Bool, stdin? : @pipe.PipeRead, stdout? : @pipe.PipeWrite, stderr? : @pipe.PipeWrite, cwd? : Bytes, orphan? : Bool) -> Int raise
 
 // Errors
 


### PR DESCRIPTION
The `posix_spawn_file_actions_addchdir` API is non-posix, and indeed it has the `_np` postfix. However it seemed to be supported by major platforms long ago. And there is no way to set cwd with `posix_spawn` except using this API.