### PR TITLE
add happy eyeball implementation

### DIFF
--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -64,8 +64,8 @@ pub async fn request(
     (uri, "/")
   }
   let path = if path == "" { b"/" } else { path }
-  let addr = @socket.Addr::resolve(host, port~)
-  let conn = @socket.TCP::connect(addr)
+  let conn = @socket.TCP::connect_to_host(host, port~)
+  defer conn.close()
   headers.push(Header("Host", host))
   match protocol {
     Http => make_request(conn, path, headers~)

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -78,7 +78,13 @@ typealias @event_loop.AddrInfo
 extern "C" fn AddrInfo::null() -> AddrInfo = "moonbitlang_async_null_addrinfo"
 
 ///|
+extern "C" fn AddrInfo::is_null(self : AddrInfo) -> Bool = "moonbitlang_async_addrinfo_is_null"
+
+///|
 extern "C" fn AddrInfo::ip(self : AddrInfo) -> UInt = "moonbitlang_async_addrinfo_get_ip"
+
+///|
+extern "C" fn AddrInfo::next(self : AddrInfo) -> AddrInfo = "moonbitlang_async_addrinfo_get_next"
 
 ///|
 extern "C" fn AddrInfo::free(self : AddrInfo) = "freeaddrinfo"

--- a/src/socket/happy_eyeball.mbt
+++ b/src/socket/happy_eyeball.mbt
@@ -1,0 +1,46 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Connect to a remote host using the happy eyeball algorithm.
+pub async fn TCP::connect_to_host(host : Bytes, port~ : Int) -> TCP raise {
+  let info = @ref.new(AddrInfo::null())
+  let ret = @event_loop.perform_job(GetAddrInfo(host~, out=info))
+  if ret > 0 {
+    raise ResolveHostnameError(ret)
+  }
+  let mut result = None
+  let mut conn_err = None
+  @async.with_task_group(fn(group) {
+    for ai = info.val; not(ai.is_null()); ai = ai.next() {
+      group.spawn_bg(allow_failure=true, fn() {
+        let conn = TCP::connect(Addr::new(ai.ip(), port)) catch {
+          err => {
+            if conn_err is None {
+              conn_err = Some(err)
+            }
+            raise err
+          }
+        }
+        result = Some(conn)
+        group.return_immediately(())
+      })
+      @async.sleep(250)
+    }
+  })
+  match result {
+    Some(conn) => conn
+    None => raise conn_err.unwrap()
+  }
+}

--- a/src/socket/moon.pkg.json
+++ b/src/socket/moon.pkg.json
@@ -3,10 +3,10 @@
     "moonbitlang/async/os_error",
     "moonbitlang/async/internal/event_loop",
     "moonbitlang/async/internal/fd_util",
-    "moonbitlang/async/io"
+    "moonbitlang/async/io",
+    "moonbitlang/async"
   ],
   "test-import": [
-    "moonbitlang/async",
     "moonbitlang/async/aqueue"
   ],
   "native-stub": [ "socket.c" ]

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -103,6 +103,14 @@ struct addrinfo *moonbitlang_async_null_addrinfo() {
   return 0;
 }
 
+int32_t moonbitlang_async_addrinfo_is_null(struct addrinfo *addrinfo) {
+  return addrinfo == 0;
+}
+
 uint32_t moonbitlang_async_addrinfo_get_ip(struct addrinfo *addrinfo) {
   return ntohl(((struct sockaddr_in*)(addrinfo->ai_addr))->sin_addr.s_addr);
+}
+
+struct addrinfo *moonbitlang_async_addrinfo_get_next(struct addrinfo *addrinfo) {
+  return addrinfo->ai_next;
 }

--- a/src/socket/socket.mbti
+++ b/src/socket/socket.mbti
@@ -29,6 +29,7 @@ impl Show for Addr
 type TCP
 fn TCP::close(Self) -> Unit
 async fn TCP::connect(Addr) -> Self raise
+async fn TCP::connect_to_host(Bytes, port~ : Int) -> Self raise
 fn TCP::enable_keepalive(Self, idle_before_keep_alive? : Int, keep_alive_count? : Int, keep_alive_interval? : Int) -> Unit raise
 #alias(recv, deprecated)
 async fn TCP::read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int raise

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -90,7 +90,7 @@ pub async fn TCP::connect(addr : Addr) -> TCP raise {
   let sock = make_tcp_socket()
   try @event_loop.perform_job(Connect(sock~, addr=addr.0)) catch {
     err => {
-      @fd_util.close(sock)
+      @event_loop.close_fd(sock)
       raise err
     }
   } noraise {


### PR DESCRIPTION
- add `@socket.TCP::connect_to_host`, which performs DNS resolution and connect to remote host using the happy eyeball algorithm
- utilize happy eyeball in `@http.request`