### PR TITLE
docs(time): Add comprehensive documentation for internal/time package

### DIFF
--- a/src/internal/time/README.mbt.md
+++ b/src/internal/time/README.mbt.md
@@ -1,0 +1,43 @@
+# Time Utilities
+
+This package provides internal time utilities for the MoonBit async library.
+
+## Overview
+
+The `time` package contains low-level time functions used internally by the async runtime. It provides access to high-precision system time for timestamping, performance measurement, and time-based operations.
+
+## Functions
+
+### `ms_since_epoch`
+
+Returns the current time as milliseconds elapsed since the Unix epoch (January 1, 1970 UTC).
+
+```moonbit
+test "ms_since_epoch returns positive timestamp" {
+  let timestamp = @time.ms_since_epoch()
+  assert_true(timestamp > 0L)
+}
+
+test "ms_since_epoch is monotonic" {
+  let start = @time.ms_since_epoch()
+  let end = @time.ms_since_epoch()
+  assert_true(end >= start)
+}
+```
+
+**Use Cases:**
+- Timestamping events in async operations
+- Performance measurement and profiling
+- Time-based calculations in schedulers
+- Timeout implementations
+- Rate limiting and throttling
+
+**Note:** This is an internal utility function. External users should use the higher-level time APIs provided by the main async library.
+
+## Implementation Details
+
+The function is implemented as a C foreign function interface (FFI) that calls the system's `gettimeofday()` function on Unix-like systems. This provides microsecond precision, which is then converted to milliseconds for the return value.
+
+## Thread Safety
+
+The `ms_since_epoch` function is thread-safe and can be called from multiple concurrent contexts without synchronization.

--- a/src/internal/time/time.mbt
+++ b/src/internal/time/time.mbt
@@ -12,5 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-///|
+/// Get the number of milliseconds elapsed since the Unix epoch (January 1, 1970 UTC).
+///
+/// This function provides high-precision timing information by returning the current time
+/// as milliseconds since the Unix epoch. It's commonly used for timestamping, performance
+/// measurement, and time-based calculations in async operations.
+///
+/// @return The current time in milliseconds since Unix epoch as an Int64
 pub extern "C" fn ms_since_epoch() -> Int64 = "moonbitlang_async_get_ms_since_epoch"


### PR DESCRIPTION
## Summary

Added complete documentation for the `src/internal/time` package as part of the documentation effort for the MoonBit async library.

### Changes Made

- **Enhanced `time.mbt`**: Added comprehensive documentation comments to the `ms_since_epoch` function with detailed description, usage context, and return value information
- **Created `README.mbt.md`**: Added package overview, function documentation, implementation details, thread safety notes, and executable test examples
- **Added tests**: Included doctests that validate the function behavior and ensure timestamp accuracy

### Documentation Coverage

✅ All public functions documented (`ms_since_epoch`)  
✅ README.mbt.md created with comprehensive package documentation  
✅ Implementation details and thread safety documented  
✅ Executable code examples with test validation  
✅ All tests pass (`moon check` and `moon test` successful)

### Key Features Documented

- **Function**: `ms_since_epoch()` - Returns milliseconds since Unix epoch
- **Implementation**: C FFI using `gettimeofday()` for high precision
- **Thread Safety**: Confirmed safe for concurrent access
- **Use Cases**: Timestamping, performance measurement, timeout implementations

The documentation follows MoonBit conventions and includes working test examples that validate the functionality.