### PR TITLE
[breaking] better errno display & add contex to `OSError`

### DIFF
--- a/src/fs/access_test.mbt
+++ b/src/fs/access_test.mbt
@@ -15,7 +15,17 @@
 ///|
 async test "exists" {
   assert_true(@fs.exists("moon.mod.json"))
+  inspect(
+    try? ignore(@fs.open("moon.mod.json", mode=ReadOnly)),
+    content="Ok(())",
+  )
   assert_false(@fs.exists("moon.mod.json.not_exist"))
+  inspect(
+    try? ignore(@fs.open("moon.mod.json.not_exist", mode=ReadOnly)),
+    content=(
+      #|Err(OSError("No such file or directory"))
+    ),
+  )
 }
 
 ///|

--- a/src/fs/access_test.mbt
+++ b/src/fs/access_test.mbt
@@ -23,7 +23,7 @@ async test "exists" {
   inspect(
     try? ignore(@fs.open("moon.mod.json.not_exist", mode=ReadOnly)),
     content=(
-      #|Err(OSError("No such file or directory"))
+      #|Err(OSError("@fs.open(): No such file or directory"))
     ),
   )
 }

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -17,7 +17,12 @@
 /// The permission of the created directory must be set in `permission`.
 pub async fn mkdir(path : String, permission~ : Int) -> Unit {
   let path = @encoding/utf8.encode(path)
-  ignore(@event_loop.perform_job(Mkdir(path~, mode=permission)))
+  ignore(
+    @event_loop.perform_job(
+      Mkdir(path~, mode=permission),
+      context="@fs.mkdir()",
+    ),
+  )
 }
 
 ///|
@@ -38,7 +43,7 @@ pub async fn rmdir(path : String, recursive? : Bool = false) -> Unit {
     }
   }
   let path = @encoding/utf8.encode(path)
-  ignore(@event_loop.perform_job(Rmdir(path~)))
+  ignore(@event_loop.perform_job(Rmdir(path~), context="@fs.rmdir()"))
 }
 
 ///|
@@ -67,7 +72,7 @@ pub fn opendir(path : String) -> Directory raise {
   let path = @encoding/utf8.encode(path)
   let dir = opendir_ffi(path)
   if dir.is_null() {
-    @os_error.check_errno()
+    @os_error.check_errno("@fs.opendir()")
   }
   dir
 }
@@ -87,7 +92,9 @@ extern "C" fn DirectoryEntry::name(ent : DirectoryEntry) -> Bytes = "moonbitlang
 ///|
 async fn Directory::read_next(dir : Directory) -> String? {
   let out = @ref.new(null_dirent)
-  ignore(@event_loop.perform_job(Readdir(dir=dir.0, out~)))
+  ignore(
+    @event_loop.perform_job(Readdir(dir=dir.0, out~), context="@fs.readdir()"),
+  )
   if physical_equal(out.val, null_dirent) {
     None
   } else {

--- a/src/fs/fs.mbt
+++ b/src/fs/fs.mbt
@@ -111,10 +111,10 @@ pub async fn open(
   }
   let flags = make_open_flags(mode~, sync~, append~, create~, truncate~)
   let job = @event_loop.Open(path=filename, flags~, mode=user_mode)
-  let fd = @event_loop.perform_job(job)
+  let fd = @event_loop.perform_job(job, context="@fs.open()")
   let kind = get_file_kind_ffi(fd)
   if kind < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno("@fs.open(): get file kind")
   }
   { fd, kind: FileKind::unsafe_from_int(kind) }
 }
@@ -157,6 +157,7 @@ pub impl @io.Reader for File with read(
   let can_poll = self.kind.can_poll()
   @event_loop.perform_job(
     Read(fd=self.fd, buf~, offset~, len=max_len, can_poll~),
+    context="@fs.File::read()",
   )
 }
 
@@ -191,7 +192,7 @@ pub impl @io.Reader for File with read_all(self) {
 pub impl @io.Writer for File with write_once(self, buf, offset~, len~) {
   let can_poll = self.kind.can_poll()
   let job = @event_loop.Write(fd=self.fd, buf~, offset~, len~, can_poll~)
-  @event_loop.perform_job(job)
+  @event_loop.perform_job(job, context="@fs.File::write()")
 }
 
 ///|
@@ -199,7 +200,7 @@ pub impl @io.Writer for File with write_once(self, buf, offset~, len~) {
 pub async fn remove(path : String) -> Unit {
   let path = @encoding/utf8.encode(path)
   let job = @event_loop.Remove(path~)
-  ignore(@event_loop.perform_job(job))
+  ignore(@event_loop.perform_job(job, context="@fs.remove()"))
 }
 
 ///|
@@ -225,7 +226,7 @@ extern "C" fn lseek_ffi(fd : Int, offset : Int64, whence : SeekMode) -> Int64 = 
 pub fn File::seek(self : File, offset : Int64, mode~ : SeekMode) -> Int64 raise {
   let offset = lseek_ffi(self.fd, offset, mode)
   if offset < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno("@fs.File::seek()")
   }
   offset
 }
@@ -255,7 +256,7 @@ extern "C" fn as_dir_ffi(fd : Int) -> Directory = "fdopendir"
 pub fn File::as_dir(self : File) -> Directory raise {
   let dir = as_dir_ffi(self.fd)
   if dir.is_null() {
-    @os_error.check_errno()
+    @os_error.check_errno("@fs.File::as_dir()")
   }
   dir
 }

--- a/src/fs/utils.mbt
+++ b/src/fs/utils.mbt
@@ -23,7 +23,7 @@ extern "C" fn sizeof_stat() -> Int = "moonbitlang_async_sizeof_stat"
 pub async fn kind(path : String) -> FileKind {
   let path = @encoding/utf8.encode(path)
   let stat = FixedArray::make(sizeof_stat(), b'0')
-  let _ = @event_loop.perform_job(Stat(path~, out=stat))
+  let _ = @event_loop.perform_job(Stat(path~, out=stat), context="@fs.kind()")
   file_kind_from_stat(stat)
 }
 
@@ -54,8 +54,10 @@ let _EACCES : Int = get_EACCES()
 ///|
 pub async fn exists(path : String) -> Bool {
   let path = @encoding/utf8.encode(path)
-  try @event_loop.perform_job(Access(path~, amode=f_ok())) catch {
-    @os_error.OSError(code) if code == _ENOENT => false
+  try
+    @event_loop.perform_job(Access(path~, amode=f_ok()), context="@fs.exists()")
+  catch {
+    @os_error.OSError(code, ..) if code == _ENOENT => false
     err => raise err
   } noraise {
     _ => true
@@ -65,9 +67,14 @@ pub async fn exists(path : String) -> Bool {
 ///|
 pub async fn can_read(path : String) -> Bool {
   let path = @encoding/utf8.encode(path)
-  try @event_loop.perform_job(Access(path~, amode=r_ok())) catch {
-    @os_error.OSError(code) if code == _ENOENT => false
-    @os_error.OSError(code) if code == _EACCES => false
+  try
+    @event_loop.perform_job(
+      Access(path~, amode=r_ok()),
+      context="@fs.can_read()",
+    )
+  catch {
+    @os_error.OSError(code, ..) if code == _ENOENT => false
+    @os_error.OSError(code, ..) if code == _EACCES => false
     err => raise err
   } noraise {
     _ => true
@@ -77,9 +84,14 @@ pub async fn can_read(path : String) -> Bool {
 ///|
 pub async fn can_write(path : String) -> Bool {
   let path = @encoding/utf8.encode(path)
-  try @event_loop.perform_job(Access(path~, amode=w_ok())) catch {
-    @os_error.OSError(code) if code == _ENOENT => false
-    @os_error.OSError(code) if code == _EACCES => false
+  try
+    @event_loop.perform_job(
+      Access(path~, amode=w_ok()),
+      context="@fs.can_write()",
+    )
+  catch {
+    @os_error.OSError(code, ..) if code == _ENOENT => false
+    @os_error.OSError(code, ..) if code == _EACCES => false
     err => raise err
   } noraise {
     _ => true
@@ -89,9 +101,14 @@ pub async fn can_write(path : String) -> Bool {
 ///|
 pub async fn can_execute(path : String) -> Bool {
   let path = @encoding/utf8.encode(path)
-  try @event_loop.perform_job(Access(path~, amode=x_ok())) catch {
-    @os_error.OSError(code) if code == _ENOENT => false
-    @os_error.OSError(code) if code == _EACCES => false
+  try
+    @event_loop.perform_job(
+      Access(path~, amode=x_ok()),
+      context="@fs.can_execute",
+    )
+  catch {
+    @os_error.OSError(code, ..) if code == _ENOENT => false
+    @os_error.OSError(code, ..) if code == _EACCES => false
     err => raise err
   } noraise {
     _ => true
@@ -108,7 +125,10 @@ pub async fn can_execute(path : String) -> Bool {
 pub async fn realpath(path : String) -> String {
   let path = @encoding/utf8.encode(path)
   let out = @ref.new(@c_buffer.null)
-  let _ = @event_loop.perform_job(Realpath(path~, out~))
+  let _ = @event_loop.perform_job(
+    Realpath(path~, out~),
+    context="@fs.realpath()",
+  )
   let c_path = out.val
   defer c_path.free()
   let len = c_path.strlen()

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -65,22 +65,22 @@ pub fn register_hook(init? : () -> Unit, exit? : () -> Unit) -> Unit {
 ///|
 pub fn with_event_loop(f : async () -> Unit) -> Unit raise {
   guard curr_loop.val is None
-  let (notify_recv, notify_send) = @fd_util.pipe()
+  let (notify_recv, notify_send) = @fd_util.pipe("initialze runtime")
   try {
-    @fd_util.set_nonblocking(notify_recv)
-    @fd_util.set_blocking(notify_send)
+    @fd_util.set_nonblocking(notify_recv, context="initialize runtime")
+    @fd_util.set_blocking(notify_send, context="initialize runtime")
   } catch {
     err => {
-      @fd_util.close(notify_recv)
-      @fd_util.close(notify_send)
+      @fd_util.close(notify_recv, context="initialize runtime")
+      @fd_util.close(notify_send, context="initialize runtime")
       raise err
     }
   }
   defer {
-    @fd_util.close(notify_recv) catch {
+    @fd_util.close(notify_recv, context="initialize runtime") catch {
       _ => ()
     }
-    @fd_util.close(notify_send) catch {
+    @fd_util.close(notify_send, context="initialize runtime") catch {
       _ => ()
     }
   }
@@ -137,7 +137,7 @@ async fn EventLoop::poll(self : Self) -> Bool {
   }
   let n = self.poll.wait(timeout~)
   if n < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno("runtime internal: poll_wait")
   }
   for i in 0..<n {
     let event = get_event(i)
@@ -147,7 +147,7 @@ async fn EventLoop::poll(self : Self) -> Bool {
       if self.pids.get(fd) is Some(handle) {
         let result = @ref.new(0)
         if event.pid_status(result) < 0 {
-          @os_error.check_errno()
+          @os_error.check_errno("runtime internal: get PID status")
         }
         handle.result = result.val
         self.pids.remove(fd)
@@ -171,7 +171,7 @@ async fn EventLoop::poll(self : Self) -> Bool {
         }
       } else {
         if not(@os_error.is_nonblocking_io_error()) {
-          @os_error.check_errno()
+          @os_error.check_errno("runtime internal: failed to get completed job")
         }
       }
     } else if self.fds.get(fd) is Some(handle) {
@@ -224,7 +224,7 @@ fn EventLoop::run_forever(self : Self) -> Unit raise {
         err => abort("detach \{fd} from loop: \{err}")
       }
     }
-    @fd_util.close(fd)
+    @fd_util.close(fd, context="runtime internal: close leaking fd")
   }
   guard self.pids.is_empty()
   self.fds.clear()
@@ -355,7 +355,7 @@ pub fn close_fd(fd : Int) -> Unit {
       }
     }
   }
-  @fd_util.close(fd) catch {
+  @fd_util.close(fd, context="") catch {
     _ => ()
   }
 }
@@ -363,6 +363,7 @@ pub fn close_fd(fd : Int) -> Unit {
 ///|
 async fn perform_job_in_worker(
   job : JobForWorker,
+  context~ : String,
   allow_cancel? : Bool = false,
 ) -> Int {
   guard curr_loop.val is Some(evloop)
@@ -390,16 +391,16 @@ async fn perform_job_in_worker(
     @coroutine.protect_from_cancel(@coroutine.suspend)
   }
   if job.err() > 0 {
-    raise @os_error.OSError(job.err())
+    raise @os_error.OSError(job.err(), context~)
   } else {
     job.ret()
   }
 }
 
 ///|
-pub async fn perform_job(job : Job) -> Int {
+pub async fn perform_job(job : Job, context~ : String) -> Int {
   match job {
-    Sleep(t) => perform_job_in_worker(JobForWorker::sleep(t))
+    Sleep(t) => perform_job_in_worker(JobForWorker::sleep(t), context~)
     Read(fd~, buf~, offset~, len~, can_poll~) =>
       if can_poll {
         let handle = prepare_fd_read(fd)
@@ -412,12 +413,12 @@ pub async fn perform_job(job : Job) -> Int {
           ret
         }
         if ret < 0 {
-          @os_error.check_errno()
+          @os_error.check_errno(context)
         }
         ret
       } else {
         let job = JobForWorker::read(fd, buf, offset, len)
-        perform_job_in_worker(job)
+        perform_job_in_worker(job, context~)
       }
     Write(fd~, buf~, offset~, len~, can_poll~) =>
       if can_poll {
@@ -431,29 +432,31 @@ pub async fn perform_job(job : Job) -> Int {
           ret
         }
         if ret < 0 {
-          @os_error.check_errno()
+          @os_error.check_errno(context)
         }
         ret
       } else {
         let job = JobForWorker::write(fd, buf, offset, len)
-        perform_job_in_worker(job)
+        perform_job_in_worker(job, context~)
       }
     Open(path~, flags~, mode~) =>
-      perform_job_in_worker(JobForWorker::open(path, flags, mode))
-    Stat(path~, out~) => perform_job_in_worker(JobForWorker::stat(path, out))
+      perform_job_in_worker(JobForWorker::open(path, flags, mode), context~)
+    Stat(path~, out~) =>
+      perform_job_in_worker(JobForWorker::stat(path, out), context~)
     Access(path~, amode~) =>
-      perform_job_in_worker(JobForWorker::access(path, amode))
-    Remove(path~) => perform_job_in_worker(JobForWorker::remove(path))
+      perform_job_in_worker(JobForWorker::access(path, amode), context~)
+    Remove(path~) => perform_job_in_worker(JobForWorker::remove(path), context~)
     Mkdir(path~, mode~) =>
-      perform_job_in_worker(JobForWorker::mkdir(path, mode))
-    Rmdir(path~) => perform_job_in_worker(JobForWorker::rmdir(path))
+      perform_job_in_worker(JobForWorker::mkdir(path, mode), context~)
+    Rmdir(path~) => perform_job_in_worker(JobForWorker::rmdir(path), context~)
     Readdir(dir~, out~) =>
-      perform_job_in_worker(JobForWorker::readdir(dir, out))
+      perform_job_in_worker(JobForWorker::readdir(dir, out), context~)
     Realpath(path~, out~) =>
-      perform_job_in_worker(JobForWorker::realpath(path, out))
+      perform_job_in_worker(JobForWorker::realpath(path, out), context~)
     Spawn(path~, args~, env~, stdin~, stdout~, stderr~, cwd~) =>
       perform_job_in_worker(
         JobForWorker::spawn(path, args, env, stdin, stdout, stderr, cwd),
+        context~,
       )
     Recvfrom(sock~, buf~, offset~, len~, addr~) => {
       let handle = prepare_fd_read(sock)
@@ -466,7 +469,7 @@ pub async fn perform_job(job : Job) -> Int {
         ret
       }
       if ret < 0 {
-        @os_error.check_errno()
+        @os_error.check_errno(context)
       }
       ret
     }
@@ -481,7 +484,7 @@ pub async fn perform_job(job : Job) -> Int {
         ret
       }
       if ret < 0 {
-        @os_error.check_errno()
+        @os_error.check_errno(context)
       }
       ret
     }
@@ -494,12 +497,12 @@ pub async fn perform_job(job : Job) -> Int {
         handle.wait_write()
         let err = get_socket_err(sock)
         if err < 0 {
-          @os_error.check_errno()
+          @os_error.check_errno(context)
         } else if err > 0 {
-          raise @os_error.OSError(err)
+          raise @os_error.OSError(err, context~)
         }
       } else {
-        @os_error.check_errno()
+        @os_error.check_errno(context)
       }
       0
     }
@@ -512,7 +515,7 @@ pub async fn perform_job(job : Job) -> Int {
         handle.wait_read()
         accept_ffi(sock, addr)
       } else {
-        @os_error.check_errno()
+        @os_error.check_errno(context)
         -1
       }
     }
@@ -521,6 +524,7 @@ pub async fn perform_job(job : Job) -> Int {
       perform_job_in_worker(
         JobForWorker::getaddrinfo(host, out),
         allow_cancel=true,
+        context~,
       )
   }
 }

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -8,7 +8,7 @@ import(
 // Values
 fn close_fd(Int) -> Unit
 
-async fn perform_job(Job) -> Int
+async fn perform_job(Job, context~ : String) -> Int
 
 fn register_hook(init? : () -> Unit, exit? : () -> Unit) -> Unit
 

--- a/src/internal/event_loop/poll.mbt
+++ b/src/internal/event_loop/poll.mbt
@@ -51,7 +51,7 @@ fn Instance::register(
   oneshot? : Bool = false,
 ) -> Unit raise {
   if self.register_ffi(fd, prev_events~, new_events~, oneshot~) < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno("poll_register")
   }
 }
 
@@ -77,7 +77,7 @@ fn Instance::register_pid(
   let out = @ref.new(0)
   let ret = self.register_pid_ffi(pid, out)
   if ret < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno("poll_register_pid")
   }
   if ret == 0 {
     Running(out.val)
@@ -96,7 +96,7 @@ extern "C" fn Instance::remove_ffi(
 ///|
 fn Instance::remove(self : Instance, fd : Int, events~ : Int) -> Unit raise {
   if 0 != self.remove_ffi(fd, events~) {
-    @os_error.check_errno()
+    @os_error.check_errno("poll_remove")
   }
 }
 
@@ -109,7 +109,7 @@ extern "C" fn Instance::remove_pid_ffi(
 ///|
 fn Instance::remove_pid(self : Instance, pid_handle : Int) -> Unit raise {
   if 0 != self.remove_pid_ffi(pid_handle) {
-    @os_error.check_errno()
+    @os_error.check_errno("poll_remove_pid")
   }
 }
 

--- a/src/internal/fd_util/fd_util.mbt
+++ b/src/internal/fd_util/fd_util.mbt
@@ -16,9 +16,9 @@
 extern "C" fn set_blocking_ffi(fd : Int) -> Int = "moonbitlang_async_set_blocking"
 
 ///|
-pub fn set_blocking(fd : Int) -> Unit raise {
+pub fn set_blocking(fd : Int, context~ : String) -> Unit raise {
   if set_blocking_ffi(fd) < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno(context)
   }
 }
 
@@ -26,9 +26,9 @@ pub fn set_blocking(fd : Int) -> Unit raise {
 extern "C" fn set_nonblocking_ffi(fd : Int) -> Int = "moonbitlang_async_set_nonblocking"
 
 ///|
-pub fn set_nonblocking(fd : Int) -> Unit raise {
+pub fn set_nonblocking(fd : Int, context~ : String) -> Unit raise {
   if set_nonblocking_ffi(fd) < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno(context)
   }
 }
 
@@ -36,9 +36,9 @@ pub fn set_nonblocking(fd : Int) -> Unit raise {
 extern "C" fn set_cloexec_ffi(fd : Int) -> Int = "moonbitlang_async_set_cloexec"
 
 ///|
-pub fn set_cloexec(fd : Int) -> Unit raise {
+pub fn set_cloexec(fd : Int, context~ : String) -> Unit raise {
   if set_cloexec_ffi(fd) < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno(context)
   }
 }
 
@@ -47,14 +47,14 @@ pub fn set_cloexec(fd : Int) -> Unit raise {
 extern "C" fn pipe_ffi(fds : FixedArray[Int]) -> Int = "moonbitlang_async_pipe"
 
 ///|
-pub fn pipe() -> (Int, Int) raise {
+pub fn pipe(context : String) -> (Int, Int) raise {
   let fds : FixedArray[Int] = [0, 0]
   if 0 != pipe_ffi(fds) {
-    @os_error.check_errno()
+    @os_error.check_errno(context)
   }
   guard fds is [r, w]
-  set_cloexec(r)
-  set_cloexec(w)
+  set_cloexec(r, context~)
+  set_cloexec(w, context~)
   (r, w)
 }
 
@@ -62,8 +62,8 @@ pub fn pipe() -> (Int, Int) raise {
 extern "C" fn close_ffi(fd : Int) -> Int = "close"
 
 ///|
-pub fn close(fd : Int) -> Unit raise {
+pub fn close(fd : Int, context~ : String) -> Unit raise {
   if close_ffi(fd) < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno(context)
   }
 }

--- a/src/internal/fd_util/pkg.generated.mbti
+++ b/src/internal/fd_util/pkg.generated.mbti
@@ -2,15 +2,15 @@
 package "moonbitlang/async/internal/fd_util"
 
 // Values
-fn close(Int) -> Unit raise
+fn close(Int, context~ : String) -> Unit raise
 
-fn pipe() -> (Int, Int) raise
+fn pipe(String) -> (Int, Int) raise
 
-fn set_blocking(Int) -> Unit raise
+fn set_blocking(Int, context~ : String) -> Unit raise
 
-fn set_cloexec(Int) -> Unit raise
+fn set_cloexec(Int, context~ : String) -> Unit raise
 
-fn set_nonblocking(Int) -> Unit raise
+fn set_nonblocking(Int, context~ : String) -> Unit raise
 
 // Errors
 

--- a/src/os_error/error.mbt
+++ b/src/os_error/error.mbt
@@ -24,7 +24,25 @@ pub fn is_nonblocking_io_error() -> Bool {
 }
 
 ///|
-pub(all) suberror OSError Int derive(Show)
+extern "C" fn strerror(errno : Int) -> @c_buffer.Buffer = "strerror"
+
+///|
+pub(all) suberror OSError Int
+
+///|
+pub impl Show for OSError with output(self, logger) -> Unit {
+  let OSError(errno) = self
+  let c_str = strerror(errno)
+  let len = c_str.strlen()
+  let data = FixedArray::make(len, (0 : Byte))
+  c_str.blit_to_bytes(dst=data, offset=0, len~)
+  logger
+  ..write_string("OSError(")
+  ..write_object(
+    @encoding/utf8.decode_lossy(data.unsafe_reinterpret_as_bytes()),
+  )
+  ..write_string(")")
+}
 
 ///|
 pub fn OSError::is_nonblocking_io_error(err : OSError) -> Bool {

--- a/src/os_error/error.mbt
+++ b/src/os_error/error.mbt
@@ -27,33 +27,36 @@ pub fn is_nonblocking_io_error() -> Bool {
 extern "C" fn strerror(errno : Int) -> @c_buffer.Buffer = "strerror"
 
 ///|
-pub(all) suberror OSError Int
+pub(all) suberror OSError {
+  OSError(Int, context~ : String)
+}
 
 ///|
 pub impl Show for OSError with output(self, logger) -> Unit {
-  let OSError(errno) = self
+  let OSError(errno, context~) = self
   let c_str = strerror(errno)
   let len = c_str.strlen()
   let data = FixedArray::make(len, (0 : Byte))
   c_str.blit_to_bytes(dst=data, offset=0, len~)
+  let errno_desc = @encoding/utf8.decode_lossy(
+    data.unsafe_reinterpret_as_bytes(),
+  )
   logger
   ..write_string("OSError(")
-  ..write_object(
-    @encoding/utf8.decode_lossy(data.unsafe_reinterpret_as_bytes()),
-  )
+  ..write_object("\{context}: \{errno_desc}")
   ..write_string(")")
 }
 
 ///|
 pub fn OSError::is_nonblocking_io_error(err : OSError) -> Bool {
-  let OSError(errno) = err
+  let OSError(errno, ..) = err
   errno_is_nonblocking_io_error(errno)
 }
 
 ///|
-pub fn check_errno() -> Unit raise OSError {
+pub fn check_errno(context : String) -> Unit raise OSError {
   let err_code = get_errno()
   if err_code != 0 {
-    raise OSError(err_code)
+    raise OSError(err_code, context~)
   }
 }

--- a/src/os_error/moon.pkg.json
+++ b/src/os_error/moon.pkg.json
@@ -1,3 +1,6 @@
 {
+  "import": [
+    "moonbitlang/async/internal/c_buffer"
+  ],
   "native-stub": [ "stub.c" ]
 }

--- a/src/os_error/pkg.generated.mbti
+++ b/src/os_error/pkg.generated.mbti
@@ -2,14 +2,16 @@
 package "moonbitlang/async/os_error"
 
 // Values
-fn check_errno() -> Unit raise OSError
+fn check_errno(String) -> Unit raise OSError
 
 fn get_errno() -> Int
 
 fn is_nonblocking_io_error() -> Bool
 
 // Errors
-pub(all) suberror OSError Int
+pub(all) suberror OSError {
+  OSError(Int, context~ : String)
+}
 fn OSError::is_nonblocking_io_error(Self) -> Bool
 impl Show for OSError
 

--- a/src/pipe/pipe.mbt
+++ b/src/pipe/pipe.mbt
@@ -36,9 +36,9 @@ pub fn PipeWrite::fd(self : PipeWrite) -> Int {
 /// Create a pipe using `pipe(2)` system call.
 /// Return the read end and write end of the pipe.
 pub fn pipe() -> (PipeRead, PipeWrite) raise {
-  let (r, w) = @fd_util.pipe()
-  @fd_util.set_nonblocking(r)
-  @fd_util.set_nonblocking(w)
+  let (r, w) = @fd_util.pipe("@pipe.pipe()")
+  @fd_util.set_nonblocking(r, context="@pipe.pipe()")
+  @fd_util.set_nonblocking(w, context="@pipe.pipe()")
   (PipeRead(r), PipeWrite(w))
 }
 
@@ -50,13 +50,13 @@ pub fn pipe() -> (PipeRead, PipeWrite) raise {
 pub let stdin : PipeRead = {
   if get_blocking(0) > 0 {
     fn init() {
-      @fd_util.set_nonblocking(0) catch {
+      @fd_util.set_nonblocking(0, context="initialize `@pipe.stdin`") catch {
         _ => ()
       }
     }
 
     fn exit() {
-      @fd_util.set_nonblocking(0) catch {
+      @fd_util.set_nonblocking(0, context="restore `@pipe.stdin`") catch {
         _ => ()
       }
     }
@@ -74,13 +74,13 @@ pub let stdin : PipeRead = {
 pub let stdout : PipeWrite = {
   if get_blocking(1) > 0 {
     fn init() {
-      @fd_util.set_nonblocking(1) catch {
+      @fd_util.set_nonblocking(1, context="initialize `@pipe.stdout`") catch {
         _ => ()
       }
     }
 
     fn exit() {
-      @fd_util.set_nonblocking(1) catch {
+      @fd_util.set_nonblocking(1, context="restore `@pipe.stdout`") catch {
         _ => ()
       }
     }
@@ -98,13 +98,13 @@ pub let stdout : PipeWrite = {
 pub let stderr : PipeWrite = {
   if get_blocking(2) > 0 {
     fn init() {
-      @fd_util.set_nonblocking(2) catch {
+      @fd_util.set_nonblocking(2, context="initialize `@pipe.stderr`") catch {
         _ => ()
       }
     }
 
     fn exit() {
-      @fd_util.set_nonblocking(2) catch {
+      @fd_util.set_nonblocking(2, context="restore `@pipe.stderr`") catch {
         _ => ()
       }
     }
@@ -142,11 +142,17 @@ pub impl @io.Reader for PipeRead with read(
   max_len? = buf.length() - offset,
 ) {
   let PipeRead(fd) = self
-  @event_loop.perform_job(Read(fd~, buf~, offset~, len=max_len, can_poll=true))
+  @event_loop.perform_job(
+    Read(fd~, buf~, offset~, len=max_len, can_poll=true),
+    context="@pipe.PipeRead::read()",
+  )
 }
 
 ///|
 pub impl @io.Writer for PipeWrite with write_once(self, buf, offset~, len~) {
   let PipeWrite(fd) = self
-  @event_loop.perform_job(Write(fd~, buf~, offset~, len~, can_poll=true))
+  @event_loop.perform_job(
+    Write(fd~, buf~, offset~, len~, can_poll=true),
+    context="@pipe.PipeRead::write()",
+  )
 }

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -87,21 +87,21 @@ pub async fn run(
       }
       let stdin = match stdin {
         Some(pipe) => {
-          @fd_util.set_blocking(pipe.fd())
+          @fd_util.set_blocking(pipe.fd(), context="@process.run()")
           pipe.fd()
         }
         None => -1
       }
       let stdout = match stdout {
         Some(pipe) => {
-          @fd_util.set_blocking(pipe.fd())
+          @fd_util.set_blocking(pipe.fd(), context="@process.run()")
           pipe.fd()
         }
         None => -1
       }
       let stderr = match stderr {
         Some(pipe) => {
-          @fd_util.set_blocking(pipe.fd())
+          @fd_util.set_blocking(pipe.fd(), context="@process.run()")
           pipe.fd()
         }
         None => -1
@@ -136,9 +136,9 @@ pub async fn run(
         stderr~,
         cwd~,
       )
-      @event_loop.perform_job(job)
+      @event_loop.perform_job(job, context="@process.run()")
     }
-  @event_loop.perform_job(WaitProcess(pid)) catch {
+  @event_loop.perform_job(WaitProcess(pid), context="@process.run()") catch {
     err if !orphan && @coroutine.is_being_cancelled() => {
       terminate_process(pid)
       raise err

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -94,7 +94,10 @@ pub suberror ResolveHostnameError Int derive(Show)
 pub async fn Addr::resolve(host : String, port~ : Int) -> Addr {
   let host = @encoding/utf8.encode(host)
   let ai_ref = AddrInfoRef::new()
-  let ret = @event_loop.perform_job(GetAddrInfo(host~, out=ai_ref))
+  let ret = @event_loop.perform_job(
+    GetAddrInfo(host~, out=ai_ref),
+    context="@socket.Addr::resolve()",
+  )
   if ret != 0 {
     raise ResolveHostnameError(ret)
   }

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -16,13 +16,13 @@
 extern "C" fn make_tcp_socket_ffi() -> Int = "moonbitlang_async_make_tcp_socket"
 
 ///|
-fn make_tcp_socket() -> Int raise {
+fn make_tcp_socket(context : String) -> Int raise {
   let sock = make_tcp_socket_ffi()
   if sock < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno(context)
   }
-  @fd_util.set_cloexec(sock)
-  @fd_util.set_nonblocking(sock)
+  @fd_util.set_cloexec(sock, context~)
+  @fd_util.set_nonblocking(sock, context~)
   sock
 }
 

--- a/src/socket/happy_eyeball.mbt
+++ b/src/socket/happy_eyeball.mbt
@@ -17,7 +17,10 @@
 pub async fn TCP::connect_to_host(host : String, port~ : Int) -> TCP {
   let host = @encoding/utf8.encode(host)
   let ai_ref = AddrInfoRef::new()
-  let ret = @event_loop.perform_job(GetAddrInfo(host~, out=ai_ref))
+  let ret = @event_loop.perform_job(
+    GetAddrInfo(host~, out=ai_ref),
+    context="@socket.TCP::connect_to_host()",
+  )
   if ret > 0 {
     raise ResolveHostnameError(ret)
   }

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -29,14 +29,14 @@ struct TCPServer(Int)
 /// Create a TCP server that is bound to `addr`,
 /// listening for incoming connections.
 pub fn TCPServer::new(addr : Addr) -> TCPServer raise {
-  let sock = make_tcp_socket()
+  let sock = make_tcp_socket("@socket.TCPServer::new()")
   if 0 != bind_ffi(sock, addr) {
-    @fd_util.close(sock)
-    @os_error.check_errno()
+    @fd_util.close(sock, context="@socket.TCPServer::new()")
+    @os_error.check_errno("@socket.TCPServer::new()")
   }
   if 0 != listen_ffi(sock) {
-    @fd_util.close(sock)
-    @os_error.check_errno()
+    @fd_util.close(sock, context="@socket.TCPServer::new()")
+    @os_error.check_errno("@socket.TCPServer::new()")
   }
   TCPServer(sock)
 }
@@ -53,13 +53,16 @@ pub fn TCPServer::close(self : TCPServer) -> Unit {
 pub async fn TCPServer::accept(self : TCPServer) -> (TCP, Addr) {
   let TCPServer(listen_sock) = self
   let addr = Addr::new(0, 0)
-  let conn = @event_loop.perform_job(Accept(sock=listen_sock, addr=addr.0))
+  let conn = @event_loop.perform_job(
+    Accept(sock=listen_sock, addr=addr.0),
+    context="@socket.TCPServer::accept",
+  )
   if disable_nagle(conn) < 0 {
-    @fd_util.close(conn)
-    @os_error.check_errno()
+    @fd_util.close(conn, context="@socket.TCPServer::accept()")
+    @os_error.check_errno("@socket.TCPServer::accept(): set TCP_NODELAY")
   }
-  @fd_util.set_cloexec(conn)
-  @fd_util.set_nonblocking(conn)
+  @fd_util.set_cloexec(conn, context="@socket.TCPServer::accept()")
+  @fd_util.set_nonblocking(conn, context="@socket.TCPServer::accept()")
   (conn, addr)
 }
 
@@ -84,19 +87,24 @@ pub fn TCP::enable_keepalive(
     sock, idle_before_keep_alive, keep_alive_count, keep_alive_interval,
   )
   if ret < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno("@socket.TCP::enable_keepalive()")
   }
 }
 
 ///|
 /// Make connection to a remote address using `connect(2)` system call.
 pub async fn TCP::connect(addr : Addr) -> TCP {
-  let sock = make_tcp_socket()
+  let sock = make_tcp_socket("@socket.TCP::connect()")
   if disable_nagle(sock) < 0 {
-    @fd_util.close(sock)
-    @os_error.check_errno()
+    @fd_util.close(sock, context="@socket.TCP::connect()")
+    @os_error.check_errno("@socket.TCP::connect(): set TCP_NODELAY")
   }
-  try @event_loop.perform_job(Connect(sock~, addr=addr.0)) catch {
+  try
+    @event_loop.perform_job(
+      Connect(sock~, addr=addr.0),
+      context="@socket.TCP::connect",
+    )
+  catch {
     err => {
       @event_loop.close_fd(sock)
       raise err
@@ -124,11 +132,15 @@ pub impl @io.Reader for TCP with read(
   let TCP(sock) = self
   @event_loop.perform_job(
     Read(fd=sock, buf~, offset~, len=max_len, can_poll=true),
+    context="@socket.TCP::read",
   )
 }
 
 ///|
 pub impl @io.Writer for TCP with write_once(self, buf, offset~, len~) {
   let TCP(sock) = self
-  @event_loop.perform_job(Write(fd=sock, buf~, offset~, len~, can_poll=true))
+  @event_loop.perform_job(
+    Write(fd=sock, buf~, offset~, len~, can_poll=true),
+    context="@socket.TCP::write",
+  )
 }

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -22,10 +22,10 @@ struct UDP(Int)
 pub fn UDP::new() -> UDP raise {
   let sock = make_udp_socket()
   if sock < 0 {
-    @os_error.check_errno()
+    @os_error.check_errno("@socket.UDP::new()")
   }
-  @fd_util.set_cloexec(sock)
-  @fd_util.set_nonblocking(sock)
+  @fd_util.set_cloexec(sock, context="@socket.UDP::new()")
+  @fd_util.set_nonblocking(sock, context="@socket.UDP::new()")
   UDP(sock)
 }
 
@@ -41,7 +41,7 @@ pub fn UDP::close(self : UDP) -> Unit {
 pub fn UDP::bind(self : UDP, addr : Addr) -> Unit raise {
   let UDP(sock) = self
   if 0 != bind_ffi(sock, addr) {
-    @os_error.check_errno()
+    @os_error.check_errno("@socket.UDP::bind()")
   }
 }
 
@@ -51,7 +51,7 @@ pub fn UDP::bind(self : UDP, addr : Addr) -> Unit raise {
 pub fn UDP::connect(self : UDP, addr : Addr) -> Unit raise {
   let UDP(sock) = self
   if 0 != connect_ffi(sock, addr) {
-    @os_error.check_errno()
+    @os_error.check_errno("@socket.UDP::connect()")
   }
 }
 
@@ -78,6 +78,7 @@ pub async fn UDP::recv(
   let UDP(sock) = self
   @event_loop.perform_job(
     Read(fd=sock, buf~, offset~, len=max_len, can_poll=true),
+    context="@socket.UDP::recv",
   )
 }
 
@@ -106,6 +107,7 @@ pub async fn UDP::recvfrom(
   let addr = Addr::new(0, 0)
   let n_read = @event_loop.perform_job(
     Recvfrom(sock~, buf~, offset~, len=max_len, addr=addr.0),
+    context="@socket.UDP::recvfrom",
   )
   (n_read, addr)
 }
@@ -126,7 +128,10 @@ pub async fn UDP::send(
   len? : Int = buf.length() - offset,
 ) -> Unit {
   let UDP(sock) = self
-  @event_loop.perform_job(Write(fd=sock, buf~, offset~, len~, can_poll=true))
+  @event_loop.perform_job(
+    Write(fd=sock, buf~, offset~, len~, can_poll=true),
+    context="@socket.UDP::send",
+  )
   |> ignore
 }
 
@@ -148,6 +153,9 @@ pub async fn UDP::sendto(
   len? : Int = buf.length() - offset,
 ) -> Unit {
   let UDP(sock) = self
-  @event_loop.perform_job(Sendto(sock~, buf~, offset~, len~, addr=addr.0))
+  @event_loop.perform_job(
+    Sendto(sock~, buf~, offset~, len~, addr=addr.0),
+    context="@socket.UDP::sendto",
+  )
   |> ignore
 }

--- a/src/worker_test.mbt
+++ b/src/worker_test.mbt
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 ///|
+async fn perform_sleep_job(t : Int) -> Unit {
+  @event_loop.perform_job(Sleep(t), context="") |> ignore
+}
+
+///|
 async test "worker basic" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {
@@ -22,7 +27,7 @@ async test "worker basic" {
         log.write_string("tick\n")
       }
     })
-    guard @event_loop.perform_job(Sleep(1000)) == 0
+    perform_sleep_job(1000)
     log.write_string("done\n")
   })
   inspect(
@@ -49,7 +54,7 @@ async test "worker multiple" {
     })
     for i in 0..<3 {
       root.spawn_bg(fn() {
-        @event_loop.perform_job(Sleep(100 + i * 200)) |> ignore
+        perform_sleep_job(100 + i * 200)
         log.write_string("#\{i} done\n")
       })
     }
@@ -79,7 +84,7 @@ async test "worker cancel1" {
       }
     })
     let task = root.spawn(allow_failure=true, fn() {
-      try @event_loop.perform_job(Sleep(1000)) catch {
+      try perform_sleep_job(1000) catch {
         err => {
           log.write_string("sleep cancelled with \{err}\n")
           raise err
@@ -117,7 +122,7 @@ async test "worker cancel2" {
       }
     })
     root.spawn_bg(allow_failure=true, fn() {
-      try @event_loop.perform_job(Sleep(1000)) catch {
+      try perform_sleep_job(1000) catch {
         err => {
           log.write_string("sleep cancelled with \{err}\n")
           raise err


### PR DESCRIPTION
This PR enhances the readability and debugging experience of `@os_error.OSError`:

- `impl Show for @os_error.OSError` now displays a `String` representation of the error
- `@os_error.OSError` now contains an extra `context~ : String` parameter, indicating the direct source of the error