### PR TITLE
[breaking]: change more `Bytes` to `String`

### DIFF
--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -6,13 +6,13 @@ import(
 )
 
 // Values
-async fn collect_output(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, cwd? : Bytes) -> (Int, Bytes, Bytes)
+async fn collect_output(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, cwd? : String) -> (Int, Bytes, Bytes)
 
-async fn collect_output_merged(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, cwd? : Bytes) -> (Int, Bytes)
+async fn collect_output_merged(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, cwd? : String) -> (Int, Bytes)
 
-async fn collect_stderr(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, cwd? : Bytes) -> (Int, Bytes)
+async fn collect_stderr(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, cwd? : String) -> (Int, Bytes)
 
-async fn collect_stdout(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stderr? : &ProcessOutput, cwd? : Bytes) -> (Int, Bytes)
+async fn collect_stdout(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stderr? : &ProcessOutput, cwd? : String) -> (Int, Bytes)
 
 fn read_from_process() -> (@pipe.PipeRead, &ProcessOutput) raise
 
@@ -20,7 +20,7 @@ async fn redirect_from_file(String) -> &ProcessInput
 
 async fn redirect_to_file(String, append? : Bool, create? : Int, truncate? : Bool) -> &ProcessOutput
 
-async fn run(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : Bytes, orphan? : Bool) -> Int
+async fn run(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : String, orphan? : Bool) -> Int
 
 fn write_to_process() -> (&ProcessInput, @pipe.PipeWrite) raise
 

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -64,11 +64,15 @@ pub async fn run(
   stdin? : &ProcessInput,
   stdout? : &ProcessOutput,
   stderr? : &ProcessOutput,
-  cwd? : Bytes,
+  cwd? : String,
   orphan? : Bool = false,
 ) -> Int {
   let cmd = @encoding/utf8.encode(cmd)
   let argv = FixedArray::make(args.length() + 2, None)
+  let cwd = match cwd {
+    None => None
+    Some(cwd) => Some(@encoding/utf8.encode(cwd))
+  }
   argv[0] = Some(cmd)
   for i in 0..<args.length() {
     argv[i + 1] = Some(@encoding/utf8.encode(args[i]))
@@ -159,7 +163,7 @@ pub async fn collect_stdout(
   inherit_env? : Bool = true,
   stdin? : &ProcessInput,
   stderr? : &ProcessOutput,
-  cwd? : Bytes,
+  cwd? : String,
 ) -> (Int, Bytes) {
   let (r, w) = read_from_process()
   @async.with_task_group(fn(group) {
@@ -190,7 +194,7 @@ pub async fn collect_stderr(
   inherit_env? : Bool = true,
   stdin? : &ProcessInput,
   stdout? : &ProcessOutput,
-  cwd? : Bytes,
+  cwd? : String,
 ) -> (Int, Bytes) {
   let (r, w) = read_from_process()
   @async.with_task_group(fn(group) {
@@ -221,7 +225,7 @@ pub async fn collect_output(
   extra_env? : Map[String, String] = {},
   inherit_env? : Bool = true,
   stdin? : &ProcessInput,
-  cwd? : Bytes,
+  cwd? : String,
 ) -> (Int, Bytes, Bytes) {
   let (r_out, w_out) = read_from_process()
   let (r_err, w_err) = read_from_process()
@@ -254,7 +258,7 @@ pub async fn collect_output_merged(
   extra_env? : Map[String, String] = {},
   inherit_env? : Bool = true,
   stdin? : &ProcessInput,
-  cwd? : Bytes,
+  cwd? : String,
 ) -> (Int, Bytes) {
   let (r, w) = read_from_process()
   @async.with_task_group(fn(group) {

--- a/src/tls/pkg.generated.mbti
+++ b/src/tls/pkg.generated.mbti
@@ -19,8 +19,8 @@ type TLS
 async fn[Inner : @io.Reader + @io.Writer] TLS::client(Inner, verify? : Bool, host? : String, sni? : Bool) -> Self
 async fn[R : @io.Reader, W : @io.Writer] TLS::client_from_pair(R, W, verify? : Bool, host? : String, sni? : Bool) -> Self
 fn TLS::close(Self) -> Unit
-async fn[Inner : @io.Reader + @io.Writer] TLS::server(Inner, private_key_file~ : Bytes, private_key_type~ : X509FileType, certificate_file~ : Bytes, certificate_type~ : X509FileType) -> Self
-async fn[R : @io.Reader, W : @io.Writer] TLS::server_from_pair(R, W, private_key_file~ : Bytes, private_key_type~ : X509FileType, certificate_file~ : Bytes, certificate_type~ : X509FileType) -> Self
+async fn[Inner : @io.Reader + @io.Writer] TLS::server(Inner, private_key_file~ : String, private_key_type~ : X509FileType, certificate_file~ : String, certificate_type~ : X509FileType) -> Self
+async fn[R : @io.Reader, W : @io.Writer] TLS::server_from_pair(R, W, private_key_file~ : String, private_key_type~ : X509FileType, certificate_file~ : String, certificate_type~ : X509FileType) -> Self
 async fn TLS::shutdown(Self) -> Unit
 impl @io.Reader for TLS
 impl @io.Writer for TLS

--- a/src/tls/tls.mbt
+++ b/src/tls/tls.mbt
@@ -134,11 +134,13 @@ pub async fn[Inner : @io.Reader + @io.Writer] TLS::client(
 pub async fn[R : @io.Reader, W : @io.Writer] TLS::server_from_pair(
   r : R,
   w : W,
-  private_key_file~ : Bytes,
+  private_key_file~ : String,
   private_key_type~ : X509FileType,
-  certificate_file~ : Bytes,
+  certificate_file~ : String,
   certificate_type~ : X509FileType,
 ) -> TLS {
+  let private_key_file = @encoding/utf8.encode(private_key_file)
+  let certificate_file = @encoding/utf8.encode(certificate_file)
   let self = TLS::from_pair(server_ctx, r, w, host=None)
   if self.ssl.use_certificate_file(certificate_file, certificate_type) != 1 {
     self.close()
@@ -171,9 +173,9 @@ pub async fn[R : @io.Reader, W : @io.Writer] TLS::server_from_pair(
 /// `certificate_file` and `certificate_type` specifies the certificate of the server.
 pub async fn[Inner : @io.Reader + @io.Writer] TLS::server(
   inner : Inner,
-  private_key_file~ : Bytes,
+  private_key_file~ : String,
   private_key_type~ : X509FileType,
-  certificate_file~ : Bytes,
+  certificate_file~ : String,
   certificate_type~ : X509FileType,
 ) -> TLS {
   TLS::server_from_pair(


### PR DESCRIPTION
Some missing file name/path are still passed via `Bytes`. This PR turn these missing bits into `String`.