### PR TITLE
add streaming http request helpers

### DIFF
--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -1,0 +1,126 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async fn test_server(port : Int, log : &Logger) -> Unit {
+  let addr = @socket.Addr::parse("127.0.0.1:\{port}")
+  @http.run_server(addr, (conn, _) => {
+    let buf = FixedArray::make(1024, b'\x00')
+    for {
+      let request = conn.read_request()
+      log.write_string(
+        "server received request: \{request.meth} \{request.path}\n",
+      )
+      while conn.read(buf) is n && n > 0 {
+        let data = @encoding/utf8.decode(buf.unsafe_reinterpret_as_bytes()[:n])
+        log.write_string("server received: \{data}")
+      }
+      conn.send_response(200, "OK")
+      log.write_string("server: sending \{request.meth} response part 1\n")
+      conn..write("\{request.meth} response part 1\n")..flush()
+      @async.sleep(100)
+      log.write_string("server: sending \{request.meth} response part 2\n")
+      conn..write("\{request.meth} response part 2\n")..end_response()
+    }
+  })
+}
+
+///|
+async test "request streaming" {
+  let port = 4213
+  let log = StringBuilder::new()
+  @async.with_task_group(group => {
+    group.spawn_bg(no_wait=true, () => test_server(port, log))
+    let buf = FixedArray::make(1024, b'\x00')
+    async fn fetch_response(client : @http.Client) {
+      while client.read(buf) is n && n > 0 {
+        let data = @encoding/utf8.decode(buf.unsafe_reinterpret_as_bytes()[:n])
+        log.write_string("client received: \{data}")
+      }
+    }
+
+    {
+      log.write_string("client sending GET request\n")
+      let (response, client) = @http.get_stream(
+        "http://localhost/get",
+        port~,
+        body="GET data\n",
+      )
+      defer client.close()
+      inspect(response.code, content="200")
+      fetch_response(client)
+    }
+    {
+      log.write_string("client sending PUT request\n")
+      let client = @http.put_stream("http://localhost/put", port~)
+      defer client.close()
+      client.flush()
+      @async.sleep(100)
+      log.write_string("client: sending PUT data part 1\n")
+      client..write("PUT data part 1\n")..flush()
+      @async.sleep(100)
+      log.write_string("client: sending PUT data part 2\n")
+      client.write("PUT data part 2\n")
+      let response = client.end_request()
+      inspect(response.code, content="200")
+      fetch_response(client)
+    }
+    log.write_string("client sending POST request\n")
+    let client = @http.post_stream("http://localhost/post", port~)
+    defer client.close()
+    client.flush()
+    @async.sleep(100)
+    log.write_string("client: sending POST data part 1\n")
+    client..write("POST data part 1\n")..flush()
+    @async.sleep(100)
+    log.write_string("client: sending POST data part 2\n")
+    client.write("POST data part 2\n")
+    let response = client.end_request()
+    inspect(response.code, content="200")
+    fetch_response(client)
+  })
+  inspect(
+    log,
+    content=(
+      #|client sending GET request
+      #|server received request: Get /get
+      #|server received: GET data
+      #|server: sending Get response part 1
+      #|client received: Get response part 1
+      #|server: sending Get response part 2
+      #|client received: Get response part 2
+      #|client sending PUT request
+      #|server received request: Put /put
+      #|client: sending PUT data part 1
+      #|server received: PUT data part 1
+      #|client: sending PUT data part 2
+      #|server received: PUT data part 2
+      #|server: sending Put response part 1
+      #|client received: Put response part 1
+      #|server: sending Put response part 2
+      #|client received: Put response part 2
+      #|client sending POST request
+      #|server received request: Post /post
+      #|client: sending POST data part 1
+      #|server received: POST data part 1
+      #|client: sending POST data part 2
+      #|server received: POST data part 2
+      #|server: sending Post response part 1
+      #|client received: Post response part 1
+      #|server: sending Post response part 2
+      #|client received: Post response part 2
+      #|
+    ),
+  )
+}

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -9,9 +9,15 @@ import(
 // Values
 async fn get(String, headers? : Map[String, String], port? : Int, body? : &@io.Data) -> (Response, &@io.Data)
 
+async fn get_stream(String, headers? : Map[String, String], port? : Int, body? : &@io.Data) -> (Response, Client)
+
 async fn post(String, &@io.Data, headers? : Map[String, String], port? : Int) -> (Response, &@io.Data)
 
+async fn post_stream(String, headers? : Map[String, String], port? : Int) -> Client
+
 async fn put(String, &@io.Data, headers? : Map[String, String], port? : Int) -> (Response, &@io.Data)
+
+async fn put_stream(String, headers? : Map[String, String], port? : Int) -> Client
 
 async fn run_server(@socket.Addr, async (ServerConnection, @socket.Addr) -> Unit, headers? : Map[String, String], dual_stack? : Bool, allow_failure? : Bool, max_connections? : Int) -> Unit
 

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -33,13 +33,10 @@ pub suberror URIParseError {
 } derive(Show)
 
 ///|
-async fn perform_request(
+fn resolve_url(
   uri : String,
-  meth : RequestMethod,
-  headers : Map[String, String],
-  body : &@io.Data,
   port? : Int,
-) -> (Response, &@io.Data) {
+) -> (Protocol, Int, String, String) raise {
   guard uri.find("://") is Some(protocol_len) else { raise InvalidFormat }
   let protocol = match uri[:protocol_len] {
     "http" => Http
@@ -61,6 +58,18 @@ async fn perform_request(
     (uri.to_string(), "/")
   }
   let path = if path == "" { "/" } else { path }
+  (protocol, port, host, path)
+}
+
+///|
+async fn perform_request(
+  uri : String,
+  meth : RequestMethod,
+  headers : Map[String, String],
+  body : &@io.Data,
+  port? : Int,
+) -> (Response, &@io.Data) {
+  let (protocol, port, host, path) = resolve_url(uri, port?)
   let client = Client::connect(host, headers~, protocol~, port~)
   defer client.close()
   client..request(meth, path)..write(body)
@@ -106,4 +115,94 @@ pub async fn post(
   port? : Int,
 ) -> (Response, &@io.Data) {
   perform_request(uri, Post, headers, content, port?)
+}
+
+///|
+/// Similar to `@http.get`, but allow reading response body streamingly.
+/// A pair `(response, client)` will be returned,
+/// where `response` is the response header from the server,
+/// and `client` is the HTTP client that performs the request.
+/// `client` can be used to read the content of response body via `@io.Reader`,
+/// see `@http.Client` for more details.
+///
+/// Note that the returned client must be manually closed via `.close()`
+/// to close the underlying connection used for the request.
+pub async fn get_stream(
+  uri : String,
+  headers? : Map[String, String] = {},
+  port? : Int,
+  body? : &@io.Data = b"",
+) -> (Response, Client) {
+  let (protocol, port, host, path) = resolve_url(uri, port?)
+  let client = Client::connect(host, headers~, protocol~, port~)
+  try {
+    client..request(Get, path)..write(body)
+    let response = client.end_request()
+    (response, client)
+  } catch {
+    err => {
+      client.close()
+      raise err
+    }
+  }
+}
+
+///|
+/// Similar to `@http.put`, but allow writing request body streamingly.
+/// The return value `client` is the HTTP client that performs the request,
+/// it can be used to write the content of request body via `@io.Writer`.
+/// Notice that writing to `@http.Client` is buffered,
+/// so if you need to send data to the server immediately, `.flush()` must be called.
+/// After writing all the content, `.end_request()` must be called
+/// to complete the request and obtain response from the server.
+/// After that, the response body from the server can be obtained 
+/// by using `client` as a `@io.Reader`. See `@http.Client` for more details.
+///
+/// Note that the returned `client` must be manually closed via `.close()`
+/// to close the underlying connection used for the request.
+pub async fn put_stream(
+  uri : String,
+  headers? : Map[String, String] = {},
+  port? : Int,
+) -> Client {
+  let (protocol, port, host, path) = resolve_url(uri, port?)
+  let client = Client::connect(host, headers~, protocol~, port~)
+  try client.request(Put, path) catch {
+    err => {
+      client.close()
+      raise err
+    }
+  } noraise {
+    _ => client
+  }
+}
+
+///|
+/// Similar to `@http.post`, but allow writing request body streamingly.
+/// The return value `client` is the HTTP client that performs the request,
+/// it can be used to write the content of request body via `@io.Writer`.
+/// Notice that writing to `@http.Client` is buffered,
+/// so if you need to send data to the server immediately, `.flush()` must be called.
+/// After writing all the content, `.end_request()` must be called
+/// to complete the request and obtain response from the server.
+/// After that, the response body from the server can be obtained 
+/// by using `client` as a `@io.Reader`. See `@http.Client` for more details.
+///
+/// Note that the returned `client` must be manually closed via `.close()`
+/// to close the underlying connection used for the request.
+pub async fn post_stream(
+  uri : String,
+  headers? : Map[String, String] = {},
+  port? : Int,
+) -> Client {
+  let (protocol, port, host, path) = resolve_url(uri, port?)
+  let client = Client::connect(host, headers~, protocol~, port~)
+  try client.request(Post, path) catch {
+    err => {
+      client.close()
+      raise err
+    }
+  } noraise {
+    _ => client
+  }
 }


### PR DESCRIPTION
Add `@http.{get_stream,put_stream,post_stream}`, which are similar to `@http.{get,put,post}`, but allow reading response body/writing request body in a streaming manner. Another point of view: `@http.xxx_stream` are convenient helpers for creating one-shot `@http.Client`.

These new API will return a `@http.Client` directly for streaming IO. **the client must be manually closed**. This is not as convenient as typical http request API such as `fetch` in JavaScript and `requests` in Python. But it allows better control on resource management and can better prevent memory/connection leak.