### PR TITLE
add helper for creating TCP/HTTP server

### DIFF
--- a/examples/http_file_server/main.mbt
+++ b/examples/http_file_server/main.mbt
@@ -104,48 +104,36 @@ pub async fn server(
   log? : (String) -> Unit = println,
 ) -> Unit {
   let base_path = path
-  let server = @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:\{port}"))
-  defer server.close()
-  @async.with_task_group(fn(ctx) {
+  @http.run_server(@socket.Addr::parse("0.0.0.0:\{port}"), fn(conn, addr) {
+    log("received new connection from \{addr}")
+    defer {
+      log("closing connection from \{addr}")
+      conn.close()
+    }
     for {
-      let (conn, addr) = server.accept()
-      let conn = @http.ServerConnection::new(conn)
-      log("received new connection from \{addr}")
-      ctx.spawn_bg(allow_failure=true, fn() {
-        defer {
-          log("closing connection from \{addr}")
-          conn.close()
+      let request = conn.read_request()
+      let (path, download_zip) = match request.path {
+        [.. path, .. "?download_zip"] => (path.to_string(), true)
+        path => (path, false)
+      }
+      log("serving \{path}")
+      guard request.meth is Get else { return }
+      let file = @fs.open(base_path + path, mode=ReadOnly) catch {
+        _ => {
+          serve_404(conn)
+          continue
         }
-        for {
-          let request = conn.read_request()
-          let (path, download_zip) = match request.path {
-            [.. path, .. "?download_zip"] => (path.to_string(), true)
-            path => (path, false)
-          }
-          log("serving \{path}")
-          match request.meth {
-            Get => {
-              let file = @fs.open(base_path + path, mode=ReadOnly) catch {
-                _ => {
-                  serve_404(conn)
-                  continue
-                }
-              }
-              defer file.close()
-              if file.kind() is Directory {
-                if download_zip {
-                  serve_zip(conn, base_path + path)
-                } else {
-                  serve_directory(conn, file.as_dir(), path~)
-                }
-              } else {
-                serve_file(conn, file, path~)
-              }
-            }
-            _ => ()
-          }
+      }
+      defer file.close()
+      if file.kind() is Directory {
+        if download_zip {
+          serve_zip(conn, base_path + path)
+        } else {
+          serve_directory(conn, file.as_dir(), path~)
         }
-      })
+      } else {
+        serve_file(conn, file, path~)
+      }
     }
   })
 }

--- a/examples/http_server_benchmark/http_server_benchmark.mbt
+++ b/examples/http_server_benchmark/http_server_benchmark.mbt
@@ -17,23 +17,11 @@ let port : Int = 3001
 
 ///|
 async fn main {
-  @async.with_task_group(fn(root) {
-    let server = @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:\{port}"))
-    let headers = { "Connection": "Keep-Alive", "Keep-Alive": "timeout=5" }
-    defer server.close()
-    for {
-      let (conn, _) = server.accept()
-      let conn = @http.ServerConnection::new(conn, headers~)
-      root.spawn_bg(allow_failure=true, fn() {
-        defer conn.close()
-        for {
-          let request = conn.read_request()
-          match (request.meth, request.path) {
-            (Get, "/") => conn..send_response(200, "OK")..end_response()
-            _ => conn..send_response(404, "NotFound")..end_response()
-          }
-        }
-      })
+  @http.run_server(@socket.Addr::parse("0.0.0.0:\{port}"), fn(conn, _) {
+    let request = conn.read_request()
+    match (request.meth, request.path) {
+      (Get, "/") => conn..send_response(200, "OK")..end_response()
+      _ => conn..send_response(404, "NotFound")..end_response()
     }
   })
 }

--- a/examples/tcp_echo_server/main.mbt
+++ b/examples/tcp_echo_server/main.mbt
@@ -14,15 +14,10 @@
 
 ///|
 async fn main {
-  @async.with_task_group(fn(root) {
-    let server = @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:4200"))
-    defer server.close()
-    for {
-      let (conn, _) = server.accept()
-      root.spawn_bg(allow_failure=true, fn() {
-        defer conn.close()
-        conn.write_reader(conn)
-      })
-    }
+  @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:4200")).run_forever(fn(
+    conn,
+    _,
+  ) {
+    conn.write_reader(conn)
   })
 }

--- a/examples/tcp_ping_pong/main.mbt
+++ b/examples/tcp_ping_pong/main.mbt
@@ -23,40 +23,33 @@ pub(all) struct Printer((String) -> Unit)
 
 ///|
 async fn server(println : Printer) -> Unit {
-  @async.with_task_group(fn(group) {
-    let server = @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:\{port}"))
-    defer server.close()
-    try {
-      for {
-        let (conn, _) = server.accept()
-        println("received new connection")
-        group.spawn_bg(fn() {
-          defer conn.close()
-          let buf = FixedArray::make(1024, b'0')
-          while conn.read(buf) is n && n > 0 {
-            @async.sleep(10)
-            let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
-            println("server received: \{@encoding/utf8.decode(msg)}")
-            let reply = "pong"
-            conn.write(reply)
-            println("server sent: \{reply}")
-            if msg == b"exit" {
-              println("server initiate terminate")
-              @async.sleep(20)
-              raise ServerTerminate
-            }
-          } else {
-            println("server: connection closed by peer")
-          }
-        })
+  @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:\{port}")).run_forever(
+    allow_failure=false,
+    fn(conn, _) {
+      println("received new connection")
+      let buf = FixedArray::make(1024, b'0')
+      while conn.read(buf) is n && n > 0 {
+        @async.sleep(10)
+        let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
+        println("server received: \{@encoding/utf8.decode(msg)}")
+        let reply = "pong"
+        conn.write(reply)
+        println("server sent: \{reply}")
+        if msg == b"exit" {
+          println("server initiate terminate")
+          @async.sleep(20)
+          raise ServerTerminate
+        }
+      } else {
+        println("server: connection closed by peer")
       }
-    } catch {
-      err => {
-        println("server terminate: \{err}")
-        raise err
-      }
+    },
+  ) catch {
+    err => {
+      println("server terminate: \{err}")
+      raise err
     }
-  })
+  }
 }
 
 ///|

--- a/examples/tcp_ping_pong/main_test.mbt
+++ b/examples/tcp_ping_pong/main_test.mbt
@@ -73,7 +73,7 @@ async test "main" {
       #|server sent: pong
       #|server initiate terminate
       #|client 6 received: pong
-      #|server terminate: Cancelled
+      #|server terminate: ServerTerminate
       #|Ok(())
     ),
   )

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -13,6 +13,8 @@ async fn post(String, &@io.Data, headers? : Map[String, String], port? : Int) ->
 
 async fn put(String, &@io.Data, headers? : Map[String, String], port? : Int) -> (Response, &@io.Data)
 
+async fn run_server(@socket.Addr, async (ServerConnection, @socket.Addr) -> Unit, headers? : Map[String, String], dual_stack? : Bool, allow_failure? : Bool, max_connections? : Int) -> Unit
+
 // Errors
 pub suberror HttpProtocolError {
   BadRequest

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -122,3 +122,41 @@ pub async fn ServerConnection::send_response(
 ) -> Unit {
   self.sender.send_response(code, reason, extra_headers~)
 }
+
+///|
+/// Create a HTTP server listening on `addr` and run its main loop.
+/// New connections are handled by the callback `f`,
+/// `f` will receive the new HTTP connection and the address of the client.
+///
+/// The client connection is closed automatically,
+/// so `f` must not close the connection manually.
+///
+/// `headers` can be used to specify persistent headers for the server,
+/// i.e. all response sent by this server will share these headers.
+///
+/// If `allow_failure` is `true` (`true` by default),
+/// failure in `f` will be silently ignored.
+///
+/// If `max_connections` is present,
+/// at most `max_connections` clients are allowed in parallel.
+/// New clients will only get handled after a previous client terminates.
+///
+/// The meaning of `dual_stack` is the same as `@socket.TcpServer::new`,
+/// see its document for more details.
+pub async fn run_server(
+  addr : @socket.Addr,
+  f : async (ServerConnection, @socket.Addr) -> Unit,
+  headers? : Map[String, String],
+  dual_stack? : Bool,
+  allow_failure? : Bool,
+  max_connections? : Int,
+) -> Unit {
+  @socket.TcpServer::new(addr, dual_stack?).run_forever(
+    allow_failure?,
+    max_connections?,
+    fn(conn, addr) {
+      let conn = ServerConnection::new(conn, headers?)
+      f(conn, addr)
+    },
+  )
+}

--- a/src/socket/dual_stack_test.mbt
+++ b/src/socket/dual_stack_test.mbt
@@ -26,19 +26,17 @@ async test "Only_V4 server" {
   let port = 4209
   @async.with_task_group(fn(root) {
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.TcpServer::new(
-        @socket.Addr::parse("0.0.0.0:\{port}"),
+      @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:\{port}")).run_forever(fn(
+          conn,
+          addr,
+        ) {
+          let addr_str = addr.to_string()
+          guard addr_str.rev_find(":") is Some(ip_end)
+          let ip = addr_str[:ip_end]
+          let msg = conn.read_all().text()
+          log.write_string("server received \{repr(msg)} from \{ip}\n")
+        },
       )
-      defer server.close()
-      for {
-        let (conn, addr) = server.accept()
-        defer conn.close()
-        let addr_str = addr.to_string()
-        guard addr_str.rev_find(":") is Some(ip_end)
-        let ip = addr_str[:ip_end]
-        let msg = conn.read_all().text()
-        log.write_string("server received \{repr(msg)} from \{ip}\n")
-      }
     })
     async fn client(protocol) {
       let conn = @socket.Tcp::connect_to_host("localhost", port~, protocol~)
@@ -75,19 +73,16 @@ async test "Only_V6 server" {
   let port = 4210
   @async.with_task_group(fn(root) {
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.TcpServer::new(
+      @socket.TcpServer::new(
         @socket.Addr::parse("[::]:\{port}"),
         dual_stack=false,
-      )
-      for {
-        let (conn, addr) = server.accept()
-        defer conn.close()
+      ).run_forever(fn(conn, addr) {
         let addr_str = addr.to_string()
         guard addr_str.rev_find(":") is Some(ip_end)
         let ip = addr_str[:ip_end]
         let msg = conn.read_all().text()
         log.write_string("server received \{repr(msg)} from \{ip}\n")
-      }
+      })
     })
     async fn client(protocol) {
       let conn = @socket.Tcp::connect_to_host("localhost", port~, protocol~)
@@ -124,16 +119,16 @@ async test "dual stack server" {
   let port = 4211
   @async.with_task_group(fn(root) {
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.TcpServer::new(@socket.Addr::parse("[::]:\{port}"))
-      for {
-        let (conn, addr) = server.accept()
-        defer conn.close()
+      @socket.TcpServer::new(@socket.Addr::parse("[::]:\{port}")).run_forever(fn(
+        conn,
+        addr,
+      ) {
         let addr_str = addr.to_string()
         guard addr_str.rev_find(":") is Some(ip_end)
         let ip = addr_str[:ip_end]
         let msg = conn.read_all().text()
         log.write_string("server received \{repr(msg)} from \{ip}\n")
-      }
+      })
     })
     async fn client(protocol) {
       let conn = @socket.Tcp::connect_to_host("localhost", port~, protocol~)

--- a/src/socket/moon.pkg.json
+++ b/src/socket/moon.pkg.json
@@ -5,7 +5,8 @@
     "moonbitlang/async/internal/fd_util",
     "moonbitlang/async/internal/c_buffer",
     "moonbitlang/async/io",
-    "moonbitlang/async"
+    "moonbitlang/async",
+    "moonbitlang/async/semaphore"
   ],
   "test-import": [
     "moonbitlang/async/aqueue"

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -70,6 +70,7 @@ type TcpServer
 async fn TcpServer::accept(Self) -> (Tcp, Addr)
 fn TcpServer::close(Self) -> Unit
 fn TcpServer::new(Addr, dual_stack? : Bool) -> Self raise
+async fn TcpServer::run_forever(Self, async (Tcp, Addr) -> Unit, allow_failure? : Bool, max_connections? : Int) -> Unit
 
 type UdpClient
 fn UdpClient::close(Self) -> Unit

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -77,6 +77,52 @@ pub fn TcpServer::new(
 }
 
 ///|
+/// Start the main loop of a TCP server,
+/// keep listening for new connections
+/// and handle connections using the callback `f`.
+/// `f` will be supplied the new connection and the address of the client.
+///
+/// The client connection will be closed automatically after `f` exits,
+/// so `f` must not close the client connection.
+/// The server will be automatically closed if `run_forever` fails.
+///
+/// If `allow_failure` is `true` (`true` by default),
+/// failure in `f` will be silently ignored.
+///
+/// If `max_connections` is present,
+/// at most `max_connections` clients are allowed in parallel.
+/// New clients will only get handled after a previous client terminates.
+pub async fn TcpServer::run_forever(
+  self : TcpServer,
+  f : async (Tcp, Addr) -> Unit,
+  allow_failure? : Bool = true,
+  max_connections? : Int,
+) -> Unit {
+  defer self.close()
+  let conn_limit = match max_connections {
+    None => None
+    Some(n) => Some(@semaphore.Semaphore::new(n))
+  }
+  @async.with_task_group(fn(group) {
+    for {
+      let (conn, addr) = self.accept()
+      if conn_limit is Some(limit) {
+        limit.acquire()
+      }
+      group.spawn_bg(allow_failure~, fn() {
+        defer conn.close()
+        if conn_limit is Some(limit) {
+          defer limit.release()
+          f(conn, addr)
+        } else {
+          f(conn, addr)
+        }
+      })
+    }
+  })
+}
+
+///|
 pub fn TcpServer::close(self : TcpServer) -> Unit {
   let TcpServer(sock) = self
   @event_loop.close_fd(sock)


### PR DESCRIPTION
This PR adds two helpers for running HTTP/TCP server: `@http.run_server` and `@socket.TcpServer::run_forever`. These helpers automatically setup a task group, loop for new connections and handle connections via a callback. They also provide other convenient features, such as controlling the max number of parallel connections.