### PR TITLE
make sure socket address are of exact length

### DIFF
--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 ///|
+priv enum AddrFamily {
+  IPv4 = 4
+  IPv6 = 6
+}
+
+///|
 /// IPv4 address + port number
 struct Addr(Bytes) derive(Eq, Compare, Hash)
 
@@ -20,7 +26,7 @@ struct Addr(Bytes) derive(Eq, Compare, Hash)
 pub extern "C" fn Addr::new(ip : UInt, port : Int) -> Addr = "moonbitlang_async_make_ip_addr"
 
 ///|
-extern "C" fn Addr::empty() -> Addr = "moonbitlang_async_make_empty_addr"
+extern "C" fn Addr::empty(family : AddrFamily) -> Addr = "moonbitlang_async_make_empty_addr"
 
 ///|
 #borrow(ip)
@@ -37,6 +43,15 @@ pub extern "C" fn Addr::port(addr : Addr) -> Int = "moonbitlang_async_ip_addr_ge
 ///|
 #borrow(addr)
 pub extern "C" fn Addr::is_ipv6(addr : Addr) -> Bool = "moonbitlang_async_addr_is_ipv6"
+
+///|
+fn Addr::family(self : Addr) -> AddrFamily {
+  if self.is_ipv6() {
+    IPv6
+  } else {
+    IPv4
+  }
+}
 
 ///|
 #borrow(addr)

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -13,14 +13,11 @@
 // limitations under the License.
 
 ///|
-extern "C" fn make_tcp_socket_ffi() -> Int = "moonbitlang_async_make_tcp_socket"
+extern "C" fn make_tcp_socket_ffi(family : AddrFamily) -> Int = "moonbitlang_async_make_tcp_socket"
 
 ///|
-extern "C" fn make_tcp_socket_ipv6_ffi() -> Int = "moonbitlang_async_make_tcp_socket_ipv6"
-
-///|
-fn make_tcp_socket(context : String) -> Int raise {
-  let sock = make_tcp_socket_ffi()
+fn make_tcp_socket(family : AddrFamily, context~ : String) -> Int raise {
+  let sock = make_tcp_socket_ffi(family)
   if sock < 0 {
     @os_error.check_errno(context)
   }
@@ -30,36 +27,11 @@ fn make_tcp_socket(context : String) -> Int raise {
 }
 
 ///|
-fn make_tcp_socket_ipv6(context : String) -> Int raise {
-  let sock = make_tcp_socket_ipv6_ffi()
-  if sock < 0 {
-    @os_error.check_errno(context)
-  }
-  @fd_util.set_cloexec(sock, context~)
-  @fd_util.set_nonblocking(sock, context~)
-  sock
-}
+extern "C" fn make_udp_socket_ffi(family : AddrFamily) -> Int = "moonbitlang_async_make_udp_socket"
 
 ///|
-extern "C" fn make_udp_socket_ffi() -> Int = "moonbitlang_async_make_udp_socket"
-
-///|
-extern "C" fn make_udp_socket_ipv6_ffi() -> Int = "moonbitlang_async_make_udp_socket_ipv6"
-
-///|
-fn make_udp_socket(context : String) -> Int raise {
-  let sock = make_udp_socket_ffi()
-  if sock < 0 {
-    @os_error.check_errno(context)
-  }
-  @fd_util.set_cloexec(sock, context~)
-  @fd_util.set_nonblocking(sock, context~)
-  sock
-}
-
-///|
-fn make_udp_socket_ipv6(context : String) -> Int raise {
-  let sock = make_udp_socket_ipv6_ffi()
+fn make_udp_socket(family : AddrFamily, context~ : String) -> Int raise {
+  let sock = make_udp_socket_ffi(family)
   if sock < 0 {
     @os_error.check_errno(context)
   }
@@ -73,15 +45,7 @@ fn make_udp_socket_ipv6(context : String) -> Int raise {
 extern "C" fn bind_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_bind"
 
 ///|
-#borrow(addr)
-extern "C" fn bind_ipv6_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_bind_ipv6"
-
-///|
 extern "C" fn set_ipv6_only(sock : Int, dual_stack : Bool) -> Int = "moonbitlang_async_set_ipv6_only"
-
-///|
-#borrow(addr)
-extern "C" fn connect_ipv6_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_connect_ipv6"
 
 ///|
 extern "C" fn listen_ffi(sock : Int) -> Int = "moonbitlang_async_listen"

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -25,12 +25,8 @@
 #include <string.h>
 #include <moonbit.h>
 
-int moonbitlang_async_make_tcp_socket() {
-  return socket(AF_INET, SOCK_STREAM, 0);
-}
-
-int moonbitlang_async_make_tcp_socket_ipv6() {
-  return socket(AF_INET6, SOCK_STREAM, 0);
+int moonbitlang_async_make_tcp_socket(int family) {
+  return socket(family == 4 ? AF_INET : AF_INET6, SOCK_STREAM, 0);
 }
 
 int moonbitlang_async_disable_nagle(int sock) {
@@ -38,28 +34,16 @@ int moonbitlang_async_disable_nagle(int sock) {
   return setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
 }
 
-int moonbitlang_async_make_udp_socket() {
-  return socket(AF_INET, SOCK_DGRAM, 0);
+int moonbitlang_async_make_udp_socket(int family) {
+  return socket(family == 4 ? AF_INET : AF_INET6, SOCK_DGRAM, 0);
 }
 
-int moonbitlang_async_make_udp_socket_ipv6() {
-  return socket(AF_INET6, SOCK_DGRAM, 0);
-}
-
-int moonbitlang_async_bind(int sockfd, struct sockaddr_in *addr) {
-  return bind(sockfd, (struct sockaddr*)addr, sizeof(struct sockaddr_in));
-}
-
-int moonbitlang_async_bind_ipv6(int sockfd, struct sockaddr_in6 *addr) {
-  return bind(sockfd, (struct sockaddr*)addr, sizeof(struct sockaddr_in6));
+int moonbitlang_async_bind(int sockfd, struct sockaddr *addr) {
+  return bind(sockfd, (struct sockaddr*)addr, Moonbit_array_length(addr));
 }
 
 int moonbitlang_async_set_ipv6_only(int sockfd, int ipv6_only) {
   return setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_only, sizeof(int));
-}
-
-int moonbitlang_async_connect_ipv6(int sockfd, struct sockaddr_in6 *addr) {
-  return connect(sockfd, (struct sockaddr*)addr, sizeof(struct sockaddr_in6));
 }
 
 int moonbitlang_async_listen(int sockfd) {
@@ -119,13 +103,22 @@ void *moonbitlang_async_make_ip_addr(uint32_t ip, int port) {
   return addr;
 }
 
-void *moonbitlang_async_make_empty_addr() {
-  // Create a sockaddr_storage structure large enough to hold both IPv4 and IPv6
-  struct sockaddr_storage *addr = (struct sockaddr_storage*)moonbit_make_bytes(
-    sizeof(struct sockaddr_storage),
-    0
-  );
-  return addr;
+void *moonbitlang_async_make_empty_addr(int family) {
+  if (family == 4) {
+    struct sockaddr *addr = (struct sockaddr*)moonbit_make_bytes(
+      sizeof(struct sockaddr_in),
+      0
+    );
+    addr->sa_family = AF_INET;
+    return addr;
+  } else {
+    struct sockaddr *addr = (struct sockaddr*)moonbit_make_bytes(
+      sizeof(struct sockaddr_in6),
+      0
+    );
+    addr->sa_family = AF_INET6;
+    return addr;
+  };
 }
 
 void *moonbitlang_async_make_ipv6_addr(uint8_t *ip, int port) {

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -29,7 +29,10 @@ pub fn Tcp::close(self : Tcp) -> Unit {
 }
 
 ///|
-struct TcpServer(@event_loop.IOHandle)
+struct TcpServer {
+  io : @event_loop.IOHandle
+  family : AddrFamily
+}
 
 ///|
 #deprecated("use `TcpServer` instead")
@@ -51,23 +54,15 @@ pub fn TcpServer::new(
   dual_stack? : Bool = true,
 ) -> TcpServer raise {
   let context = "@socket.TcpServer::new()"
-  let sock = if addr.is_ipv6() {
-    make_tcp_socket_ipv6(context)
-  } else {
-    make_tcp_socket(context)
-  }
+  let family = addr.family()
+  let sock = make_tcp_socket(family, context~)
   if addr.is_ipv6() && addr.is_ipv6_wildcard() {
     if 0 != set_ipv6_only(sock, !dual_stack) {
       @fd_util.close(sock, context~)
       @os_error.check_errno(context)
     }
   }
-  let bind_result = if addr.is_ipv6() {
-    bind_ipv6_ffi(sock, addr)
-  } else {
-    bind_ffi(sock, addr)
-  }
-  if bind_result != 0 {
+  if bind_ffi(sock, addr) != 0 {
     @fd_util.close(sock, context~)
     @os_error.check_errno(context)
   }
@@ -75,7 +70,7 @@ pub fn TcpServer::new(
     @fd_util.close(sock, context~)
     @os_error.check_errno(context)
   }
-  TcpServer(@event_loop.IOHandle::from_fd(sock, kind=Socket))
+  { io: @event_loop.IOHandle::from_fd(sock, kind=Socket), family }
 }
 
 ///|
@@ -126,18 +121,16 @@ pub async fn TcpServer::run_forever(
 
 ///|
 pub fn TcpServer::close(self : TcpServer) -> Unit {
-  let TcpServer(sock) = self
-  sock.close()
+  self.io.close()
 }
 
 ///|
 /// Accept a new connection on a listening TCP server.
 /// The accepted connection will be returned together with the address of peer.
 pub async fn TcpServer::accept(self : TcpServer) -> (Tcp, Addr) {
-  let TcpServer(listen_sock) = self
   // Create a big enough Addr to hold both IPv4 and IPv6 address
-  let addr = Addr::empty()
-  let conn = listen_sock.accept(addr.0, context="@socket.TcpServer::accept")
+  let addr = Addr::empty(self.family)
+  let conn = self.io.accept(addr.0, context="@socket.TcpServer::accept")
   if disable_nagle(conn.fd()) < 0 {
     @fd_util.close(conn.fd(), context="@socket.TcpServer::accept()")
     @os_error.check_errno("@socket.TcpServer::accept(): set TCP_NODELAY")
@@ -178,11 +171,8 @@ pub fn Tcp::enable_keepalive(
 /// Make connection to a remote address using `connect(2)` system call.
 pub async fn Tcp::connect(addr : Addr) -> Tcp {
   let context = "@socket.Tcp::connect()"
-  let sock = if addr.is_ipv6() {
-    make_tcp_socket_ipv6(context)
-  } else {
-    make_tcp_socket(context)
-  }
+  let family = addr.family()
+  let sock = make_tcp_socket(family, context~)
   if disable_nagle(sock) < 0 {
     @fd_util.close(sock, context~)
     @os_error.check_errno("@socket.Tcp::connect(): set TCP_NODELAY")

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -26,17 +26,9 @@ struct UdpClient(@event_loop.IOHandle)
 /// the specified remote server.
 pub fn UdpClient::new(server : Addr) -> UdpClient raise {
   let context = "@socket.UdpClient::new()"
-  let sock = if server.is_ipv6() {
-    make_udp_socket_ipv6(context)
-  } else {
-    make_udp_socket(context)
-  }
-  let connect_result = if server.is_ipv6() {
-    connect_ipv6_ffi(sock, server)
-  } else {
-    connect_ffi(sock, server)
-  }
-  if 0 != connect_result {
+  let family = server.family()
+  let sock = make_udp_socket(family, context~)
+  if 0 != connect_ffi(sock, server) {
     @fd_util.close(sock, context~)
     @os_error.check_errno(context)
   }
@@ -51,12 +43,14 @@ pub fn UdpClient::close(self : UdpClient) -> Unit {
 
 ///|
 /// A UDP server bound to a listen address and receive packets from clients.
-struct UdpServer(@event_loop.IOHandle)
+struct UdpServer {
+  io : @event_loop.IOHandle
+  family : AddrFamily
+}
 
 ///|
 pub fn UdpServer::close(self : UdpServer) -> Unit {
-  let UdpServer(sock) = self
-  sock.close()
+  self.io.close()
 }
 
 ///|
@@ -74,27 +68,19 @@ pub fn UdpServer::new(
   dual_stack? : Bool = true,
 ) -> UdpServer raise {
   let context = "@socket.UdpServer::new()"
-  let sock = if addr.is_ipv6() {
-    make_udp_socket_ipv6(context)
-  } else {
-    make_udp_socket(context)
-  }
+  let family = addr.family()
+  let sock = make_udp_socket(family, context~)
   if addr.is_ipv6() && addr.is_ipv6_wildcard() {
     if 0 != set_ipv6_only(sock, !dual_stack) {
       @fd_util.close(sock, context~)
       @os_error.check_errno(context)
     }
   }
-  let bind_result = if addr.is_ipv6() {
-    bind_ipv6_ffi(sock, addr)
-  } else {
-    bind_ffi(sock, addr)
-  }
-  if bind_result != 0 {
+  if bind_ffi(sock, addr) != 0 {
     @fd_util.close(sock, context~)
     @os_error.check_errno(context)
   }
-  UdpServer(@event_loop.IOHandle::from_fd(sock, kind=Socket))
+  { io: @event_loop.IOHandle::from_fd(sock, kind=Socket), family }
 }
 
 ///|
@@ -141,10 +127,9 @@ pub async fn UdpServer::recvfrom(
   offset? : Int = 0,
   max_len? : Int = buf.length() - offset,
 ) -> (Int, Addr) {
-  let UdpServer(sock) = self
   // Create a big enough Addr to hold both IPv4 and IPv6 address
-  let addr = Addr::empty()
-  let n_read = sock.recvfrom(
+  let addr = Addr::empty(self.family)
+  let n_read = self.io.recvfrom(
     buf,
     offset~,
     len=max_len,
@@ -187,8 +172,7 @@ pub async fn UdpServer::sendto(
   offset? : Int = 0,
   len? : Int = buf.length() - offset,
 ) -> Unit {
-  let UdpServer(sock) = self
-  sock.sendto(
+  self.io.sendto(
     buf,
     offset~,
     len~,


### PR DESCRIPTION
Previously, some network API such as `accept()` allocate a buffer of size `sizeof(struct sockaddr_storage)` to hold the result address. This is because the address family is unknown (IPv4 or IPv6), so the exact size of address cannot be known in advance. However, this implementation strategy is incorrect: it will break the `derive(Eq, Compare, Hash)` on `@socket.Addr`.

This PR refactors socket address handling, and make sure all socket address are of exact length. The strategy is to:

- store the address family in `@socket.{TcpServer,UdpServer}` object
- fill the `sa_family` when initializing empty address, based on stored family information
- use the `sa_family` field to determine socket address size in `accept` etc.