### PR TITLE
add predicates for `@os_error.OSError`

### DIFF
--- a/src/fs/stub.c
+++ b/src/fs/stub.c
@@ -102,14 +102,6 @@ int moonbitlang_async_f_ok() {
   return F_OK;
 }
 
-int moonbitlang_async_get_ENOENT() {
-  return ENOENT;
-}
-
-int moonbitlang_async_get_EACCES() {
-  return EACCES;
-}
-
 #ifdef __MACH__
 #define GET_STAT_TIMESTAMP(statp, kind) (statp)->st_##kind##timespec
 #else

--- a/src/fs/utils.mbt
+++ b/src/fs/utils.mbt
@@ -76,21 +76,9 @@ extern "C" fn w_ok() -> Int = "moonbitlang_async_w_ok"
 extern "C" fn x_ok() -> Int = "moonbitlang_async_x_ok"
 
 ///|
-extern "C" fn get_ENOENT() -> Int = "moonbitlang_async_get_ENOENT"
-
-///|
-let _ENOENT : Int = get_ENOENT()
-
-///|
-extern "C" fn get_EACCES() -> Int = "moonbitlang_async_get_EACCES"
-
-///|
-let _EACCES : Int = get_EACCES()
-
-///|
 pub async fn exists(path : StringView) -> Bool {
   try @event_loop.access(path, amode=f_ok(), context="@fs.exists()") catch {
-    @os_error.OSError(code, ..) if code == _ENOENT => false
+    @os_error.OSError(_) as err if err.is_ENOENT() => false
     err => raise err
   } noraise {
     _ => true
@@ -100,8 +88,8 @@ pub async fn exists(path : StringView) -> Bool {
 ///|
 pub async fn can_read(path : StringView) -> Bool {
   try @event_loop.access(path, amode=r_ok(), context="@fs.can_read()") catch {
-    @os_error.OSError(code, ..) if code == _ENOENT => false
-    @os_error.OSError(code, ..) if code == _EACCES => false
+    @os_error.OSError(_) as err if err.is_ENOENT() => false
+    @os_error.OSError(_) as err if err.is_EACCES() => false
     err => raise err
   } noraise {
     _ => true
@@ -111,8 +99,8 @@ pub async fn can_read(path : StringView) -> Bool {
 ///|
 pub async fn can_write(path : StringView) -> Bool {
   try @event_loop.access(path, amode=w_ok(), context="@fs.can_write()") catch {
-    @os_error.OSError(code, ..) if code == _ENOENT => false
-    @os_error.OSError(code, ..) if code == _EACCES => false
+    @os_error.OSError(_) as err if err.is_ENOENT() => false
+    @os_error.OSError(_) as err if err.is_EACCES() => false
     err => raise err
   } noraise {
     _ => true
@@ -122,8 +110,8 @@ pub async fn can_write(path : StringView) -> Bool {
 ///|
 pub async fn can_execute(path : StringView) -> Bool {
   try @event_loop.access(path, amode=x_ok(), context="@fs.can_execute") catch {
-    @os_error.OSError(code, ..) if code == _ENOENT => false
-    @os_error.OSError(code, ..) if code == _EACCES => false
+    @os_error.OSError(_) as err if err.is_ENOENT() => false
+    @os_error.OSError(_) as err if err.is_EACCES() => false
     err => raise err
   } noraise {
     _ => true

--- a/src/os_error/error.mbt
+++ b/src/os_error/error.mbt
@@ -22,6 +22,15 @@ extern "C" fn errno_is_nonblocking_io_error(errno : Int) -> Bool = "moonbitlang_
 extern "C" fn errno_is_EINTR(errno : Int) -> Bool = "moonbitlang_async_is_EINTR"
 
 ///|
+extern "C" fn errno_is_ENOENT(errno : Int) -> Bool = "moonbitlang_async_is_ENOENT"
+
+///|
+extern "C" fn errno_is_EEXIST(errno : Int) -> Bool = "moonbitlang_async_is_EEXIST"
+
+///|
+extern "C" fn errno_is_EACCES(errno : Int) -> Bool = "moonbitlang_async_is_EACCES"
+
+///|
 pub fn is_nonblocking_io_error() -> Bool {
   errno_is_nonblocking_io_error(get_errno())
 }
@@ -60,6 +69,27 @@ pub fn OSError::is_nonblocking_io_error(err : OSError) -> Bool {
 pub fn OSError::is_EINTR(err : OSError) -> Bool {
   let OSError(errno, ..) = err
   errno_is_EINTR(errno)
+}
+
+///|
+/// Detect whether the error is the `ENOENT` (no such file or directory) error.
+pub fn OSError::is_ENOENT(err : OSError) -> Bool {
+  let OSError(errno, ..) = err
+  errno_is_ENOENT(errno)
+}
+
+///|
+/// Detect whether the error is the `EEXIST` (already exists) error.
+pub fn OSError::is_EEXIST(err : OSError) -> Bool {
+  let OSError(errno, ..) = err
+  errno_is_EEXIST(errno)
+}
+
+///|
+/// Detect whether the error is the `EACCES` (permission denied) error.
+pub fn OSError::is_EACCES(err : OSError) -> Bool {
+  let OSError(errno, ..) = err
+  errno_is_EACCES(errno)
 }
 
 ///|

--- a/src/os_error/moon.pkg.json
+++ b/src/os_error/moon.pkg.json
@@ -2,5 +2,9 @@
   "import": [
     "moonbitlang/async/internal/c_buffer"
   ],
+  "test-import": [
+    "moonbitlang/async",
+    "moonbitlang/async/fs"
+  ],
   "native-stub": [ "stub.c" ]
 }

--- a/src/os_error/os_error_test.mbt
+++ b/src/os_error/os_error_test.mbt
@@ -1,0 +1,31 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "is_ENOENT" {
+  let result = try? @fs.open("does_not_exist", mode=ReadOnly)
+  guard result is Err(@os_error.OSError(_) as err) else {
+    fail("result is not OSError")
+  }
+  assert_true(err.is_ENOENT())
+}
+
+///|
+async test "is_EEXIST" {
+  let result = try? @fs.mkdir("src", permission=0o755)
+  guard result is Err(@os_error.OSError(_) as err) else {
+    fail("result is not OSError")
+  }
+  assert_true(err.is_EEXIST())
+}

--- a/src/os_error/pkg.generated.mbti
+++ b/src/os_error/pkg.generated.mbti
@@ -12,7 +12,10 @@ fn is_nonblocking_io_error() -> Bool
 pub(all) suberror OSError {
   OSError(Int, context~ : String)
 }
+fn OSError::is_EACCES(Self) -> Bool
+fn OSError::is_EEXIST(Self) -> Bool
 fn OSError::is_EINTR(Self) -> Bool
+fn OSError::is_ENOENT(Self) -> Bool
 fn OSError::is_nonblocking_io_error(Self) -> Bool
 fn OSError::output(Self, &Logger) -> Unit // from trait `Show`
 fn OSError::to_string(Self) -> String // from trait `Show`

--- a/src/os_error/stub.c
+++ b/src/os_error/stub.c
@@ -29,6 +29,18 @@ int moonbitlang_async_is_EINTR(int err) {
   return err == EINTR;
 }
 
+int moonbitlang_async_is_ENOENT(int err) {
+  return err == ENOENT;
+}
+
+int moonbitlang_async_is_EEXIST(int err) {
+  return err == EEXIST;
+}
+
+int moonbitlang_async_is_EACCES(int err) {
+  return err == EACCES;
+}
+
 char *moonbitlang_async_errno_to_string(int err) {
   return strerror(err);
 }


### PR DESCRIPTION
add predicates for testing some commonly used error code on `@os_error.OSError`. Once we get target OS `#cfg` in the future, this can be replaced by `const`.