### PR TITLE
do not perform non-blocking IO in worker thread

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -394,49 +394,47 @@ async fn perform_job_in_worker(
 }
 
 ///|
-async fn perform_read_job(job : JobForWorker, fd : Int) -> Int raise {
-  prepare_fd_read(fd)
-  perform_job_in_worker(job) catch {
-    @os_error.OSError(_) as err if err.is_nonblocking_io_error() => {
-      wait_fd_read(fd)
-      perform_job_in_worker(job)
-    }
-    err => raise err
-  }
-}
-
-///|
-async fn perform_write_job(job : JobForWorker, fd : Int) -> Int raise {
-  prepare_fd_write(fd)
-  perform_job_in_worker(job) catch {
-    @os_error.OSError(_) as err if err.is_nonblocking_io_error() => {
-      wait_fd_write(fd)
-      perform_job_in_worker(job)
-    }
-    err => raise err
-  }
-}
-
-///|
 pub async fn perform_job(job : Job) -> Int raise {
   match job {
     Sleep(t) => perform_job_in_worker(JobForWorker::sleep(t))
-    Read(fd~, buf~, offset~, len~, can_poll~) => {
-      let job = JobForWorker::read(fd, buf, offset, len)
+    Read(fd~, buf~, offset~, len~, can_poll~) =>
       if can_poll {
-        perform_read_job(job, fd)
+        prepare_fd_read(fd)
+        let ret = read_ffi(fd, buf, offset~, len~)
+        let ret = if ret < 0 && @os_error.is_nonblocking_io_error() {
+          wait_fd_read(fd)
+          read_ffi(fd, buf, offset~, len~)
+        } else {
+          @coroutine.pause()
+          ret
+        }
+        if ret < 0 {
+          @os_error.check_errno()
+        }
+        ret
       } else {
+        let job = JobForWorker::read(fd, buf, offset, len)
         perform_job_in_worker(job)
       }
-    }
-    Write(fd~, buf~, offset~, len~, can_poll~) => {
-      let job = JobForWorker::write(fd, buf, offset, len)
+    Write(fd~, buf~, offset~, len~, can_poll~) =>
       if can_poll {
-        perform_write_job(job, fd)
+        prepare_fd_write(fd)
+        let ret = write_ffi(fd, buf, offset~, len~)
+        let ret = if ret < 0 && @os_error.is_nonblocking_io_error() {
+          wait_fd_write(fd)
+          write_ffi(fd, buf, offset~, len~)
+        } else {
+          @coroutine.pause()
+          ret
+        }
+        if ret < 0 {
+          @os_error.check_errno()
+        }
+        ret
       } else {
+        let job = JobForWorker::write(fd, buf, offset, len)
         perform_job_in_worker(job)
       }
-    }
     Open(path~, flags~, mode~) =>
       perform_job_in_worker(JobForWorker::open(path, flags, mode))
     Stat(path~, out~) => perform_job_in_worker(JobForWorker::stat(path, out))
@@ -452,16 +450,36 @@ pub async fn perform_job(job : Job) -> Int raise {
       perform_job_in_worker(
         JobForWorker::spawn(path, args, env, stdin, stdout, stderr, cwd),
       )
-    Recvfrom(sock~, buf~, offset~, len~, addr~) =>
-      perform_read_job(
-        JobForWorker::recvfrom(sock, buf, offset, len, addr),
-        sock,
-      )
-    Sendto(sock~, buf~, offset~, len~, addr~) =>
-      perform_write_job(
-        JobForWorker::sendto(sock, buf, offset, len, addr),
-        sock,
-      )
+    Recvfrom(sock~, buf~, offset~, len~, addr~) => {
+      prepare_fd_read(sock)
+      let ret = recvfrom_ffi(sock, buf, offset~, len~, addr~)
+      let ret = if ret < 0 && @os_error.is_nonblocking_io_error() {
+        wait_fd_read(sock)
+        recvfrom_ffi(sock, buf, offset~, len~, addr~)
+      } else {
+        @coroutine.pause()
+        ret
+      }
+      if ret < 0 {
+        @os_error.check_errno()
+      }
+      ret
+    }
+    Sendto(sock~, buf~, offset~, len~, addr~) => {
+      prepare_fd_write(sock)
+      let ret = sendto_ffi(sock, buf, offset~, len~, addr~)
+      let ret = if ret < 0 && @os_error.is_nonblocking_io_error() {
+        wait_fd_write(sock)
+        sendto_ffi(sock, buf, offset~, len~, addr~)
+      } else {
+        @coroutine.pause()
+        ret
+      }
+      if ret < 0 {
+        @os_error.check_errno()
+      }
+      ret
+    }
     Connect(sock~, addr~) => {
       prepare_fd_write(sock)
       if 0 == connect_ffi(sock, addr) {
@@ -512,3 +530,41 @@ extern "C" fn accept_ffi(sock : Int, addr_buf : Bytes) -> Int = "moonbitlang_asy
 
 ///|
 extern "C" fn get_socket_err(sock : Int) -> Int = "moonbitlang_async_getsockerr"
+
+///|
+#borrow(buf)
+extern "C" fn read_ffi(
+  fd : Int,
+  buf : FixedArray[Byte],
+  offset~ : Int,
+  len~ : Int,
+) -> Int = "moonbitlang_async_read"
+
+///|
+#borrow(buf)
+extern "C" fn write_ffi(
+  fd : Int,
+  buf : Bytes,
+  offset~ : Int,
+  len~ : Int,
+) -> Int = "moonbitlang_async_write"
+
+///|
+#borrow(buf, addr)
+extern "C" fn recvfrom_ffi(
+  fd : Int,
+  buf : FixedArray[Byte],
+  offset~ : Int,
+  len~ : Int,
+  addr~ : Bytes,
+) -> Int = "moonbitlang_async_recvfrom"
+
+///|
+#borrow(buf, addr)
+extern "C" fn sendto_ffi(
+  fd : Int,
+  buf : Bytes,
+  offset~ : Int,
+  len~ : Int,
+  addr~ : Bytes,
+) -> Int = "moonbitlang_async_sendto"

--- a/src/internal/event_loop/job.mbt
+++ b/src/internal/event_loop/job.mbt
@@ -107,26 +107,6 @@ extern "C" fn JobForWorker::spawn(
 ) -> JobForWorker = "moonbitlang_async_make_spawn_job"
 
 ///|
-#owned(buf, addr)
-extern "C" fn JobForWorker::recvfrom(
-  sock : Int,
-  buf : FixedArray[Byte],
-  offset : Int,
-  len : Int,
-  addr : Bytes,
-) -> JobForWorker = "moonbitlang_async_make_recvfrom_job"
-
-///|
-#owned(buf, addr)
-extern "C" fn JobForWorker::sendto(
-  sock : Int,
-  buf : Bytes,
-  offset : Int,
-  len : Int,
-  addr : Bytes,
-) -> JobForWorker = "moonbitlang_async_make_sendto_job"
-
-///|
 #external
 pub type AddrInfo
 

--- a/src/internal/event_loop/misc_stub.c
+++ b/src/internal/event_loop/misc_stub.c
@@ -15,6 +15,7 @@
  */
 
 #include <sys/socket.h>
+#include <unistd.h>
 #include <moonbit.h>
 
 int moonbitlang_async_connect(int sockfd, moonbit_bytes_t addr) {
@@ -32,4 +33,40 @@ int moonbitlang_async_getsockerr(int sockfd) {
   if (getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &err, &opt_len) < 0)
     return -1;
   return err;
+}
+
+int moonbitlang_async_read(int fd, char *buf, int offset, int len) {
+  return read(fd, buf + offset, len);
+}
+
+int moonbitlang_async_write(int fd, char *buf, int offset, int len) {
+  return write(fd, buf + offset, len);
+}
+
+int moonbitlang_async_recvfrom(
+  int sock,
+  char *buf,
+  int offset,
+  int len,
+  moonbit_bytes_t addr
+) {
+  socklen_t addr_size = Moonbit_array_length(addr);
+  return recvfrom(sock, buf + offset, len, 0, (struct sockaddr*)addr, &addr_size);
+}
+
+int moonbitlang_async_sendto(
+  int sock,
+  char *buf,
+  int offset,
+  int len,
+  moonbit_bytes_t addr
+) {
+  return sendto(
+    sock,
+    buf + offset,
+    len,
+    0,
+    (struct sockaddr*)addr,
+    Moonbit_array_length(addr)
+  );
 }


### PR DESCRIPTION
For non-blocking IO, such as socket/pipe, work is divided into three steps:

1. try to read/write immediately. On successful, there will be a memory copy between us and the kernel
1. if IO not ready yet, wait for readiness via polling
1. after poll issues readiness, perform read/write again, making data copy between us and kernel

Previously, step 1 and step 3 above are performed in worker threads. In theory this means more parallelism, because the data copy between us and kernel won't block the main thread. But benchmark shows that the cost of communication and synchronization between threads outweighs the benefit of this approach. So this PR move the non-blocking read/write operation into main thread to reduce thread synchronization cost and improve throughput.