### PR TITLE
tweak dual stack socket API

### DIFF
--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -43,6 +43,17 @@ pub extern "C" fn Addr::is_ipv6(addr : Addr) -> Bool = "moonbitlang_async_addr_i
 extern "C" fn Addr::get_ipv6_byte(addr : Addr, index : Int) -> Int = "moonbitlang_async_addr_get_ipv6_byte"
 
 ///|
+fn Addr::is_ipv6_wildcard(addr : Addr) -> Bool {
+  for i in 0..<16 {
+    if addr.get_ipv6_byte(i) != 0 {
+      break false
+    }
+  } else {
+    true
+  }
+}
+
+///|
 pub impl Show for Addr with output(self, logger) {
   if self.is_ipv6() {
     // IPv6 address format

--- a/src/socket/dual_stack_test.mbt
+++ b/src/socket/dual_stack_test.mbt
@@ -75,7 +75,10 @@ async test "Only_V6 server" {
   let port = 4210
   @async.with_task_group(fn(root) {
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.TcpServer::new(@socket.Addr::parse("[::]:\{port}"))
+      let server = @socket.TcpServer::new(
+        @socket.Addr::parse("[::]:\{port}"),
+        dual_stack=false,
+      )
       for {
         let (conn, addr) = server.accept()
         defer conn.close()
@@ -121,7 +124,7 @@ async test "dual stack server" {
   let port = 4211
   @async.with_task_group(fn(root) {
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.TcpServer::new_dual_stack(port)
+      let server = @socket.TcpServer::new(@socket.Addr::parse("[::]:\{port}"))
       for {
         let (conn, addr) = server.accept()
         defer conn.close()
@@ -217,7 +220,10 @@ async test "Only_V6 UDP server" {
   let port = 4210
   @async.with_task_group(fn(root) {
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.UdpServer::new(@socket.Addr::parse("[::]:\{port}"))
+      let server = @socket.UdpServer::new(
+        @socket.Addr::parse("[::]:\{port}"),
+        dual_stack=false,
+      )
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for {
@@ -264,7 +270,7 @@ async test "dual stack UDP server" {
   let port = 4211
   @async.with_task_group(fn(root) {
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.UdpServer::new_dual_stack(port)
+      let server = @socket.UdpServer::new(@socket.Addr::parse("[::]:\{port}"))
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for {

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -77,7 +77,7 @@ extern "C" fn bind_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_bind
 extern "C" fn bind_ipv6_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_bind_ipv6"
 
 ///|
-extern "C" fn bind_dual_stack(sock : Int, port : Int) -> Int = "moonbitlang_async_bind_dual_stack"
+extern "C" fn set_ipv6_only(sock : Int, dual_stack : Bool) -> Int = "moonbitlang_async_set_ipv6_only"
 
 ///|
 #borrow(addr)

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -69,8 +69,7 @@ impl @io.Writer for Tcp
 type TcpServer
 async fn TcpServer::accept(Self) -> (Tcp, Addr)
 fn TcpServer::close(Self) -> Unit
-fn TcpServer::new(Addr) -> Self raise
-fn TcpServer::new_dual_stack(Int) -> Self raise
+fn TcpServer::new(Addr, dual_stack? : Bool) -> Self raise
 
 type UdpClient
 fn UdpClient::close(Self) -> Unit
@@ -80,8 +79,7 @@ async fn UdpClient::send(Self, Bytes, offset? : Int, len? : Int) -> Unit
 
 type UdpServer
 fn UdpServer::close(Self) -> Unit
-fn UdpServer::new(Addr) -> Self raise
-fn UdpServer::new_dual_stack(Int) -> Self raise
+fn UdpServer::new(Addr, dual_stack? : Bool) -> Self raise
 async fn UdpServer::recvfrom(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> (Int, Addr)
 async fn UdpServer::sendto(Self, Bytes, Addr, offset? : Int, len? : Int) -> Unit
 

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -51,24 +51,11 @@ int moonbitlang_async_bind(int sockfd, struct sockaddr_in *addr) {
 }
 
 int moonbitlang_async_bind_ipv6(int sockfd, struct sockaddr_in6 *addr) {
-  int ipv6_only = 1;
-  int ret = setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_only, sizeof(int));
-  if (ret < 0) return ret;
-
   return bind(sockfd, (struct sockaddr*)addr, sizeof(struct sockaddr_in6));
 }
 
-int moonbitlang_async_bind_dual_stack(int sockfd, int port) {
-  int ipv6_only = 0;
-  int ret = setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_only, sizeof(int));
-  if (ret < 0) return ret;
-
-  struct sockaddr_in6 addr;
-  addr.sin6_family = AF_INET6;
-  addr.sin6_port = htons(port);
-  memset(&(addr.sin6_addr), 0, sizeof(struct in6_addr));
-  return bind(sockfd, (struct sockaddr*)&addr, sizeof(struct sockaddr_in6));
-
+int moonbitlang_async_set_ipv6_only(int sockfd, int ipv6_only) {
+  return setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_only, sizeof(int));
 }
 
 int moonbitlang_async_connect_ipv6(int sockfd, struct sockaddr_in6 *addr) {

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -37,15 +37,28 @@ pub typealias TcpServer as TCPServer
 /// Create a TCP server that is bound to `addr`,
 /// listening for incoming connections.
 ///
-/// If `addr` is an IPv6 (including the wildcard address `[::]`),
-/// the server will be IPv6 only.
-/// For dual stack server, see `@socket.TcpServer::new_dual_stack`.
-pub fn TcpServer::new(addr : Addr) -> TcpServer raise {
+/// If `addr` is the IPv6 wildcard address `[::]`
+/// and `dual_stack` is `true` (`true` by default),
+/// the server will work in dual stack mode,
+/// accepting connections from both IPv4 clients and IPv6 clients.
+/// The address of IPv4 clients are represented via IPv4-mapped IPv6 address.
+///
+/// If `addr` is not `[::]`, `dual_stack` is ignored.
+pub fn TcpServer::new(
+  addr : Addr,
+  dual_stack? : Bool = true,
+) -> TcpServer raise {
   let context = "@socket.TcpServer::new()"
   let sock = if addr.is_ipv6() {
     make_tcp_socket_ipv6(context)
   } else {
     make_tcp_socket(context)
+  }
+  if addr.is_ipv6() && addr.is_ipv6_wildcard() {
+    if 0 != set_ipv6_only(sock, !dual_stack) {
+      @fd_util.close(sock, context~)
+      @os_error.check_errno(context)
+    }
   }
   let bind_result = if addr.is_ipv6() {
     bind_ipv6_ffi(sock, addr)
@@ -53,24 +66,6 @@ pub fn TcpServer::new(addr : Addr) -> TcpServer raise {
     bind_ffi(sock, addr)
   }
   if bind_result != 0 {
-    @fd_util.close(sock, context~)
-    @os_error.check_errno(context)
-  }
-  if 0 != listen_ffi(sock) {
-    @fd_util.close(sock, context~)
-    @os_error.check_errno(context)
-  }
-  TcpServer(sock)
-}
-
-///|
-/// Create a dual stack TCP server that listen for connections
-/// from all IPv4 and IPv6 clients at `port`.
-/// The address of IPv4 clients are represented via IPv4-mapped IPv6 address.
-pub fn TcpServer::new_dual_stack(port : Int) -> TcpServer raise {
-  let context = "@socket.TcpServer::new_dual_stack()"
-  let sock = make_tcp_socket_ipv6(context)
-  if bind_dual_stack(sock, port) != 0 {
     @fd_util.close(sock, context~)
     @os_error.check_errno(context)
   }

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -62,15 +62,28 @@ pub fn UdpServer::close(self : UdpServer) -> Unit {
 ///|
 /// Create a UDP server listening at `addr`.
 ///
-/// If `addr` is an IPv6 (including the wildcard address `[::]`),
-/// the server will be IPv6 only.
-/// For dual stack server, see `@socket.UdpServer::new_dual_stack`.
-pub fn UdpServer::new(addr : Addr) -> UdpServer raise {
+/// If `addr` is the IPv6 wildcard address `[::]`
+/// and `dual_stack` is `true` (`true` by default),
+/// the server will work in dual stack mode,
+/// receiving packets from both IPv4 peers and IPv6 peers.
+/// The address of IPv4 peers are represented via IPv4-mapped IPv6 address.
+///
+/// If `addr` is not `[::]`, `dual_stack` is ignored.
+pub fn UdpServer::new(
+  addr : Addr,
+  dual_stack? : Bool = true,
+) -> UdpServer raise {
   let context = "@socket.UdpServer::new()"
   let sock = if addr.is_ipv6() {
     make_udp_socket_ipv6(context)
   } else {
     make_udp_socket(context)
+  }
+  if addr.is_ipv6() && addr.is_ipv6_wildcard() {
+    if 0 != set_ipv6_only(sock, !dual_stack) {
+      @fd_util.close(sock, context~)
+      @os_error.check_errno(context)
+    }
   }
   let bind_result = if addr.is_ipv6() {
     bind_ipv6_ffi(sock, addr)
@@ -78,20 +91,6 @@ pub fn UdpServer::new(addr : Addr) -> UdpServer raise {
     bind_ffi(sock, addr)
   }
   if bind_result != 0 {
-    @fd_util.close(sock, context~)
-    @os_error.check_errno(context)
-  }
-  UdpServer(sock)
-}
-
-///|
-/// Create a new dual stack UDP server listening at `port`.
-/// The server will receive packets from both IPv4 peers and IPv6 peers.
-/// The address of IPv4 peers are represented via IPv4-mapped IPv6 address.
-pub fn UdpServer::new_dual_stack(port : Int) -> UdpServer raise {
-  let context = "@socket.UdpServer::new_dual_stack()"
-  let sock = make_udp_socket_ipv6(context)
-  if bind_dual_stack(sock, port) != 0 {
     @fd_util.close(sock, context~)
     @os_error.check_errno(context)
   }


### PR DESCRIPTION
Remove `new_dual_stack` method from `@socket.TcpServer` and `@socket.UdpServer`, make `dual_stack` an optional parameter of `@socket.TcpServer::new` and `@socket.UdpServer::new`. The new `dual_stack` parameter is `true` by default, but only take effect when the specified server address is `[::]`.

Since the two `new_dual_stack` methods are not yet released, this is not a breaking changed.