### PR TITLE
fix `ESRCH` error on MacOS due to race condition

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -314,7 +314,10 @@ async fn wait_fd_write(fd : Int) -> Unit raise {
 ///|
 async fn wait_pid(pid : Int) -> Int raise {
   guard curr_loop.val is Some(evloop)
-  let alt_id = evloop.poll.register_pid(pid)
+  let alt_id = match evloop.poll.register_pid(pid) {
+    Running(id) => id
+    Stopped(ret) => return ret
+  }
   guard evloop.pids.get(alt_id) is None
   let handle = { result: 0, waiter: @coroutine.current_coroutine() }
   evloop.pids[alt_id] = handle

--- a/src/internal/event_loop/poll.mbt
+++ b/src/internal/event_loop/poll.mbt
@@ -56,15 +56,34 @@ fn Instance::register(
 }
 
 ///|
-extern "C" fn Instance::register_pid_ffi(self : Instance, pid : Int) -> Int = "moonbitlang_async_poll_register_pid"
+#borrow(out)
+extern "C" fn Instance::register_pid_ffi(
+  self : Instance,
+  pid : Int,
+  out : Ref[Int],
+) -> Int = "moonbitlang_async_poll_register_pid"
 
 ///|
-fn Instance::register_pid(self : Instance, pid : Int) -> Int raise {
-  let handle = self.register_pid_ffi(pid)
-  if handle < 0 {
+priv enum RegisterPidResult {
+  Running(Int)
+  Stopped(Int)
+}
+
+///|
+fn Instance::register_pid(
+  self : Instance,
+  pid : Int,
+) -> RegisterPidResult raise {
+  let out = @ref.new(0)
+  let ret = self.register_pid_ffi(pid, out)
+  if ret < 0 {
     @os_error.check_errno()
   }
-  handle
+  if ret == 0 {
+    Running(out.val)
+  } else {
+    Stopped(out.val)
+  }
 }
 
 ///|


### PR DESCRIPTION
It seems that `kevent` returns `ESRCH` for already terminated process, causing random CI failure on MacOS. However, even if a process already terminated, its pid remain valid until its parent `wait` for it. So this PR fixes the issue by calling `waitpid` immediately if `kevent` returns `ESRCH`.