### PR TITLE
[breaking] `seek` should be async

### DIFF
--- a/src/fs/fs.mbt
+++ b/src/fs/fs.mbt
@@ -217,7 +217,7 @@ pub(all) enum SeekMode {
 }
 
 ///|
-extern "C" fn lseek_ffi(fd : Int, offset : Int64, whence : SeekMode) -> Int64 = "moonbitlang_async_lseek"
+fn SeekMode::to_int(self : SeekMode) -> Int = "%identity"
 
 ///|
 /// Change current position in file for reading and writing.
@@ -225,24 +225,20 @@ extern "C" fn lseek_ffi(fd : Int, offset : Int64, whence : SeekMode) -> Int64 = 
 /// The offset is interpreted using `mode`, see `SeekMode` for more detail.
 /// Current position in the file after seeking (relative to start of file)
 /// will be returned.
-pub fn File::seek(self : File, offset : Int64, mode~ : SeekMode) -> Int64 raise {
-  let offset = lseek_ffi(self.fd(), offset, mode)
-  if offset < 0 {
-    @os_error.check_errno("@fs.File::seek()")
-  }
-  offset
+pub async fn File::seek(self : File, offset : Int64, mode~ : SeekMode) -> Int64 {
+  self.io.seek(offset, mode.to_int(), context="@fs.File::seek()")
 }
 
 ///|
 /// Get current position in the file. Can only be applied to a regular file.
-pub fn File::curr_pos(self : File) -> Int64 raise {
+pub async fn File::curr_pos(self : File) -> Int64 {
   self.seek(0, mode=Relative)
 }
 
 ///|
 /// Get the size of the file. This method will not change position in the file.
 /// Can only be applied to a regular file.
-pub fn File::size(self : File) -> Int64 raise {
+pub async fn File::size(self : File) -> Int64 {
   let curr_pos = self.curr_pos()
   let size = self.seek(0, mode=FromEnd)
   ignore(self.seek(curr_pos, mode=FromStart))

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -62,12 +62,12 @@ fn File::as_dir(Self) -> Directory raise
 fn File::atime(Self) -> (Int64, Int) raise
 fn File::close(Self) -> Unit
 fn File::ctime(Self) -> (Int64, Int) raise
-fn File::curr_pos(Self) -> Int64 raise
+async fn File::curr_pos(Self) -> Int64
 fn File::fd(Self) -> Int
 fn File::kind(Self) -> FileKind
 fn File::mtime(Self) -> (Int64, Int) raise
-fn File::seek(Self, Int64, mode~ : SeekMode) -> Int64 raise
-fn File::size(Self) -> Int64 raise
+async fn File::seek(Self, Int64, mode~ : SeekMode) -> Int64
+async fn File::size(Self) -> Int64
 async fn File::sync(Self, only_data? : Bool) -> Unit
 impl @io.Reader for File
 impl @io.Writer for File

--- a/src/fs/stub.c
+++ b/src/fs/stub.c
@@ -23,11 +23,6 @@
 #include <sys/stat.h>
 #include <moonbit.h>
 
-int64_t moonbitlang_async_lseek(int fd, int64_t offset, int mode) {
-  static int whence_list[] = { SEEK_SET, SEEK_END, SEEK_CUR };
-  return lseek(fd, offset, whence_list[mode]);
-}
-
 int moonbitlang_async_dir_is_null(DIR *dir) {
   return dir == 0;
 }

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -58,6 +58,19 @@ pub async fn stat(
 }
 
 ///|
+pub async fn IOHandle::seek(
+  handle : IOHandle,
+  offset : Int64,
+  whence : Int,
+  context~ : String,
+) -> Int64 {
+  let out = @ref.new(0L)
+  let job = JobForWorker::seek(handle.fd, offset, whence, out)
+  let _ = perform_job_in_worker(job, context~)
+  out.val
+}
+
+///|
 pub async fn access(path : StringView, amode~ : Int, context~ : String) -> Int {
   let path_bytes = @encoding/utf8.encode(path)
   perform_job_in_worker(JobForWorker::access(path_bytes, amode), context~) catch {

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -57,6 +57,7 @@ fn IOHandle::from_fd(Int) -> Self
 async fn IOHandle::fsync(Self, only_data~ : Bool, context~ : String) -> Unit
 async fn IOHandle::read(Self, FixedArray[Byte], offset~ : Int, len~ : Int, can_poll~ : Bool, context~ : String) -> Int
 async fn IOHandle::recvfrom(Self, FixedArray[Byte], offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
+async fn IOHandle::seek(Self, Int64, Int, context~ : String) -> Int64
 async fn IOHandle::sendto(Self, Bytes, offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 async fn IOHandle::write(Self, Bytes, offset~ : Int, len~ : Int, can_poll~ : Bool, context~ : String) -> Int
 

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -83,6 +83,15 @@ extern "C" fn JobForWorker::stat(
 ) -> JobForWorker = "moonbitlang_async_make_stat_job"
 
 ///|
+#owned(out)
+extern "C" fn JobForWorker::seek(
+  fd : Int,
+  offset : Int64,
+  whence : Int,
+  out : Ref[Int64],
+) -> JobForWorker = "moonbitlang_async_make_seek_job"
+
+///|
 #owned(path)
 extern "C" fn JobForWorker::access(path : Bytes, amode : Int) -> JobForWorker = "moonbitlang_async_make_access_job"
 


### PR DESCRIPTION
Seeking file is an expensive operation that may involve disk IO. It should be `async`, but previously it was not. This PR makes `@fs.File::seek` and related functions `async`, most notably `@fs.File::size` also become `async`.