### PR TITLE
use `String` for paths in `@event_loop`

### DIFF
--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -16,7 +16,6 @@
 /// Create a directory at `path`.
 /// The permission of the created directory must be set in `permission`.
 pub async fn mkdir(path : String, permission~ : Int) -> Unit {
-  let path = @encoding/utf8.encode(path)
   @event_loop.mkdir(path, mode=permission, context="@fs.mkdir()")
 }
 
@@ -35,12 +34,10 @@ pub async fn rmdir(path : String, recursive? : Bool = false) -> Unit {
       if stat.kind() is Directory {
         rmdir(path, recursive=true)
       } else {
-        let path = @encoding/utf8.encode(path)
         @event_loop.remove(path, context~)
       }
     }
   }
-  let path = @encoding/utf8.encode(path)
   @event_loop.rmdir(path, context~)
 }
 

--- a/src/fs/fs.mbt
+++ b/src/fs/fs.mbt
@@ -104,7 +104,6 @@ pub async fn open(
   create? : Int,
   truncate? : Bool = false,
 ) -> File {
-  let filename = @encoding/utf8.encode(filename)
   let (create, user_mode) = match create {
     None => (false, 0)
     Some(mode) => (true, mode)
@@ -217,7 +216,6 @@ pub async fn File::sync(self : File, only_data? : Bool = false) -> Unit {
 ///|
 /// Remove the file located at `path`. `path` is encoded using UTF8.
 pub async fn remove(path : String) -> Unit {
-  let path = @encoding/utf8.encode(path)
   @event_loop.remove(path, context="@fs.remove()")
 }
 

--- a/src/fs/stat.mbt
+++ b/src/fs/stat.mbt
@@ -34,7 +34,6 @@ async fn Stat::from_path(
   follow_symlink~ : Bool,
   context~ : String,
 ) -> Stat {
-  let path = @encoding/utf8.encode(path)
   @event_loop.stat(path, follow_symlink~, context~)
 }
 

--- a/src/fs/utils.mbt
+++ b/src/fs/utils.mbt
@@ -88,7 +88,6 @@ let _EACCES : Int = get_EACCES()
 
 ///|
 pub async fn exists(path : String) -> Bool {
-  let path = @encoding/utf8.encode(path)
   try @event_loop.access(path, amode=f_ok(), context="@fs.exists()") catch {
     @os_error.OSError(code, ..) if code == _ENOENT => false
     err => raise err
@@ -99,7 +98,6 @@ pub async fn exists(path : String) -> Bool {
 
 ///|
 pub async fn can_read(path : String) -> Bool {
-  let path = @encoding/utf8.encode(path)
   try @event_loop.access(path, amode=r_ok(), context="@fs.can_read()") catch {
     @os_error.OSError(code, ..) if code == _ENOENT => false
     @os_error.OSError(code, ..) if code == _EACCES => false
@@ -111,7 +109,6 @@ pub async fn can_read(path : String) -> Bool {
 
 ///|
 pub async fn can_write(path : String) -> Bool {
-  let path = @encoding/utf8.encode(path)
   try @event_loop.access(path, amode=w_ok(), context="@fs.can_write()") catch {
     @os_error.OSError(code, ..) if code == _ENOENT => false
     @os_error.OSError(code, ..) if code == _EACCES => false
@@ -123,7 +120,6 @@ pub async fn can_write(path : String) -> Bool {
 
 ///|
 pub async fn can_execute(path : String) -> Bool {
-  let path = @encoding/utf8.encode(path)
   try @event_loop.access(path, amode=x_ok(), context="@fs.can_execute") catch {
     @os_error.OSError(code, ..) if code == _ENOENT => false
     @os_error.OSError(code, ..) if code == _EACCES => false
@@ -141,7 +137,6 @@ pub async fn can_execute(path : String) -> Bool {
 /// If the path contains cyclic symbolic link,
 /// an error will be raised.
 pub async fn realpath(path : String) -> String {
-  let path = @encoding/utf8.encode(path)
   let result = @event_loop.realpath(path, context="@fs.realpath()")
   @encoding/utf8.decode(result)
 }

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -22,11 +22,12 @@ pub type DirectoryEntry
 
 ///|
 pub async fn open(
-  path : Bytes,
+  path : String,
   flags~ : Int,
   mode~ : Int,
   context~ : String,
 ) -> Int {
+  let path = @encoding/utf8.encode(path)
   perform_job_in_worker(JobForWorker::open(path, flags, mode), context~)
 }
 
@@ -43,10 +44,11 @@ pub fn Stat::new() -> Stat {
 
 ///|
 pub async fn stat(
-  path : Bytes,
+  path : String,
   follow_symlink~ : Bool,
   context~ : String,
 ) -> Stat {
+  let path = @encoding/utf8.encode(path)
   let stat = Stat::new()
   let _ = perform_job_in_worker(
     JobForWorker::stat(path, stat, follow_symlink~),
@@ -56,7 +58,8 @@ pub async fn stat(
 }
 
 ///|
-pub async fn access(path : Bytes, amode~ : Int, context~ : String) -> Int {
+pub async fn access(path : String, amode~ : Int, context~ : String) -> Int {
+  let path = @encoding/utf8.encode(path)
   perform_job_in_worker(JobForWorker::access(path, amode), context~)
 }
 
@@ -66,17 +69,20 @@ pub async fn fsync(fd : Int, only_data~ : Bool, context~ : String) -> Unit {
 }
 
 ///|
-pub async fn remove(path : Bytes, context~ : String) -> Unit {
+pub async fn remove(path : String, context~ : String) -> Unit {
+  let path = @encoding/utf8.encode(path)
   perform_job_in_worker(JobForWorker::remove(path), context~) |> ignore
 }
 
 ///|
-pub async fn mkdir(path : Bytes, mode~ : Int, context~ : String) -> Unit {
+pub async fn mkdir(path : String, mode~ : Int, context~ : String) -> Unit {
+  let path = @encoding/utf8.encode(path)
   perform_job_in_worker(JobForWorker::mkdir(path, mode), context~) |> ignore
 }
 
 ///|
-pub async fn rmdir(path : Bytes, context~ : String) -> Unit {
+pub async fn rmdir(path : String, context~ : String) -> Unit {
+  let path = @encoding/utf8.encode(path)
   perform_job_in_worker(JobForWorker::rmdir(path), context~) |> ignore
 }
 
@@ -91,7 +97,8 @@ pub async fn readdir(dir : Directory, context~ : String) -> DirectoryEntry {
 }
 
 ///|
-pub async fn realpath(path : Bytes, context~ : String) -> Bytes {
+pub async fn realpath(path : String, context~ : String) -> Bytes {
+  let path = @encoding/utf8.encode(path)
   let out = @ref.new(@c_buffer.null)
   let _ = perform_job_in_worker(JobForWorker::realpath(path, out), context~)
   let c_path = out.val

--- a/src/internal/event_loop/network.mbt
+++ b/src/internal/event_loop/network.mbt
@@ -145,9 +145,10 @@ extern "C" fn gai_strerror(code : Int) -> @c_buffer.Buffer = "gai_strerror"
 
 ///|
 pub async fn getaddrinfo(
-  host : Bytes,
+  host : String,
   context~ : String,
 ) -> Result[AddrInfo, String] {
+  let host = @encoding/utf8.encode(host)
   let out = AddrInfoRef::new()
   let ret = perform_job_in_worker(
     JobForWorker::getaddrinfo(host, out),

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "moonbitlang/async/internal/event_loop"
 // Values
 async fn accept(Int, Bytes, context~ : String) -> Int
 
-async fn access(Bytes, amode~ : Int, context~ : String) -> Int
+async fn access(String, amode~ : Int, context~ : String) -> Int
 
 fn close_fd(Int) -> Unit
 
@@ -12,25 +12,25 @@ async fn connect(Int, Bytes, context~ : String) -> Int
 
 async fn fsync(Int, only_data~ : Bool, context~ : String) -> Unit
 
-async fn getaddrinfo(Bytes, context~ : String) -> Result[AddrInfo, String]
+async fn getaddrinfo(String, context~ : String) -> Result[AddrInfo, String]
 
-async fn mkdir(Bytes, mode~ : Int, context~ : String) -> Unit
+async fn mkdir(String, mode~ : Int, context~ : String) -> Unit
 
-async fn open(Bytes, flags~ : Int, mode~ : Int, context~ : String) -> Int
+async fn open(String, flags~ : Int, mode~ : Int, context~ : String) -> Int
 
 async fn read(Int, FixedArray[Byte], offset~ : Int, len~ : Int, can_poll~ : Bool, context~ : String) -> Int
 
 async fn readdir(Directory, context~ : String) -> DirectoryEntry
 
-async fn realpath(Bytes, context~ : String) -> Bytes
+async fn realpath(String, context~ : String) -> Bytes
 
 async fn recvfrom(Int, FixedArray[Byte], offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 
 fn register_hook(init? : () -> Unit, exit? : () -> Unit) -> Unit
 
-async fn remove(Bytes, context~ : String) -> Unit
+async fn remove(String, context~ : String) -> Unit
 
-async fn rmdir(Bytes, context~ : String) -> Unit
+async fn rmdir(String, context~ : String) -> Unit
 
 async fn sendto(Int, Bytes, offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 
@@ -38,7 +38,7 @@ async fn sleep(Int) -> Unit
 
 async fn spawn(Bytes, FixedArray[Bytes?], env~ : FixedArray[Bytes?], stdin~ : Int, stdout~ : Int, stderr~ : Int, cwd~ : Bytes?, context~ : String) -> Int
 
-async fn stat(Bytes, follow_symlink~ : Bool, context~ : String) -> Stat
+async fn stat(String, follow_symlink~ : Bool, context~ : String) -> Stat
 
 async fn wait_pid(Int) -> Unit
 

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -139,7 +139,6 @@ pub async fn Addr::resolve(
   protocol? : IpProtocolPreference = NoPreference,
 ) -> Addr {
   // TODO: Add option to prefer ipv6 or ipv4
-  let host = @encoding/utf8.encode(host)
   let context = "@socket.Addr::resolve()"
   let ai_root = match @event_loop.getaddrinfo(host, context~) {
     Ok(ai_root) => ai_root

--- a/src/socket/happy_eyeball.mbt
+++ b/src/socket/happy_eyeball.mbt
@@ -31,7 +31,6 @@ pub async fn Tcp::connect_to_host(
   port~ : Int,
   protocol? : IpProtocolPreference = NoPreference,
 ) -> Tcp {
-  let host = @encoding/utf8.encode(host)
   let context = "@socket.Tcp::connect_to_host()"
   let ai = match @event_loop.getaddrinfo(host, context~) {
     Ok(ai) => ai


### PR DESCRIPTION
Other backends, such as js and Windows, may not use C string for paths etc. This PR moves path encoding logic to `@event_loop`, and let runtime API accept `String` directly, so that different runtime implementation can decide their own encoding methods.