### PR TITLE
add TLS SNI & host name verification support

### DIFF
--- a/src/tls/ffi.mbt
+++ b/src/tls/ffi.mbt
@@ -56,6 +56,10 @@ extern "C" fn SSL::new(ctx : SSL_CTX, rbio : BIO, wbio : BIO) -> SSL = "moonbitl
 extern "C" fn SSL::connect(self : SSL) -> Int = "moonbitlang_async_tls_ssl_connect"
 
 ///|
+#borrow(host)
+extern "C" fn SSL::set_sni(self : SSL, host : Bytes) -> Int = "moonbitlang_async_tls_ssl_set_sni"
+
+///|
 extern "C" fn SSL::set_verify(self : SSL, verify : Bool) = "moonbitlang_async_tls_ssl_set_verify"
 
 ///|

--- a/src/tls/ffi.mbt
+++ b/src/tls/ffi.mbt
@@ -57,6 +57,10 @@ extern "C" fn SSL::connect(self : SSL) -> Int = "moonbitlang_async_tls_ssl_conne
 
 ///|
 #borrow(host)
+extern "C" fn SSL::set_host(self : SSL, host : Bytes) -> Int = "moonbitlang_async_tls_ssl_set_host"
+
+///|
+#borrow(host)
 extern "C" fn SSL::set_sni(self : SSL, host : Bytes) -> Int = "moonbitlang_async_tls_ssl_set_sni"
 
 ///|

--- a/src/tls/stub.c
+++ b/src/tls/stub.c
@@ -25,6 +25,8 @@
 #define BIO_CTRL_FLUSH 11
 #define SSL_CTRL_MODE 33
 #define SSL_MODE_ENABLE_PARTIAL_WRITE 0x00000001U
+#define SSL_CTRL_SET_TLSEXT_HOSTNAME 55
+#define TLSEXT_NAMETYPE_host_name 0
 
 typedef struct BIO_METHOD BIO_METHOD;
 typedef struct BIO BIO;
@@ -48,6 +50,7 @@ typedef struct SSL_METHOD SSL_METHOD;
   IMPORT_FUNC(void, SSL_set_bio, (SSL *s, BIO *rbio, BIO *wbio))\
   IMPORT_FUNC(int, SSL_connect, (SSL *ssl))\
   IMPORT_FUNC(void, SSL_set_verify, (SSL *ssl, int mode, int (*verify_cb)(int, void*)))\
+  IMPORT_FUNC(long, SSL_ctrl, (SSL *ssl, int cmd, long larg, void *parg))\
   IMPORT_FUNC(int, SSL_accept, (SSL *ssl))\
   IMPORT_FUNC(int, SSL_use_certificate_file, (SSL *ssl, const char *file, int type))\
   IMPORT_FUNC(int, SSL_use_PrivateKey_file, (SSL *ssl, const char *file, int type))\
@@ -213,6 +216,10 @@ SSL *moonbitlang_async_tls_ssl_new(SSL_CTX *ctx, BIO *rbio, BIO *wbio) {
 
 int moonbitlang_async_tls_ssl_connect(SSL *ssl) {
   return SSL_connect(ssl);
+}
+
+int moonbitlang_async_tls_ssl_set_sni(SSL *ssl, void *host) {
+  return SSL_ctrl(ssl, SSL_CTRL_SET_TLSEXT_HOSTNAME, TLSEXT_NAMETYPE_host_name, host);
 }
 
 void moonbitlang_async_tls_ssl_set_verify(SSL *ssl, int verify) {

--- a/src/tls/stub.c
+++ b/src/tls/stub.c
@@ -50,6 +50,7 @@ typedef struct SSL_METHOD SSL_METHOD;
   IMPORT_FUNC(void, SSL_set_bio, (SSL *s, BIO *rbio, BIO *wbio))\
   IMPORT_FUNC(int, SSL_connect, (SSL *ssl))\
   IMPORT_FUNC(void, SSL_set_verify, (SSL *ssl, int mode, int (*verify_cb)(int, void*)))\
+  IMPORT_FUNC(int, SSL_set1_host, (SSL *ssl, const char *host))\
   IMPORT_FUNC(long, SSL_ctrl, (SSL *ssl, int cmd, long larg, void *parg))\
   IMPORT_FUNC(int, SSL_accept, (SSL *ssl))\
   IMPORT_FUNC(int, SSL_use_certificate_file, (SSL *ssl, const char *file, int type))\
@@ -216,6 +217,10 @@ SSL *moonbitlang_async_tls_ssl_new(SSL_CTX *ctx, BIO *rbio, BIO *wbio) {
 
 int moonbitlang_async_tls_ssl_connect(SSL *ssl) {
   return SSL_connect(ssl);
+}
+
+int moonbitlang_async_tls_ssl_set_host(SSL *ssl, const char *host) {
+  return SSL_set1_host(ssl, host);
 }
 
 int moonbitlang_async_tls_ssl_set_sni(SSL *ssl, void *host) {

--- a/src/tls/tls.mbt
+++ b/src/tls/tls.mbt
@@ -16,6 +16,7 @@
 /// A TLS-encrypted connection
 struct TLS {
   ssl : SSL
+  host : Bytes?
   read_end : Endpoint
   write_end : Endpoint
 }
@@ -31,13 +32,14 @@ fn[R : @io.Reader, W : @io.Writer] TLS::from_pair(
   ctx : SSL_CTX,
   r : R,
   w : W,
+  host~ : Bytes?,
 ) -> TLS {
   let read_end = Endpoint::new_read(r)
   let write_end = Endpoint::new_write(w)
   let rbio = create_rbio(read_end, (bio, dst, len) => bio.read(dst, len))
   let wbio = create_wbio(write_end, (bio, src, len) => bio.write(src, len))
   let ssl = SSL::new(ctx, rbio, wbio)
-  { ssl, read_end, write_end }
+  { ssl, host, read_end, write_end }
 }
 
 ///|
@@ -59,22 +61,31 @@ async fn TLS::handle_error(self : TLS, err : Int) -> Unit raise {
 /// `client_from_pair` will perform verification on server's certificate,
 /// using the default verification setting of the OpenSSL library.
 ///
-/// If `sni` is present, its value will set the host name for the
-/// Server Name Indication (SNI) field in ClientHello packet of TLS.
+/// If `host` is present, it will be used to verify the peer's certificate.
+///
+/// If `host` is present and `sni` is `true` (`true` by default),
+/// Server Name Indication (SNI) field of TLS will be set to `host`.
 pub async fn[R : @io.Reader, W : @io.Writer] TLS::client_from_pair(
   r : R,
   w : W,
   verify~ : Bool = true,
-  sni? : Bytes,
+  host? : Bytes,
+  sni~ : Bool = true,
 ) -> TLS raise {
-  let self = TLS::from_pair(client_ctx, r, w)
+  let self = TLS::from_pair(client_ctx, r, w, host~)
   if not(verify) {
     self.ssl.set_verify(false)
   }
-  if sni is Some(host) {
-    guard self.ssl.set_sni(host) > 0 else {
+  if host is Some(host) {
+    guard self.ssl.set_host(host) > 0 else {
       self.close()
       raise OpenSSLError(err_get_error())
+    }
+    if sni {
+      guard self.ssl.set_sni(host) > 0 else {
+        self.close()
+        raise OpenSSLError(err_get_error())
+      }
     }
   }
   while self.ssl.connect() is ret && ret <= 0 {
@@ -96,14 +107,17 @@ pub async fn[R : @io.Reader, W : @io.Writer] TLS::client_from_pair(
 /// `client` will perform verification on server's certificate,
 /// using the default verification setting of the OpenSSL library.
 ///
-/// If `sni` is present, its value will set the host name for the
-/// Server Name Indication (SNI) field in ClientHello packet of TLS.
+/// If `host` is present, it will be used to verify the peer's certificate.
+///
+/// If `host` is present and `sni` is `true` (`true` by default),
+/// Server Name Indication (SNI) field of TLS will be set to `host`.
 pub async fn[Inner : @io.Reader + @io.Writer] TLS::client(
   inner : Inner,
   verify~ : Bool = true,
-  sni? : Bytes,
+  host? : Bytes,
+  sni~ : Bool = true,
 ) -> TLS raise {
-  TLS::client_from_pair(inner, inner, verify~, sni?)
+  TLS::client_from_pair(inner, inner, verify~, host?, sni~)
 }
 
 ///|
@@ -124,7 +138,7 @@ pub async fn[R : @io.Reader, W : @io.Writer] TLS::server_from_pair(
   certificate_file~ : Bytes,
   certificate_type~ : X509FileType,
 ) -> TLS raise {
-  let self = TLS::from_pair(server_ctx, r, w)
+  let self = TLS::from_pair(server_ctx, r, w, host=None)
   if self.ssl.use_certificate_file(certificate_file, certificate_type) != 1 {
     self.close()
     raise OpenSSLError(err_get_error())
@@ -221,6 +235,8 @@ pub fn TLS::close(self : TLS) -> Unit {
   self.read_end.close()
   self.write_end.close()
   self.ssl.free()
+  // We must make sure the host string lives longer than `self.ssl`
+  ignore(self.host)
 }
 
 ///|

--- a/src/tls/tls.mbt
+++ b/src/tls/tls.mbt
@@ -58,14 +58,24 @@ async fn TLS::handle_error(self : TLS, err : Int) -> Unit raise {
 /// If `verify` is `true` (`true` by default),
 /// `client_from_pair` will perform verification on server's certificate,
 /// using the default verification setting of the OpenSSL library.
+///
+/// If `sni` is present, its value will set the host name for the
+/// Server Name Indication (SNI) field in ClientHello packet of TLS.
 pub async fn[R : @io.Reader, W : @io.Writer] TLS::client_from_pair(
   r : R,
   w : W,
   verify~ : Bool = true,
+  sni? : Bytes,
 ) -> TLS raise {
   let self = TLS::from_pair(client_ctx, r, w)
   if not(verify) {
     self.ssl.set_verify(false)
+  }
+  if sni is Some(host) {
+    guard self.ssl.set_sni(host) > 0 else {
+      self.close()
+      raise OpenSSLError(err_get_error())
+    }
   }
   while self.ssl.connect() is ret && ret <= 0 {
     self.handle_error(self.ssl.get_error(ret)) catch {
@@ -85,11 +95,15 @@ pub async fn[R : @io.Reader, W : @io.Writer] TLS::client_from_pair(
 /// If `verify` is `true` (`true` by default),
 /// `client` will perform verification on server's certificate,
 /// using the default verification setting of the OpenSSL library.
+///
+/// If `sni` is present, its value will set the host name for the
+/// Server Name Indication (SNI) field in ClientHello packet of TLS.
 pub async fn[Inner : @io.Reader + @io.Writer] TLS::client(
   inner : Inner,
   verify~ : Bool = true,
+  sni? : Bytes,
 ) -> TLS raise {
-  TLS::client_from_pair(inner, inner, verify~)
+  TLS::client_from_pair(inner, inner, verify~, sni?)
 }
 
 ///|

--- a/src/tls/tls.mbti
+++ b/src/tls/tls.mbti
@@ -16,8 +16,8 @@ impl Show for OpenSSLError
 
 // Types and methods
 type TLS
-async fn[Inner : @io.Reader + @io.Writer] TLS::client(Inner, verify? : Bool) -> Self raise
-async fn[R : @io.Reader, W : @io.Writer] TLS::client_from_pair(R, W, verify? : Bool) -> Self raise
+async fn[Inner : @io.Reader + @io.Writer] TLS::client(Inner, verify? : Bool, sni? : Bytes) -> Self raise
+async fn[R : @io.Reader, W : @io.Writer] TLS::client_from_pair(R, W, verify? : Bool, sni? : Bytes) -> Self raise
 fn TLS::close(Self) -> Unit
 async fn TLS::read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int raise
 async fn[Inner : @io.Reader + @io.Writer] TLS::server(Inner, private_key_file~ : Bytes, private_key_type~ : X509FileType, certificate_file~ : Bytes, certificate_type~ : X509FileType) -> Self raise

--- a/src/tls/tls.mbti
+++ b/src/tls/tls.mbti
@@ -16,8 +16,8 @@ impl Show for OpenSSLError
 
 // Types and methods
 type TLS
-async fn[Inner : @io.Reader + @io.Writer] TLS::client(Inner, verify? : Bool, sni? : Bytes) -> Self raise
-async fn[R : @io.Reader, W : @io.Writer] TLS::client_from_pair(R, W, verify? : Bool, sni? : Bytes) -> Self raise
+async fn[Inner : @io.Reader + @io.Writer] TLS::client(Inner, verify? : Bool, host? : Bytes, sni? : Bool) -> Self raise
+async fn[R : @io.Reader, W : @io.Writer] TLS::client_from_pair(R, W, verify? : Bool, host? : Bytes, sni? : Bool) -> Self raise
 fn TLS::close(Self) -> Unit
 async fn TLS::read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int raise
 async fn[Inner : @io.Reader + @io.Writer] TLS::server(Inner, private_key_file~ : Bytes, private_key_type~ : X509FileType, certificate_file~ : Bytes, certificate_type~ : X509FileType) -> Self raise


### PR DESCRIPTION
This PR adds Server Name Indication (SNI) support to the `@tls` package, as well as host name verification for security sake