### PR TITLE
add `reuse_addr` option for TCP/HTTP server

### DIFF
--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -19,7 +19,7 @@ async fn put(String, &@io.Data, headers? : Map[String, String], port? : Int) -> 
 
 async fn put_stream(String, headers? : Map[String, String], port? : Int) -> Client
 
-async fn run_server(@socket.Addr, async (ServerConnection, @socket.Addr) -> Unit, headers? : Map[String, String], dual_stack? : Bool, allow_failure? : Bool, max_connections? : Int) -> Unit
+async fn run_server(@socket.Addr, async (ServerConnection, @socket.Addr) -> Unit, headers? : Map[String, String], dual_stack? : Bool, reuse_addr? : Bool, allow_failure? : Bool, max_connections? : Int) -> Unit
 
 // Errors
 pub suberror HttpProtocolError {

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -146,17 +146,18 @@ pub async fn ServerConnection::send_response(
 /// at most `max_connections` clients are allowed in parallel.
 /// New clients will only get handled after a previous client terminates.
 ///
-/// The meaning of `dual_stack` is the same as `@socket.TcpServer::new`,
+/// The meaning of `dual_stack` and `reuse_addr` is the same as `@socket.TcpServer::new`,
 /// see its document for more details.
 pub async fn run_server(
   addr : @socket.Addr,
   f : async (ServerConnection, @socket.Addr) -> Unit,
   headers? : Map[String, String],
   dual_stack? : Bool,
+  reuse_addr? : Bool,
   allow_failure? : Bool,
   max_connections? : Int,
 ) -> Unit {
-  @socket.TcpServer::new(addr, dual_stack?).run_forever(
+  @socket.TcpServer::new(addr, dual_stack?, reuse_addr?).run_forever(
     allow_failure?,
     max_connections?,
     fn(conn, addr) {

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -58,6 +58,9 @@ extern "C" fn connect_ffi(sock : Int, addr : Addr) -> Int = "moonbitlang_async_c
 extern "C" fn disable_nagle(sock : Int) -> Int = "moonbitlang_async_disable_nagle"
 
 ///|
+extern "C" fn allow_reuse_addr(sock : Int) -> Int = "moonbitlang_async_allow_reuse_addr"
+
+///|
 extern "C" fn enable_keepalive_ffi(
   sock : Int,
   keep_idle : Int,

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -51,7 +51,7 @@ type TcpServer
 async fn TcpServer::accept(Self) -> (Tcp, Addr)
 fn TcpServer::addr(Self) -> Addr
 fn TcpServer::close(Self) -> Unit
-fn TcpServer::new(Addr, dual_stack? : Bool) -> Self raise
+fn TcpServer::new(Addr, dual_stack? : Bool, reuse_addr? : Bool) -> Self raise
 async fn TcpServer::run_forever(Self, async (Tcp, Addr) -> Unit, allow_failure? : Bool, max_connections? : Int) -> Unit
 
 type UdpClient

--- a/src/socket/reuse_addr_test.mbt
+++ b/src/socket/reuse_addr_test.mbt
@@ -1,0 +1,36 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "reuse addr" {
+  let port = 4214
+  @async.with_task_group(group => {
+    group.spawn_bg(() => for _ in 0..<2 {
+      let server = @socket.TcpServer::new(
+        @socket.Addr::parse("127.0.0.1:\{port}"),
+        reuse_addr=true,
+      )
+      defer server.close()
+      let (conn, _) = server.accept()
+      defer conn.close()
+      conn.write("abcd")
+    })
+    @async.sleep(100)
+    for _ in 0..<2 {
+      let conn = @socket.Tcp::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+      defer conn.close()
+      inspect(conn.read_all().text(), content="abcd")
+    }
+  })
+}

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -34,6 +34,11 @@ int moonbitlang_async_disable_nagle(int sock) {
   return setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
 }
 
+int moonbitlang_async_allow_reuse_addr(int sock) {
+  int reuse_addr = 1;
+  return setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse_addr, sizeof(int));
+}
+
 int moonbitlang_async_make_udp_socket(int family) {
   return socket(family == 4 ? AF_INET : AF_INET6, SOCK_DGRAM, 0);
 }

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -54,9 +54,18 @@ pub typealias TcpServer as TCPServer
 /// If the port of `addr` is zero, the server will be bound to a random port,
 /// assigned by the operating system.
 /// The actual listen address can be retrieved via `.addr()`.
+///
+/// If `reuse_addr` is `true` (`false` by default),
+/// the `SO_REUSEADDR` option will be enabled on the server,
+/// allowing in currently-in-use socket address
+/// (as long as there is no one else currently listening on the same address).
+/// This is useful for avoiding "address already in use" error while testing.
+/// WARNING: enabling `reuse_addr` on production is unsafe,
+/// packets from the previous listener of the address may be accidentally received.
 pub fn TcpServer::new(
   addr : Addr,
   dual_stack? : Bool = true,
+  reuse_addr? : Bool = false,
 ) -> TcpServer raise {
   let context = "@socket.TcpServer::new()"
   let family = addr.family()
@@ -66,6 +75,9 @@ pub fn TcpServer::new(
       @fd_util.close(sock, context~)
       @os_error.check_errno(context)
     }
+  }
+  if reuse_addr {
+    guard allow_reuse_addr(sock) >= 0 else { @os_error.check_errno(context) }
   }
   if bind_ffi(sock, addr) != 0 {
     @fd_util.close(sock, context~)


### PR DESCRIPTION
add `reuse_addr` option for TCP/HTTP server, to avoid "address already in use" error when testing. Note that enabling `reuse_addr` in production is not recommended.