### PR TITLE
Improve buffered reader API

### DIFF
--- a/src/io/buffered_reader.mbt
+++ b/src/io/buffered_reader.mbt
@@ -167,6 +167,9 @@ pub async fn[R : Reader] BufferedReader::op_as_view(
   start? : Int = 0,
   end~ : Int,
 ) -> BytesView {
+  if start == end {
+    return ""
+  }
   guard start < end
   self.ensure(end)
   self.buf.unsafe_reinterpret_as_bytes()[self.start + start:self.start + end]
@@ -229,5 +232,24 @@ pub async fn[R : Reader] BufferedReader::find_opt(
       return None
     }
     continue self.start + len
+  }
+}
+
+///|
+/// Read content from a buffered reader until newline (`\n`).
+/// If the reader already reaches EOF, `None` is returned.
+/// Otherwise, the content of the line (without the trailing newline) is returned,
+/// and the content of the line and the newline character
+/// will be conusmed from the reader.
+/// The returned string is decoded with UTF8.
+pub async fn[R : Reader] BufferedReader::read_line(self : Self[R]) -> String? {
+  match self.find_opt("\n") {
+    None if self.len == 0 => None
+    None => Some(self.read_all().text())
+    Some(newline_index) => {
+      let line = @encoding/utf8.decode(self[:newline_index])
+      self.drop(newline_index + 1)
+      Some(line)
+    }
   }
 }

--- a/src/io/buffered_reader_test.mbt
+++ b/src/io/buffered_reader_test.mbt
@@ -312,3 +312,16 @@ async test "lazy drop" {
   })
   inspect(log.to_string(), content="cdgh")
 }
+
+///|
+async test "BufferedReader::read_line" {
+  let file = @fs.open("LICENSE", mode=ReadOnly)
+  defer file.close()
+  let reader = @io.BufferedReader::new(file)
+  let lines = []
+  while reader.read_line() is Some(line) {
+    lines.push(line)
+  }
+  inspect(lines.length(), content="202")
+  assert_eq(lines.join("\n") + "\n", @fs.read_file("LICENSE").text())
+}

--- a/src/io/moon.pkg.json
+++ b/src/io/moon.pkg.json
@@ -3,6 +3,7 @@
   "test-import": [
     "moonbitlang/async",
     "moonbitlang/async/pipe",
+    "moonbitlang/async/fs",
     "moonbitlang/async/internal/bytes_util"
   ]
 }

--- a/src/io/pkg.generated.mbti
+++ b/src/io/pkg.generated.mbti
@@ -20,6 +20,7 @@ async fn[R : Reader] BufferedReader::op_get(Self[R], Int) -> Byte
 async fn[R : Reader] BufferedReader::read(Self[R], FixedArray[Byte], offset? : Int, max_len? : Int) -> Int // from trait `Reader`
 async fn[R : Reader] BufferedReader::read_all(Self[R]) -> &Data // from trait `Reader`
 async fn[R : Reader] BufferedReader::read_exactly(Self[R], Int) -> Bytes // from trait `Reader`
+async fn[R : Reader] BufferedReader::read_line(Self[R]) -> String?
 impl[R : Reader] Reader for BufferedReader[R]
 
 type BufferedWriter[W]


### PR DESCRIPTION
- add `@io.BufferedReader::find_opt`, which returns `None` on EOF, so that EOF can be handled more robustly
- add `@io.BufferedReader::read_line`