### PR TITLE
[breaking] classify TCP listen socket and TCP connection

### DIFF
--- a/examples/http_file_server/main.mbt
+++ b/examples/http_file_server/main.mbt
@@ -111,11 +111,10 @@ pub async fn server(
   log~ : (String) -> Unit = println,
 ) -> Unit raise {
   let base_path = path
-  let listen_sock = @socket.TCP::new()
-  defer listen_sock.close()
-  listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
+  let server = @socket.TCPServer::new(@socket.Addr::parse("0.0.0.0:\{port}"))
+  defer server.close()
   for {
-    let (conn, addr) = listen_sock.accept()
+    let (conn, addr) = server.accept()
     log("received new connection from \{addr}")
     ctx.spawn_bg(allow_failure=true, fn() {
       defer {

--- a/examples/http_file_server/server_test.mbt
+++ b/examples/http_file_server/server_test.mbt
@@ -67,9 +67,8 @@ let port = 4207
 
 ///|
 async fn client(path : Bytes) -> Response raise {
-  let conn = @socket.TCP::new()
+  let conn = @socket.TCP::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   defer conn.close()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   conn..write(b"GET ")..write(path)..write(b" HTTP/1.1\r\n\r\n")
   parse_reply(@io.BufferedReader::new(conn))
 }

--- a/examples/tcp_echo_server/main.mbt
+++ b/examples/tcp_echo_server/main.mbt
@@ -15,11 +15,10 @@
 ///|
 fn main_prog() -> Unit raise {
   @async.with_event_loop(fn(root) {
-    let listen_sock = @socket.TCP::new()
-    defer listen_sock.close()
-    listen_sock..bind(@socket.Addr::parse("0.0.0.0:4200"))..listen()
+    let server = @socket.TCPServer::new(@socket.Addr::parse("0.0.0.0:4200"))
+    defer server.close()
     for {
-      let (conn, addr) = listen_sock.accept()
+      let (conn, addr) = server.accept()
       println("received new connection from \{addr}")
       root.spawn_bg(fn() {
         defer conn.close()

--- a/examples/tcp_ping_pong/main.mbt
+++ b/examples/tcp_ping_pong/main.mbt
@@ -24,12 +24,11 @@ pub(all) struct Printer((String) -> Unit)
 ///|
 async fn server(println : Printer) -> Unit raise {
   @async.with_task_group(fn(group) {
-    let listen_sock = @socket.TCP::new()
-    defer listen_sock.close()
-    listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
+    let server = @socket.TCPServer::new(@socket.Addr::parse("0.0.0.0:\{port}"))
+    defer server.close()
     try {
       for {
-        let (conn, _) = listen_sock.accept()
+        let (conn, _) = server.accept()
         println("received new connection")
         group.spawn_bg(fn() {
           defer conn.close()
@@ -62,9 +61,8 @@ async fn server(println : Printer) -> Unit raise {
 
 ///|
 async fn client(println : Printer, id : Int, msg : Bytes) -> Unit raise {
-  let conn = @socket.TCP::new()
+  let conn = @socket.TCP::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   defer conn.close()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   // The sleep here is used to make test result stable and portable,
   // because this message is in race condition
   // with server side "received connection" message

--- a/src/socket/connect_burst_test.mbt
+++ b/src/socket/connect_burst_test.mbt
@@ -20,14 +20,13 @@ let port = 4206
 
 ///|
 async fn server() -> Int raise {
-  let listen_sock = @socket.TCP::new()
+  let server = @socket.TCPServer::new(@socket.Addr::parse("0.0.0.0:\{port}"))
+  defer server.close()
   let mut num_connection = 0
   try
     @async.with_task_group(fn(group) {
-      listen_sock..bind(@socket.Addr::parse("0.0.0.0:\{port}"))..listen()
-      defer listen_sock.close()
       for {
-        let (conn, _) = listen_sock.accept()
+        let (conn, _) = server.accept()
         num_connection += 1
         group.spawn_bg(fn() {
           defer conn.close()
@@ -52,9 +51,8 @@ async fn server() -> Int raise {
 
 ///|
 async fn client(msg : Bytes) -> Unit raise {
-  let conn = @socket.TCP::new()
+  let conn = @socket.TCP::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   defer conn.close()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   conn.write(msg)
 }
 

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -13,7 +13,18 @@
 // limitations under the License.
 
 ///|
-extern "C" fn make_tcp_socket() -> Int = "moonbitlang_async_make_tcp_socket"
+extern "C" fn make_tcp_socket_ffi() -> Int = "moonbitlang_async_make_tcp_socket"
+
+///|
+fn make_tcp_socket() -> Int raise {
+  let sock = make_tcp_socket_ffi()
+  if sock < 0 {
+    @os_error.check_errno()
+  }
+  @fd_util.set_cloexec(sock)
+  @fd_util.set_nonblocking(sock)
+  sock
+}
 
 ///|
 extern "C" fn make_udp_socket() -> Int = "moonbitlang_async_make_udp_socket"

--- a/src/socket/read_exactly_test.mbt
+++ b/src/socket/read_exactly_test.mbt
@@ -23,10 +23,11 @@ test "read_exactly" {
   @async.with_event_loop(fn(root) {
     // server
     root.spawn_bg(fn() {
-      let listen_sock = @socket.TCP::new()
-      defer listen_sock.close()
-      listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
-      let (conn, _) = listen_sock.accept()
+      let server = @socket.TCPServer::new(
+        @socket.Addr::parse("127.0.0.1:\{port}"),
+      )
+      defer server.close()
+      let (conn, _) = server.accept()
       defer conn.close()
       let msg1 = conn.read_exactly(4)
       @async.sleep(10)
@@ -43,9 +44,8 @@ test "read_exactly" {
     })
     // client
     root.spawn_bg(fn() {
-      let conn = @socket.TCP::new()
+      let conn = @socket.TCP::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
       defer conn.close()
-      conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
       conn.write([1, 2, 3, 4, 5, 6])
       log("first message sent")
       @async.sleep(30)
@@ -77,10 +77,11 @@ test "read_exactly failure" {
   let result = try? @async.with_event_loop(fn(root) {
       // server
       root.spawn_bg(fn() {
-        let listen_sock = @socket.TCP::new()
-        defer listen_sock.close()
-        listen_sock..bind(@socket.Addr::parse("127.0.0.1:\{port}"))..listen()
-        let (conn, _) = listen_sock.accept()
+        let server = @socket.TCPServer::new(
+          @socket.Addr::parse("127.0.0.1:\{port}"),
+        )
+        defer server.close()
+        let (conn, _) = server.accept()
         defer conn.close()
         let msg1 = conn.read_exactly(4)
         @async.sleep(10)
@@ -97,9 +98,10 @@ test "read_exactly failure" {
       })
       // client
       root.spawn_bg(fn() {
-        let conn = @socket.TCP::new()
+        let conn = @socket.TCP::connect(
+          @socket.Addr::parse("127.0.0.1:\{port}"),
+        )
         defer conn.close()
-        conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
         conn.write([1, 2, 3, 4, 5, 6])
         log("first message sent")
       })

--- a/src/socket/socket.mbti
+++ b/src/socket/socket.mbti
@@ -27,13 +27,9 @@ impl Hash for Addr
 impl Show for Addr
 
 type TCP
-async fn TCP::accept(Self) -> (Self, Addr) raise
-fn TCP::bind(Self, Addr) -> Unit raise
 fn TCP::close(Self) -> Unit
-async fn TCP::connect(Self, Addr) -> Unit raise
+async fn TCP::connect(Addr) -> Self raise
 fn TCP::enable_keepalive(Self, idle_before_keep_alive? : Int, keep_alive_count? : Int, keep_alive_interval? : Int) -> Unit raise
-fn TCP::listen(Self) -> Unit raise
-fn TCP::new() -> Self raise
 #alias(recv, deprecated)
 async fn TCP::read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int raise
 #deprecated
@@ -42,6 +38,11 @@ async fn TCP::recv_exactly(Self, Int) -> Bytes raise
 async fn TCP::send(Self, @bytes.View) -> Unit raise
 impl @moonbitlang/async/io.Reader for TCP
 impl @moonbitlang/async/io.Writer for TCP
+
+type TCPServer
+async fn TCPServer::accept(Self) -> (TCP, Addr) raise
+fn TCPServer::close(Self) -> Unit
+fn TCPServer::new(Addr) -> Self raise
 
 type UDP
 fn UDP::bind(Self, Addr) -> Unit raise

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -13,21 +13,8 @@
 // limitations under the License.
 
 ///|
-/// A TCP socket directly corresponding to OS socket.
+/// A TCP connection
 struct TCP(Int)
-
-///|
-/// Create a new TCP socket using the `socket(2)` system call.
-/// The created socket always operate in non-blocking mode.
-pub fn TCP::new() -> TCP raise {
-  let sock = make_tcp_socket()
-  if sock < 0 {
-    @os_error.check_errno()
-  }
-  @fd_util.set_cloexec(sock)
-  @fd_util.set_nonblocking(sock)
-  TCP(sock)
-}
 
 ///|
 pub fn TCP::close(self : TCP) -> Unit {
@@ -36,22 +23,40 @@ pub fn TCP::close(self : TCP) -> Unit {
 }
 
 ///|
-/// Bind the socket to an address using the `bind(2)` system call.
-pub fn TCP::bind(self : TCP, addr : Addr) -> Unit raise {
-  let TCP(sock) = self
+struct TCPServer(Int)
+
+///|
+/// Create a TCP server that is bound to `addr`,
+/// listening for incoming connections.
+pub fn TCPServer::new(addr : Addr) -> TCPServer raise {
+  let sock = make_tcp_socket()
   if 0 != bind_ffi(sock, addr) {
+    @fd_util.close(sock)
     @os_error.check_errno()
   }
+  if 0 != listen_ffi(sock) {
+    @fd_util.close(sock)
+    @os_error.check_errno()
+  }
+  TCPServer(sock)
 }
 
 ///|
-/// Turn the socket into listen mode using `listen(2)` system call,
-/// so that it can start accepting connections.
-pub fn TCP::listen(self : TCP) -> Unit raise {
-  let TCP(sock) = self
-  if 0 != listen_ffi(sock) {
-    @os_error.check_errno()
-  }
+pub fn TCPServer::close(self : TCPServer) -> Unit {
+  let TCPServer(sock) = self
+  @event_loop.close_fd(sock)
+}
+
+///|
+/// Accept a new connection on a listening TCP server.
+/// The accepted connection will be returned together with the address of peer.
+pub async fn TCPServer::accept(self : TCPServer) -> (TCP, Addr) raise {
+  let TCPServer(listen_sock) = self
+  let addr = Addr::new(0, 0)
+  let conn = @event_loop.perform_job(Accept(sock=listen_sock, addr=addr.0))
+  @fd_util.set_cloexec(conn)
+  @fd_util.set_nonblocking(conn)
+  (conn, addr)
 }
 
 ///|
@@ -80,22 +85,17 @@ pub fn TCP::enable_keepalive(
 }
 
 ///|
-/// Accept a new connection on a listening socket using `accept(2)` system call.
-/// A new socket representing the accepted connection
-/// will be returned together with the address of peer.
-pub async fn TCP::accept(self : TCP) -> (TCP, Addr) raise {
-  let TCP(listen_sock) = self
-  let addr = Addr::new(0, 0)
-  let conn = @event_loop.perform_job(Accept(sock=listen_sock, addr=addr.0))
-  @fd_util.set_nonblocking(conn)
-  (conn, addr)
-}
-
-///|
 /// Make connection to a remote address using `connect(2)` system call.
-pub async fn TCP::connect(self : TCP, addr : Addr) -> Unit raise {
-  let TCP(sock) = self
-  ignore(@event_loop.perform_job(Connect(sock~, addr=addr.0)))
+pub async fn TCP::connect(addr : Addr) -> TCP raise {
+  let sock = make_tcp_socket()
+  try @event_loop.perform_job(Connect(sock~, addr=addr.0)) catch {
+    err => {
+      @fd_util.close(sock)
+      raise err
+    }
+  } noraise {
+    _ => TCP(sock)
+  }
 }
 
 ///|


### PR DESCRIPTION
This PR makes TCP socket API more high level, splitting `@socket.TCP` into two types. `@socket.TCP` now only represents TCP connections, and listen socket in represented as `@socket.TCPServer`. Raw TCP operations such as `bind`, `listen` and `connect` are removed and absorbed into socket creation API. Socket creation API now come in three flavors:

- `TCPServer::new(addr)` create a listen socket that is bound to and listen on `addr`
- `TCP::connect(addr)` create a socket that connects to `addr`
- `TCPServer::accept` return new incoming connection on a listen socket