### PR TITLE
add IP protocol preference & dual stack server support

### DIFF
--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -124,22 +124,31 @@ fn ResolveHostnameError::from_error_code(code : Int) -> ResolveHostnameError {
 }
 
 ///|
+pub(all) enum IPProtocolPreference {
+  Only_V4
+  Only_V6
+  Favor_V4
+  Favor_V6
+  No_Preference
+} derive(Show)
+
+///|
 /// Resolve a IPv4 or IPv6 address by hostname.
 ///
-/// An IPv4 address will be returned only if
-/// the system has at least one IPv4 address configured.
-/// Similarly an IPv6 address will be returned only if
-/// the system has at least one IPv6 address configured.
-///
-/// When both IPv4 and IPv6 is available,
-/// currently `Addr::resolve` favors IPv4 address.
-pub async fn Addr::resolve(host : String, port~ : Int) -> Addr {
+/// By default, `Addr::resolve` return the first available address.
+/// Preference on IPv4 v.s. IPv6 can be configured via `protocol`.
+/// See `IPProtocolPreference` for available options.
+pub async fn Addr::resolve(
+  host : String,
+  port~ : Int,
+  protocol? : IPProtocolPreference = No_Preference,
+) -> Addr {
   // TODO: Add option to prefer ipv6 or ipv4
   let host = @encoding/utf8.encode(host)
   let ai_ref = AddrInfoRef::new()
   let ret = @event_loop.perform_job(
     GetAddrInfo(host~, out=ai_ref),
-    context="@socket.Addr::resolve_all()",
+    context="@socket.Addr::resolve()",
   )
   if ret != 0 {
     raise ResolveHostnameError::from_error_code(ret)
@@ -147,14 +156,41 @@ pub async fn Addr::resolve(host : String, port~ : Int) -> Addr {
   let ai_root = ai_ref.get_and_clear()
   defer ai_root.free()
   let first_addr = ai_root.to_addr(port)
-  if first_addr.is_ipv6() {
-    // if first address is IPv6, try to search for an IPv4 address
-    for ai = ai_root.next(); not(ai.is_null()); ai = ai.next() {
-      let addr = ai.to_addr(port)
-      if not(addr.is_ipv6()) {
-        return addr
+
+  // search for address with preferred protocol
+  match protocol {
+    Favor_V4 | Only_V4 => {
+      if not(first_addr.is_ipv6()) {
+        return first_addr
+      }
+      for ai = ai_root.next(); not(ai.is_null()); ai = ai.next() {
+        let addr = ai.to_addr(port)
+        if not(addr.is_ipv6()) {
+          return addr
+        }
+      }
+      if protocol is Only_V4 {
+        raise ResolveHostnameError("No available IPv4 address")
+      } else {
+        first_addr
       }
     }
+    Favor_V6 | Only_V6 => {
+      if first_addr.is_ipv6() {
+        return first_addr
+      }
+      for ai = ai_root.next(); not(ai.is_null()); ai = ai.next() {
+        let addr = ai.to_addr(port)
+        if addr.is_ipv6() {
+          return addr
+        }
+      }
+      if protocol is Only_V6 {
+        raise ResolveHostnameError("No available IPv6 address")
+      } else {
+        first_addr
+      }
+    }
+    No_Preference => first_addr
   }
-  first_addr
 }

--- a/src/socket/dual_stack_test.mbt
+++ b/src/socket/dual_stack_test.mbt
@@ -1,0 +1,162 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let all_protocol_preferences : FixedArray[@socket.IPProtocolPreference] = [
+  @socket.Favor_V4,
+  @socket.Only_V4,
+  @socket.Favor_V6,
+  @socket.Only_V6,
+]
+
+///|
+async test "Only_V4 server" {
+  let log = StringBuilder::new()
+  let port = 4209
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(no_wait=true, fn() {
+      let server = @socket.TCPServer::new(
+        @socket.Addr::parse("0.0.0.0:\{port}"),
+      )
+      for {
+        let (conn, addr) = server.accept()
+        defer conn.close()
+        let addr_str = addr.to_string()
+        guard addr_str.rev_find(":") is Some(ip_end)
+        let ip = addr_str[:ip_end]
+        let msg = conn.read_all().text()
+        log.write_string("server received \{repr(msg)} from \{ip}\n")
+      }
+    })
+    async fn client(protocol) {
+      let conn = @socket.TCP::connect_to_host("localhost", port~, protocol~)
+      defer conn.close()
+      conn.write("message")
+    }
+
+    for protocol in all_protocol_preferences {
+      let result = try? client(protocol)
+      @async.sleep(100)
+      log.write_string("client(\{protocol}): \{result}\n")
+    }
+    // give some time for the server to process the last connection
+    @async.sleep(300)
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|server received "message" from 127.0.0.1
+      #|client(Favor_V4): Ok(())
+      #|server received "message" from 127.0.0.1
+      #|client(Only_V4): Ok(())
+      #|server received "message" from 127.0.0.1
+      #|client(Favor_V6): Ok(())
+      #|client(Only_V6): Err(OSError("@socket.TCP::connect: Connection refused"))
+      #|
+    ),
+  )
+}
+
+///|
+async test "Only_V6 server" {
+  let log = StringBuilder::new()
+  let port = 4210
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(no_wait=true, fn() {
+      let server = @socket.TCPServer::new(@socket.Addr::parse("[::]:\{port}"))
+      for {
+        let (conn, addr) = server.accept()
+        defer conn.close()
+        let addr_str = addr.to_string()
+        guard addr_str.rev_find(":") is Some(ip_end)
+        let ip = addr_str[:ip_end]
+        let msg = conn.read_all().text()
+        log.write_string("server received \{repr(msg)} from \{ip}\n")
+      }
+    })
+    async fn client(protocol) {
+      let conn = @socket.TCP::connect_to_host("localhost", port~, protocol~)
+      defer conn.close()
+      conn.write("message")
+    }
+
+    for protocol in all_protocol_preferences {
+      let result = try? client(protocol)
+      @async.sleep(100)
+      log.write_string("client(\{protocol}): \{result}\n")
+    }
+    // give some time for the server to process the last connection
+    @async.sleep(300)
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|server received "message" from [::1]
+      #|client(Favor_V4): Ok(())
+      #|client(Only_V4): Err(OSError("@socket.TCP::connect: Connection refused"))
+      #|server received "message" from [::1]
+      #|client(Favor_V6): Ok(())
+      #|server received "message" from [::1]
+      #|client(Only_V6): Ok(())
+      #|
+    ),
+  )
+}
+
+///|
+async test "dual stack server" {
+  let log = StringBuilder::new()
+  let port = 4211
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(no_wait=true, fn() {
+      let server = @socket.TCPServer::new_dual_stack(port)
+      for {
+        let (conn, addr) = server.accept()
+        defer conn.close()
+        let addr_str = addr.to_string()
+        guard addr_str.rev_find(":") is Some(ip_end)
+        let ip = addr_str[:ip_end]
+        let msg = conn.read_all().text()
+        log.write_string("server received \{repr(msg)} from \{ip}\n")
+      }
+    })
+    async fn client(protocol) {
+      let conn = @socket.TCP::connect_to_host("localhost", port~, protocol~)
+      defer conn.close()
+      conn.write("message")
+    }
+
+    for protocol in all_protocol_preferences {
+      let result = try? client(protocol)
+      @async.sleep(100)
+      log.write_string("client(\{protocol}): \{result}\n")
+    }
+    // give some time for the server to process the last connection
+    @async.sleep(300)
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|server received "message" from [::ffff:127.0.0.1]
+      #|client(Favor_V4): Ok(())
+      #|server received "message" from [::ffff:127.0.0.1]
+      #|client(Only_V4): Ok(())
+      #|server received "message" from [::1]
+      #|client(Favor_V6): Ok(())
+      #|server received "message" from [::1]
+      #|client(Only_V6): Ok(())
+      #|
+    ),
+  )
+}

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -52,6 +52,9 @@ extern "C" fn bind_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_bind
 extern "C" fn bind_ipv6_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_bind_ipv6"
 
 ///|
+extern "C" fn bind_dual_stack(sock : Int, port : Int) -> Int = "moonbitlang_async_bind_dual_stack"
+
+///|
 #borrow(addr)
 extern "C" fn connect_ipv6_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_connect_ipv6"
 

--- a/src/socket/happy_eyeball.mbt
+++ b/src/socket/happy_eyeball.mbt
@@ -14,7 +14,23 @@
 
 ///|
 /// Connect to a remote host using the happy eyeball algorithm.
-pub async fn TCP::connect_to_host(host : String, port~ : Int) -> TCP {
+/// Preference on IPv4 v.s. IPv6 can be configured via `protocol`:
+///
+/// - if `protocol` is `No_Preference` (the default behavior),
+///   the first successful connection will be returned, regardless of the protocol.
+/// - if `protocol` is `Favor_V4`,
+///   an IPv6 connection will only be returned if no IPv4 address is available
+/// - if `protocol` is `Only_V4`,
+///   `connect_to_host` will fail if no IPv4 address is available
+/// - if `protocol` is `Favor_V6`,
+///   an IPv6 connection will only be returned if no IPv4 address is available
+/// - if `protocol` is `Only_V6`,
+///   `connect_to_host` will fail if no IPv4 address is available
+pub async fn TCP::connect_to_host(
+  host : String,
+  port~ : Int,
+  protocol? : IPProtocolPreference = No_Preference,
+) -> TCP {
   let host = @encoding/utf8.encode(host)
   let ai_ref = AddrInfoRef::new()
   let ret = @event_loop.perform_job(
@@ -28,25 +44,57 @@ pub async fn TCP::connect_to_host(host : String, port~ : Int) -> TCP {
   let mut conn_err = None
   let ai = ai_ref.get_and_clear()
   defer ai.free()
-  @async.with_task_group(fn(group) {
-    for ai = ai; not(ai.is_null()); ai = ai.next() {
-      group.spawn_bg(allow_failure=true, fn() {
-        let conn = TCP::connect(ai.to_addr(port)) catch {
-          err => {
-            if conn_err is None {
-              conn_err = Some(err)
-            }
-            raise err
-          }
+  async fn connect_with_protocol(protocol : IPProtocolPreference) {
+    @async.with_task_group(fn(group) {
+      for ai = ai; not(ai.is_null()); ai = ai.next() {
+        let addr = ai.to_addr(port)
+        match (protocol, addr.is_ipv6()) {
+          (Only_V4 | Favor_V4, true) => continue
+          (Only_V6 | Favor_V6, false) => continue
+          _ => ()
         }
-        result = Some(conn)
-        group.return_immediately(())
-      })
-      @async.sleep(250)
+        group.spawn_bg(allow_failure=true, fn() {
+          let conn = TCP::connect(addr) catch {
+            err => {
+              if conn_err is None {
+                conn_err = Some(err)
+              }
+              raise err
+            }
+          }
+          result = Some(conn)
+          group.return_immediately(())
+        })
+        @async.sleep(250)
+      }
+    })
+  }
+
+  match protocol {
+    No_Preference | Only_V4 | Only_V6 => connect_with_protocol(protocol)
+    Favor_V4 => {
+      connect_with_protocol(Only_V4)
+      if result is None {
+        connect_with_protocol(Only_V6)
+      }
     }
-  })
+    Favor_V6 => {
+      connect_with_protocol(Only_V6)
+      if result is None {
+        connect_with_protocol(Only_V4)
+      }
+    }
+  }
   match result {
     Some(conn) => conn
-    None => raise conn_err.unwrap()
+    None =>
+      match (conn_err, protocol) {
+        (Some(err), _) => raise err
+        (None, Only_V4) =>
+          raise ResolveHostnameError("No available IPv4 address")
+        (None, Only_V6) =>
+          raise ResolveHostnameError("No available IPv6 address")
+        (None, _) => panic()
+      }
   }
 }

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -17,16 +17,25 @@ fn Addr::is_ipv6(Self) -> Bool
 fn Addr::new(UInt, Int) -> Self
 fn Addr::parse(String) -> Self raise InvalidAddr
 fn Addr::port(Self) -> Int
-async fn Addr::resolve(String, port~ : Int) -> Self
+async fn Addr::resolve(String, port~ : Int, protocol? : IPProtocolPreference) -> Self
 impl Compare for Addr
 impl Eq for Addr
 impl Hash for Addr
 impl Show for Addr
 
+pub(all) enum IPProtocolPreference {
+  Only_V4
+  Only_V6
+  Favor_V4
+  Favor_V6
+  No_Preference
+}
+impl Show for IPProtocolPreference
+
 type TCP
 fn TCP::close(Self) -> Unit
 async fn TCP::connect(Addr) -> Self
-async fn TCP::connect_to_host(String, port~ : Int) -> Self
+async fn TCP::connect_to_host(String, port~ : Int, protocol? : IPProtocolPreference) -> Self
 fn TCP::enable_keepalive(Self, idle_before_keep_alive? : Int, keep_alive_count? : Int, keep_alive_interval? : Int) -> Unit raise
 impl @moonbitlang/async/io.Reader for TCP
 impl @moonbitlang/async/io.Writer for TCP
@@ -35,6 +44,7 @@ type TCPServer
 async fn TCPServer::accept(Self) -> (TCP, Addr)
 fn TCPServer::close(Self) -> Unit
 fn TCPServer::new(Addr) -> Self raise
+fn TCPServer::new_dual_stack(Int) -> Self raise
 
 type UDP
 fn UDP::bind(Self, Addr) -> Unit raise

--- a/src/socket/resolve_host_test.mbt
+++ b/src/socket/resolve_host_test.mbt
@@ -13,14 +13,6 @@
 // limitations under the License.
 
 ///|
-async test "resolve localhost" {
-  inspect(
-    @socket.Addr::resolve("localhost", port=4200),
-    content="127.0.0.1:4200",
-  )
-}
-
-///|
 async test "resolve mooncakes.io" {
   inspect(
     @socket.Addr::resolve("mooncakes.io", port=443),
@@ -54,4 +46,24 @@ async test "resolve cancel" {
 async test "resolve failure" {
   let result = try? @socket.Addr::resolve("does.not.exist", port=443)
   assert_true(result is Err(@socket.ResolveHostnameError(_)))
+}
+
+///|
+async test "resolve preference" {
+  inspect(
+    @socket.Addr::resolve("localhost", port=80, protocol=Favor_V4),
+    content="127.0.0.1:80",
+  )
+  inspect(
+    @socket.Addr::resolve("localhost", port=80, protocol=Only_V4),
+    content="127.0.0.1:80",
+  )
+  inspect(
+    @socket.Addr::resolve("localhost", port=80, protocol=Favor_V6),
+    content="[::1]:80",
+  )
+  inspect(
+    @socket.Addr::resolve("localhost", port=80, protocol=Only_V6),
+    content="[::1]:80",
+  )
 }

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -51,7 +51,24 @@ int moonbitlang_async_bind(int sockfd, struct sockaddr_in *addr) {
 }
 
 int moonbitlang_async_bind_ipv6(int sockfd, struct sockaddr_in6 *addr) {
+  int ipv6_only = 1;
+  int ret = setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_only, sizeof(int));
+  if (ret < 0) return ret;
+
   return bind(sockfd, (struct sockaddr*)addr, sizeof(struct sockaddr_in6));
+}
+
+int moonbitlang_async_bind_dual_stack(int sockfd, int port) {
+  int ipv6_only = 0;
+  int ret = setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_only, sizeof(int));
+  if (ret < 0) return ret;
+
+  struct sockaddr_in6 addr;
+  addr.sin6_family = AF_INET6;
+  addr.sin6_port = htons(port);
+  memset(&(addr.sin6_addr), 0, sizeof(struct in6_addr));
+  return bind(sockfd, (struct sockaddr*)&addr, sizeof(struct sockaddr_in6));
+
 }
 
 int moonbitlang_async_connect_ipv6(int sockfd, struct sockaddr_in6 *addr) {

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -28,11 +28,16 @@ struct TCPServer(Int)
 ///|
 /// Create a TCP server that is bound to `addr`,
 /// listening for incoming connections.
+///
+/// If `addr` is an IPv6 (including the wildcard address `[::]`),
+/// the server will be IPv6 only.
+/// For dual stack server, see `@socket.TCPServer::new_dual_stack`.
 pub fn TCPServer::new(addr : Addr) -> TCPServer raise {
+  let context = "@socket.TCPServer::new()"
   let sock = if addr.is_ipv6() {
-    make_tcp_socket_ipv6("@socket.TCPServer::new()")
+    make_tcp_socket_ipv6(context)
   } else {
-    make_tcp_socket("@socket.TCPServer::new()")
+    make_tcp_socket(context)
   }
   let bind_result = if addr.is_ipv6() {
     bind_ipv6_ffi(sock, addr)
@@ -40,12 +45,30 @@ pub fn TCPServer::new(addr : Addr) -> TCPServer raise {
     bind_ffi(sock, addr)
   }
   if bind_result != 0 {
-    @fd_util.close(sock, context="@socket.TCPServer::new()")
-    @os_error.check_errno("@socket.TCPServer::new()")
+    @fd_util.close(sock, context~)
+    @os_error.check_errno(context)
   }
   if 0 != listen_ffi(sock) {
-    @fd_util.close(sock, context="@socket.TCPServer::new()")
-    @os_error.check_errno("@socket.TCPServer::new()")
+    @fd_util.close(sock, context~)
+    @os_error.check_errno(context)
+  }
+  TCPServer(sock)
+}
+
+///|
+/// Create a dual stack TCP server that listen for connections
+/// from all IPv4 and IPv6 clients at `port`.
+/// The address of IPv4 clients are represented via IPv4-mapped IPv6 address.
+pub fn TCPServer::new_dual_stack(port : Int) -> TCPServer raise {
+  let context = "@socket.TCPServer::new_dual_stack()"
+  let sock = make_tcp_socket_ipv6(context)
+  if bind_dual_stack(sock, port) != 0 {
+    @fd_util.close(sock, context~)
+    @os_error.check_errno(context)
+  }
+  if 0 != listen_ffi(sock) {
+    @fd_util.close(sock, context~)
+    @os_error.check_errno(context)
   }
   TCPServer(sock)
 }


### PR DESCRIPTION
- add IP protocol preference option to `@socket.TCP::connect_to_host` and `@socket.Addr::resolve`. Available options are `Only_V4`, `Favor_V4`, `Only_V6`, `Favor_V6` and  `No_preference`
- add dual stack server support to `@socket.TCPServer` via `@socket.TCPServer::new_dual_stack`
- `@socket.TCPServer::new` now always operates in IPv4-only or IPv6-only mode, depending on the listen address