### PR TITLE
add `write_string` method to `@io.Writer`

### DIFF
--- a/src/io/pkg.generated.mbti
+++ b/src/io/pkg.generated.mbti
@@ -22,6 +22,10 @@ async fn[W : Writer] BufferedWriter::flush(Self[W]) -> Unit
 fn[W] BufferedWriter::new(W, size? : Int) -> Self[W]
 impl[W : Writer] Writer for BufferedWriter[W]
 
+pub(all) enum Encoding {
+  UTF8
+}
+
 // Type aliases
 
 // Traits
@@ -35,5 +39,6 @@ pub(open) trait Writer {
   async write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int
   async write(Self, BytesView) -> Unit = _
   async write_reader(Self, &Reader) -> Unit = _
+  async write_string(Self, StringView, encoding~ : Encoding) -> Unit = _
 }
 

--- a/src/io/writer.mbt
+++ b/src/io/writer.mbt
@@ -13,10 +13,16 @@
 // limitations under the License.
 
 ///|
+pub(all) enum Encoding {
+  UTF8
+}
+
+///|
 pub(open) trait Writer {
   async write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int
   async write(Self, @bytes.View) -> Unit = _
   async write_reader(Self, &Reader) -> Unit = _
+  async write_string(Self, StringView, encoding~ : Encoding) -> Unit = _
 }
 
 ///|
@@ -48,4 +54,11 @@ impl Writer with write_reader(self, reader) {
       continue offset + progress
     }
   }
+}
+
+///|
+impl Writer with write_string(self, str, encoding~) {
+  guard encoding is UTF8
+  let data = @encoding/utf8.encode(str, bom=false)
+  self.write(data)
 }

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -103,3 +103,16 @@ test "write cancel" {
     ),
   )
 }
+
+///|
+test "write_string" {
+  @async.with_event_loop(fn(root) {
+    let (r, w) = @pipe.pipe()
+    defer r.close()
+    root.spawn_bg(fn() {
+      defer w.close()
+      w.write_string("abcd中文☺", encoding=UTF8)
+    })
+    inspect(@encoding/utf8.decode(r.read_all()), content="abcd中文☺")
+  })
+}


### PR DESCRIPTION
This PR adds a new method `write_string` to `@io.Writer`. This new method has a default implementation, so this is a non-breaking change. `write_string` writes a MoonBit string to a writer with the specified encoding. Currently the only supported encoding is `UTF8`