### PR TITLE
use abstract type for HTTP body instead of type parameter in helpers

### DIFF
--- a/examples/http_file_server/server_test.mbt
+++ b/examples/http_file_server/server_test.mbt
@@ -34,7 +34,7 @@ async fn client(
   let response = conn.get(path)
   output_response(response, logger)
   match handle_response {
-    None => logger.write_string(conn.read_all() |> @encoding/utf8.decode)
+    None => logger.write_string(conn.read_all().text())
     Some(f) => f(conn)
   }
 }

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -80,6 +80,13 @@ pub impl @io.Reader for Client with read(
 }
 
 ///|
+/// Read the whole response body from a HTTP client.
+/// Must be called after `end_request`.
+pub async fn Client::read_all(self : Client) -> &Body {
+  @io.Reader::read_all(self.reader)
+}
+
+///|
 /// Write data to the body of the request currently being sent.
 /// Must be called after `send_request`.
 /// `end_request` must be called after all content of response body has been sent.
@@ -158,33 +165,36 @@ pub async fn Client::get(
   self : Client,
   path : String,
   extra_headers? : Map[String, String] = {},
+  body? : &Body,
 ) -> Response {
   self.request(Get, path, extra_headers~)
+  if body is Some(body) {
+    self.write(body.to_bytes())
+  }
   self.end_request()
 }
 
 ///|
 /// Perform a `PUT` request to the server, see `Client::request` for more details.
-pub async fn[B : Body] Client::put(
+pub async fn Client::put(
   self : Client,
   path : String,
-  body : B,
+  body : &Body,
   extra_headers? : Map[String, String] = {},
 ) -> Response {
-  self.request(Put, path, extra_headers~)
-  body.write(self.sender)
-  self.end_request()
+  self..request(Put, path, extra_headers~)..write(body.to_bytes()).end_request()
 }
 
 ///|
 /// Perform a `POST` request to the server, see `Client::request` for more details.
-pub async fn[B : Body] Client::post(
+pub async fn Client::post(
   self : Client,
   path : String,
-  body : B,
+  body : &Body,
   extra_headers? : Map[String, String] = {},
 ) -> Response {
-  self.request(Post, path, extra_headers~)
-  body.write(self.sender)
-  self.end_request()
+  self
+  ..request(Post, path, extra_headers~)
+  ..write(body.to_bytes())
+  .end_request()
 }

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -6,11 +6,11 @@ import(
 )
 
 // Values
-async fn[ResBody : Body] get(String, headers? : Map[String, String], port? : Int) -> (Response, ResBody)
+async fn get(String, headers? : Map[String, String], port? : Int, body? : &Body) -> (Response, &Body)
 
-async fn[ReqBody : Body, ResBody : Body] post(String, ReqBody, headers? : Map[String, String], port? : Int) -> (Response, ResBody)
+async fn post(String, &Body, headers? : Map[String, String], port? : Int) -> (Response, &Body)
 
-async fn[ReqBody : Body, ResBody : Body] put(String, ReqBody, headers? : Map[String, String], port? : Int) -> (Response, ResBody)
+async fn put(String, &Body, headers? : Map[String, String], port? : Int) -> (Response, &Body)
 
 // Errors
 pub suberror HttpProtocolError {
@@ -32,9 +32,10 @@ fn Client::close(Self) -> Unit
 async fn Client::connect(String, headers? : Map[String, String], protocol? : Protocol, port? : Int) -> Self
 async fn Client::end_request(Self) -> Response
 async fn Client::flush(Self) -> Unit
-async fn Client::get(Self, String, extra_headers? : Map[String, String]) -> Response
-async fn[B : Body] Client::post(Self, String, B, extra_headers? : Map[String, String]) -> Response
-async fn[B : Body] Client::put(Self, String, B, extra_headers? : Map[String, String]) -> Response
+async fn Client::get(Self, String, extra_headers? : Map[String, String], body? : &Body) -> Response
+async fn Client::post(Self, String, &Body, extra_headers? : Map[String, String]) -> Response
+async fn Client::put(Self, String, &Body, extra_headers? : Map[String, String]) -> Response
+async fn Client::read_all(Self) -> &Body
 async fn Client::request(Self, RequestMethod, String, extra_headers? : Map[String, String]) -> Unit
 async fn Client::skip_response_body(Self) -> Unit
 impl @moonbitlang/async/io.Reader for Client
@@ -76,11 +77,16 @@ fn ServerConnection::close(Self) -> Unit
 async fn ServerConnection::end_response(Self) -> Unit
 async fn ServerConnection::flush(Self) -> Unit
 fn ServerConnection::new(@socket.TCP, headers? : Map[String, String]) -> Self
+async fn ServerConnection::read_all(Self) -> &Body
 async fn ServerConnection::read_request(Self) -> Request
 async fn ServerConnection::send_response(Self, Int, String, extra_headers? : Map[String, String]) -> Unit
 async fn ServerConnection::skip_request_body(Self) -> Unit
 impl @moonbitlang/async/io.Reader for ServerConnection
 impl @moonbitlang/async/io.Writer for ServerConnection
+
+async fn Body::binary(&Self) -> Bytes
+async fn Body::json(&Self) -> Json
+async fn Body::text(&Self) -> String
 
 // Type aliases
 

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -33,13 +33,13 @@ pub suberror URIParseError {
 } derive(Show)
 
 ///|
-async fn[ReqBody : Body, ResBody : Body] perform_request(
+async fn perform_request(
   uri : String,
   meth : RequestMethod,
   headers : Map[String, String],
-  body : ReqBody,
+  body : &Body,
   port? : Int,
-) -> (Response, ResBody) {
+) -> (Response, &Body) {
   guard uri.find("://") is Some(protocol_len) else { raise InvalidFormat }
   let protocol = match uri[:protocol_len] {
     "http" => Http
@@ -63,11 +63,9 @@ async fn[ReqBody : Body, ResBody : Body] perform_request(
   let path = if path == "" { "/" } else { path }
   let client = Client::connect(host, headers~, protocol~, port~)
   defer client.close()
-  client.request(meth, path)
-  body.write(client.sender)
+  client..request(meth, path)..write(body.to_bytes())
   let response = client.end_request()
-  let body = ResBody::read(client.reader)
-  (response, body)
+  (response, client.read_all())
 }
 
 ///|
@@ -79,32 +77,33 @@ async fn[ReqBody : Body, ResBody : Body] perform_request(
 /// By default it is the standard port for the specified protocol.
 ///
 /// See `Client::request` for more details.
-pub async fn[ResBody : Body] get(
+pub async fn get(
   uri : String,
   headers? : Map[String, String] = {},
   port? : Int,
-) -> (Response, ResBody) {
-  perform_request(uri, Get, headers, b"", port?)
+  body? : &Body = b"",
+) -> (Response, &Body) {
+  perform_request(uri, Get, headers, body, port?)
 }
 
 ///|
 /// Similar to `get`, but performs a `PUT` request instead.
-pub async fn[ReqBody : Body, ResBody : Body] put(
+pub async fn put(
   uri : String,
-  content : ReqBody,
+  content : &Body,
   headers? : Map[String, String] = {},
   port? : Int,
-) -> (Response, ResBody) {
+) -> (Response, &Body) {
   perform_request(uri, Put, headers, content, port?)
 }
 
 ///|
 /// Similar to `get`, but performs a `POST` request instead.
-pub async fn[ReqBody : Body, ResBody : Body] post(
+pub async fn post(
   uri : String,
-  content : ReqBody,
+  content : &Body,
   headers? : Map[String, String] = {},
   port? : Int,
-) -> (Response, ResBody) {
+) -> (Response, &Body) {
   perform_request(uri, Post, headers, content, port?)
 }

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -14,9 +14,9 @@
 
 ///|
 async test "https request" {
-  let (_, (result : String)) = @http.get("https://www.example.org")
+  let (_, result) = @http.get("https://www.example.org")
   inspect(
-    result,
+    result.text(),
     content=(
       #|<!doctype html>
       #|<html>
@@ -71,9 +71,9 @@ async test "https request" {
 
 ///|
 async test "http request" {
-  let (_, (result : String)) = @http.get("http://www.example.org")
+  let (_, result) = @http.get("http://www.example.org")
   inspect(
-    result,
+    result.text(),
     content=(
       #|<!doctype html>
       #|<html>

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -53,6 +53,13 @@ pub impl @io.Reader for ServerConnection with read(
 }
 
 ///|
+/// Read the whole request body from a HTTP server.
+/// Must be called after `read_request`.
+pub async fn ServerConnection::read_all(self : ServerConnection) -> &Body {
+  @io.Reader::read_all(self.reader)
+}
+
+///|
 /// Read a single request from the connection.
 /// If the body of the last request is not consumed yet,
 /// it will be discarded.

--- a/src/http/types.mbt
+++ b/src/http/types.mbt
@@ -44,36 +44,56 @@ pub(all) struct Response {
 /// Currently `Bytes` (for binary data), `String` (UTF8 encoded),
 /// and `Json` (also UTF8 encoded) are supported.
 trait Body {
-  async read(Reader) -> Self
-  async write(Self, Sender) -> Unit
+  async to_bytes(Self) -> Bytes
 }
 
 ///|
-pub impl Body for Bytes with read(reader) {
-  reader.read_all()
+pub impl Body for Bytes with to_bytes(self) {
+  self
 }
 
 ///|
-pub impl Body for Bytes with write(self, sender) {
-  sender.write(self)
+pub impl Body for String with to_bytes(self) {
+  @encoding/utf8.encode(self)
 }
 
 ///|
-pub impl Body for String with read(reader) {
-  @encoding/utf8.decode(reader.read_all())
+pub impl Body for Json with to_bytes(self) {
+  self.stringify() |> @encoding/utf8.encode
+}
+
+// ==============================================================================
+// internal node: the `Body` trait serves two purpose.
+// When the user is sending data, we use `to_bytes` to convert user data to binary.
+// When the user is receiving data, raw data is always represented as raw binary,
+// so `&Body` always internally hold a `Bytes`,
+// and the user may use these helpers below to convert them to different format.
+//
+// Technically we should use two types for these two purposes,
+// but that would mean two different names, instead of the simple `Body`.
+// So currently we take this rather hacky approach for simplicify of API.
+// ==============================================================================
+
+///|
+/// Extract the raw binary data in request/response body.
+pub async fn &Body::binary(self : &Body) -> Bytes {
+  self.to_bytes()
 }
 
 ///|
-pub impl Body for String with write(self, sender) {
-  sender.write_string(self, encoding=UTF8)
+/// Extract request/response body as a UTF8 encoded string.
+///
+/// Calling this method will cause string decoding,
+/// so user should avoid calling `.text()` more than once.
+pub async fn &Body::text(self : &Body) -> String {
+  self.to_bytes() |> @encoding/utf8.decode
 }
 
 ///|
-pub impl Body for Json with read(reader) {
-  @encoding/utf8.decode(reader.read_all()) |> @json.parse
-}
-
-///|
-pub impl Body for Json with write(self, sender) {
-  sender.write_string(self.stringify(), encoding=UTF8)
+/// Extract request/response body as a UTF8 encoded JSON.
+///
+/// Calling this method will cause string decoding and json parsing,
+/// so user should avoid calling `.json()` more than once.
+pub async fn &Body::json(self : &Body) -> Json {
+  self.to_bytes() |> @encoding/utf8.decode |> @json.parse
 }


### PR DESCRIPTION
In #93, `@http.get` etc. uses a type parameter `ResBody : Body` for message body in return type. However, if the user wants to simply ignore the body, this is inconvenient, as the compiler will complain that it cannot deduce the type parameter `ResBody`.

This PR makes `@http.get` etc. returns a `&Body` trait object type, and attach methods `.binary()`, `.text()` and `.json()` to `&Body`. This way the whole body can be ignored without problem, while obtaining the content of the body is still convenient.