### PR TITLE
[breaking] modify semantic of `@async.with_timeout`

### DIFF
--- a/src/aqueue/aqueue_test.mbt
+++ b/src/aqueue/aqueue_test.mbt
@@ -100,7 +100,10 @@ async test "aqueue cancellation" {
         }
         log.write_string("get => \{x}\n")
       }
-    })
+    }) catch {
+      @async.TimeoutError => ()
+      err => raise err
+    }
   })
   inspect(
     log.to_string(),

--- a/src/async.mbt
+++ b/src/async.mbt
@@ -37,28 +37,28 @@ pub fnalias @coroutine.sleep
 pub fnalias @coroutine.pause
 
 ///|
+pub suberror TimeoutError derive(Show)
+
+///|
 /// `with_timeout(timeout, f)` run the async function `f`.
 ///
-/// - If `f` return before `timeout`, `with_timeout` will immediately stop.
+/// - If `f` return `value` before `timeout`,
+///   `with_timeout` will return `value` immediately.
 ///
-/// - If `f` fail before `timeout`, `with_timeout` will also fail immediately.
+/// - If `f` fail before `timeout`, `with_timeout` will fail immediately.
 ///
-/// - If `f` is still running after `timeout` milliseconds, `f` will be cancelled.
-///   In this case, by default, `with_timeout` will return normally.
-///   However, if the optional argument `error` is explicitly set,
-///   `with_timeout` will raise the given error in this case.
-pub async fn with_timeout(
+/// - If `f` is still running after `timeout` milliseconds,
+///   `with_timeout` will fail with `TimeoutError`,
+///   or the value of `error`, if explicitly specified.
+pub async fn[X] with_timeout(
   time : Int,
-  f : async () -> Unit,
-  error? : Error,
-) -> Unit {
+  f : async () -> X,
+  error? : Error = TimeoutError,
+) -> X {
   with_task_group(fn(group) {
     group.spawn_bg(no_wait=true, fn() {
       sleep(time)
-      match error {
-        Some(err) => raise err
-        None => group.return_immediately(())
-      }
+      raise error
     })
     f()
   })

--- a/src/group_defer_test.mbt
+++ b/src/group_defer_test.mbt
@@ -104,7 +104,7 @@ async test "group defer cancelled" {
         log.write_string("tick\n")
       }
     })
-    @async.with_timeout(500, fn() {
+    @async.with_timeout_opt(500, fn() {
       @async.with_task_group(fn(group) {
         group.add_defer(fn() {
           @async.protect_from_cancel(fn() {
@@ -126,6 +126,7 @@ async test "group defer cancelled" {
         @async.sleep(2000)
       })
     })
+    |> ignore
     log.write_string("group terminated\n")
   })
   inspect(

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -89,7 +89,7 @@ async test "write cancel" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(_) {
     let writer = { logger: log, base_timeout: 40 }
-    @async.with_timeout(60, fn() { writer.write(b"abcd") })
+    @async.with_timeout_opt(60, fn() { writer.write(b"abcd") }) |> ignore
   })
   // The `write` here is partial and corrupted,
   // but we have no choice because making `write` atomic may cause hang

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -18,13 +18,16 @@ fn with_event_loop(async (TaskGroup[Unit]) -> Unit) -> Unit raise
 
 async fn[X] with_task_group(async (TaskGroup[X]) -> X) -> X
 
-async fn with_timeout(Int, async () -> Unit, error? : Error) -> Unit
+async fn[X] with_timeout(Int, async () -> X, error? : Error) -> X
 
 async fn[X] with_timeout_opt(Int, async () -> X) -> X?
 
 // Errors
 pub suberror AlreadyTerminated
 impl Show for AlreadyTerminated
+
+pub suberror TimeoutError
+impl Show for TimeoutError
 
 // Types and methods
 pub(all) enum RetryMethod {

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -104,23 +104,22 @@ async test "protect_from_cancel wait" {
 ///|
 async test "protect_from_cancel with_timeout" {
   let log = StringBuilder::new()
-  log.write_object(
-    try? @async.with_task_group(fn(root) {
-      root.spawn_bg(fn() {
-        @async.sleep(200)
-        log.write_string("200ms tick\n")
-        @async.sleep(200)
-        log.write_string("400ms tick\n")
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(fn() {
+      @async.sleep(200)
+      log.write_string("200ms tick\n")
+      @async.sleep(200)
+      log.write_string("400ms tick\n")
+    })
+    @async.with_timeout_opt(300, fn() {
+      @async.protect_from_cancel(fn() {
+        @async.sleep(500)
+        log.write_string("critial job finished\n")
       })
-      @async.with_timeout(300, fn() {
-        @async.protect_from_cancel(fn() {
-          @async.sleep(500)
-          log.write_string("critial job finished\n")
-        })
-      })
-      log.write_string("`with_timeout` containing critical job finished\n")
-    }),
-  )
+    })
+    |> ignore
+    log.write_string("`with_timeout` containing critical job finished\n")
+  })
   inspect(
     log.to_string(),
     content=(
@@ -128,7 +127,7 @@ async test "protect_from_cancel with_timeout" {
       #|400ms tick
       #|critial job finished
       #|`with_timeout` containing critical job finished
-      #|Ok(())
+      #|
     ),
   )
 }
@@ -167,25 +166,24 @@ async test "protect_from_cancel fail" {
 ///|
 async test "protect_from_cancel nested1" {
   let log = StringBuilder::new()
-  log.write_object(
-    try? @async.with_task_group(fn(root) {
-      root.spawn_bg(fn() {
-        @async.sleep(200)
-        log.write_string("200ms tick\n")
-        @async.sleep(200)
-        log.write_string("400ms tick\n")
-      })
-      @async.with_timeout(300, fn() {
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(fn() {
+      @async.sleep(200)
+      log.write_string("200ms tick\n")
+      @async.sleep(200)
+      log.write_string("400ms tick\n")
+    })
+    @async.with_timeout_opt(300, fn() {
+      @async.protect_from_cancel(fn() {
         @async.protect_from_cancel(fn() {
-          @async.protect_from_cancel(fn() {
-            @async.sleep(500)
-            log.write_string("critial job finished\n")
-          })
+          @async.sleep(500)
+          log.write_string("critial job finished\n")
         })
       })
-      log.write_string("`with_timeout` containing critical job finished\n")
-    }),
-  )
+    })
+    |> ignore
+    log.write_string("`with_timeout` containing critical job finished\n")
+  })
   inspect(
     log.to_string(),
     content=(
@@ -193,7 +191,7 @@ async test "protect_from_cancel nested1" {
       #|400ms tick
       #|critial job finished
       #|`with_timeout` containing critical job finished
-      #|Ok(())
+      #|
     ),
   )
 }
@@ -201,29 +199,28 @@ async test "protect_from_cancel nested1" {
 ///|
 async test "protect_from_cancel nested2" {
   let log = StringBuilder::new()
-  log.write_object(
-    try? @async.with_task_group(fn(root) {
-      root.spawn_bg(fn() {
-        @async.sleep(200)
-        log.write_string("200ms tick\n")
-        @async.sleep(200)
-        log.write_string("400ms tick\n")
-        @async.sleep(200)
-        log.write_string("600ms tick\n")
-      })
-      @async.with_timeout(100, fn() {
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(fn() {
+      @async.sleep(200)
+      log.write_string("200ms tick\n")
+      @async.sleep(200)
+      log.write_string("400ms tick\n")
+      @async.sleep(200)
+      log.write_string("600ms tick\n")
+    })
+    @async.with_timeout_opt(100, fn() {
+      @async.protect_from_cancel(fn() {
         @async.protect_from_cancel(fn() {
-          @async.protect_from_cancel(fn() {
-            @async.sleep(300)
-            log.write_string("inner critial job finished\n")
-          })
-          @async.sleep(200)
-          log.write_string("outer critial job finished\n")
+          @async.sleep(300)
+          log.write_string("inner critial job finished\n")
         })
+        @async.sleep(200)
+        log.write_string("outer critial job finished\n")
       })
-      log.write_string("`with_timeout` containing critical job finished\n")
-    }),
-  )
+    })
+    |> ignore
+    log.write_string("`with_timeout` containing critical job finished\n")
+  })
   inspect(
     log.to_string(),
     content=(
@@ -233,7 +230,7 @@ async test "protect_from_cancel nested2" {
       #|outer critial job finished
       #|`with_timeout` containing critical job finished
       #|600ms tick
-      #|Ok(())
+      #|
     ),
   )
 }

--- a/src/retry_test.mbt
+++ b/src/retry_test.mbt
@@ -122,7 +122,10 @@ async test "retry cancelled1" {
       i = i + 1
       raise Err
     })
-  })
+  }) catch {
+    @async.TimeoutError => ()
+    err => raise err
+  }
   inspect(
     log.to_string(),
     content=(
@@ -143,7 +146,10 @@ async test "retry cancelled2" {
       i = i + 1
       raise Err
     })
-  })
+  }) catch {
+    @async.TimeoutError => ()
+    err => raise err
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/with_timeout_test.mbt
+++ b/src/with_timeout_test.mbt
@@ -42,28 +42,28 @@ async test "with_timeout normal exit" {
 ///|
 async test "with_timeout failure" {
   let log = StringBuilder::new()
-  log.write_object(
-    try? @async.with_task_group(fn(root) {
-      root.spawn_bg(fn() {
-        @async.sleep(200)
-        log.write_string("200ms tick\n")
-      })
-      @async.with_timeout(300, fn() {
-        @async.sleep(100)
-        raise Err
-      }) catch {
-        err => {
-          log.write_string("main task fail with \{err}\n")
-          raise err
-        }
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(fn() {
+      @async.sleep(200)
+      log.write_string("200ms tick\n")
+    })
+    @async.with_timeout(300, fn() {
+      @async.sleep(100)
+      raise Err
+    }) catch {
+      err => {
+        log.write_string("main task fail with \{err}\n")
+        raise err
       }
-    }),
-  )
+    }
+  }) catch {
+    err => log.write_object(err)
+  }
   inspect(
     log.to_string(),
     content=(
       #|main task fail with Err
-      #|Err(Err)
+      #|Err
     ),
   )
 }
@@ -85,7 +85,9 @@ async test "with_timeout timeout" {
           }
         }
         log.write_string("task finished\n")
-      })
+      }) catch {
+        err => log.write_string("`with_timeout` fail with \{err}\n")
+      }
       log.write_string("main task finished\n")
     }),
   )
@@ -93,6 +95,7 @@ async test "with_timeout timeout" {
     log.to_string(),
     content=(
       #|task cancelled
+      #|`with_timeout` fail with TimeoutError
       #|main task finished
       #|300ms tick
       #|Ok(())
@@ -120,8 +123,12 @@ async test "with_timeout nested1" {
             }
           }
           log.write_string("task finished after 2s\n")
-        })
-      })
+        }) catch {
+          err => log.write_string("inner `with_timeout` fail with \{err}\n")
+        }
+      }) catch {
+        err => log.write_string("outer `with_timeout` fail with \{err}\n")
+      }
       log.write_string("main task finished\n")
     }),
   )
@@ -130,6 +137,8 @@ async test "with_timeout nested1" {
     content=(
       #|200ms tick
       #|task cancelled
+      #|inner `with_timeout` fail with Cancelled
+      #|outer `with_timeout` fail with TimeoutError
       #|main task finished
       #|400ms tick
       #|Ok(())
@@ -157,8 +166,12 @@ async test "with_timeout nested2" {
             }
           }
           log.write_string("task finished after 2s\n")
-        })
-      })
+        }) catch {
+          err => log.write_string("inner `with_timeout` fail with \{err}\n")
+        }
+      }) catch {
+        err => log.write_string("outer `with_timeout` fail with \{err}\n")
+      }
       log.write_string("main task finished\n")
     }),
   )
@@ -167,6 +180,7 @@ async test "with_timeout nested2" {
     content=(
       #|300ms tick
       #|task cancelled
+      #|inner `with_timeout` fail with TimeoutError
       #|main task finished
       #|600ms tick
       #|Ok(())
@@ -268,28 +282,28 @@ async test "with_timeout_opt normal exit" {
 ///|
 async test "with_timeout_opt failure" {
   let log = StringBuilder::new()
-  log.write_object(
-    try? @async.with_task_group(fn(root) {
-      root.spawn_bg(fn() {
-        @async.sleep(200)
-        log.write_string("200ms tick\n")
-      })
-      @async.with_timeout(1000, fn() {
-        @async.sleep(100)
-        raise Err
-      }) catch {
-        err => {
-          log.write_string("main task fail with \{err}\n")
-          raise err
-        }
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(fn() {
+      @async.sleep(200)
+      log.write_string("200ms tick\n")
+    })
+    @async.with_timeout(1000, fn() {
+      @async.sleep(100)
+      raise Err
+    }) catch {
+      err => {
+        log.write_string("main task fail with \{err}\n")
+        raise err
       }
-    }),
-  )
+    }
+  }) catch {
+    err => log.write_object(err)
+  }
   inspect(
     log.to_string(),
     content=(
       #|main task fail with Err
-      #|Err(Err)
+      #|Err
     ),
   )
 }


### PR DESCRIPTION
Previously, the default semantic of `with_timeout` on timeout is silent fall-through. However, this semantic will restrict the result type of `with_timeout` to `Unit`. This PR modifies the semantic of `with_timeout` and make it raise `@async.TimeoutError` on timeout by default. This allows changing the result type of `with_timeout` to arbitrary type. The previous silent fall-through semantic can be recovered via:
```moonbit
@async.with_timeout_opt(t, f) |> ignore
// or:
@async.with_timeout(t, f) catch {
  @async.TimeoutError => ()
  err => raiser err
}
```