### PR TITLE
fix TLS infinite loop when peer close the connection unexpectedly

### DIFF
--- a/src/tls/tls.mbt
+++ b/src/tls/tls.mbt
@@ -49,7 +49,11 @@ fn[R : @io.Reader, W : @io.Writer] Tls::from_pair(
 ///|
 async fn Tls::handle_error(self : Tls, err : Int) -> Unit {
   match err {
+    SSL_ERROR_WANT_READ if self.read_end.state is Closed =>
+      raise ConnectionClosed
     SSL_ERROR_WANT_READ => self.read_end.wait()
+    SSL_ERROR_WANT_WRITE if self.write_end.state is Closed =>
+      raise ConnectionClosed
     SSL_ERROR_WANT_WRITE => self.write_end.wait()
     SSL_ERROR_SSL | SSL_ERROR_SYSCALL => raise OpenSSLError(err_get_error())
     SSL_ERROR_ZERO_RETURN => raise ConnectionClosed

--- a/src/tls/tls_test.mbt
+++ b/src/tls/tls_test.mbt
@@ -139,3 +139,79 @@ async test "echo" {
     ),
   )
 }
+
+///|
+async test "`connect` accidental close" {
+  @async.with_task_group(fn(root) {
+    let (client_read_from_server, server_write_to_client) = @pipe.pipe()
+    let (server_read_from_client, client_write_to_server) = @pipe.pipe()
+    // server
+    root.spawn_bg(fn() {
+      defer {
+        server_read_from_client.close()
+        server_write_to_client.close()
+      }
+      let buf = FixedArray::make(1024, b'\x00')
+      let _ = server_read_from_client.read(buf)
+
+    })
+    // client
+    root.spawn_bg(fn() {
+      defer {
+        client_read_from_server.close()
+        client_write_to_server.close()
+      }
+      let client = try? @tls.Tls::client_from_pair(
+          client_read_from_server,
+          client_write_to_server,
+          verify=false,
+        )
+      match client {
+        Ok(client) => {
+          client.close()
+          fail("expected `ConnectionClosed` error")
+        }
+        Err(err) => inspect(err, content="ConnectionClosed")
+      }
+    })
+  })
+}
+
+///|
+async test "`read` accidental close" {
+  @async.with_task_group(fn(root) {
+    let (client_read_from_server, server_write_to_client) = @pipe.pipe()
+    let (server_read_from_client, client_write_to_server) = @pipe.pipe()
+    // server
+    root.spawn_bg(fn() {
+      defer {
+        server_read_from_client.close()
+        server_write_to_client.close()
+      }
+      let server = @tls.Tls::server_from_pair(
+        server_read_from_client,
+        server_write_to_client,
+        private_key_file="test_keys/key.pem",
+        private_key_type=PEM,
+        certificate_file="test_keys/cert.pem",
+        certificate_type=PEM,
+      )
+      server.close()
+    })
+    // client
+    root.spawn_bg(fn() {
+      defer {
+        client_read_from_server.close()
+        client_write_to_server.close()
+      }
+      let client = @tls.Tls::client_from_pair(
+        client_read_from_server,
+        client_write_to_server,
+        verify=false,
+      )
+      defer client.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      inspect(try? client.read(buf), content="Err(ConnectionClosed)")
+    })
+  })
+}


### PR DESCRIPTION
OpenSSL's `SSL_read`/`SSL_write` does not seem to handle zero return from the underlying BIO correctly. It keeps reporting `SSL_WANT_READ` in this case, instead of `SSL_ZERO_RETURN` or others. So if the peer closed the underlying connection unexpectedly when `@tls.Tls` is attempting a read (e.g. in `connect` or `read`), current implementation falls into infinite loop. This PR fixes the issue and handle peer connection close properly.