### PR TITLE
get local address of TCP/UDP client/server

### DIFF
--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -64,3 +64,14 @@ extern "C" fn enable_keepalive_ffi(
   keep_count : Int,
   keep_intv : Int,
 ) -> Int = "moonbitlang_async_enable_keepalive"
+
+///|
+#borrow(addr_out)
+extern "C" fn getsockname_ffi(sock : Int, addr_out : Addr) -> Int = "moonbitlang_async_getsockname"
+
+///|
+fn getsockname(sock : Int, family : AddrFamily) -> Addr {
+  let addr = Addr::empty(family)
+  guard getsockname_ffi(sock, addr) == 0
+  addr
+}

--- a/src/socket/getsockname_test.mbt
+++ b/src/socket/getsockname_test.mbt
@@ -1,0 +1,64 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "getsockname TCP" {
+  @async.with_task_group(group => {
+    let server = @socket.TcpServer::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server_addr = server.addr()
+    guard server_addr.to_string() is [.. "127.0.0.1:", ..] else {
+      raise Failure("incorrect server address \{server_addr}")
+    }
+    let client_addr_from_server = group.spawn(() => {
+      defer server.close()
+      let (conn, peer_addr) = server.accept()
+      assert_eq(conn.addr(), server_addr)
+      inspect(conn.read_all().text(), content="abcd")
+      peer_addr
+    })
+    let client_addr = group.spawn(() => {
+      let client = @socket.Tcp::connect(server_addr)
+      defer client.close()
+      client.write("abcd")
+      client.addr()
+    })
+    assert_eq(client_addr_from_server.wait(), client_addr.wait())
+  })
+}
+
+///|
+async test "getsockname UDP" {
+  @async.with_task_group(group => {
+    let server = @socket.UdpServer::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server_addr = server.addr()
+    guard server_addr.to_string() is [.. "127.0.0.1:", ..] else {
+      raise Failure("incorrect server address \{server_addr}")
+    }
+    let client_addr_from_server = group.spawn(() => {
+      defer server.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      let (n, peer_addr) = server.recvfrom(buf)
+      let data = buf.unsafe_reinterpret_as_bytes()[:n]
+      inspect(@encoding/utf8.decode(data), content="abcd")
+      peer_addr
+    })
+    let client_addr = group.spawn(() => {
+      let client = @socket.UdpClient::new(server_addr)
+      defer client.close()
+      client.send(b"abcd")
+      client.addr()
+    })
+    assert_eq(client_addr_from_server.wait(), client_addr.wait())
+  })
+}

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -38,6 +38,7 @@ impl Show for IpProtocolPreference
 
 #alias(TCP, deprecated)
 type Tcp
+fn Tcp::addr(Self) -> Addr
 fn Tcp::close(Self) -> Unit
 async fn Tcp::connect(Addr) -> Self
 async fn Tcp::connect_to_host(String, port~ : Int, protocol? : IpProtocolPreference) -> Self
@@ -48,17 +49,20 @@ impl @io.Writer for Tcp
 #alias(TCPServer, deprecated)
 type TcpServer
 async fn TcpServer::accept(Self) -> (Tcp, Addr)
+fn TcpServer::addr(Self) -> Addr
 fn TcpServer::close(Self) -> Unit
 fn TcpServer::new(Addr, dual_stack? : Bool) -> Self raise
 async fn TcpServer::run_forever(Self, async (Tcp, Addr) -> Unit, allow_failure? : Bool, max_connections? : Int) -> Unit
 
 type UdpClient
+fn UdpClient::addr(Self) -> Addr
 fn UdpClient::close(Self) -> Unit
 fn UdpClient::new(Addr) -> Self raise
 async fn UdpClient::recv(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int
 async fn UdpClient::send(Self, Bytes, offset? : Int, len? : Int) -> Unit
 
 type UdpServer
+fn UdpServer::addr(Self) -> Addr
 fn UdpServer::close(Self) -> Unit
 fn UdpServer::new(Addr, dual_stack? : Bool) -> Self raise
 async fn UdpServer::recvfrom(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> (Int, Addr)

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -192,3 +192,8 @@ void* moonbitlang_async_addrinfo_to_addr(struct addrinfo *addrinfo, int port) {
       return NULL;
   }
 }
+
+int moonbitlang_async_getsockname(int sock, struct sockaddr *addr_out) {
+  socklen_t len = Moonbit_array_length(addr_out);
+  return getsockname(sock, addr_out, &len);
+}

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -16,6 +16,7 @@
 /// A Tcp connection
 struct Tcp {
   io : @event_loop.IOHandle
+  family : AddrFamily
   read_buf : @io.ReaderBuffer
 }
 
@@ -49,6 +50,10 @@ pub typealias TcpServer as TCPServer
 /// The address of IPv4 clients are represented via IPv4-mapped IPv6 address.
 ///
 /// If `addr` is not `[::]`, `dual_stack` is ignored.
+///
+/// If the port of `addr` is zero, the server will be bound to a random port,
+/// assigned by the operating system.
+/// The actual listen address can be retrieved via `.addr()`.
 pub fn TcpServer::new(
   addr : Addr,
   dual_stack? : Bool = true,
@@ -71,6 +76,12 @@ pub fn TcpServer::new(
     @os_error.check_errno(context)
   }
   { io: @event_loop.IOHandle::from_fd(sock, kind=Socket), family }
+}
+
+///|
+/// Get the address the server is listening on
+pub fn TcpServer::addr(server : TcpServer) -> Addr {
+  getsockname(server.io.fd(), server.family)
 }
 
 ///|
@@ -137,7 +148,7 @@ pub async fn TcpServer::accept(self : TcpServer) -> (Tcp, Addr) {
   }
   @fd_util.set_cloexec(conn.fd(), context="@socket.TcpServer::accept()")
   @fd_util.set_nonblocking(conn.fd(), context="@socket.TcpServer::accept()")
-  ({ io: conn, read_buf: @io.ReaderBuffer::new() }, addr)
+  ({ io: conn, family: self.family, read_buf: @io.ReaderBuffer::new() }, addr)
 }
 
 ///|
@@ -184,8 +195,14 @@ pub async fn Tcp::connect(addr : Addr) -> Tcp {
       raise err
     }
   } noraise {
-    _ => { io: conn, read_buf: @io.ReaderBuffer::new() }
+    _ => { io: conn, family, read_buf: @io.ReaderBuffer::new() }
   }
+}
+
+///|
+/// Get the local address of a TCP connection.
+pub fn Tcp::addr(sock : Tcp) -> Addr {
+  getsockname(sock.io.fd(), sock.family)
 }
 
 ///|

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -18,7 +18,10 @@
 /// UDP is a connectionless protocol, here "connected" means
 /// the client always send packet to and receive packet from
 /// the specified remote server.
-struct UdpClient(@event_loop.IOHandle)
+struct UdpClient {
+  io : @event_loop.IOHandle
+  family : AddrFamily
+}
 
 ///|
 /// Create a new UDP client connected to server at `addr`.
@@ -32,13 +35,18 @@ pub fn UdpClient::new(server : Addr) -> UdpClient raise {
     @fd_util.close(sock, context~)
     @os_error.check_errno(context)
   }
-  UdpClient(@event_loop.IOHandle::from_fd(sock, kind=Socket))
+  { io: @event_loop.IOHandle::from_fd(sock, kind=Socket), family }
 }
 
 ///|
 pub fn UdpClient::close(self : UdpClient) -> Unit {
-  let UdpClient(sock) = self
-  sock.close()
+  self.io.close()
+}
+
+///|
+/// Get the local address of a UDP client.
+pub fn UdpClient::addr(self : UdpClient) -> Addr {
+  getsockname(self.io.fd(), self.family)
 }
 
 ///|
@@ -63,6 +71,10 @@ pub fn UdpServer::close(self : UdpServer) -> Unit {
 /// The address of IPv4 peers are represented via IPv4-mapped IPv6 address.
 ///
 /// If `addr` is not `[::]`, `dual_stack` is ignored.
+///
+/// If the port of `addr` is zero, the server will be bound to a random port,
+/// assigned by the operating system.
+/// The actual listen address can be retrieved via `.addr()`.
 pub fn UdpServer::new(
   addr : Addr,
   dual_stack? : Bool = true,
@@ -81,6 +93,12 @@ pub fn UdpServer::new(
     @os_error.check_errno(context)
   }
   { io: @event_loop.IOHandle::from_fd(sock, kind=Socket), family }
+}
+
+///|
+/// Get the listen address of a UDP server.
+pub fn UdpServer::addr(self : UdpServer) -> Addr {
+  getsockname(self.io.fd(), self.family)
 }
 
 ///|
@@ -103,8 +121,7 @@ pub async fn UdpClient::recv(
   offset? : Int = 0,
   max_len? : Int = buf.length() - offset,
 ) -> Int {
-  let UdpClient(sock) = self
-  sock.read(buf, offset~, len=max_len, context="@socket.UdpClient::recv")
+  self.io.read(buf, offset~, len=max_len, context="@socket.UdpClient::recv")
 }
 
 ///|
@@ -153,8 +170,7 @@ pub async fn UdpClient::send(
   offset? : Int = 0,
   len? : Int = buf.length() - offset,
 ) -> Unit {
-  let UdpClient(sock) = self
-  sock.write(buf, offset~, len~, context="@socket.UdpClient::send") |> ignore
+  self.io.write(buf, offset~, len~, context="@socket.UdpClient::send") |> ignore
 }
 
 ///|


### PR DESCRIPTION
This PR adds a new `addr() -> Addr` method for `@socket.{TcpServer,Tcp,UdpClient,UdpServer}`, which returns the local address of the socket. Usage:

- get the local address of a client
- get the listen address of the server when it is bound to a random port (via passing zero as the port number on server creation)