### PR TITLE
Add proxy for http client 

### DIFF
--- a/src/http/README.mbt.md
+++ b/src/http/README.mbt.md
@@ -51,6 +51,29 @@ async test {
 }
 ```
 
+## Using HTTP Proxy
+
+The HTTP client supports routing requests through HTTP proxies using the CONNECT method.
+Both HTTP and HTTPS target servers are supported through the proxy.
+
+Create a proxy configuration:
+
+`let proxy = @http.Proxy::all("proxy.example.com", port=8080)` - for all protocols
+
+`let proxy = @http.Proxy::http("proxy.example.com", port=8080)` - HTTP only
+
+`let proxy = @http.Proxy::https("proxy.example.com", port=8080)` - HTTPS only
+
+`let proxy = @http.Proxy::custom("http-proxy.com", http_port=8080, "https-proxy.com", https_port=8443)` - different proxies
+
+Use it with simple HTTP requests:
+
+`let (response, body) = @http.get("http://www.example.org", proxy~)`
+
+Or with a persistent client connection:
+
+`let client = @http.Client::connect("www.example.org", protocol=@http.Http, proxy~)`
+
 ## Writing HTTP servers
 The `@http.ServerConnection` type provides abstraction for a connection in a HTTP server.
 It can be created via `@http.ServerConnection::new(tcp_connection)`.

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -33,16 +33,28 @@ struct Client {
 /// so `headers` should not be used by the caller later.
 /// The following headers is automatically set,
 /// and must not be specified in `headers`:
-/// 
+///
 /// - Host
 /// - Content-Length, Transfer-Encoding
+///
+/// If `proxy` is provided, the connection will be established through
+/// the specified HTTP proxy using the CONNECT method.
 pub async fn Client::connect(
   host : String,
   headers? : Map[String, String] = {},
   protocol? : Protocol = Https,
   port? : Int = protocol.default_port(),
+  proxy? : Proxy,
 ) -> Client {
-  let conn = @socket.Tcp::connect_to_host(host, port~)
+  let conn = match proxy {
+    None => @socket.Tcp::connect_to_host(host, port~)
+    Some(proxy) =>
+      match proxy.should_use(protocol) {
+        Some((proxy_host, proxy_port)) =>
+          connect_through_proxy(proxy_host, proxy_port, host, port)
+        None => @socket.Tcp::connect_to_host(host, port~)
+      }
+  }
   let tls = match protocol {
     Http => None
     Https => Some(@tls.Tls::client(conn, host~))

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -7,17 +7,17 @@ import(
 )
 
 // Values
-async fn get(String, headers? : Map[String, String], port? : Int, body? : &@io.Data) -> (Response, &@io.Data)
+async fn get(String, headers? : Map[String, String], port? : Int, body? : &@io.Data, proxy? : Proxy) -> (Response, &@io.Data)
 
-async fn get_stream(String, headers? : Map[String, String], port? : Int, body? : &@io.Data) -> (Response, Client)
+async fn get_stream(String, headers? : Map[String, String], port? : Int, body? : &@io.Data, proxy? : Proxy) -> (Response, Client)
 
-async fn post(String, &@io.Data, headers? : Map[String, String], port? : Int) -> (Response, &@io.Data)
+async fn post(String, &@io.Data, headers? : Map[String, String], port? : Int, proxy? : Proxy) -> (Response, &@io.Data)
 
-async fn post_stream(String, headers? : Map[String, String], port? : Int) -> Client
+async fn post_stream(String, headers? : Map[String, String], port? : Int, proxy? : Proxy) -> Client
 
-async fn put(String, &@io.Data, headers? : Map[String, String], port? : Int) -> (Response, &@io.Data)
+async fn put(String, &@io.Data, headers? : Map[String, String], port? : Int, proxy? : Proxy) -> (Response, &@io.Data)
 
-async fn put_stream(String, headers? : Map[String, String], port? : Int) -> Client
+async fn put_stream(String, headers? : Map[String, String], port? : Int, proxy? : Proxy) -> Client
 
 async fn run_server(@socket.Addr, async (ServerConnection, @socket.Addr) -> Unit, headers? : Map[String, String], dual_stack? : Bool, reuse_addr? : Bool, allow_failure? : Bool, max_connections? : Int) -> Unit
 
@@ -29,6 +29,12 @@ pub suberror HttpProtocolError {
 }
 impl Show for HttpProtocolError
 
+pub suberror ProxyConnectError {
+  ProxyConnectionFailed(String)
+  ProxyAuthenticationRequired
+}
+impl Show for ProxyConnectError
+
 pub suberror URIParseError {
   InvalidFormat
   UnsupportedProtocol(String)
@@ -38,7 +44,7 @@ impl Show for URIParseError
 // Types and methods
 type Client
 fn Client::close(Self) -> Unit
-async fn Client::connect(String, headers? : Map[String, String], protocol? : Protocol, port? : Int) -> Self
+async fn Client::connect(String, headers? : Map[String, String], protocol? : Protocol, port? : Int, proxy? : Proxy) -> Self
 async fn Client::end_request(Self) -> Response
 async fn Client::flush(Self) -> Unit
 async fn Client::get(Self, String, extra_headers? : Map[String, String], body? : &@io.Data) -> Response
@@ -54,6 +60,12 @@ pub(all) enum Protocol {
   Https
 }
 fn Protocol::default_port(Self) -> Int
+
+type Proxy
+fn Proxy::all(String, port~ : Int) -> Self
+fn Proxy::custom(String, http_port~ : Int, String, https_port~ : Int) -> Self
+fn Proxy::http(String, port~ : Int) -> Self
+fn Proxy::https(String, port~ : Int) -> Self
 
 pub(all) struct Request {
   meth : RequestMethod

--- a/src/http/proxy.mbt
+++ b/src/http/proxy.mbt
@@ -1,0 +1,100 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// HTTP proxy configuration
+enum Proxy {
+  ForHttp(String, Int)
+  ForHttps(String, Int)
+  ForAll(String, Int)
+  Custom(http~ : (String, Int), https~ : (String, Int))
+}
+
+///|
+/// Create a proxy configuration for HTTP requests only
+pub fn Proxy::http(host : String, port~ : Int) -> Proxy {
+  ForHttp(host, port)
+}
+
+///|
+/// Create a proxy configuration for HTTPS requests only
+pub fn Proxy::https(host : String, port~ : Int) -> Proxy {
+  ForHttps(host, port)
+}
+
+///|
+/// Create a proxy configuration for all protocols (HTTP and HTTPS)
+pub fn Proxy::all(host : String, port~ : Int) -> Proxy {
+  ForAll(host, port)
+}
+
+///|
+/// Create a custom proxy configuration with different proxies for HTTP and HTTPS
+pub fn Proxy::custom(
+  http_host : String,
+  http_port~ : Int,
+  https_host : String,
+  https_port~ : Int,
+) -> Proxy {
+  Custom(http=(http_host, http_port), https=(https_host, https_port))
+}
+
+///|
+fn Proxy::should_use(self : Proxy, protocol : Protocol) -> (String, Int)? {
+  match (self, protocol) {
+    (ForHttp(host, port), Http) => Some((host, port))
+    (ForHttps(host, port), Https) => Some((host, port))
+    (ForAll(host, port), _) => Some((host, port))
+    (Custom(http~, ..), Http) => Some(http)
+    (Custom(https~, ..), Https) => Some(https)
+    _ => None
+  }
+}
+
+///|
+/// Error raised when proxy connection fails
+pub suberror ProxyConnectError {
+  ProxyConnectionFailed(String)
+  ProxyAuthenticationRequired
+} derive(Show)
+
+///|
+async fn connect_through_proxy(
+  host : String,
+  port : Int,
+  target_host : String,
+  target_port : Int,
+) -> @socket.Tcp {
+  let proxy_conn = @socket.Tcp::connect_to_host(host, port~)
+  let request = "CONNECT \{target_host}:\{target_port} HTTP/1.1\r\nHost: \{target_host}:\{target_port}\r\n\r\n"
+  proxy_conn.write(request)
+  let reader = Reader::new(proxy_conn)
+  let response = reader.read_response() catch {
+    err => {
+      proxy_conn.close()
+      raise ProxyConnectionFailed("Failed to read proxy response: \{err}")
+    }
+  }
+  if response.code != 200 {
+    proxy_conn.close()
+    match response.code {
+      407 => raise ProxyAuthenticationRequired
+      _ =>
+        raise ProxyConnectionFailed(
+          "Proxy returned status code \{response.code}: \{response.reason}",
+        )
+    }
+  }
+  proxy_conn
+}

--- a/src/http/proxy_test.mbt
+++ b/src/http/proxy_test.mbt
@@ -1,0 +1,76 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Manual tests for HTTP proxy functionality
+///
+/// These tests require a local HTTP proxy running at 127.0.0.1:7890
+///
+
+// ///|
+// async test "access youtube.com through proxy with Proxy::all" {
+//   let proxy = Proxy::all("127.0.0.1", port=7890)
+//   let (response, body) = @http.get("https://www.youtube.com", proxy~)
+//   inspect(response.code, content="200")
+//   let text = body.text()
+//   assert_true(text.contains("YouTube"))
+// }
+
+// ///|
+// async test "access youtube.com through proxy with Proxy::https" {
+//   let proxy = Proxy::https("127.0.0.1", port=7890)
+//   let (response, body) = @http.get("https://www.youtube.com", proxy~)
+//   inspect(response.code, content="200")
+//   let text = body.text()
+//   assert_true(text.contains("YouTube"))
+// }
+
+// ///|
+// async test "access youtube.com with Client through proxy" {
+//   let proxy = Proxy::all("127.0.0.1", port=7890)
+//   let client = Client::connect("www.youtube.com", protocol=Https, proxy~)
+//   defer client.close()
+//   let response = client..request(Get, "/").end_request()
+//   inspect(response.code, content="200")
+//   let body = client.read_all()
+//   let text = body.text()
+//   assert_true(text.contains("YouTube"))
+// }
+
+// ///|
+// async test "multiple requests through proxy" {
+//   let proxy = Proxy::all("127.0.0.1", port=7890)
+//
+//   let (response1, body1) = @http.get("https://www.youtube.com", proxy~)
+//   inspect(response1.code, content="200")
+//   assert_true(body1.text().contains("YouTube"))
+//
+//   let (response2, body2) = @http.get("https://www.youtube.com", proxy~)
+//   inspect(response2.code, content="200")
+//   assert_true(body2.text().contains("YouTube"))
+// }
+
+// ///|
+// async test "access youtube.com with custom proxy" {
+//   let proxy = Proxy::custom(
+//     "127.0.0.1",
+//     http_port=7890,
+//     "127.0.0.1",
+//     https_port=7890,
+//   )
+//
+//   let (response, body) = @http.get("https://www.youtube.com", proxy~)
+//   inspect(response.code, content="200")
+//   assert_true(body.text().contains("YouTube"))
+// }

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -68,9 +68,10 @@ async fn perform_request(
   headers : Map[String, String],
   body : &@io.Data,
   port? : Int,
+  proxy? : Proxy,
 ) -> (Response, &@io.Data) {
   let (protocol, port, host, path) = resolve_url(uri, port?)
-  let client = Client::connect(host, headers~, protocol~, port~)
+  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
   defer client.close()
   client..request(meth, path)..write(body)
   let response = client.end_request()
@@ -85,14 +86,17 @@ async fn perform_request(
 /// `port` is the port number to connect to.
 /// By default it is the standard port for the specified protocol.
 ///
+/// If `proxy` is provided, the request will be sent through the specified HTTP proxy.
+///
 /// See `Client::request` for more details.
 pub async fn get(
   uri : String,
   headers? : Map[String, String] = {},
   port? : Int,
   body? : &@io.Data = b"",
+  proxy? : Proxy,
 ) -> (Response, &@io.Data) {
-  perform_request(uri, Get, headers, body, port?)
+  perform_request(uri, Get, headers, body, port?, proxy?)
 }
 
 ///|
@@ -102,8 +106,9 @@ pub async fn put(
   content : &@io.Data,
   headers? : Map[String, String] = {},
   port? : Int,
+  proxy? : Proxy,
 ) -> (Response, &@io.Data) {
-  perform_request(uri, Put, headers, content, port?)
+  perform_request(uri, Put, headers, content, port?, proxy?)
 }
 
 ///|
@@ -113,8 +118,9 @@ pub async fn post(
   content : &@io.Data,
   headers? : Map[String, String] = {},
   port? : Int,
+  proxy? : Proxy,
 ) -> (Response, &@io.Data) {
-  perform_request(uri, Post, headers, content, port?)
+  perform_request(uri, Post, headers, content, port?, proxy?)
 }
 
 ///|
@@ -125,6 +131,8 @@ pub async fn post(
 /// `client` can be used to read the content of response body via `@io.Reader`,
 /// see `@http.Client` for more details.
 ///
+/// If `proxy` is provided, the request will be sent through the specified HTTP proxy.
+///
 /// Note that the returned client must be manually closed via `.close()`
 /// to close the underlying connection used for the request.
 pub async fn get_stream(
@@ -132,9 +140,10 @@ pub async fn get_stream(
   headers? : Map[String, String] = {},
   port? : Int,
   body? : &@io.Data = b"",
+  proxy? : Proxy,
 ) -> (Response, Client) {
   let (protocol, port, host, path) = resolve_url(uri, port?)
-  let client = Client::connect(host, headers~, protocol~, port~)
+  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
   try {
     client..request(Get, path)..write(body)
     let response = client.end_request()
@@ -155,8 +164,10 @@ pub async fn get_stream(
 /// so if you need to send data to the server immediately, `.flush()` must be called.
 /// After writing all the content, `.end_request()` must be called
 /// to complete the request and obtain response from the server.
-/// After that, the response body from the server can be obtained 
+/// After that, the response body from the server can be obtained
 /// by using `client` as a `@io.Reader`. See `@http.Client` for more details.
+///
+/// If `proxy` is provided, the request will be sent through the specified HTTP proxy.
 ///
 /// Note that the returned `client` must be manually closed via `.close()`
 /// to close the underlying connection used for the request.
@@ -164,9 +175,10 @@ pub async fn put_stream(
   uri : String,
   headers? : Map[String, String] = {},
   port? : Int,
+  proxy? : Proxy,
 ) -> Client {
   let (protocol, port, host, path) = resolve_url(uri, port?)
-  let client = Client::connect(host, headers~, protocol~, port~)
+  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
   try client.request(Put, path) catch {
     err => {
       client.close()
@@ -185,8 +197,10 @@ pub async fn put_stream(
 /// so if you need to send data to the server immediately, `.flush()` must be called.
 /// After writing all the content, `.end_request()` must be called
 /// to complete the request and obtain response from the server.
-/// After that, the response body from the server can be obtained 
+/// After that, the response body from the server can be obtained
 /// by using `client` as a `@io.Reader`. See `@http.Client` for more details.
+///
+/// If `proxy` is provided, the request will be sent through the specified HTTP proxy.
 ///
 /// Note that the returned `client` must be manually closed via `.close()`
 /// to close the underlying connection used for the request.
@@ -194,9 +208,10 @@ pub async fn post_stream(
   uri : String,
   headers? : Map[String, String] = {},
   port? : Int,
+  proxy? : Proxy,
 ) -> Client {
   let (protocol, port, host, path) = resolve_url(uri, port?)
-  let client = Client::connect(host, headers~, protocol~, port~)
+  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
   try client.request(Post, path) catch {
     err => {
       client.close()


### PR DESCRIPTION
Add a proxy for http client. 

- The proxy is implemented in `proxy.mbt`
- Update `README.mbt.md`
- Add a commented test at `proxy_test.mbt`, it can be verified when developers have a proxy server