### PR TITLE
[breaking] refactor UDP API & add dual stack UDP server support

### DIFF
--- a/examples/udp_echo_server/main.mbt
+++ b/examples/udp_echo_server/main.mbt
@@ -15,9 +15,8 @@
 ///|
 async fn main {
   @async.with_task_group(fn(root) {
-    let server = @socket.UDP::new()
+    let server = @socket.UdpServer::new(@socket.Addr::parse("0.0.0.0:4200"))
     defer server.close()
-    server.bind(@socket.Addr::parse("0.0.0.0:4200"))
     for {
       let buf = FixedArray::make(1024, b'0')
       let (n, addr) = server.recvfrom(buf)

--- a/examples/udp_ping_pong/main.mbt
+++ b/examples/udp_ping_pong/main.mbt
@@ -24,9 +24,10 @@ pub(all) struct Printer((String) -> Unit)
 ///|
 async fn server(println : Printer) -> Unit {
   @async.with_task_group(fn(group) {
-    let server_sock = @socket.UDP::new()
+    let server_sock = @socket.UdpServer::new(
+      @socket.Addr::parse("0.0.0.0:\{port}"),
+    )
     defer server_sock.close()
-    server_sock.bind(@socket.Addr::parse("0.0.0.0:\{port}"))
     let buf = FixedArray::make(1024, b'0')
     while server_sock.recvfrom(buf) is (n, addr) && n > 0 {
       group.spawn_bg(fn() {
@@ -54,9 +55,8 @@ async fn server(println : Printer) -> Unit {
 
 ///|
 async fn client(println : Printer, id : Int, msg : String) -> Unit {
-  let conn = @socket.UDP::new()
+  let conn = @socket.UdpClient::new(@socket.Addr::parse("127.0.0.1:\{port}"))
   defer conn.close()
-  conn.connect(@socket.Addr::parse("127.0.0.1:\{port}"))
   conn.send(@encoding/utf8.encode(msg))
   println("client \{id} sent: \{msg}")
   let buf = FixedArray::make(1024, b'0')

--- a/src/socket/dual_stack_test.mbt
+++ b/src/socket/dual_stack_test.mbt
@@ -29,6 +29,7 @@ async test "Only_V4 server" {
       let server = @socket.TCPServer::new(
         @socket.Addr::parse("0.0.0.0:\{port}"),
       )
+      defer server.close()
       for {
         let (conn, addr) = server.accept()
         defer conn.close()
@@ -135,6 +136,151 @@ async test "dual stack server" {
       let conn = @socket.TCP::connect_to_host("localhost", port~, protocol~)
       defer conn.close()
       conn.write("message")
+    }
+
+    for protocol in all_protocol_preferences {
+      let result = try? client(protocol)
+      @async.sleep(100)
+      log.write_string("client(\{protocol}): \{result}\n")
+    }
+    // give some time for the server to process the last connection
+    @async.sleep(300)
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|server received "message" from [::ffff:127.0.0.1]
+      #|client(Favor_V4): Ok(())
+      #|server received "message" from [::ffff:127.0.0.1]
+      #|client(Only_V4): Ok(())
+      #|server received "message" from [::1]
+      #|client(Favor_V6): Ok(())
+      #|server received "message" from [::1]
+      #|client(Only_V6): Ok(())
+      #|
+    ),
+  )
+}
+
+///|
+async test "Only_V4 UDP server" {
+  let log = StringBuilder::new()
+  let port = 4209
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(no_wait=true, fn() {
+      let server = @socket.UdpServer::new(
+        @socket.Addr::parse("0.0.0.0:\{port}"),
+      )
+      defer server.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      for {
+        let (len, addr) = server.recvfrom(buf)
+        let msg = @encoding/utf8.decode(buf.unsafe_reinterpret_as_bytes()[:len])
+        let addr_str = addr.to_string()
+        guard addr_str.rev_find(":") is Some(ip_end)
+        let ip = addr_str[:ip_end]
+        log.write_string("server received \{repr(msg)} from \{ip}\n")
+      }
+    })
+    async fn client(protocol) {
+      let addr = @socket.Addr::resolve("localhost", port~, protocol~)
+      let client = @socket.UdpClient::new(addr)
+      defer client.close()
+      client.send("message")
+    }
+
+    for protocol in all_protocol_preferences {
+      let result = try? client(protocol)
+      @async.sleep(100)
+      log.write_string("client(\{protocol}): \{result}\n")
+    }
+    // give some time for the server to process the last connection
+    @async.sleep(300)
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|server received "message" from 127.0.0.1
+      #|client(Favor_V4): Ok(())
+      #|server received "message" from 127.0.0.1
+      #|client(Only_V4): Ok(())
+      #|client(Favor_V6): Ok(())
+      #|client(Only_V6): Ok(())
+      #|
+    ),
+  )
+}
+
+///|
+async test "Only_V6 UDP server" {
+  let log = StringBuilder::new()
+  let port = 4210
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(no_wait=true, fn() {
+      let server = @socket.UdpServer::new(@socket.Addr::parse("[::]:\{port}"))
+      defer server.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      for {
+        let (len, addr) = server.recvfrom(buf)
+        let msg = @encoding/utf8.decode(buf.unsafe_reinterpret_as_bytes()[:len])
+        let addr_str = addr.to_string()
+        guard addr_str.rev_find(":") is Some(ip_end)
+        let ip = addr_str[:ip_end]
+        log.write_string("server received \{repr(msg)} from \{ip}\n")
+      }
+    })
+    async fn client(protocol) {
+      let addr = @socket.Addr::resolve("localhost", port~, protocol~)
+      let client = @socket.UdpClient::new(addr)
+      defer client.close()
+      client.send("message")
+    }
+
+    for protocol in all_protocol_preferences {
+      let result = try? client(protocol)
+      @async.sleep(100)
+      log.write_string("client(\{protocol}): \{result}\n")
+    }
+    // give some time for the server to process the last connection
+    @async.sleep(300)
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|client(Favor_V4): Ok(())
+      #|client(Only_V4): Ok(())
+      #|server received "message" from [::1]
+      #|client(Favor_V6): Ok(())
+      #|server received "message" from [::1]
+      #|client(Only_V6): Ok(())
+      #|
+    ),
+  )
+}
+
+///|
+async test "dual stack UDP server" {
+  let log = StringBuilder::new()
+  let port = 4211
+  @async.with_task_group(fn(root) {
+    root.spawn_bg(no_wait=true, fn() {
+      let server = @socket.UdpServer::new_dual_stack(port)
+      defer server.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      for {
+        let (len, addr) = server.recvfrom(buf)
+        let msg = @encoding/utf8.decode(buf.unsafe_reinterpret_as_bytes()[:len])
+        let addr_str = addr.to_string()
+        guard addr_str.rev_find(":") is Some(ip_end)
+        let ip = addr_str[:ip_end]
+        log.write_string("server received \{repr(msg)} from \{ip}\n")
+      }
+    })
+    async fn client(protocol) {
+      let addr = @socket.Addr::resolve("localhost", port~, protocol~)
+      let client = @socket.UdpClient::new(addr)
+      defer client.close()
+      client.send("message")
     }
 
     for protocol in all_protocol_preferences {

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -41,7 +41,32 @@ fn make_tcp_socket_ipv6(context : String) -> Int raise {
 }
 
 ///|
-extern "C" fn make_udp_socket() -> Int = "moonbitlang_async_make_udp_socket"
+extern "C" fn make_udp_socket_ffi() -> Int = "moonbitlang_async_make_udp_socket"
+
+///|
+extern "C" fn make_udp_socket_ipv6_ffi() -> Int = "moonbitlang_async_make_udp_socket_ipv6"
+
+///|
+fn make_udp_socket(context : String) -> Int raise {
+  let sock = make_udp_socket_ffi()
+  if sock < 0 {
+    @os_error.check_errno(context)
+  }
+  @fd_util.set_cloexec(sock, context~)
+  @fd_util.set_nonblocking(sock, context~)
+  sock
+}
+
+///|
+fn make_udp_socket_ipv6(context : String) -> Int raise {
+  let sock = make_udp_socket_ipv6_ffi()
+  if sock < 0 {
+    @os_error.check_errno(context)
+  }
+  @fd_util.set_cloexec(sock, context~)
+  @fd_util.set_nonblocking(sock, context~)
+  sock
+}
 
 ///|
 #borrow(addr)

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -72,15 +72,18 @@ fn TCPServer::close(Self) -> Unit
 fn TCPServer::new(Addr) -> Self raise
 fn TCPServer::new_dual_stack(Int) -> Self raise
 
-type UDP
-fn UDP::bind(Self, Addr) -> Unit raise
-fn UDP::close(Self) -> Unit
-fn UDP::connect(Self, Addr) -> Unit raise
-fn UDP::new() -> Self raise
-async fn UDP::recv(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int
-async fn UDP::recvfrom(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> (Int, Addr)
-async fn UDP::send(Self, Bytes, offset? : Int, len? : Int) -> Unit
-async fn UDP::sendto(Self, Bytes, Addr, offset? : Int, len? : Int) -> Unit
+type UdpClient
+fn UdpClient::close(Self) -> Unit
+fn UdpClient::new(Addr) -> Self raise
+async fn UdpClient::recv(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int
+async fn UdpClient::send(Self, Bytes, offset? : Int, len? : Int) -> Unit
+
+type UdpServer
+fn UdpServer::close(Self) -> Unit
+fn UdpServer::new(Addr) -> Self raise
+fn UdpServer::new_dual_stack(Int) -> Self raise
+async fn UdpServer::recvfrom(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> (Int, Addr)
+async fn UdpServer::sendto(Self, Bytes, Addr, offset? : Int, len? : Int) -> Unit
 
 // Type aliases
 

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -13,60 +13,93 @@
 // limitations under the License.
 
 ///|
-/// A UDP socket directly corresponding to OS socket
-struct UDP(Int)
+/// A UDP client "connected" to a remote UDP server.
+///
+/// UDP is a connectionless protocol, here "connected" means
+/// the client always send packet to and receive packet from
+/// the specified remote server.
+struct UdpClient(Int)
 
 ///|
-/// Create a new UDP socket using the `socket(2)` system call.
-/// The created socket always operate in non-blocking mode.
-pub fn UDP::new() -> UDP raise {
-  let sock = make_udp_socket()
-  if sock < 0 {
-    @os_error.check_errno("@socket.UDP::new()")
+/// Create a new UDP client connected to server at `addr`.
+/// The client always send packet to and receive packet from
+/// the specified remote server.
+pub fn UdpClient::new(server : Addr) -> UdpClient raise {
+  let context = "@socket.UdpClient::new()"
+  let sock = if server.is_ipv6() {
+    make_udp_socket_ipv6(context)
+  } else {
+    make_udp_socket(context)
   }
-  @fd_util.set_cloexec(sock, context="@socket.UDP::new()")
-  @fd_util.set_nonblocking(sock, context="@socket.UDP::new()")
-  UDP(sock)
+  let connect_result = if server.is_ipv6() {
+    connect_ipv6_ffi(sock, server)
+  } else {
+    connect_ffi(sock, server)
+  }
+  if 0 != connect_result {
+    @fd_util.close(sock, context~)
+    @os_error.check_errno(context)
+  }
+  UdpClient(sock)
 }
 
 ///|
-pub fn UDP::close(self : UDP) -> Unit {
-  let UDP(sock) = self
+pub fn UdpClient::close(self : UdpClient) -> Unit {
+  let UdpClient(sock) = self
   @event_loop.close_fd(sock)
 }
 
 ///|
-/// Bind the socket to an address using the `bind(2)` system call,
-/// so that the socket can be used to receive packets from the address.
-pub fn UDP::bind(self : UDP, addr : Addr) -> Unit raise {
-  let UDP(sock) = self
+/// A UDP server bound to a listen address and receive packets from clients.
+struct UdpServer(Int)
+
+///|
+pub fn UdpServer::close(self : UdpServer) -> Unit {
+  let UdpServer(sock) = self
+  @event_loop.close_fd(sock)
+}
+
+///|
+/// Create a UDP server listening at `addr`.
+///
+/// If `addr` is an IPv6 (including the wildcard address `[::]`),
+/// the server will be IPv6 only.
+/// For dual stack server, see `@socket.UdpServer::new_dual_stack`.
+pub fn UdpServer::new(addr : Addr) -> UdpServer raise {
+  let context = "@socket.UdpServer::new()"
+  let sock = if addr.is_ipv6() {
+    make_udp_socket_ipv6(context)
+  } else {
+    make_udp_socket(context)
+  }
   let bind_result = if addr.is_ipv6() {
     bind_ipv6_ffi(sock, addr)
   } else {
     bind_ffi(sock, addr)
   }
-  if 0 != bind_result {
-    @os_error.check_errno("@socket.UDP::bind()")
+  if bind_result != 0 {
+    @fd_util.close(sock, context~)
+    @os_error.check_errno(context)
   }
+  UdpServer(sock)
 }
 
 ///|
-/// "connect" the socket to remote address using `connect(2)` system call.
-/// For UDP socket, connect means setting the default address for `send`.
-pub fn UDP::connect(self : UDP, addr : Addr) -> Unit raise {
-  let UDP(sock) = self
-  let connect_result = if addr.is_ipv6() {
-    connect_ipv6_ffi(sock, addr)
-  } else {
-    connect_ffi(sock, addr)
+/// Create a new dual stack UDP server listening at `port`.
+/// The server will receive packets from both IPv4 peers and IPv6 peers.
+/// The address of IPv4 peers are represented via IPv4-mapped IPv6 address.
+pub fn UdpServer::new_dual_stack(port : Int) -> UdpServer raise {
+  let context = "@socket.UdpServer::new_dual_stack()"
+  let sock = make_udp_socket_ipv6(context)
+  if bind_dual_stack(sock, port) != 0 {
+    @fd_util.close(sock, context~)
+    @os_error.check_errno(context)
   }
-  if 0 != connect_result {
-    @os_error.check_errno("@socket.UDP::connect()")
-  }
+  UdpServer(sock)
 }
 
 ///|
-/// Receive packet from a UDP socket  using `recv(2)` system call.
+/// Receive packet from a UDP client.
 /// For `udp.recv(buf, offset~, max_len~)`,
 /// at most `max_len` bytes of data will be written to `buf`, starting from `offset`.
 /// The number of received bytes will be returned.
@@ -76,26 +109,25 @@ pub fn UDP::connect(self : UDP, addr : Addr) -> Unit raise {
 /// If the buffer is smaller than the received packet,
 /// the rest of the packet will be lost.
 ///
-/// At most one task can read from a UDP socket at any time.
+/// At most one task can read from a UDP client at any time.
 /// To allow multiple reader,
 /// use a worker task for reading and use `@async.Queue` to distribute the data.
-pub async fn UDP::recv(
-  self : UDP,
+pub async fn UdpClient::recv(
+  self : UdpClient,
   buf : FixedArray[Byte],
   offset? : Int = 0,
   max_len? : Int = buf.length() - offset,
 ) -> Int {
-  let UDP(sock) = self
+  let UdpClient(sock) = self
   @event_loop.perform_job(
     Read(fd=sock, buf~, offset~, len=max_len, can_poll=true),
-    context="@socket.UDP::recv",
+    context="@socket.UdpClient::recv",
   )
 }
 
 ///|
-/// Same as `UDP::recv`, but also return the address of sender.
-/// Receive packet from a UDP socket  using `recvfrom(2)` system call.
-/// For `udp.recv(buf, offset~, max_len~)`,
+/// Receive packet from a UDP server, and obtain the source address of the packet.
+/// For `udp.recvfrom(buf, offset~, max_len~)`,
 /// at most `max_len` bytes of data will be written to `buf`, starting from `offset`.
 /// The number of received bytes and the source address of the packet will be returned.
 ///
@@ -104,69 +136,66 @@ pub async fn UDP::recv(
 /// If the buffer is smaller than the received packet,
 /// the rest of the packet will be lost.
 ///
-/// At most one task can read from a UDP socket at any time.
+/// At most one task can read from a UDP server at any time.
 /// To allow multiple reader,
 /// use a worker task for reading and use `@async.Queue` to distribute the data.
-pub async fn UDP::recvfrom(
-  self : UDP,
+pub async fn UdpServer::recvfrom(
+  self : UdpServer,
   buf : FixedArray[Byte],
   offset? : Int = 0,
   max_len? : Int = buf.length() - offset,
 ) -> (Int, Addr) {
-  let UDP(sock) = self
+  let UdpServer(sock) = self
   // Create a big enough Addr to hold both IPv4 and IPv6 address
   let addr = Addr::empty()
   let n_read = @event_loop.perform_job(
     Recvfrom(sock~, buf~, offset~, len=max_len, addr=addr.0),
-    context="@socket.UDP::recvfrom",
+    context="@socket.UdpServer::recvfrom",
   )
   (n_read, addr)
 }
 
 ///|
-/// Send data through a UDP socket using `send(2)` system call.
-/// The address of the remote peer is determined by `bind` or `connect`.
+/// Send data through a UDP client.
 ///
 /// UDP is a datagram based protocol, every call of `send` will send exactly one packet.
 ///
-/// At most one task can write to a UDP socket at any time.
+/// At most one task can write to a UDP client at any time.
 /// To allow multiple writers,
 /// use a worker task for reading and use `@async.Queue` to gather the data.
-pub async fn UDP::send(
-  self : UDP,
+pub async fn UdpClient::send(
+  self : UdpClient,
   buf : Bytes,
   offset? : Int = 0,
   len? : Int = buf.length() - offset,
 ) -> Unit {
-  let UDP(sock) = self
+  let UdpClient(sock) = self
   @event_loop.perform_job(
     Write(fd=sock, buf~, offset~, len~, can_poll=true),
-    context="@socket.UDP::send",
+    context="@socket.UdpClient::send",
   )
   |> ignore
 }
 
 ///|
-/// Same as `send`, but the address to send is explicitly passed as argument.
-/// Send data through a UDP socket using `sendto(2)` system call.
-/// The address of the remote peer is determined by `bind` or `connect`.
+/// Send a packet to `addr` through a UDP server.
 ///
 /// UDP is a datagram based protocol, every call of `send` will send exactly one packet.
 ///
-/// At most one task can write to a UDP socket at any time.
+/// At most one task can write to a UDP server at any time.
 /// To allow multiple writers,
 /// use a worker task for reading and use `@async.Queue` to gather the data.
-pub async fn UDP::sendto(
-  self : UDP,
+pub async fn UdpServer::sendto(
+  self : UdpServer,
   buf : Bytes,
   addr : Addr,
   offset? : Int = 0,
   len? : Int = buf.length() - offset,
 ) -> Unit {
-  let UDP(sock) = self
+  let UdpServer(sock) = self
   @event_loop.perform_job(
     Sendto(sock~, buf~, offset~, len~, addr=addr.0),
-    context="@socket.UDP::sendto",
+    context="@socket.UdpServer::sendto",
   )
   |> ignore
 }


### PR DESCRIPTION
The UDP API is currently a bit messy, and lacks proper IPv6 support. This PR refactors UDP API, make it more high level, and add proper IPv6 support to it. Specifically, the `UDP` type is split into two types, `UdpClient` and `UdpServer`:

- `UdpClient` is created via `UdpClient::new(server_addr)`, it receives a random port from the OS, send packet to and receive packet from server at `server_addr`. `UdpClient` provides `send` and `recv`
- `UdpServer` is created via `UdpServer::new(listen_addr)` (for IPv4 only or IPv6 only server) or `UdpServer::new_dual_stack(port)` (for dual stack server). The server is bound to the specified address, and provides `sendto` and `recvfrom` methods
    
Note that UDP is a connection-less protocol. So the client and server concept here merely means different address setting under the hood (`UdpClient` itself uses a random local address, and has a fixed target address when sending packets. `UdpServer` is bound to a specified address, and may send to/receive from any remote peer)

