### PR TITLE
add ability to spawn orphan process and obtain PID & wait for PID

### DIFF
--- a/src/process/cancel_test.mbt
+++ b/src/process/cancel_test.mbt
@@ -58,12 +58,12 @@ async test "orphan process" {
     let (r, w) = @process.read_from_process()
     let task = root.spawn(allow_failure=true, fn() {
       defer log.write_string("process terminates\n")
-      @process.run(
+      let pid = @process.spawn_orphan(
         "sh",
         ["-c", "echo first; sleep 1; echo second"],
         stdout=w,
-        orphan=true,
       )
+      @process.wait_pid(pid)
     })
     root.spawn_bg(fn() {
       defer r.close()

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -21,7 +21,11 @@ async fn redirect_from_file(String) -> &ProcessInput
 
 async fn redirect_to_file(String, append? : Bool, create? : Int, truncate? : Bool) -> &ProcessOutput
 
-async fn run(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : String, orphan? : Bool) -> Int
+async fn run(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : String) -> Int
+
+async fn spawn_orphan(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : String) -> Int
+
+async fn wait_pid(Int) -> Int
 
 fn write_to_process() -> (&ProcessInput, @pipe.PipeWrite) raise
 

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -26,6 +26,144 @@ extern "C" fn terminate_process(pid : Int) = "moonbitlang_async_terminate_proces
 extern "C" fn get_process_result(pid : Int, out : Ref[Int]) -> Int = "moonbitlang_async_get_process_result"
 
 ///|
+async fn spawn(
+  cmd : String,
+  args : Array[String],
+  extra_env~ : Map[String, String],
+  inherit_env~ : Bool,
+  stdin~ : &ProcessInput?,
+  stdout~ : &ProcessOutput?,
+  stderr~ : &ProcessOutput?,
+  cwd~ : String?,
+  context~ : String,
+) -> Int {
+  let cmd = @encoding/utf8.encode(cmd)
+  let argv = FixedArray::make(args.length() + 2, None)
+  let cwd = match cwd {
+    None => None
+    Some(cwd) => Some(@encoding/utf8.encode(cwd))
+  }
+  argv[0] = Some(cmd)
+  for i in 0..<args.length() {
+    argv[i + 1] = Some(@encoding/utf8.encode(args[i]))
+  }
+  defer {
+    if stdin is Some(p) {
+      p.after_spawn()
+    }
+    if stdout is Some(p) {
+      p.after_spawn()
+    }
+    if stderr is Some(p) {
+      p.after_spawn()
+    }
+  }
+  let stdin = match stdin {
+    Some(pipe) => {
+      @fd_util.set_blocking(pipe.fd(), context~)
+      pipe.fd()
+    }
+    None => -1
+  }
+  let stdout = match stdout {
+    Some(pipe) => {
+      @fd_util.set_blocking(pipe.fd(), context~)
+      pipe.fd()
+    }
+    None => -1
+  }
+  let stderr = match stderr {
+    Some(pipe) => {
+      @fd_util.set_blocking(pipe.fd(), context~)
+      pipe.fd()
+    }
+    None => -1
+  }
+  let extra_count = extra_env.size()
+  let env = match (inherit_env, extra_count) {
+    (true, 0) => curr_env
+    (false, 0) => [None]
+    (_, n) => {
+      let curr_env = if inherit_env { curr_env } else { [None] }
+      let envp = FixedArray::make(n + curr_env.length(), None)
+      let mut i = 0
+      for k, v in extra_env {
+        envp[i] = Some(@encoding/utf8.encode("\{k}=\{v}"))
+        i = i + 1
+      }
+      curr_env.blit_to(envp, src_offset=0, dst_offset=i, len=curr_env.length())
+      envp
+    }
+  }
+  let job = @event_loop.Spawn(
+    path=cmd,
+    args=argv,
+    env~,
+    stdin~,
+    stdout~,
+    stderr~,
+    cwd~,
+  )
+  @event_loop.perform_job(job, context~)
+}
+
+///|
+/// Execute a system process with command `cmd`,
+/// and provide `args` as extra arguments to `cmd.
+/// Both `cmd` and elements of `args` are encoded using UTF8.
+/// The process ID of the spawned process will be returned.
+///
+/// The spawned process would be *orphan*, meaning that it will
+/// keep running until completion or explicitly terminated,
+/// even if the task that calls `spawn_orphan` is cancelled.
+/// Users are recommended to use `@process.run` whenever possible,
+/// because `@process.run` has better structured concurrency integration.
+/// `spawn_orphan` should only be used when:
+///
+/// - the process is intended to be orphan,
+///   i.e. keep running after parent process terminates
+/// - operations on the process ID is needed, such as sending signals to the child process
+///
+/// The meaning of the arguments is the same as `@process.run`,
+/// see `@process.run` for more details.
+pub async fn spawn_orphan(
+  cmd : String,
+  args : Array[String],
+  extra_env? : Map[String, String] = {},
+  inherit_env? : Bool = true,
+  stdin? : &ProcessInput,
+  stdout? : &ProcessOutput,
+  stderr? : &ProcessOutput,
+  cwd? : String,
+) -> Int {
+  spawn(
+    cmd,
+    args,
+    extra_env~,
+    inherit_env~,
+    stdin~,
+    stdout~,
+    stderr~,
+    cwd~,
+    context="@process.spawn_orphan()",
+  )
+}
+
+///|
+/// Wait for the process with specfic ID to terminate,
+/// and return the exit code of the process.
+pub async fn wait_pid(pid : Int) -> Int {
+  let context = "@process.wait_pid()"
+  ignore(@event_loop.perform_job(WaitProcess(pid), context~))
+  let out = @ref.new(0)
+  let ret = get_process_result(pid, out)
+  if ret < 0 {
+    @os_error.check_errno(context)
+  }
+  out.val
+}
+
+///|
 /// Execute a system process with command `cmd`,
 /// and provide `args` as extra arguments to `cmd.
 /// Both `cmd` and elements of `args` are encoded using UTF8.
@@ -33,8 +171,7 @@ extern "C" fn get_process_result(pid : Int, out : Ref[Int]) -> Int = "moonbitlan
 /// `run` will block until the new process terminates,
 /// and returns the exit status of the process.
 /// If current task is cancelled while blocking,
-/// the spawned process will be terminated via `SIGTERM`,
-/// unless `orphan` is `true` (`false` by default).
+/// the spawned process will be terminated via `SIGTERM`.
 /// To run the process in background, use `@async.spawn` or `@async.spawn_bg`.
 ///
 /// If `inherit_env` is `true` (`true` by default),
@@ -69,86 +206,21 @@ pub async fn run(
   stdout? : &ProcessOutput,
   stderr? : &ProcessOutput,
   cwd? : String,
-  orphan? : Bool = false,
 ) -> Int {
-  let cmd = @encoding/utf8.encode(cmd)
-  let argv = FixedArray::make(args.length() + 2, None)
-  let cwd = match cwd {
-    None => None
-    Some(cwd) => Some(@encoding/utf8.encode(cwd))
-  }
-  argv[0] = Some(cmd)
-  for i in 0..<args.length() {
-    argv[i + 1] = Some(@encoding/utf8.encode(args[i]))
-  }
   let context = "@process.run()"
-  let pid = {
-      defer {
-        if stdin is Some(p) {
-          p.after_spawn()
-        }
-        if stdout is Some(p) {
-          p.after_spawn()
-        }
-        if stderr is Some(p) {
-          p.after_spawn()
-        }
-      }
-      let stdin = match stdin {
-        Some(pipe) => {
-          @fd_util.set_blocking(pipe.fd(), context~)
-          pipe.fd()
-        }
-        None => -1
-      }
-      let stdout = match stdout {
-        Some(pipe) => {
-          @fd_util.set_blocking(pipe.fd(), context~)
-          pipe.fd()
-        }
-        None => -1
-      }
-      let stderr = match stderr {
-        Some(pipe) => {
-          @fd_util.set_blocking(pipe.fd(), context~)
-          pipe.fd()
-        }
-        None => -1
-      }
-      let extra_count = extra_env.size()
-      let env = match (inherit_env, extra_count) {
-        (true, 0) => curr_env
-        (false, 0) => [None]
-        (_, n) => {
-          let curr_env = if inherit_env { curr_env } else { [None] }
-          let envp = FixedArray::make(n + curr_env.length(), None)
-          let mut i = 0
-          for k, v in extra_env {
-            envp[i] = Some(@encoding/utf8.encode("\{k}=\{v}"))
-            i = i + 1
-          }
-          curr_env.blit_to(
-            envp,
-            src_offset=0,
-            dst_offset=i,
-            len=curr_env.length(),
-          )
-          envp
-        }
-      }
-      let job = @event_loop.Spawn(
-        path=cmd,
-        args=argv,
-        env~,
-        stdin~,
-        stdout~,
-        stderr~,
-        cwd~,
-      )
-      @event_loop.perform_job(job, context~)
-    }
+  let pid = spawn(
+    cmd,
+    args,
+    extra_env~,
+    inherit_env~,
+    stdin~,
+    stdout~,
+    stderr~,
+    cwd~,
+    context~,
+  )
   ignore(@event_loop.perform_job(WaitProcess(pid), context~)) catch {
-    err if !orphan && @coroutine.is_being_cancelled() => {
+    err if @coroutine.is_being_cancelled() => {
       terminate_process(pid)
       raise err
     }

--- a/src/process/wait_test.mbt
+++ b/src/process/wait_test.mbt
@@ -43,3 +43,27 @@ async test "basic wait" {
 async test "wait exitcode" {
   inspect(@process.run("sh", ["-c", "exit 42"]), content="42")
 }
+
+///|
+async test "wait_pid" {
+  let log = StringBuilder::new()
+  @async.with_task_group(fn(group) {
+    group.spawn_bg(fn() {
+      for _ in 0..<2 {
+        @async.sleep(800)
+        log.write_string("tick\n")
+      }
+    })
+    let pid = @process.spawn_orphan("sh", ["-c", "sleep 1; exit 42"])
+    log.write_string("process terminated with \{@process.wait_pid(pid)}\n")
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|tick
+      #|process terminated with 42
+      #|tick
+      #|
+    ),
+  )
+}


### PR DESCRIPTION
- add `@process.spawn_orphan`, which spawns an orphan process without any structured concurrency integration, and return its PID. This is useful for spawning process that need to run after parent process exit, or sending signals to child process via PID
- add `@process.wait_pid` for waiting for a PID directly. This can be used to wait for external process or process spawned by `@process.spawn_orphan`
- [breaking] the `orphan` parameter of `@process.run` is removed
    