### PR TITLE
buffer whole HTTP request/response for performance

### DIFF
--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -83,9 +83,24 @@ pub impl @io.Reader for Client with read(
 /// Write data to the body of the request currently being sent.
 /// Must be called after `send_request`.
 /// `end_request` must be called after all content of response body has been sent.
+///
+/// Writing to `@http.Client` MAY be buffered,
+/// call `flush` manually to ensure data is delivered to the remote peer.
 pub impl @io.Writer for Client with write_once(self, buf, offset~, len~) {
   guard self.sender.mode is SendingBody
   self.sender.write_once(buf, offset~, len~)
+}
+
+///|
+pub impl @io.Writer for Client with write_reader(self, reader) {
+  guard self.sender.mode is SendingBody
+  self.sender.write_reader(reader)
+}
+
+///|
+/// Flush buffered data in the request body being sent, if any.
+pub async fn Client::flush(self : Client) -> Unit {
+  self.sender.flush()
 }
 
 ///|

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -31,6 +31,7 @@ type Client
 fn Client::close(Self) -> Unit
 async fn Client::connect(String, headers? : Map[String, String], protocol? : Protocol, port? : Int) -> Self
 async fn Client::end_request(Self) -> Response
+async fn Client::flush(Self) -> Unit
 async fn Client::get(Self, String, extra_headers? : Map[String, String]) -> Response
 async fn[B : Body] Client::post(Self, String, B, extra_headers? : Map[String, String]) -> Response
 async fn[B : Body] Client::put(Self, String, B, extra_headers? : Map[String, String]) -> Response
@@ -73,6 +74,7 @@ pub(all) struct Response {
 type ServerConnection
 fn ServerConnection::close(Self) -> Unit
 async fn ServerConnection::end_response(Self) -> Unit
+async fn ServerConnection::flush(Self) -> Unit
 fn ServerConnection::new(@socket.TCP, headers? : Map[String, String]) -> Self
 async fn ServerConnection::read_request(Self) -> Request
 async fn ServerConnection::send_response(Self, Int, String, extra_headers? : Map[String, String]) -> Unit

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -71,19 +71,23 @@ impl @io.Writer for Sender with write_once(self, buf, offset~, len~) {
     SendingBody => {
       // Reserve enough space for chunk length and '\r\n' in the buffer,
       // so that we can commit the whole chunk in a single write to avoid small writes
-      let max_len = self.send_buf.length() - 7
+      if self.send_len + 7 >= self.send_buf.length() {
+        self.flush()
+      }
+      let max_len = self.send_buf.length() - self.send_len - 7
       let len = @cmp.minimum(max_len, len)
-      self.send_buf[3] = '\r'
-      self.send_buf[4] = '\n'
-      self.send_buf.blit_from_bytes(5, buf, offset, len)
-      self.send_buf[5 + len] = '\r'
-      self.send_buf[6 + len] = '\n'
       let len_str = encode_int(len, base=16)
-      let start = 3 - len_str.length()
-      self.send_buf.blit_from_bytes(start, len_str, 0, len_str.length())
-      self.writer.write(
-        self.send_buf.unsafe_reinterpret_as_bytes()[start:len + 7],
-      )
+      let len_str_len = len_str.length()
+      self.send_buf.blit_from_bytes(self.send_len, len_str, 0, len_str_len)
+      let curr_len = self.send_len + len_str_len
+      self.send_buf[curr_len] = '\r'
+      self.send_buf[curr_len + 1] = '\n'
+      let curr_len = curr_len + 2
+      self.send_buf.blit_from_bytes(curr_len, buf, offset, len)
+      let curr_len = curr_len + len
+      self.send_buf[curr_len] = '\r'
+      self.send_buf[curr_len + 1] = '\n'
+      self.send_len = curr_len + 2
       len
     }
   }
@@ -103,6 +107,7 @@ impl @io.Writer for Sender with write_reader(self, reader) {
         }
       }
     SendingBody => {
+      self.flush()
       self.send_buf[3] = '\r'
       self.send_buf[4] = '\n'
       let max_len = self.send_buf.length() - 7
@@ -126,7 +131,14 @@ impl @io.Writer for Sender with write_reader(self, reader) {
 
 ///|
 async fn Sender::end_body(self : Sender) -> Unit {
-  self.writer.write("0\r\n\r\n")
+  if self.send_len + 5 > self.send_buf.length() {
+    self.flush()
+    self.writer.write("0\r\n\r\n")
+  } else {
+    self.send_buf.blit_from_bytes(self.send_len, "0\r\n\r\n", 0, 5)
+    self.send_len += 5
+    self.flush()
+  }
   self.mode = SendingHeader
 }
 
@@ -168,7 +180,6 @@ async fn Sender::send_request(
   self.write(self.headers)
   self.send_headers(extra_headers)
   self.write("Transfer-Encoding: chunked\r\n\r\n")
-  self.flush()
   self.mode = SendingBody
 }
 
@@ -189,6 +200,5 @@ async fn Sender::send_response(
   self.write(self.headers)
   self.send_headers(extra_headers)
   self.write("Transfer-Encoding: chunked\r\n\r\n")
-  self.flush()
   self.mode = SendingBody
 }

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -77,6 +77,9 @@ pub async fn ServerConnection::skip_request_body(
 /// Write data to the body of the response currently being sent.
 /// Must be called after `send_response`.
 /// `end_response` must be called after all content of response body has been sent.
+///
+/// Writing to `@http.ServerConnection` MAY be buffered,
+/// call `flush` manually to ensure data is delivered to the remote peer.
 pub impl @io.Writer for ServerConnection with write_once(
   self,
   buf,
@@ -85,6 +88,18 @@ pub impl @io.Writer for ServerConnection with write_once(
 ) {
   guard self.sender.mode is SendingBody
   self.sender.write_once(buf, offset~, len~)
+}
+
+///|
+pub impl @io.Writer for ServerConnection with write_reader(self, reader) {
+  guard self.sender.mode is SendingBody
+  self.sender.write_reader(reader)
+}
+
+///|
+/// Flush buffered data in the response body being sent, if any.
+pub async fn ServerConnection::flush(self : ServerConnection) -> Unit {
+  self.sender.flush()
 }
 
 ///|


### PR DESCRIPTION
#93 introduces a performance regression. The new API introduces an extra network write for empty/small HTTP body, which may significantly damage performance on heavy load. This PR optimizes the HTTP API to allow buffering of the whole HTTP message, including header and body. This resolves the performance regression, at the cost that `@http.Client` and `@http.ServerConnection` now behaves as a buffered writer, so an explicit `flush` operation is provided, and users may need to call `flush` manually for streaming request/response body.

The `write_reader` operation, on the other hand, remains non-buffered. The rationale is that users cannot interrupt the `write_reader` operation and insert `flush` in the middle, so making `write_reader` buffered will rule out the possibility of real-time delivery of a reader stream. If this leads to performance issue in the future, we can introduce a separated "buffered" flag for `@http.Client`/`@http.ServerConnection`.