### PR TITLE
fix random process-related failure on MacOS

### DIFF
--- a/src/internal/event_loop/poll.c
+++ b/src/internal/event_loop/poll.c
@@ -200,7 +200,7 @@ int moonbitlang_async_poll_register_pid(int kqfd, pid_t pid, int *out) {
 
   // process already terminated
   int wstatus;
-  ret = waitpid(pid, &wstatus, WNOHANG);
+  ret = waitpid(pid, &wstatus, 0);
   if (ret > 0) {
     *out = WEXITSTATUS(wstatus);
     return 1;


### PR DESCRIPTION
It seems that even after `kevent` reports `ESRCH` on a process, `waitpid(_, _, WNOHANG)` may still return zero. I removed the `WNOHANG` flag. If everything works as expected this should not cause any hang problem (but this PR won't exist at all if everything work as expected, though). It seems that `libuv` also handle things this way.