### PR TITLE
add `fatal_error` parameter to `@async.retry`

### DIFF
--- a/src/async.mbt
+++ b/src/async.mbt
@@ -144,15 +144,20 @@ pub(all) enum RetryMethod {
 /// However, if `max_retry` is set,
 /// the number of retry attempts will not exceed the value of `max_retry`.
 /// If retry attempts reaches limit, `retry` will raise the error from `f`'s last attempt.
+///
+/// If `fatal_error` is present, and `f` raises an error `err` such that
+/// `fatal_error(err)` is `true`, `retry` will fail immediately with `err`.
 pub async fn[X] retry(
   strategy : RetryMethod,
   max_retry? : Int,
+  fatal_error? : (Error) -> Bool,
   f : async () -> X,
 ) -> X {
   match strategy {
     Immediate =>
       for i = 0; ; i = i + 1 {
         try f() catch {
+          err if fatal_error is Some(f) && f(err) => raise err
           err if @coroutine.is_being_cancelled() => raise err
           err if max_retry is Some(max) && i >= max => raise err
           _ => ()
@@ -163,6 +168,7 @@ pub async fn[X] retry(
     FixedDelay(t) =>
       for i = 0; ; i = i + 1 {
         try f() catch {
+          err if fatal_error is Some(f) && f(err) => raise err
           err if @coroutine.is_being_cancelled() => raise err
           err if max_retry is Some(max) && i >= max => raise err
           _ => sleep(t)
@@ -173,6 +179,7 @@ pub async fn[X] retry(
     ExponentialDelay(initial~, factor~, maximum~) =>
       for i = 0, timeout = initial; ; i = i + 1 {
         try f() catch {
+          err if fatal_error is Some(f) && f(err) => raise err
           err if @coroutine.is_being_cancelled() => raise err
           err if max_retry is Some(max) && i >= max => raise err
           _ => {

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -8,7 +8,7 @@ async fn pause() -> Unit
 
 async fn protect_from_cancel(async () -> Unit) -> Unit
 
-async fn[X] retry(RetryMethod, max_retry? : Int, async () -> X) -> X
+async fn[X] retry(RetryMethod, max_retry? : Int, fatal_error? : (Error) -> Bool, async () -> X) -> X
 
 fn run_async_main(async () -> Unit) -> Unit
 
@@ -46,7 +46,7 @@ fn[X] TaskGroup::add_defer(Self[X], async () -> Unit) -> Unit raise
 fn[X] TaskGroup::return_immediately(Self[X], X) -> Unit raise
 fn[G, X] TaskGroup::spawn(Self[G], async () -> X, no_wait? : Bool, allow_failure? : Bool) -> Task[X] raise
 fn[X] TaskGroup::spawn_bg(Self[X], async () -> Unit, no_wait? : Bool, allow_failure? : Bool) -> Unit raise
-fn[X] TaskGroup::spawn_loop(Self[X], async () -> IterResult, no_wait? : Bool, allow_failure? : Bool, retry? : RetryMethod, max_retry? : Int) -> Unit raise
+fn[X] TaskGroup::spawn_loop(Self[X], async () -> IterResult, no_wait? : Bool, allow_failure? : Bool, retry? : RetryMethod, max_retry? : Int, fatal_error? : (Error) -> Bool) -> Unit raise
 
 // Type aliases
 pub typealias @moonbitlang/async/aqueue.Queue as Queue

--- a/src/retry_test.mbt
+++ b/src/retry_test.mbt
@@ -160,3 +160,38 @@ async test "retry cancelled2" {
     ),
   )
 }
+
+///|
+async test "retry fatal_error" {
+  let log = StringBuilder::new()
+  fn fatal_error(err) {
+    not(err is @async.TimeoutError)
+  }
+
+  let mut i = 0
+  async fn worker() {
+    log.write_string("worker run #\{i}\n")
+    i = i + 1
+    if i < 3 {
+      @async.with_timeout(100, () => @async.sleep(1000))
+    } else {
+      raise Failure("fatal error")
+    }
+  }
+
+  inspect(
+    try? @async.retry(Immediate, fatal_error~, worker),
+    content=(
+      #|Err(Failure("fatal error"))
+    ),
+  )
+  inspect(
+    log.to_string(),
+    content=(
+      #|worker run #0
+      #|worker run #1
+      #|worker run #2
+      #|
+    ),
+  )
+}

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -259,7 +259,7 @@ fnalias retry as moonbitlang_async_retry
 /// If `retry_method` is set, within each loop,
 /// the spawned task will be automatically restarted on failure.
 /// The restart strategy is determined by the value of `retry_method`.
-/// `max_retry` will be passed as-is to `retry`.
+/// `max_retry` and `fatal_error` will be passed as-is to `retry`.
 /// See `retry` and `RetryMethod` for more details.
 ///
 /// The meaning of `no_wait` and `allow_failure` is the same as `spawn_bg`.
@@ -270,12 +270,14 @@ pub fn[X] TaskGroup::spawn_loop(
   allow_failure? : Bool = false,
   retry? : RetryMethod,
   max_retry? : Int,
+  fatal_error? : (Error) -> Bool,
 ) -> Unit raise {
   self.spawn_bg(no_wait~, allow_failure~, fn() {
     for {
       let result = match retry {
         None => f()
-        Some(strategy) => moonbitlang_async_retry(strategy, f, max_retry?)
+        Some(strategy) =>
+          moonbitlang_async_retry(strategy, f, max_retry?, fatal_error?)
       }
       guard result is IterContinue else { break }
     }


### PR DESCRIPTION
add a new optional parameter `fatal_error` to `@async.retry`. When the retried code fail with an error `err` such that `fatal_error(err) is true`, `@async.retry` will fail immediately instead of retrying. This allows selective retry on only a specific class of error.