### PR TITLE
[breaking]: specify protocol in `@http.get` etc.

### DIFF
--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -7,11 +7,11 @@ import(
 
 // Values
 #alias(request, deprecated)
-async fn get(Bytes, headers? : Array[Header], protocol? : Protocol, port? : Int) -> (Response, Bytes)
+async fn get(Bytes, headers? : Array[Header], port? : Int) -> (Response, Bytes)
 
-async fn post(Bytes, Bytes, headers? : Array[Header], protocol? : Protocol, port? : Int) -> (Response, Bytes)
+async fn post(Bytes, Bytes, headers? : Array[Header], port? : Int) -> (Response, Bytes)
 
-async fn put(Bytes, Bytes, headers? : Array[Header], protocol? : Protocol, port? : Int) -> (Response, Bytes)
+async fn put(Bytes, Bytes, headers? : Array[Header], port? : Int) -> (Response, Bytes)
 
 async fn[Writer : @io.Writer] send_request(Writer, Request, Body) -> Unit
 
@@ -24,6 +24,12 @@ pub suberror HttpProtocolError {
   NotImplemented
 }
 impl Show for HttpProtocolError
+
+pub suberror URIParseError {
+  InvalidFormat
+  UnsupportedProtocol(String)
+}
+impl Show for URIParseError
 
 // Types and methods
 pub(all) enum Body {

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -27,20 +27,38 @@ pub fn Protocol::default_port(p : Protocol) -> Int {
 }
 
 ///|
+pub suberror URIParseError {
+  InvalidFormat
+  UnsupportedProtocol(String)
+} derive(Show)
+
+///|
 async fn perform_request(
   uri : Bytes,
   meth : RequestMethod,
   headers : Array[Header],
   body : Body,
-  protocol~ : Protocol,
-  port~ : Int,
+  port? : Int,
 ) -> (Response, Bytes) raise {
-  let (host, path) = for i = 0; i < uri.length(); i = i + 1 {
-    if uri[i] == '/' {
-      break (uri[:i].to_bytes(), uri[i:].to_bytes())
-    }
+  guard uri.find("://") is Some(protocol_len) else { raise InvalidFormat }
+  let protocol = match uri[:protocol_len] {
+    "http" => Http
+    "https" => Https
+    protocol => raise UnsupportedProtocol(@bytes_util.ascii_to_string(protocol))
+  }
+  let port = match port {
+    Some(port) => port
+    None =>
+      match protocol {
+        Http => 80
+        Https => 443
+      }
+  }
+  let uri = uri[protocol_len + 3:]
+  let (host, path) = if uri.find("/") is Some(i) {
+    (uri[:i].to_bytes(), uri[i:].to_bytes())
   } else {
-    (uri, "/")
+    (uri.to_bytes(), "/")
   }
   let path = if path == "" { b"/" } else { path }
   let client = Client::connect(host, headers~, protocol~, port~)
@@ -52,23 +70,21 @@ async fn perform_request(
 }
 
 ///|
-/// Perform a HTTP `GET` request to `uri`,
-/// which should be a URI without the protocol part.
+/// Perform a HTTP `GET` request to `uri`.
+/// Supported protocols are `http://` and `https://`.
 /// The HTTP response message and the whole response body will be returned.
 ///
-/// The protocol can be specified via `protocol`, which is `Https` by default.
-/// By default the standard port number of `protocol` is used,
-/// but this can be overriden by explicitly passing `port`.
+/// `port` is the port number to connect to.
+/// By default it is the standard port for the specified protocol.
 ///
 /// See `Client::request` for more details.
 #alias(request, deprecated)
 pub async fn get(
   uri : Bytes,
   headers? : Array[Header] = [],
-  protocol? : Protocol = Https,
-  port? : Int = protocol.default_port(),
+  port? : Int,
 ) -> (Response, Bytes) raise {
-  perform_request(uri, Get, headers, Empty, protocol~, port~)
+  perform_request(uri, Get, headers, Empty, port?)
 }
 
 ///|
@@ -77,10 +93,9 @@ pub async fn put(
   uri : Bytes,
   content : Bytes,
   headers? : Array[Header] = [],
-  protocol? : Protocol = Https,
-  port? : Int = protocol.default_port(),
+  port? : Int,
 ) -> (Response, Bytes) raise {
-  perform_request(uri, Put, headers, Fixed(content), protocol~, port~)
+  perform_request(uri, Put, headers, Fixed(content), port?)
 }
 
 ///|
@@ -89,8 +104,7 @@ pub async fn post(
   uri : Bytes,
   content : Bytes,
   headers? : Array[Header] = [],
-  protocol? : Protocol = Https,
-  port? : Int = protocol.default_port(),
+  port? : Int,
 ) -> (Response, Bytes) raise {
-  perform_request(uri, Post, headers, Fixed(content), protocol~, port~)
+  perform_request(uri, Post, headers, Fixed(content), port?)
 }

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -16,7 +16,7 @@
 test "https request" {
   let log = StringBuilder::new()
   @async.with_event_loop(fn(_) {
-    let (_, result) = @http.get("www.example.org")
+    let (_, result) = @http.get("https://www.example.org")
     log.write_string(@bytes_util.ascii_to_string(result))
   })
   inspect(
@@ -77,7 +77,7 @@ test "https request" {
 test "http request" {
   let log = StringBuilder::new()
   @async.with_event_loop(fn(_) {
-    let (_, result) = @http.get("www.example.org", protocol=Http)
+    let (_, result) = @http.get("http://www.example.org")
     log.write_string(@bytes_util.ascii_to_string(result))
   })
   inspect(


### PR DESCRIPTION
The previous signature of `@http.get` etc. is not intuitive because the protocol part is specified separately. This PR instead let the user specify the protocol in the URI, e.g. `https://www.example.org`