### PR TITLE
add process helpers

### DIFF
--- a/src/process/basic_test.mbt
+++ b/src/process/basic_test.mbt
@@ -38,6 +38,7 @@ test "basic_ls" {
       #|cancel_test.mbt
       #|cwd_test.mbt
       #|env_test.mbt
+      #|helper_test.mbt
       #|moon.pkg.json
       #|pkg.generated.mbti
       #|process.mbt

--- a/src/process/cwd_test.mbt
+++ b/src/process/cwd_test.mbt
@@ -40,6 +40,7 @@ test "set cwd" {
       #|cancel_test.mbt
       #|cwd_test.mbt
       #|env_test.mbt
+      #|helper_test.mbt
       #|moon.pkg.json
       #|pkg.generated.mbti
       #|process.mbt

--- a/src/process/helper_test.mbt
+++ b/src/process/helper_test.mbt
@@ -1,0 +1,44 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "collect_output" {
+  @async.with_event_loop(fn(_) {
+    let (code, output) = @process.collect_stdout("sh", ["-c", "printf abcd"])
+    inspect(code, content="0")
+    inspect(@bytes_util.ascii_to_string(output), content="abcd")
+  })
+}
+
+///|
+test "collect_error" {
+  @async.with_event_loop(fn(_) {
+    let (code, output) = @process.collect_stderr("sh", ["-c", "printf abcd >&2"])
+    inspect(code, content="0")
+    inspect(@bytes_util.ascii_to_string(output), content="abcd")
+  })
+}
+
+///|
+test "collect_output" {
+  @async.with_event_loop(fn(_) {
+    let (code, stdout, stderr) = @process.collect_output("sh", [
+      "-c", "printf ab; printf ab >&2; printf cd; printf cd >&2",
+    ])
+    inspect(code, content="0")
+    inspect(@bytes_util.ascii_to_string(stdout), content="abcd")
+    inspect(@bytes_util.ascii_to_string(stderr), content="abcd")
+  })
+}

--- a/src/process/moon.pkg.json
+++ b/src/process/moon.pkg.json
@@ -4,10 +4,10 @@
     "moonbitlang/async/internal/coroutine",
     "moonbitlang/async/internal/fd_util",
     "moonbitlang/async/fs",
-    "moonbitlang/async/pipe"
+    "moonbitlang/async/pipe",
+    "moonbitlang/async"
   ],
   "test-import": [
-    "moonbitlang/async",
     "moonbitlang/async/internal/bytes_util"
   ],
   "native-stub": [ "stub.c" ]

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -6,6 +6,12 @@ import(
 )
 
 // Values
+async fn collect_output(Bytes, Array[Bytes], extra_env? : Map[Bytes, Bytes], inherit_env? : Bool, stdin? : &ProcessInput, cwd? : Bytes) -> (Int, Bytes, Bytes)
+
+async fn collect_stderr(Bytes, Array[Bytes], extra_env? : Map[Bytes, Bytes], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, cwd? : Bytes) -> (Int, Bytes)
+
+async fn collect_stdout(Bytes, Array[Bytes], extra_env? : Map[Bytes, Bytes], inherit_env? : Bool, stdin? : &ProcessInput, stderr? : &ProcessOutput, cwd? : Bytes) -> (Int, Bytes)
+
 fn read_from_process() -> (@pipe.PipeRead, &ProcessOutput) raise
 
 async fn redirect_from_file(Bytes) -> &ProcessInput

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -147,6 +147,101 @@ pub async fn run(
 }
 
 ///|
+/// Run a process and collect its standard output.
+/// Return the exit code of the process and the content of its standard output.
+///
+/// The meaning of parameters is the same as `@process.run`
+pub async fn collect_stdout(
+  cmd : Bytes,
+  args : Array[Bytes],
+  extra_env? : Map[Bytes, Bytes] = {},
+  inherit_env? : Bool = true,
+  stdin? : &ProcessInput,
+  stderr? : &ProcessOutput,
+  cwd? : Bytes,
+) -> (Int, Bytes) {
+  let (r, w) = read_from_process()
+  @async.with_task_group(fn(group) {
+    let exit_code = group.spawn(() => run(
+      cmd,
+      args,
+      extra_env~,
+      inherit_env~,
+      stdin?,
+      stdout=w,
+      stderr?,
+      cwd?,
+    ))
+    let output = r.read_all()
+    (exit_code.wait(), output)
+  })
+}
+
+///|
+/// Run a process and collect its standard error.
+/// Return the exit code of the process and the content of its standard error.
+///
+/// The meaning of parameters is the same as `@process.run`
+pub async fn collect_stderr(
+  cmd : Bytes,
+  args : Array[Bytes],
+  extra_env? : Map[Bytes, Bytes] = {},
+  inherit_env? : Bool = true,
+  stdin? : &ProcessInput,
+  stdout? : &ProcessOutput,
+  cwd? : Bytes,
+) -> (Int, Bytes) {
+  let (r, w) = read_from_process()
+  @async.with_task_group(fn(group) {
+    let exit_code = group.spawn(() => run(
+      cmd,
+      args,
+      extra_env~,
+      inherit_env~,
+      stdin?,
+      stdout?,
+      stderr=w,
+      cwd?,
+    ))
+    let output = r.read_all()
+    (exit_code.wait(), output)
+  })
+}
+
+///|
+/// Run a process and collect its standard output & standard error.
+/// Return the exit code of the process, the content of its standard output,
+/// and the content of its standard error.
+///
+/// The meaning of parameters is the same as `@process.run`
+pub async fn collect_output(
+  cmd : Bytes,
+  args : Array[Bytes],
+  extra_env? : Map[Bytes, Bytes] = {},
+  inherit_env? : Bool = true,
+  stdin? : &ProcessInput,
+  cwd? : Bytes,
+) -> (Int, Bytes, Bytes) {
+  let (r_out, w_out) = read_from_process()
+  let (r_err, w_err) = read_from_process()
+  @async.with_task_group(fn(group) {
+    let exit_code = group.spawn(() => run(
+      cmd,
+      args,
+      extra_env~,
+      inherit_env~,
+      stdin?,
+      stdout=w_out,
+      stderr=w_err,
+      cwd?,
+    ))
+    let stdout = r_out.read_all()
+    let stderr = r_err.read_all()
+    (exit_code.wait(), stdout, stderr)
+  })
+}
+
+///|
 /// Create a temporary pipe for reading from stdout/stderr of a process.
 /// The return value is a pair `(r, w)`,
 /// where `r` is a `@pipe.PipeRead` that can be used to read process output,

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -151,9 +151,12 @@ pub async fn run(
 /// The return value is a pair `(r, w)`,
 /// where `r` is a `@pipe.PipeRead` that can be used to read process output,
 /// and `w` should be passed to `@process.run`.
+///
+/// `w` is temporary: it can only be passed to one `@process.run` call.
+/// However, it is safe to pass `w` to both `stdout` and `stderr` of the same process.
 pub fn read_from_process() -> (@pipe.PipeRead, &ProcessOutput) raise {
   let (r, w) = @pipe.pipe()
-  (r, TempPipeWrite(w))
+  (r, TempPipeWrite::{ pipe: w, closed: false })
 }
 
 ///|
@@ -163,7 +166,7 @@ pub fn read_from_process() -> (@pipe.PipeRead, &ProcessOutput) raise {
 /// and `r` should be passed to `@process.run`.
 pub fn write_to_process() -> (&ProcessInput, @pipe.PipeWrite) raise {
   let (r, w) = @pipe.pipe()
-  (TempPipeRead(r), w)
+  (TempPipeRead::{ pipe: r, closed: false }, w)
 }
 
 ///|
@@ -220,29 +223,41 @@ pub impl ProcessOutput for @pipe.PipeWrite with fd(self) {
 }
 
 ///|
-priv struct TempPipeRead(@pipe.PipeRead)
+priv struct TempPipeRead {
+  pipe : @pipe.PipeRead
+  mut closed : Bool
+}
 
 ///|
-priv struct TempPipeWrite(@pipe.PipeWrite)
+priv struct TempPipeWrite {
+  pipe : @pipe.PipeWrite
+  mut closed : Bool
+}
 
 ///|
 impl ProcessOutput for TempPipeWrite with fd(self) {
-  self.0.fd()
+  self.pipe.fd()
 }
 
 ///|
 impl ProcessOutput for TempPipeWrite with after_spawn(self) {
-  self.0.close()
+  if !self.closed {
+    self.closed = true
+    self.pipe.close()
+  }
 }
 
 ///|
 impl ProcessInput for TempPipeRead with fd(self) {
-  self.0.fd()
+  self.pipe.fd()
 }
 
 ///|
 impl ProcessInput for TempPipeRead with after_spawn(self) {
-  self.0.close()
+  if !self.closed {
+    self.closed = true
+    self.pipe.close()
+  }
 }
 
 ///|

--- a/src/process/redirect_test.mbt
+++ b/src/process/redirect_test.mbt
@@ -69,3 +69,23 @@ test "redirect to file" {
   })
   inspect(log.to_string(), content="abcd")
 }
+
+///|
+test "merge stdout and stderr" {
+  @async.with_event_loop(fn(root) {
+    let (r, w) = @process.read_from_process()
+    defer r.close()
+    root.spawn_bg(fn() {
+      @process.run("sh", ["-c", "echo abcd; echo efgh >&2"], stdout=w, stderr=w)
+      |> ignore
+    })
+    inspect(
+      @bytes_util.ascii_to_string(r.read_all()),
+      content=(
+        #|abcd
+        #|efgh
+        #|
+      ),
+    )
+  })
+}


### PR DESCRIPTION
- the temp pipe created by `read_from_process()` can now be passed to both stdout and stderr of the same process
- add `@process.collect_stdout`, `@process.collect_stderr` and `@process.collect_output`, which are the same as `@process.run`, except that the output of the process is collected and returned