### PR TITLE
add timestamp support for `@fs`

### DIFF
--- a/src/fs/dir_test.mbt
+++ b/src/fs/dir_test.mbt
@@ -19,9 +19,10 @@ async test "read_all" {
   let list = dir.read_all()
   list.sort()
   @json.inspect(list, content=[
-    "fs.mbt", "stub.c", "dir.mbt", "utils.mbt", "dir_test.mbt", "eof_test.mbt", "moon.pkg.json",
-    "seek_test.mbt", "walk_test.mbt", "mkdir_test.mbt", "access_test.mbt", "create_test.mbt",
-    "read_all_test.mbt", "realpath_test.mbt", "pkg.generated.mbti", "text_file_test.mbt",
+    "fs.mbt", "stub.c", "dir.mbt", "stat.mbt", "utils.mbt", "dir_test.mbt", "eof_test.mbt",
+    "moon.pkg.json", "seek_test.mbt", "walk_test.mbt", "mkdir_test.mbt", "access_test.mbt",
+    "create_test.mbt", "read_all_test.mbt", "realpath_test.mbt", "pkg.generated.mbti",
+    "text_file_test.mbt", "timestamp_test.mbt",
   ])
 }
 
@@ -46,10 +47,11 @@ async test "as_dir" {
     kinds.push("\{file}: \{kind}")
   }
   @json.inspect(kinds, content=[
-    "fs.mbt: Regular", "stub.c: Regular", "dir.mbt: Regular", "utils.mbt: Regular",
-    "dir_test.mbt: Regular", "eof_test.mbt: Regular", "moon.pkg.json: Regular", "seek_test.mbt: Regular",
-    "walk_test.mbt: Regular", "mkdir_test.mbt: Regular", "access_test.mbt: Regular",
-    "create_test.mbt: Regular", "read_all_test.mbt: Regular", "realpath_test.mbt: Regular",
-    "pkg.generated.mbti: Regular", "text_file_test.mbt: Regular",
+    "fs.mbt: Regular", "stub.c: Regular", "dir.mbt: Regular", "stat.mbt: Regular",
+    "utils.mbt: Regular", "dir_test.mbt: Regular", "eof_test.mbt: Regular", "moon.pkg.json: Regular",
+    "seek_test.mbt: Regular", "walk_test.mbt: Regular", "mkdir_test.mbt: Regular",
+    "access_test.mbt: Regular", "create_test.mbt: Regular", "read_all_test.mbt: Regular",
+    "realpath_test.mbt: Regular", "pkg.generated.mbti: Regular", "text_file_test.mbt: Regular",
+    "timestamp_test.mbt: Regular",
   ])
 }

--- a/src/fs/fs.mbt
+++ b/src/fs/fs.mbt
@@ -112,11 +112,7 @@ pub async fn open(
   let flags = make_open_flags(mode~, sync~, append~, create~, truncate~)
   let job = @event_loop.Open(path=filename, flags~, mode=user_mode)
   let fd = @event_loop.perform_job(job, context="@fs.open()")
-  let kind = get_file_kind_ffi(fd)
-  if kind < 0 {
-    @os_error.check_errno("@fs.open(): get file kind")
-  }
-  { fd, kind: FileKind::unsafe_from_int(kind) }
+  { fd, kind: Stat::from_fd(fd, context="@fs.open()").kind() }
 }
 
 ///|
@@ -270,20 +266,44 @@ fn FileKind::can_poll(self : FileKind) -> Bool {
 }
 
 ///|
-fn FileKind::unsafe_from_int(x : Int) -> FileKind = "%identity"
-
-///|
-extern "C" fn get_file_kind_ffi(fd : Int) -> Int = "moonbitlang_async_file_kind"
-
-///|
 pub fn File::kind(self : File) -> FileKind {
   self.kind
 }
 
 ///|
+/// Get the last access time of a file.
+/// The return value is a pair `(s, ns)`,
+/// representing the time of `s` seconds + `ns` nanoseconds.
+pub fn File::atime(self : File) -> (Int64, Int) raise {
+  Stat::from_fd(self.fd, context="@fs.File::atime()").atime()
+}
+
+///|
+/// Get the last modification time of a file.
+/// The return value is a pair `(s, ns)`,
+/// representing the time of `s` seconds + `ns` nanoseconds.
+pub fn File::mtime(self : File) -> (Int64, Int) raise {
+  Stat::from_fd(self.fd, context="@fs.File::mtime()").mtime()
+}
+
+///|
+/// Get the last status change time of a file.
+/// The return value is a pair `(s, ns)`,
+/// representing the time of `s` seconds + `ns` nanoseconds.
+pub fn File::ctime(self : File) -> (Int64, Int) raise {
+  Stat::from_fd(self.fd, context="@fs.File::ctime()").ctime()
+}
+
+///|
 /// Read the contents of the file located at `path`.
-pub async fn read_file(path : String) -> &@io.Data {
-  let file = open(path, mode=ReadOnly)
+/// If `sync_timestamp` is `true` (`false` by default),
+/// `read_file` will block until timestamp change is written to the file system.
+pub async fn read_file(
+  path : String,
+  sync_timestamp? : Bool = false,
+) -> &@io.Data {
+  let sync_mode = if sync_timestamp { Full } else { NoSync }
+  let file = open(path, mode=ReadOnly, sync=sync_mode)
   defer file.close()
   file.read_all()
 }

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -6,6 +6,8 @@ import(
 )
 
 // Values
+async fn atime(String) -> (Int64, Int)
+
 async fn can_execute(String) -> Bool
 
 async fn can_read(String) -> Bool
@@ -14,17 +16,21 @@ async fn can_write(String) -> Bool
 
 async fn create(String, permission~ : Int, sync? : SyncMode) -> File
 
+async fn ctime(String) -> (Int64, Int)
+
 async fn exists(String) -> Bool
 
 async fn kind(String) -> FileKind
 
 async fn mkdir(String, permission~ : Int) -> Unit
 
+async fn mtime(String) -> (Int64, Int)
+
 async fn open(String, mode~ : Mode, sync? : SyncMode, append? : Bool, create? : Int, truncate? : Bool) -> File
 
 fn opendir(String) -> Directory raise
 
-async fn read_file(String) -> &@io.Data
+async fn read_file(String, sync_timestamp? : Bool) -> &@io.Data
 
 #deprecated
 async fn read_text_file(String, encoding~ : @io.Encoding) -> String
@@ -53,10 +59,13 @@ async fn Directory::read_all(Self, include_hidden? : Bool, include_special? : Bo
 
 type File
 fn File::as_dir(Self) -> Directory raise
+fn File::atime(Self) -> (Int64, Int) raise
 fn File::close(Self) -> Unit
+fn File::ctime(Self) -> (Int64, Int) raise
 fn File::curr_pos(Self) -> Int64 raise
 fn File::fd(Self) -> Int
 fn File::kind(Self) -> FileKind
+fn File::mtime(Self) -> (Int64, Int) raise
 fn File::seek(Self, Int64, mode~ : SeekMode) -> Int64 raise
 fn File::size(Self) -> Int64 raise
 impl @io.Reader for File

--- a/src/fs/stat.mbt
+++ b/src/fs/stat.mbt
@@ -1,0 +1,97 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+priv struct Stat(FixedArray[Byte])
+
+///|
+extern "C" fn sizeof_stat() -> Int = "moonbitlang_async_sizeof_stat"
+
+///|
+fn Stat::new() -> Stat {
+  FixedArray::make(sizeof_stat(), b'0')
+}
+
+///|
+#borrow(stat)
+extern "C" fn Stat::from_fd_ffi(fd : Int, stat : Stat) -> Int = "fstat"
+
+///|
+fn Stat::from_fd(fd : Int, context~ : String) -> Stat raise {
+  let stat = Stat::new()
+  if Stat::from_fd_ffi(fd, stat) < 0 {
+    @os_error.check_errno(context)
+  }
+  stat
+}
+
+///|
+async fn Stat::from_path(path : String, context~ : String) -> Stat {
+  let stat = Stat::new()
+  let path = @encoding/utf8.encode(path)
+  let _ = @event_loop.perform_job(Stat(path~, out=stat.0), context~)
+  stat
+}
+
+///|
+#borrow(stat)
+extern "C" fn Stat::kind(stat : Stat) -> FileKind = "moonbitlang_async_file_kind_from_stat"
+
+///|
+#borrow(stat, sec_out, nsec_out)
+extern "C" fn Stat::atime_ffi(
+  stat : Stat,
+  sec_out : Ref[Int64],
+  nsec_out : Ref[Int],
+) = "moonbitlang_async_atime_from_stat"
+
+///|
+fn Stat::atime(stat : Stat) -> (Int64, Int) {
+  let sec = @ref.new(0L)
+  let nsec = @ref.new(0)
+  stat.atime_ffi(sec, nsec)
+  (sec.val, nsec.val)
+}
+
+///|
+#borrow(stat, sec_out, nsec_out)
+extern "C" fn Stat::mtime_ffi(
+  stat : Stat,
+  sec_out : Ref[Int64],
+  nsec_out : Ref[Int],
+) = "moonbitlang_async_mtime_from_stat"
+
+///|
+fn Stat::mtime(stat : Stat) -> (Int64, Int) {
+  let sec = @ref.new(0L)
+  let nsec = @ref.new(0)
+  stat.mtime_ffi(sec, nsec)
+  (sec.val, nsec.val)
+}
+
+///|
+#borrow(stat, sec_out, nsec_out)
+extern "C" fn Stat::ctime_ffi(
+  stat : Stat,
+  sec_out : Ref[Int64],
+  nsec_out : Ref[Int],
+) = "moonbitlang_async_ctime_from_stat"
+
+///|
+fn Stat::ctime(stat : Stat) -> (Int64, Int) {
+  let sec = @ref.new(0L)
+  let nsec = @ref.new(0)
+  stat.ctime_ffi(sec, nsec)
+  (sec.val, nsec.val)
+}

--- a/src/fs/stub.c
+++ b/src/fs/stub.c
@@ -113,3 +113,36 @@ int moonbitlang_async_get_ENOENT() {
 int moonbitlang_async_get_EACCES() {
   return EACCES;
 }
+
+#ifdef __MACH__
+#define GET_STAT_TIMESTAMP(statp, kind) (statp)->st_##kind##timespec
+#else
+#define GET_STAT_TIMESTAMP(statp, kind) (statp)->st_##kind##tim
+#endif
+
+void moonbitlang_async_atime_from_stat(
+  struct stat *stat,
+  int64_t *sec_out,
+  int32_t *nsec_out
+) {
+  *sec_out = GET_STAT_TIMESTAMP(stat, a).tv_sec;
+  *nsec_out = GET_STAT_TIMESTAMP(stat, a).tv_nsec;
+}
+
+void moonbitlang_async_mtime_from_stat(
+  struct stat *stat,
+  int64_t *sec_out,
+  int32_t *nsec_out
+) {
+  *sec_out = GET_STAT_TIMESTAMP(stat, m).tv_sec;
+  *nsec_out = GET_STAT_TIMESTAMP(stat, m).tv_nsec;
+}
+
+void moonbitlang_async_ctime_from_stat(
+  struct stat *stat,
+  int64_t *sec_out,
+  int32_t *nsec_out
+) {
+  *sec_out = GET_STAT_TIMESTAMP(stat, c).tv_sec;
+  *nsec_out = GET_STAT_TIMESTAMP(stat, c).tv_nsec;
+}

--- a/src/fs/timestamp_test.mbt
+++ b/src/fs/timestamp_test.mbt
@@ -1,0 +1,96 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn diff_timestamp(t1 : (Int64, Int), t2 : (Int64, Int)) -> Int64 {
+  let (s1, ns1) = t1
+  let (s2, ns2) = t2
+  (s1 - s2) * 1_000_000_000 + (ns1 - ns2).to_int64()
+}
+
+///|
+async test "timestamp for path" {
+  let path = "target/timestamp_test"
+  @async.with_task_group(fn(group) {
+    @fs.write_file(path, "abcd", create=0o644)
+    group.add_defer(() => @fs.remove(path))
+    let atime_1 = @fs.atime(path)
+    let mtime_1 = @fs.mtime(path)
+    let ctime_1 = @fs.ctime(path)
+    @async.sleep(500)
+    inspect(@fs.read_file(path, sync_timestamp=true).text(), content="abcd")
+    let atime_2 = @fs.atime(path)
+    let mtime_2 = @fs.mtime(path)
+    let ctime_2 = @fs.ctime(path)
+    assert_true(diff_timestamp(atime_2, atime_1) > 500_000_000)
+    assert_eq(mtime_2, mtime_1)
+    assert_eq(ctime_2, ctime_1)
+    @async.sleep(500)
+    @fs.write_file(path, "1234")
+    let atime_3 = @fs.atime(path)
+    let mtime_3 = @fs.mtime(path)
+    let ctime_3 = @fs.ctime(path)
+    assert_eq(atime_3, atime_2)
+    assert_true(diff_timestamp(mtime_3, mtime_2) > 500_000_000)
+    assert_true(diff_timestamp(ctime_3, ctime_2) > 500_000_000)
+    @async.sleep(500)
+    let _ = @process.run("chmod", ["666", path])
+    let atime_4 = @fs.atime(path)
+    let mtime_4 = @fs.mtime(path)
+    let ctime_4 = @fs.ctime(path)
+    assert_eq(atime_4, atime_3)
+    assert_eq(mtime_4, mtime_3)
+    assert_true(diff_timestamp(ctime_4, ctime_3) > 500_000_000)
+  })
+}
+
+///|
+async test "timestamp for opened file" {
+  let path = "target/opened_file_timestamp_test"
+  @async.with_task_group(fn(group) {
+    @fs.write_file(path, "abcd", create=0o644)
+    group.add_defer(() => @fs.remove(path))
+    let file = @fs.open(path, mode=ReadWrite, sync=Full)
+    defer file.close()
+    let atime_1 = file.atime()
+    let mtime_1 = file.mtime()
+    let ctime_1 = file.mtime()
+    @async.sleep(500)
+    let _ = file.seek(0, mode=FromStart)
+    inspect(file.read_all().text(), content="abcd")
+    let atime_2 = file.atime()
+    let mtime_2 = file.mtime()
+    let ctime_2 = file.mtime()
+    assert_true(diff_timestamp(atime_2, atime_1) > 500_000_000)
+    assert_eq(mtime_2, mtime_1)
+    assert_eq(ctime_2, ctime_1)
+    let _ = file.seek(0, mode=FromStart)
+    @async.sleep(500)
+    file.write("1234")
+    let atime_3 = file.atime()
+    let mtime_3 = file.mtime()
+    let ctime_3 = file.mtime()
+    assert_eq(atime_3, atime_2)
+    assert_true(diff_timestamp(mtime_3, mtime_2) > 500_000_000)
+    assert_true(diff_timestamp(ctime_3, ctime_2) > 500_000_000)
+    @async.sleep(500)
+    let _ = @process.run("chmod", ["666", path])
+    let atime_4 = @fs.atime(path)
+    let mtime_4 = @fs.mtime(path)
+    let ctime_4 = @fs.ctime(path)
+    assert_eq(atime_4, atime_3)
+    assert_eq(mtime_4, mtime_3)
+    assert_true(diff_timestamp(ctime_4, ctime_3) > 500_000_000)
+  })
+}

--- a/src/fs/utils.mbt
+++ b/src/fs/utils.mbt
@@ -13,18 +13,32 @@
 // limitations under the License.
 
 ///|
-#borrow(stat)
-extern "C" fn file_kind_from_stat(stat : FixedArray[Byte]) -> FileKind = "moonbitlang_async_file_kind_from_stat"
-
-///|
-extern "C" fn sizeof_stat() -> Int = "moonbitlang_async_sizeof_stat"
-
-///|
 pub async fn kind(path : String) -> FileKind {
-  let path = @encoding/utf8.encode(path)
-  let stat = FixedArray::make(sizeof_stat(), b'0')
-  let _ = @event_loop.perform_job(Stat(path~, out=stat), context="@fs.kind()")
-  file_kind_from_stat(stat)
+  Stat::from_path(path, context="@fs.kind()").kind()
+}
+
+///|
+/// Get the last access time of a file at `path`.
+/// The return value is a pair `(s, ns)`,
+/// representing the time of `s` seconds + `ns` nanoseconds.
+pub async fn atime(path : String) -> (Int64, Int) {
+  Stat::from_path(path, context="@fs.atime()").atime()
+}
+
+///|
+/// Get the last modification time of a file at `path`.
+/// The return value is a pair `(s, ns)`,
+/// representing the time of `s` seconds + `ns` nanoseconds.
+pub async fn mtime(path : String) -> (Int64, Int) {
+  Stat::from_path(path, context="@fs.mtime()").mtime()
+}
+
+///|
+/// Get the last status change time of a file at `path`.
+/// The return value is a pair `(s, ns)`,
+/// representing the time of `s` seconds + `ns` nanoseconds.
+pub async fn ctime(path : String) -> (Int64, Int) {
+  Stat::from_path(path, context="@fs.ctime()").ctime()
 }
 
 ///|


### PR DESCRIPTION
add `File::{atime,mtime,ctime}` and `@fs.{atime,mtime,ctime}` for getting timestamps of a file.