### PR TITLE
add more fs utilities

### DIFF
--- a/src/fs/create_test.mbt
+++ b/src/fs/create_test.mbt
@@ -60,3 +60,15 @@ test "create or append" {
   })
   inspect(log.to_string(), content="abcdefgh")
 }
+
+///|
+test "wrapper test" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(_) {
+    let path = b"fs_wrapper_test"
+    @fs.write_file(path, b"abcd", create=0o644)
+    log.write_string(@fs.read_file(path) |> @bytes_util.ascii_to_string)
+    @fs.remove(path)
+  })
+  inspect(log.to_string(), content="abcd")
+}

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -27,8 +27,7 @@ pub async fn mkdir(path : Bytes, permission~ : Int) -> Unit raise {
 /// `path` must be an empty directory, otherwise `rmdir` will fail.
 pub async fn rmdir(path : Bytes, recursive? : Bool = false) -> Unit raise {
   if recursive {
-    let dir = opendir(path)
-    for file in dir.read_all() {
+    for file in readdir(path) {
       let file = path + "/" + file
       if kind(file) is Directory {
         rmdir(file, recursive=true)
@@ -115,4 +114,27 @@ pub async fn Directory::read_all(
     result.push(entry)
   }
   result
+}
+
+///|
+/// Read all entries in the directory located at `path`.
+/// - If `include_special` is `true` (`false` by default),
+///   `.` (current directory) and `..` (parent directory) will be included too
+/// - If `include_hidden` is `true` (`true` by default),
+///   directory entries starting with `.` (except `.` and `..`) will be included
+/// - If `sort` is `true` (`false` by default),
+///   the result will be sorted using `Array::sort`.
+pub async fn readdir(
+  path : Bytes,
+  include_hidden? : Bool = true,
+  include_special? : Bool = false,
+  sort? : Bool = false,
+) -> Array[Bytes] raise {
+  let dir = opendir(path)
+  defer dir.close()
+  let list = dir.read_all(include_hidden~, include_special~)
+  if sort {
+    list.sort()
+  }
+  list
 }

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -21,8 +21,22 @@ pub async fn mkdir(path : Bytes, permission~ : Int) -> Unit raise {
 
 ///|
 /// Remove a directory at `path`,
+/// If `recursive` is `true` (`false` by default),
+/// files and directories in `path` will be removed recursively.
+/// If `recursive` is `false`,
 /// `path` must be an empty directory, otherwise `rmdir` will fail.
-pub async fn rmdir(path : Bytes) -> Unit raise {
+pub async fn rmdir(path : Bytes, recursive? : Bool = false) -> Unit raise {
+  if recursive {
+    let dir = opendir(path)
+    for file in dir.read_all() {
+      let file = path + "/" + file
+      if kind(file) is Directory {
+        rmdir(file, recursive=true)
+      } else {
+        remove(file)
+      }
+    }
+  }
   ignore(@event_loop.perform_job(Rmdir(path~)))
 }
 

--- a/src/fs/fs.mbt
+++ b/src/fs/fs.mbt
@@ -271,3 +271,28 @@ extern "C" fn get_file_kind_ffi(fd : Int) -> Int = "moonbitlang_async_file_kind"
 pub fn File::kind(self : File) -> FileKind {
   self.kind
 }
+
+///|
+/// Read the contents of the file located at `path`.
+pub async fn read_file(path : Bytes) -> Bytes raise {
+  let file = open(path, mode=ReadOnly)
+  defer file.close()
+  file.read_all()
+}
+
+///|
+/// Write data to a file located at `path`.
+/// The meaning of `sync`, `append`, `create`, truncate`
+/// is the same as `open`, see `open` for more details.
+pub async fn write_file(
+  path : Bytes,
+  content : Bytes,
+  sync? : SyncMode = Data,
+  append? : Bool = false,
+  create? : Int,
+  truncate? : Bool = false,
+) -> Unit raise {
+  let file = open(path, mode=WriteOnly, sync~, append~, create?, truncate~)
+  defer file.close()
+  file.write(content)
+}

--- a/src/fs/mkdir_test.mbt
+++ b/src/fs/mkdir_test.mbt
@@ -17,8 +17,7 @@ test "mkdir" {
   let log = StringBuilder::new()
   @async.with_event_loop(fn(_) {
     @fs.mkdir("mkdir_test", permission=0o755)
-    let file = @fs.create("mkdir_test/file", permission=0o644)
-    file.close()
+    @fs.write_file("mkdir_test/file", "", create=0o644)
     {
       let dir = @fs.opendir("mkdir_test")
       defer dir.close()
@@ -29,10 +28,5 @@ test "mkdir" {
     @fs.remove("mkdir_test/file")
     @fs.rmdir("mkdir_test")
   })
-  inspect(
-    log.to_string(),
-    content=(
-      #|["file"]
-    ),
-  )
+  inspect(log.to_string(), content="[\"file\"]")
 }

--- a/src/fs/mkdir_test.mbt
+++ b/src/fs/mkdir_test.mbt
@@ -30,3 +30,19 @@ test "mkdir" {
   })
   inspect(log.to_string(), content="[\"file\"]")
 }
+
+///|
+test "rmdir recursive" {
+  let log = StringBuilder::new()
+  @async.with_event_loop(fn(_) {
+    @fs.mkdir("rmdir_test", permission=0o755)
+    @fs.write_file("rmdir_test/file", "", create=0o644)
+    @fs.mkdir("rmdir_test/inner", permission=0o755)
+    @fs.write_file("rmdir_test/inner/file", "", create=0o644)
+    @fs.rmdir("rmdir_test") catch {
+      _ => log.write_string("non-recursive removal fails")
+    }
+    @fs.rmdir("rmdir_test", recursive=true)
+  })
+  inspect(log.to_string(), content="non-recursive removal fails")
+}

--- a/src/fs/mkdir_test.mbt
+++ b/src/fs/mkdir_test.mbt
@@ -18,13 +18,11 @@ test "mkdir" {
   @async.with_event_loop(fn(_) {
     @fs.mkdir("mkdir_test", permission=0o755)
     @fs.write_file("mkdir_test/file", "", create=0o644)
-    {
-      let dir = @fs.opendir("mkdir_test")
-      defer dir.close()
-      let list = dir.read_all().map(name => @bytes_util.ascii_to_string(name))
-      list.sort()
-      log.write_object(list)
-    }
+    log.write_object(
+      @fs.readdir("mkdir_test", sort=true).map(name => @bytes_util.ascii_to_string(
+        name,
+      )),
+    )
     @fs.remove("mkdir_test/file")
     @fs.rmdir("mkdir_test")
   })

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -20,9 +20,13 @@ async fn open(Bytes, mode~ : Mode, sync? : SyncMode, append? : Bool, create? : I
 
 fn opendir(Bytes) -> Directory raise
 
+async fn read_file(Bytes) -> Bytes
+
 async fn remove(Bytes) -> Unit
 
 async fn rmdir(Bytes) -> Unit
+
+async fn write_file(Bytes, Bytes, sync? : SyncMode, append? : Bool, create? : Int, truncate? : Bool) -> Unit
 
 // Errors
 

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -24,7 +24,7 @@ async fn read_file(Bytes) -> Bytes
 
 async fn remove(Bytes) -> Unit
 
-async fn rmdir(Bytes) -> Unit
+async fn rmdir(Bytes, recursive? : Bool) -> Unit
 
 async fn write_file(Bytes, Bytes, sync? : SyncMode, append? : Bool, create? : Int, truncate? : Bool) -> Unit
 

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -22,6 +22,8 @@ fn opendir(Bytes) -> Directory raise
 
 async fn read_file(Bytes) -> Bytes
 
+async fn readdir(Bytes, include_hidden? : Bool, include_special? : Bool, sort? : Bool) -> Array[Bytes]
+
 async fn remove(Bytes) -> Unit
 
 async fn rmdir(Bytes, recursive? : Bool) -> Unit


### PR DESCRIPTION
- `@fs.read_file` and `@fs.write_file` directly read/write file by path
- `@fs.rmdir` has a new optional argument `recursive` for recursively removing a directory
- `@fs.readdir` for directly reading the content of a directory by path