### PR TITLE
add HTTP server helper

### DIFF
--- a/examples/http_file_server/main.mbt
+++ b/examples/http_file_server/main.mbt
@@ -14,7 +14,7 @@
 
 ///|
 async fn serve_directory(
-  conn : @socket.TCP,
+  conn : @http.ServerConnection,
   dir : @fs.Directory,
   path~ : Bytes,
 ) -> Unit raise {
@@ -48,16 +48,17 @@ async fn serve_directory(
     ..write_bytes(b"</a><br/>\n")
   }
   content.write_bytes(b"</div></body></html>")
-  @http.send_response(
-    conn,
-    { code: 200, reason: "OK", headers: [Header("Content-Type", "text/html")] },
+  conn.send_response(
+    200,
+    "OK",
+    extra_headers=[Header("Content-Type", "text/html")],
     Fixed(content.to_bytes()),
   )
 }
 
 ///|
 async fn serve_file(
-  conn : @socket.TCP,
+  conn : @http.ServerConnection,
   file : @fs.File,
   path~ : Bytes,
 ) -> Unit raise {
@@ -73,15 +74,16 @@ async fn serve_file(
     [.., .. ".mkv"] => "video/x-matroska"
     _ => "appliaction/octet-stream"
   }
-  @http.send_response(
-    conn,
-    { code: 200, reason: "OK", headers: [Header("Content-Type", content_type)] },
+  conn.send_response(
+    200,
+    "OK",
+    extra_headers=[Header("Content-Type", content_type)],
     Stream(file),
   )
 }
 
 ///|
-async fn serve_zip(conn : @socket.TCP, path : Bytes) -> Unit raise {
+async fn serve_zip(conn : @http.ServerConnection, path : Bytes) -> Unit raise {
   let base_name = if path.rev_find("/") is Some(i) {
     path[i + 1:].to_bytes()
   } else {
@@ -94,16 +96,13 @@ async fn serve_zip(conn : @socket.TCP, path : Bytes) -> Unit raise {
       @process.run("zip", ["-q", "-r", "-", path], stdout=zip_write_to_use)
       |> ignore
     })
-    @http.send_response(
-      conn,
-      {
-        code: 200,
-        reason: "OK",
-        headers: [
-          Header("Content-Type", "application/octet-stream"),
-          Header("Content-Disposition", "filename=" + base_name + ".zip"),
-        ],
-      },
+    conn.send_response(
+      200,
+      "OK",
+      extra_headers=[
+        Header("Content-Type", "application/octet-stream"),
+        Header("Content-Disposition", "filename=" + base_name + ".zip"),
+      ],
       Stream(we_read_from_zip),
     )
   })
@@ -113,14 +112,11 @@ async fn serve_zip(conn : @socket.TCP, path : Bytes) -> Unit raise {
 let page_for_404 : Bytes = b"<html><head></head><body>Page Not Found</body></html>"
 
 ///|
-async fn serve_404(conn : @socket.TCP) -> Unit raise {
-  @http.send_response(
-    conn,
-    {
-      code: 404,
-      reason: "NotFound",
-      headers: [Header("Content-Type", "text/html")],
-    },
+async fn serve_404(conn : @http.ServerConnection) -> Unit raise {
+  conn.send_response(
+    404,
+    "NotFound",
+    extra_headers=[Header("Content-Type", "text/html")],
     Fixed(page_for_404),
   )
 }
@@ -137,16 +133,15 @@ pub async fn server(
   defer server.close()
   for {
     let (conn, addr) = server.accept()
+    let conn = @http.ServerConnection::new(conn)
     log("received new connection from \{addr}")
     ctx.spawn_bg(allow_failure=true, fn() {
       defer {
         log("closing connection from \{addr}")
         conn.close()
       }
-      let src = @http.Reader::new(conn)
       for {
-        let request = src.read_request()
-        src.skip_body()
+        let request = conn.read_request()
         let (path, download_zip) = match request.path {
           [.. path, .. "?download_zip"] => (path.to_bytes(), true)
           path => (path, false)

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/async/http"
 
 import(
   "moonbitlang/async/io"
+  "moonbitlang/async/socket"
 )
 
 // Values
@@ -91,6 +92,14 @@ pub(all) struct Response {
   reason : Bytes
   headers : Array[Header]
 }
+
+type ServerConnection
+fn ServerConnection::close(Self) -> Unit
+fn ServerConnection::new(@socket.TCP, headers? : Array[Header]) -> Self
+async fn ServerConnection::read_request(Self) -> Request
+async fn ServerConnection::send_response(Self, Int, Bytes, Body, extra_headers? : Array[Header]) -> Unit
+async fn ServerConnection::skip_body(Self) -> Unit
+impl @io.Reader for ServerConnection
 
 // Type aliases
 

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -24,45 +24,49 @@ pub(all) enum Body {
 async fn[Writer : @io.Writer] send_headers(
   w : Writer,
   headers : Array[Header],
-  body : Body,
 ) -> Unit raise {
   for header in headers {
     let Header(k, v) = header
     w..write(k)..write(": ")..write(v)..write("\r\n")
   }
+}
+
+///|
+async fn[Writer : @io.Writer] send_body_headers(
+  w : Writer,
+  body : Body,
+) -> Unit raise {
   match body {
-    Empty => w.write("\r\n")
+    Empty => ()
     Fixed(body) =>
       w
       ..write(b"Content-Length: ")
       ..write(encode_int(body.length(), base=10))
-      ..write("\r\n\r\n")
-    Stream(_) => w.write(b"Transfer-Encoding: chunked\r\n\r\n")
+      ..write("\r\n")
+    Stream(_) => w.write(b"Transfer-Encoding: chunked\r\n")
   }
 }
 
 ///|
-async fn[Writer : @io.Writer] send_body(w : Writer, body : Body) -> Unit raise {
-  match body {
-    Empty => ()
-    Fixed(body) => w.write(body)
-    Stream(body) => {
-      let buf = FixedArray::make(1031, b'0')
-      // Reserve enough space for chunk length and '\r\n' in the buffer,
-      // so that we can commit the whole chunk in a single write to avoid small writes
-      while body.read(buf, offset=5, max_len=buf.length() - 7) is n && n > 0 {
-        buf[5 + n] = '\r'
-        buf[6 + n] = '\n'
-        let len = encode_int(n, base=16)
-        let start = 3 - len.length()
-        buf[3] = '\r'
-        buf[4] = '\n'
-        buf.blit_from_bytes(start, len, 0, len.length())
-        w.write(buf.unsafe_reinterpret_as_bytes()[start:n + 7])
-      } else {
-        w.write("0\r\n\r\n")
-      }
-    }
+async fn[Writer : @io.Writer] send_body_chunked(
+  w : Writer,
+  buf : FixedArray[Byte],
+  body : &@io.Reader,
+) -> Unit raise {
+  // Reserve enough space for chunk length and '\r\n' in the buffer,
+  // so that we can commit the whole chunk in a single write to avoid small writes
+  let max_len = buf.length() - 7
+  while body.read(buf, offset=5, max_len~) is n && n > 0 {
+    buf[5 + n] = '\r'
+    buf[6 + n] = '\n'
+    let len = encode_int(n, base=16)
+    let start = 3 - len.length()
+    buf[3] = '\r'
+    buf[4] = '\n'
+    buf.blit_from_bytes(start, len, 0, len.length())
+    w.write(buf.unsafe_reinterpret_as_bytes()[start:n + 7])
+  } else {
+    w.write("0\r\n\r\n")
   }
 }
 
@@ -86,9 +90,18 @@ pub async fn[Writer : @io.Writer] send_request(
     Patch => w.write("PATCH ")
   }
   w..write(request.path)..write(" HTTP/1.1\r\n")
-  send_headers(w, request.headers, body)
+  send_headers(w, request.headers)
+  send_body_headers(w, body)
+  w.write("\r\n")
   w.flush()
-  send_body(w0, body)
+  match body {
+    Empty => ()
+    Fixed(body) => w0.write(body)
+    Stream(body) => {
+      let buf = FixedArray::make(1024, b'0')
+      send_body_chunked(w0, buf, body)
+    }
+  }
 }
 
 ///|
@@ -105,7 +118,16 @@ pub async fn[Writer : @io.Writer] send_response(
   ..write(" ")
   ..write(response.reason)
   ..write("\r\n")
-  send_headers(w, response.headers, body)
+  send_headers(w, response.headers)
+  send_body_headers(w, body)
+  w.write("\r\n")
   w.flush()
-  send_body(w0, body)
+  match body {
+    Empty => ()
+    Fixed(body) => w0.write(body)
+    Stream(body) => {
+      let buf = FixedArray::make(1024, b'0')
+      send_body_chunked(w0, buf, body)
+    }
+  }
 }

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -1,0 +1,119 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A single HTTP server connection
+struct ServerConnection {
+  headers : Array[Header]
+  reader : Reader
+  conn : @socket.TCP
+  send_buf : FixedArray[Byte]
+  mut send_len : Int
+}
+
+///|
+/// Create a new HTTP server connection from a TCP connection.
+///
+/// `headers` can be used to specify persistent headers for the connection,
+/// i.e. all response sent by this connection will share these headers.
+/// The following headers is automatically set,
+/// and must not be specified in `headers`:
+/// 
+/// - Content-Length, Transfer-Encoding
+pub fn ServerConnection::new(
+  conn : @socket.TCP,
+  headers? : Array[Header] = [],
+) -> ServerConnection {
+  let reader = Reader::new(conn)
+  let send_buf = FixedArray::make(1024, b'0')
+  { headers, reader, conn, send_buf, send_len: 0 }
+}
+
+///|
+/// Close the connection, the underlying TCP connection will be closed as well.
+pub fn ServerConnection::close(self : ServerConnection) -> Unit {
+  self.conn.close()
+}
+
+///|
+pub impl @io.Reader for ServerConnection with read(self, buf, offset~, max_len~) {
+  self.reader.read(buf, offset~, max_len~)
+}
+
+///|
+/// Read a single request from the connection.
+/// If the body of the last request is not consumed yet,
+/// it will be discarded.
+///
+/// After calling `read_request`,
+/// the body of the request can be obtained by using `ServerConnection`
+/// as a `@io.Reader`.
+pub async fn ServerConnection::read_request(
+  self : ServerConnection,
+) -> Request raise {
+  self.reader.skip_body()
+  self.reader.read_request()
+}
+
+///|
+/// Manually discard the body of the request currently being processed.
+pub async fn ServerConnection::skip_body(self : ServerConnection) -> Unit raise {
+  self.reader.skip_body()
+}
+
+///|
+async fn ServerConnection::flush(self : Self) -> Unit raise {
+  if self.send_len > 0 {
+    self.conn.write(self.send_buf.unsafe_reinterpret_as_bytes()[:self.send_len])
+    self.send_len = 0
+  }
+}
+
+///|
+impl @io.Writer for ServerConnection with write_once(self, buf, offset~, len~) {
+  if self.send_len >= self.send_buf.length() {
+    self.flush()
+  }
+  let len = @cmp.minimum(len, self.send_buf.length() - self.send_len)
+  self.send_buf.blit_from_bytes(self.send_len, buf, offset, len)
+  self.send_len += len
+  len
+}
+
+///|
+/// Send a response to the peer.
+pub async fn ServerConnection::send_response(
+  self : ServerConnection,
+  code : Int,
+  reason : Bytes,
+  body : Body,
+  extra_headers? : Array[Header] = [],
+) -> Unit raise {
+  self
+  ..write("HTTP/1.1 ")
+  ..write(encode_int(code, base=10))
+  ..write(" ")
+  ..write(reason)
+  ..write("\r\n")
+  send_headers(self, self.headers)
+  send_headers(self, extra_headers)
+  send_body_headers(self, body)
+  self.write("\r\n")
+  self.flush()
+  match body {
+    Empty => ()
+    Fixed(body) => self.conn.write(body)
+    Stream(body) => send_body_chunked(self.conn, self.send_buf, body)
+  }
+}


### PR DESCRIPTION
This PR introduces a new type `@http.ServerConnection`, which represents a TCP connection running HTTP on the server side. `@http.ServerConnection` is easier to work with than raw HTTP read/write API. Furthermore, `@http.ServerConnection` allows sharing buffer used by HTTP for the whole connection, across different requests. This means it would have better performance. `@http.ServerConnection` should be the recommended way to write HTTP server over TCP.