### PR TITLE
fix pid leak on MacOS

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -16,7 +16,7 @@
 priv struct EventLoop {
   poll : Instance
   fds : Map[Int, FdHandle]
-  pids : Map[Int, ProcessHandle]
+  pids : Map[Int, @coroutine.Coroutine]
   notify_recv : Int
   max_worker_count : Int
   job_queue : @deque.Deque[JobForWorker]
@@ -31,12 +31,6 @@ priv struct FdHandle {
   mut events : Int
   mut read : @coroutine.Coroutine?
   mut write : @coroutine.Coroutine?
-}
-
-///|
-priv struct ProcessHandle {
-  mut result : Int
-  waiter : @coroutine.Coroutine
 }
 
 ///|
@@ -147,13 +141,8 @@ fn EventLoop::poll(self : Self) -> Unit raise {
     let events = event.events()
     let fd = event.fd()
     if (events & ProcessEvent) != 0 {
-      if self.pids.get(fd) is Some(handle) {
-        handle.waiter.wake()
-        let result = @ref.new(0)
-        if event.pid_status(result) < 0 {
-          @os_error.check_errno("runtime internal: get PID status")
-        }
-        handle.result = result.val
+      if self.pids.get(fd) is Some(coro) {
+        coro.wake()
       }
     } else if fd == self.notify_recv {
       while fetch_completion_ffi(self.notify_recv) is job_id && job_id >= 0 {
@@ -206,8 +195,8 @@ fn EventLoop::cleanup(self : Self) -> Unit raise {
   for _, coro in self.jobs {
     coro.cancel()
   }
-  for pid, handle in self.pids {
-    handle.waiter.cancel()
+  for pid, coro in self.pids {
+    coro.cancel()
     self.poll.remove_pid(pid)
   }
   self.pids.clear()
@@ -315,17 +304,16 @@ async fn wait_pid(pid : Int) -> Int {
   guard curr_loop.val is Some(evloop)
   let alt_id = match evloop.poll.register_pid(pid) {
     Running(id) => id
-    Stopped(ret) => return ret
+    Stopped => return 0
   }
   guard evloop.pids.get(alt_id) is None
-  let handle = { result: 0, waiter: @coroutine.current_coroutine() }
-  evloop.pids[alt_id] = handle
+  evloop.pids[alt_id] = @coroutine.current_coroutine()
   defer {
     evloop.pids.remove(alt_id)
     evloop.poll.remove_pid(alt_id)
   }
   @coroutine.suspend()
-  handle.result
+  0
 }
 
 ///|

--- a/src/internal/event_loop/poll.mbt
+++ b/src/internal/event_loop/poll.mbt
@@ -56,17 +56,12 @@ fn Instance::register(
 }
 
 ///|
-#borrow(out)
-extern "C" fn Instance::register_pid_ffi(
-  self : Instance,
-  pid : Int,
-  out : Ref[Int],
-) -> Int = "moonbitlang_async_poll_register_pid"
+extern "C" fn Instance::register_pid_ffi(self : Instance, pid : Int) -> Int = "moonbitlang_async_poll_register_pid"
 
 ///|
 priv enum RegisterPidResult {
   Running(Int)
-  Stopped(Int)
+  Stopped
 }
 
 ///|
@@ -74,15 +69,14 @@ fn Instance::register_pid(
   self : Instance,
   pid : Int,
 ) -> RegisterPidResult raise {
-  let out = @ref.new(0)
-  let ret = self.register_pid_ffi(pid, out)
-  if ret < 0 {
-    @os_error.check_errno("poll_register_pid")
-  }
-  if ret == 0 {
-    Running(out.val)
+  let ret = self.register_pid_ffi(pid)
+  if ret >= 0 {
+    Running(ret)
+  } else if ret == -2 {
+    Stopped
   } else {
-    Stopped(out.val)
+    @os_error.check_errno("poll_register_pid")
+    Stopped
   }
 }
 
@@ -127,10 +121,6 @@ extern "C" fn Event::fd(self : Event) -> Int = "moonbitlang_async_event_get_fd"
 
 ///|
 extern "C" fn Event::events(self : Event) -> Int = "moonbitlang_async_event_get_events"
-
-///|
-#borrow(out)
-extern "C" fn Event::pid_status(self : Event, out : Ref[Int]) -> Int = "moonbitlang_async_event_get_pid_status"
 
 ///|
 extern "C" fn Instance::wait(self : Instance, timeout~ : Int) -> Int = "moonbitlang_async_poll_wait"

--- a/src/process/moon.pkg.json
+++ b/src/process/moon.pkg.json
@@ -6,7 +6,8 @@
     "moonbitlang/async/fs",
     "moonbitlang/async/pipe",
     "moonbitlang/async",
-    "moonbitlang/async/io"
+    "moonbitlang/async/io",
+    "moonbitlang/async/os_error"
   ],
   "test-import": [
     "moonbitlang/async/internal/bytes_util"

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -22,6 +22,10 @@ let curr_env : FixedArray[Bytes?] = get_curr_env()
 extern "C" fn terminate_process(pid : Int) = "moonbitlang_async_terminate_process"
 
 ///|
+#borrow(out)
+extern "C" fn get_process_result(pid : Int, out : Ref[Int]) -> Int = "moonbitlang_async_get_process_result"
+
+///|
 /// Execute a system process with command `cmd`,
 /// and provide `args` as extra arguments to `cmd.
 /// Both `cmd` and elements of `args` are encoded using UTF8.
@@ -77,6 +81,7 @@ pub async fn run(
   for i in 0..<args.length() {
     argv[i + 1] = Some(@encoding/utf8.encode(args[i]))
   }
+  let context = "@process.run()"
   let pid = {
       defer {
         if stdin is Some(p) {
@@ -91,21 +96,21 @@ pub async fn run(
       }
       let stdin = match stdin {
         Some(pipe) => {
-          @fd_util.set_blocking(pipe.fd(), context="@process.run()")
+          @fd_util.set_blocking(pipe.fd(), context~)
           pipe.fd()
         }
         None => -1
       }
       let stdout = match stdout {
         Some(pipe) => {
-          @fd_util.set_blocking(pipe.fd(), context="@process.run()")
+          @fd_util.set_blocking(pipe.fd(), context~)
           pipe.fd()
         }
         None => -1
       }
       let stderr = match stderr {
         Some(pipe) => {
-          @fd_util.set_blocking(pipe.fd(), context="@process.run()")
+          @fd_util.set_blocking(pipe.fd(), context~)
           pipe.fd()
         }
         None => -1
@@ -140,15 +145,21 @@ pub async fn run(
         stderr~,
         cwd~,
       )
-      @event_loop.perform_job(job, context="@process.run()")
+      @event_loop.perform_job(job, context~)
     }
-  @event_loop.perform_job(WaitProcess(pid), context="@process.run()") catch {
+  ignore(@event_loop.perform_job(WaitProcess(pid), context~)) catch {
     err if !orphan && @coroutine.is_being_cancelled() => {
       terminate_process(pid)
       raise err
     }
     err => raise err
   }
+  let out = @ref.new(0)
+  let ret = get_process_result(pid, out)
+  if ret < 0 {
+    @os_error.check_errno(context)
+  }
+  out.val
 }
 
 ///|

--- a/src/process/stub.c
+++ b/src/process/stub.c
@@ -40,6 +40,17 @@ moonbit_bytes_t *moonbitlang_async_get_curr_env() {
   return result;
 }
 
+int moonbitlang_async_get_process_result(pid_t pid, int *out) {
+  int wstatus;
+  int ret = waitpid(pid, &wstatus, 0);
+  if (ret > 0) {
+    *out = WEXITSTATUS(wstatus);
+    return 0;
+  } else {
+    return -1;
+  }
+}
+
 void moonbitlang_async_terminate_process(pid_t pid) {
   kill(pid, SIGTERM);
 }


### PR DESCRIPTION
It seems that `kqueue` will not `wait` the process when it issues process event. Even though we can obtain the process exit status from `kqueue`, we still need to manually `wait` the process, otherwise its `pid` will not be freed. When a long-running program spawn a lot of process, this can cause an exhaustion of pid. This PR fixes the issue.