### PR TITLE
set `TCP_NODELAY`, disable Nagle's algorithm

### DIFF
--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -41,6 +41,9 @@ extern "C" fn listen_ffi(sock : Int) -> Int = "moonbitlang_async_listen"
 extern "C" fn connect_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_connect"
 
 ///|
+extern "C" fn disable_nagle(sock : Int) -> Int = "moonbitlang_async_disable_nagle"
+
+///|
 extern "C" fn enable_keepalive_ffi(
   sock : Int,
   keep_idle : Int,

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -27,6 +27,11 @@ int moonbitlang_async_make_tcp_socket() {
   return socket(AF_INET, SOCK_STREAM, 0);
 }
 
+int moonbitlang_async_disable_nagle(int sock) {
+  int enable = 1;
+  return setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
+}
+
 int moonbitlang_async_make_udp_socket() {
   return socket(AF_INET, SOCK_DGRAM, 0);
 }

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -54,6 +54,10 @@ pub async fn TCPServer::accept(self : TCPServer) -> (TCP, Addr) raise {
   let TCPServer(listen_sock) = self
   let addr = Addr::new(0, 0)
   let conn = @event_loop.perform_job(Accept(sock=listen_sock, addr=addr.0))
+  if disable_nagle(conn) < 0 {
+    @fd_util.close(conn)
+    @os_error.check_errno()
+  }
   @fd_util.set_cloexec(conn)
   @fd_util.set_nonblocking(conn)
   (conn, addr)
@@ -88,6 +92,10 @@ pub fn TCP::enable_keepalive(
 /// Make connection to a remote address using `connect(2)` system call.
 pub async fn TCP::connect(addr : Addr) -> TCP raise {
   let sock = make_tcp_socket()
+  if disable_nagle(sock) < 0 {
+    @fd_util.close(sock)
+    @os_error.check_errno()
+  }
   try @event_loop.perform_job(Connect(sock~, addr=addr.0)) catch {
     err => {
       @event_loop.close_fd(sock)


### PR DESCRIPTION
Nagle's algorithm causes huge latency over high speed network, especially when combined with delayed ACK.