### PR TITLE
fix MacOS version detection

### DIFF
--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -38,8 +38,8 @@
 #define WAKEUP_METHOD_COND_VAR
 
 #include <Availability.h>
-#ifdef __MAC_OS_X_VERSION_MAX_ALLOWED
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 260000
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
 #define posix_spawn_file_actions_addchdir_np posix_spawn_file_actions_addchdir
 #endif
 #endif


### PR DESCRIPTION
When the library is compiled with MacOS SDK version `>= 26.0`, but the executable is run on a system with MacOS version `< 26.0`, the program will call the non-existent `posix_spawn_file_actions_addchdir`. This PR fixes the problem.