### PR TITLE
add `@http.Client` type for more flexible HTTP client

### DIFF
--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -15,7 +15,7 @@
 ///|
 /// Simple HTTP client which connect to a remote host via TCP
 struct Client {
-  host : Bytes
+  headers : Array[Header]
   reader : Reader
   conn : @socket.TCP
   tls : @tls.TLS?
@@ -26,8 +26,19 @@ struct Client {
 /// If `protocol` is `Https` (`Https` by default),
 /// a TLS connection will be established,
 /// and the certificate of the remote peer will be verified.
+///
+/// `headers` can be used to specify persistent headers for the client,
+/// i.e. all requests made from this client will share these headers.
+/// The ownership of `headers` will be transferred to the new client,
+/// so `headers` should not be used by the caller later.
+/// The following headers is automatically set,
+/// and must not be specified in `headers`:
+/// 
+/// - Host
+/// - Content-Length, Transfer-Encoding
 pub async fn Client::connect(
   host : Bytes,
+  headers? : Array[Header] = [],
   protocol? : Protocol = Https,
   port? : Int = protocol.default_port(),
 ) -> Client raise {
@@ -40,7 +51,8 @@ pub async fn Client::connect(
     None => Reader::new(conn)
     Some(tls) => Reader::new(tls)
   }
-  { host, conn, tls, reader }
+  headers.push(Header("Host", host))
+  { headers, conn, tls, reader }
 }
 
 ///|
@@ -77,23 +89,24 @@ pub impl @io.Reader for Client with read(self, buf, offset~, max_len~) {
 /// the next request MUST NOT be made before the body of the response is consumed.
 /// If you don't care about the response body, use `skip_body` to skip it.
 ///
-/// Additional HTTP headers can be passed via `headers`.
-/// The ownership of `headers` will be transferred to `request`,
-/// so `headers` should be a temporary array.
+/// In addition to headers in `Client::connect`,
+/// extra HTTP headers can be passed via `extra_headers`.
 /// The following headers is automatically set by `request`,
-/// and must not be specified in `headers`:
+/// and must not be specified in `extra_headers`:
 /// 
 /// - Host
 /// - Content-Length, Transfer-Encoding
 pub async fn Client::request(
   self : Client,
-  request : Request,
+  meth : RequestMethod,
+  path : Bytes,
+  extra_headers? : Array[Header] = [],
   body : Body,
 ) -> Response raise {
-  request.headers.push(Header("Host", self.host))
+  let headers = self.headers + extra_headers
   match self.tls {
-    Some(tls) => send_request(tls, request, body)
-    None => send_request(self.conn, request, body)
+    Some(tls) => send_request(tls, { meth, path, headers }, body)
+    None => send_request(self.conn, { meth, path, headers }, body)
   }
   self.reader.read_response()
 }
@@ -110,10 +123,10 @@ pub async fn Client::skip_body(self : Client) -> Unit raise {
 pub async fn Client::get(
   self : Client,
   path : Bytes,
-  headers? : Array[Header] = [],
+  extra_headers? : Array[Header] = [],
   body? : Body = Empty,
 ) -> Response raise {
-  self.request({ meth: Get, path, headers }, body)
+  self.request(Get, path, extra_headers~, body)
 }
 
 ///|
@@ -122,9 +135,9 @@ pub async fn Client::put(
   self : Client,
   path : Bytes,
   body : Body,
-  headers? : Array[Header] = [],
+  extra_headers? : Array[Header] = [],
 ) -> Response raise {
-  self.request({ meth: Put, path, headers }, body)
+  self.request(Put, path, extra_headers~, body)
 }
 
 ///|
@@ -133,7 +146,7 @@ pub async fn Client::post(
   self : Client,
   path : Bytes,
   body : Body,
-  headers? : Array[Header] = [],
+  extra_headers? : Array[Header] = [],
 ) -> Response raise {
-  self.request({ meth: Post, path, headers }, body)
+  self.request(Post, path, extra_headers~, body)
 }

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -76,6 +76,15 @@ pub impl @io.Reader for Client with read(self, buf, offset~, max_len~) {
 /// After performing a request,
 /// the next request MUST NOT be made before the body of the response is consumed.
 /// If you don't care about the response body, use `skip_body` to skip it.
+///
+/// Additional HTTP headers can be passed via `headers`.
+/// The ownership of `headers` will be transferred to `request`,
+/// so `headers` should be a temporary array.
+/// The following headers is automatically set by `request`,
+/// and must not be specified in `headers`:
+/// 
+/// - Host
+/// - Content-Length, Transfer-Encoding
 pub async fn Client::request(
   self : Client,
   request : Request,

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -1,0 +1,130 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Simple HTTP client which connect to a remote host via TCP
+struct Client {
+  host : Bytes
+  reader : Reader
+  conn : @socket.TCP
+  tls : @tls.TLS?
+}
+
+///|
+/// Create a new HTTP client by connecting to a remote host.
+/// If `protocol` is `Https` (`Https` by default),
+/// a TLS connection will be established,
+/// and the certificate of the remote peer will be verified.
+pub async fn Client::connect(
+  host : Bytes,
+  protocol? : Protocol = Https,
+  port? : Int = protocol.default_port(),
+) -> Client raise {
+  let conn = @socket.TCP::connect_to_host(host, port~)
+  let tls = match protocol {
+    Http => None
+    Https => Some(@tls.TLS::client(conn, host~))
+  }
+  let reader = match tls {
+    None => Reader::new(conn)
+    Some(tls) => Reader::new(tls)
+  }
+  { host, conn, tls, reader }
+}
+
+///|
+/// Close a HTTP client and release underlying resource.
+/// In particular close the underlying TCP connection.
+pub fn Client::close(self : Client) -> Unit {
+  if self.tls is Some(tls) {
+    tls.close()
+  }
+  self.conn.close()
+}
+
+///|
+/// Gracefully shutdown a HTTP client, in particular perform TLS shutdown.
+/// This MUST be called before `close`
+/// and MUST NOT be called on fatal network or TLS error.
+pub async fn Client::shutdown(self : Client) -> Unit raise {
+  if self.tls is Some(tls) {
+    tls.shutdown()
+  }
+}
+
+///|
+pub impl @io.Reader for Client with read(self, buf, offset~, max_len~) {
+  self.reader.read(buf, offset~, max_len~)
+}
+
+///|
+/// Send a HTTP request to the server, and return the response from the server.
+/// Only the header of the response will be received and returned,
+/// the body of the response can be extracted by using `Client` as a `@io.Reader`.
+///
+/// After performing a request,
+/// the next request MUST NOT be made before the body of the response is consumed.
+/// If you don't care about the response body, use `skip_body` to skip it.
+pub async fn Client::request(
+  self : Client,
+  request : Request,
+  body : Body,
+) -> Response raise {
+  request.headers.push(Header("Host", self.host))
+  match self.tls {
+    Some(tls) => send_request(tls, request, body)
+    None => send_request(self.conn, request, body)
+  }
+  self.reader.read_response()
+}
+
+///|
+/// Skip the body of the response currently being produced,
+/// so that the next request can be made.
+pub async fn Client::skip_body(self : Client) -> Unit raise {
+  self.reader.skip_body()
+}
+
+///|
+/// Perform a `GET` request to the server, see `Client::request` for more details.
+pub async fn Client::get(
+  self : Client,
+  path : Bytes,
+  headers? : Array[Header] = [],
+  body? : Body = Empty,
+) -> Response raise {
+  self.request({ meth: Get, path, headers }, body)
+}
+
+///|
+/// Perform a `PUT` request to the server, see `Client::request` for more details.
+pub async fn Client::put(
+  self : Client,
+  path : Bytes,
+  body : Body,
+  headers? : Array[Header] = [],
+) -> Response raise {
+  self.request({ meth: Put, path, headers }, body)
+}
+
+///|
+/// Perform a `POST` request to the server, see `Client::request` for more details.
+pub async fn Client::post(
+  self : Client,
+  path : Bytes,
+  body : Body,
+  headers? : Array[Header] = [],
+) -> Response raise {
+  self.request({ meth: Post, path, headers }, body)
+}

--- a/src/http/moon.pkg.json
+++ b/src/http/moon.pkg.json
@@ -1,12 +1,12 @@
 {
   "import": [
-    "moonbitlang/async",
     "moonbitlang/async/io",
     "moonbitlang/async/socket",
     "moonbitlang/async/tls",
     "moonbitlang/async/internal/bytes_util"
   ],
   "test-import": [
+    "moonbitlang/async",
     "moonbitlang/async/pipe",
     "moonbitlang/async/fs"
   ]

--- a/src/http/parser_test.mbt
+++ b/src/http/parser_test.mbt
@@ -147,13 +147,13 @@ test "read_request chunked" {
       #|transfer-encoding: chunked
       #|{
       #|  "import": [
-      #|    "moonbitlang/async",
       #|    "moonbitlang/async/io",
       #|    "moonbitlang/async/socket",
       #|    "moonbitlang/async/tls",
       #|    "moonbitlang/async/internal/bytes_util"
       #|  ],
       #|  "test-import": [
+      #|    "moonbitlang/async",
       #|    "moonbitlang/async/pipe",
       #|    "moonbitlang/async/fs"
       #|  ]

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -6,7 +6,12 @@ import(
 )
 
 // Values
-async fn request(Bytes, headers? : Array[Header], protocol? : Protocol, port? : Int) -> (Response, Bytes) raise
+#alias(request, deprecated)
+async fn get(Bytes, headers? : Array[Header], protocol? : Protocol, port? : Int) -> (Response, Bytes) raise
+
+async fn post(Bytes, Bytes, headers? : Array[Header], protocol? : Protocol, port? : Int) -> (Response, Bytes) raise
+
+async fn put(Bytes, Bytes, headers? : Array[Header], protocol? : Protocol, port? : Int) -> (Response, Bytes) raise
 
 async fn[Writer : @io.Writer] send_request(Writer, Request, Body) -> Unit raise
 

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -34,11 +34,11 @@ pub(all) enum Body {
 
 type Client
 fn Client::close(Self) -> Unit
-async fn Client::connect(Bytes, protocol? : Protocol, port? : Int) -> Self raise
-async fn Client::get(Self, Bytes, headers? : Array[Header], body? : Body) -> Response raise
-async fn Client::post(Self, Bytes, Body, headers? : Array[Header]) -> Response raise
-async fn Client::put(Self, Bytes, Body, headers? : Array[Header]) -> Response raise
-async fn Client::request(Self, Request, Body) -> Response raise
+async fn Client::connect(Bytes, headers? : Array[Header], protocol? : Protocol, port? : Int) -> Self raise
+async fn Client::get(Self, Bytes, extra_headers? : Array[Header], body? : Body) -> Response raise
+async fn Client::post(Self, Bytes, Body, extra_headers? : Array[Header]) -> Response raise
+async fn Client::put(Self, Bytes, Body, extra_headers? : Array[Header]) -> Response raise
+async fn Client::request(Self, RequestMethod, Bytes, extra_headers? : Array[Header], Body) -> Response raise
 async fn Client::shutdown(Self) -> Unit raise
 async fn Client::skip_body(Self) -> Unit raise
 impl @io.Reader for Client

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -6,7 +6,7 @@ import(
 )
 
 // Values
-async fn request(Bytes, headers? : Array[Header], protocol? : RequestProtocol, port? : Int) -> (Response, Bytes) raise
+async fn request(Bytes, headers? : Array[Header], protocol? : Protocol, port? : Int) -> (Response, Bytes) raise
 
 async fn[Writer : @io.Writer] send_request(Writer, Request, Body) -> Unit raise
 
@@ -27,8 +27,25 @@ pub(all) enum Body {
   Stream(&@io.Reader)
 }
 
+type Client
+fn Client::close(Self) -> Unit
+async fn Client::connect(Bytes, protocol? : Protocol, port? : Int) -> Self raise
+async fn Client::get(Self, Bytes, headers? : Array[Header], body? : Body) -> Response raise
+async fn Client::post(Self, Bytes, Body, headers? : Array[Header]) -> Response raise
+async fn Client::put(Self, Bytes, Body, headers? : Array[Header]) -> Response raise
+async fn Client::request(Self, Request, Body) -> Response raise
+async fn Client::shutdown(Self) -> Unit raise
+async fn Client::skip_body(Self) -> Unit raise
+impl @io.Reader for Client
+
 pub(all) struct Header(Bytes, Bytes)
 
+
+pub(all) enum Protocol {
+  Http
+  Https
+}
+fn Protocol::default_port(Self) -> Int
 
 type Reader
 fn[R : @io.Reader] Reader::new(R) -> Self
@@ -56,11 +73,6 @@ pub(all) enum RequestMethod {
   Patch
 }
 impl Show for RequestMethod
-
-pub(all) enum RequestProtocol {
-  Http
-  Https
-}
 
 pub(all) struct Response {
   code : Int

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -43,9 +43,9 @@ async fn perform_request(
     (uri, "/")
   }
   let path = if path == "" { b"/" } else { path }
-  let client = Client::connect(host, protocol~, port~)
+  let client = Client::connect(host, headers~, protocol~, port~)
   defer client.close()
-  let response = client.request({ meth, path, headers }, body)
+  let response = client.request(meth, path, body)
   let body = client.read_all()
   client.shutdown()
   (response, body)

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -27,27 +27,13 @@ pub fn Protocol::default_port(p : Protocol) -> Int {
 }
 
 ///|
-/// Perform a HTTP network request to `uri`,
-/// which should be a URI without the protocol part.
-/// The HTTP response message and the whole response body will be returned.
-///
-/// The protocol can be specified via `protocol`, which is `Https` by default.
-/// By default the standard port number of `protocol` is used,
-/// but this can be overriden by explicitly passing `port`.
-///
-/// Additional HTTP headers can be passed via `headers`.
-/// The ownership of `headers` will be transferred to `request`,
-/// so `headers` should be a temporary array.
-/// The following headers is automatically set by `request`,
-/// and must not be specified in `headers`:
-/// 
-/// - Host
-/// - Content-Length, Transfer-Encoding
-pub async fn request(
+async fn perform_request(
   uri : Bytes,
-  headers? : Array[Header] = [],
-  protocol? : Protocol = Https,
-  port? : Int = protocol.default_port(),
+  meth : RequestMethod,
+  headers : Array[Header],
+  body : Body,
+  protocol~ : Protocol,
+  port~ : Int,
 ) -> (Response, Bytes) raise {
   let (host, path) = for i = 0; i < uri.length(); i = i + 1 {
     if uri[i] == '/' {
@@ -59,8 +45,52 @@ pub async fn request(
   let path = if path == "" { b"/" } else { path }
   let client = Client::connect(host, protocol~, port~)
   defer client.close()
-  let response = client.get(path, headers~)
+  let response = client.request({ meth, path, headers }, body)
   let body = client.read_all()
   client.shutdown()
   (response, body)
+}
+
+///|
+/// Perform a HTTP `GET` request to `uri`,
+/// which should be a URI without the protocol part.
+/// The HTTP response message and the whole response body will be returned.
+///
+/// The protocol can be specified via `protocol`, which is `Https` by default.
+/// By default the standard port number of `protocol` is used,
+/// but this can be overriden by explicitly passing `port`.
+///
+/// See `Client::request` for more details.
+#alias(request, deprecated)
+pub async fn get(
+  uri : Bytes,
+  headers? : Array[Header] = [],
+  protocol? : Protocol = Https,
+  port? : Int = protocol.default_port(),
+) -> (Response, Bytes) raise {
+  perform_request(uri, Get, headers, Empty, protocol~, port~)
+}
+
+///|
+/// Similar to `get`, but performs a `PUT` request instead.
+pub async fn put(
+  uri : Bytes,
+  content : Bytes,
+  headers? : Array[Header] = [],
+  protocol? : Protocol = Https,
+  port? : Int = protocol.default_port(),
+) -> (Response, Bytes) raise {
+  perform_request(uri, Put, headers, Fixed(content), protocol~, port~)
+}
+
+///|
+/// Similar to `get`, but performs a `POST` request instead.
+pub async fn post(
+  uri : Bytes,
+  content : Bytes,
+  headers? : Array[Header] = [],
+  protocol? : Protocol = Https,
+  port? : Int = protocol.default_port(),
+) -> (Response, Bytes) raise {
+  perform_request(uri, Post, headers, Fixed(content), protocol~, port~)
 }

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -13,21 +13,17 @@
 // limitations under the License.
 
 ///|
-pub(all) enum RequestProtocol {
+pub(all) enum Protocol {
   Http
   Https
 }
 
 ///|
-async fn[Conn : @io.Reader + @io.Writer] make_request(
-  conn : Conn,
-  path : Bytes,
-  headers~ : Array[Header],
-) -> (Response, Bytes) raise {
-  send_request(conn, { meth: Get, path, headers }, Empty)
-  let reader = Reader::new(conn)
-  let response = reader.read_response()
-  (response, reader.read_all())
+pub fn Protocol::default_port(p : Protocol) -> Int {
+  match p {
+    Http => 80
+    Https => 443
+  }
 }
 
 ///|
@@ -50,11 +46,8 @@ async fn[Conn : @io.Reader + @io.Writer] make_request(
 pub async fn request(
   uri : Bytes,
   headers? : Array[Header] = [],
-  protocol? : RequestProtocol = Https,
-  port? : Int = match protocol {
-    Http => 80
-    Https => 443
-  },
+  protocol? : Protocol = Https,
+  port? : Int = protocol.default_port(),
 ) -> (Response, Bytes) raise {
   let (host, path) = for i = 0; i < uri.length(); i = i + 1 {
     if uri[i] == '/' {
@@ -64,27 +57,10 @@ pub async fn request(
     (uri, "/")
   }
   let path = if path == "" { b"/" } else { path }
-  let conn = @socket.TCP::connect_to_host(host, port~)
-  defer conn.close()
-  headers.push(Header("Host", host))
-  match protocol {
-    Http => make_request(conn, path, headers~)
-    Https => {
-      let conn = @tls.TLS::client(conn, host~)
-      defer conn.close()
-      try make_request(conn, path, headers~) catch {
-        err => {
-          if not(err is (@tls.OpenSSLError(_) | @tls.ConnectionClosed)) {
-            @async.with_timeout(1000, () => conn.shutdown())
-          }
-          raise err
-        }
-      } noraise {
-        result => {
-          @async.with_timeout(1000, () => conn.shutdown())
-          result
-        }
-      }
-    }
-  }
+  let client = Client::connect(host, protocol~, port~)
+  defer client.close()
+  let response = client.get(path, headers~)
+  let body = client.read_all()
+  client.shutdown()
+  (response, body)
 }

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -16,7 +16,7 @@
 test "https request" {
   let log = StringBuilder::new()
   @async.with_event_loop(fn(_) {
-    let (_, result) = @http.request("www.example.org")
+    let (_, result) = @http.get("www.example.org")
     log.write_string(@bytes_util.ascii_to_string(result))
   })
   inspect(
@@ -77,7 +77,7 @@ test "https request" {
 test "http request" {
   let log = StringBuilder::new()
   @async.with_event_loop(fn(_) {
-    let (_, result) = @http.request("www.example.org", protocol=Http)
+    let (_, result) = @http.get("www.example.org", protocol=Http)
     log.write_string(@bytes_util.ascii_to_string(result))
   })
   inspect(

--- a/src/http/send_test.mbt
+++ b/src/http/send_test.mbt
@@ -110,13 +110,13 @@ test "send_request stream" {
       #|105\r
       #|{
       #|  "import": [
-      #|    "moonbitlang/async",
       #|    "moonbitlang/async/io",
       #|    "moonbitlang/async/socket",
       #|    "moonbitlang/async/tls",
       #|    "moonbitlang/async/internal/bytes_util"
       #|  ],
       #|  "test-import": [
+      #|    "moonbitlang/async",
       #|    "moonbitlang/async/pipe",
       #|    "moonbitlang/async/fs"
       #|  ]


### PR DESCRIPTION
This PR introduces a new type `@http.Client`, which encapsulates a HTTP/HTTPS connection to a remote host. It can be used to perform multiple HTTP requests via a single connection, or perform streaming read on response body when it is long.

`@http.request` is renamed to `@http.get`, and is now a wrapper over `@http.Client`. Two extra convenient wrappers, `@http.put` and `@http.post` are introduced.