### PR TITLE
fix `@io.Writer::write` to prevent hang

### DIFF
--- a/src/io/moon.pkg.json
+++ b/src/io/moon.pkg.json
@@ -1,5 +1,5 @@
 {
-  "import": [ "moonbitlang/async" ],
+  "import": [],
   "test-import": [
     "moonbitlang/async",
     "moonbitlang/async/pipe"

--- a/src/io/writer.mbt
+++ b/src/io/writer.mbt
@@ -29,12 +29,10 @@ impl Writer with write(self, view) {
   if offset == end {
     return
   }
-  @async.protect_from_cancel(fn() {
-    for offset = start; offset < end; {
-      let progress = self.write_once(view.data(), offset~, len=end - offset)
-      continue offset + progress
-    }
-  })
+  for offset = start + offset; offset < end; {
+    let progress = self.write_once(view.data(), offset~, len=end - offset)
+    continue offset + progress
+  }
 }
 
 ///|

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -71,3 +71,35 @@ test "write reader" {
     ),
   )
 }
+
+///|
+struct DummyWriter {
+  logger : &Logger
+  base_timeout : Int
+}
+
+///|
+impl @io.Writer for DummyWriter with write_once(self, buf, offset~, len~) {
+  guard offset < len
+  @async.sleep(self.base_timeout)
+  self.logger.write_string("writing byte \{buf[offset]}\n")
+  1
+}
+
+///|
+test "write cancel" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(_) {
+    let writer = { logger: log, base_timeout: 40 }
+    @async.with_timeout(60, fn() { writer.write(b"abcd") })
+  })
+  // The `write` here is partial and corrupted,
+  // but we have no choice because making `write` atomic may cause hang
+  inspect(
+    log.to_string(),
+    content=(
+      #|writing byte b'\x61'
+      #|
+    ),
+  )
+}


### PR DESCRIPTION
Previously, `@io.Writer::write` is guaranteed to be atomic (either no data is written at all, or all data are successfully written, unless an error occur when writing). But this behavior may cause indefinite hang, for example if the peer is broken on a network socket. This PR chooses another path: now `@io.Writer::write` may be cancelled midway, resulting in partial data being written, so that it will not hang. The user can still make the write atomic by manually wrapping it with `@async.protect_from_cancel`