### PR TITLE
fix bug where async queue/semaphore accidentally swallow value/resource

### DIFF
--- a/src/aqueue/aqueue.mbt
+++ b/src/aqueue/aqueue.mbt
@@ -75,6 +75,20 @@ pub async fn[X] Queue::get(self : Queue[X]) -> X {
   let reader = { value: None, coro: Some(@coroutine.current_coroutine()) }
   self.readers.push_back(reader)
   @coroutine.suspend() catch {
+    _ if reader.value is Some(value) =>
+      // This may happen if:
+      //
+      // - `put` is called, the value is removed from the queue
+      //   and assigned to `reader.value`
+      // - the task is called after `put`, before `get` is actually woken
+      //
+      // In this case, if we cancel `get`,
+      // the value would be swollen, which is incorrect.
+      // It is also difficult to put the value back to the queue
+      // while maintaining correct order.
+      // So we choose to swallow the cancellation signal here,
+      // which is fine because cancellation is level-triggered.
+      return value
     err => {
       reader.coro = None
       raise err

--- a/src/aqueue/aqueue_test.mbt
+++ b/src/aqueue/aqueue_test.mbt
@@ -135,7 +135,13 @@ async test "aqueue cancellation no_swallow" {
     @async.sleep(100)
     inspect(q.try_get(), content="None")
   })
-  inspect(log.to_string(), content="")
+  inspect(
+    log.to_string(),
+    content=(
+      #|get() => 42
+      #|
+    ),
+  )
 }
 
 ///|

--- a/src/semaphore/semaphore.mbt
+++ b/src/semaphore/semaphore.mbt
@@ -13,10 +13,27 @@
 // limitations under the License.
 
 ///|
+priv struct Waiter {
+  // In the rare case where:
+  //
+  // - `release` wake up a waiter, the piece of resource is assigned to that waiter
+  // - the waiter is immediately cancelled after woken up by `release`,
+  //   but before the waiter's coroutine actually resumes execution
+  //
+  // we must swallow the cancellation signal,
+  // as otherwise the piece of resource will be gone forever.
+  // So we set `acquired = true` after waking up a waiter,
+  // and use this flag to protect against dangerous cancellation.
+  mut acquired : Bool
+  // `None` indicates that the waiter is cancelled
+  mut coro : @coroutine.Coroutine?
+}
+
+///|
 struct Semaphore {
   mut value : Int
   size : Int
-  waiters : @deque.Deque[Ref[@coroutine.Coroutine?]]
+  waiters : @deque.Deque[Waiter]
 }
 
 ///|
@@ -43,8 +60,11 @@ pub fn Semaphore::release(self : Semaphore) -> Unit {
   }
   loop self.waiters.pop_front() {
     None => self.value += 1
-    Some({ val: None }) => continue self.waiters.pop_front()
-    Some({ val: Some(waiter) }) => waiter.wake()
+    Some({ coro: None, .. }) => continue self.waiters.pop_front()
+    Some({ coro: Some(coro), .. } as waiter) => {
+      waiter.acquired = true
+      coro.wake()
+    }
   }
 }
 
@@ -63,11 +83,12 @@ pub async fn Semaphore::acquire(self : Semaphore) -> Unit {
   if self.value > 0 {
     self.value -= 1
   } else {
-    let waiter = @ref.new(Some(@coroutine.current_coroutine()))
+    let waiter = { coro: Some(@coroutine.current_coroutine()), acquired: false }
     self.waiters.push_back(waiter)
     @coroutine.suspend() catch {
+      _ if waiter.acquired => ()
       err => {
-        waiter.val = None
+        waiter.coro = None
         raise err
       }
     }

--- a/src/semaphore/semaphore_test.mbt
+++ b/src/semaphore/semaphore_test.mbt
@@ -100,6 +100,31 @@ async test "semaphore cancellation" {
 }
 
 ///|
+async test "semaphore cancellation no_swallow" {
+  let log = StringBuilder::new()
+  @async.with_task_group(fn(root) {
+    let semaphore = @semaphore.Semaphore::new(1)
+    semaphore.acquire()
+    let acquire_taskire_task = root.spawn(allow_failure=true, fn() {
+      semaphore.acquire()
+      log.write_string("acquire() succeed\n")
+    })
+    @async.sleep(100)
+    semaphore.release()
+    acquire_taskire_task.cancel()
+    @async.sleep(100)
+    inspect(semaphore.try_acquire(), content="false")
+  })
+  inspect(
+    log.to_string(),
+    content=(
+      #|acquire() succeed
+      #|
+    ),
+  )
+}
+
+///|
 async test "semaphore fairness" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {


### PR DESCRIPTION
In the following case:

- a waiter of an async queue/semaphore is woken, a value/one unit of resource is assigned to that waiter
- the waiter is immediately cancelled, after it is woken, but before it actually resumes running

current implementation will wrongly swallow the value/resource. This PR fixes the bug by preventing the immediate cancellation signal. Since our cancellation mechanism is level-triggered (i.e. the next async operation will still get cancelled), preventing one cancellation point is safe. In real world this bug should only happen in rare cases, as it requires the two events to happen in a single round of scheduler loop.