### PR TITLE
ignore `SIGPIPE`

### DIFF
--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -175,11 +175,12 @@ void moonbitlang_async_init_thread_pool(int notify_send) {
   pthread_sigmask(SIG_BLOCK, &pool.wakeup_signal, &pool.old_sigmask);
 #endif
 
-  sigset_t sigpipe;
-  sigemptyset(&sigpipe);
-  sigaddset(&sigpipe, SIGPIPE);
-  sigaddset(&sigpipe, SIGCHLD);
-  pthread_sigmask(SIG_BLOCK, &sigpipe, 0);
+  sigset_t signals_to_block;
+  sigemptyset(&signals_to_block);
+  sigaddset(&signals_to_block, SIGCHLD);
+  pthread_sigmask(SIG_BLOCK, &signals_to_block, 0);
+
+  signal(SIGPIPE, SIG_IGN);
 
   pool.notify_send = notify_send;
   pool.initialized = 1;

--- a/src/pipe/moon.pkg.json
+++ b/src/pipe/moon.pkg.json
@@ -10,6 +10,7 @@
   "targets": {
     "ffi.mbt": [ "native" ],
     "pipe.mbt": [ "native" ],
-    "read_exactly_test.mbt": [ "native" ]
+    "read_exactly_test.mbt": [ "native" ],
+    "reader_closed_test.mbt": [ "native" ]
   }
 }

--- a/src/pipe/reader_closed_test.mbt
+++ b/src/pipe/reader_closed_test.mbt
@@ -1,0 +1,21 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "reader closed" {
+  let (r, w) = @pipe.pipe()
+  r.close()
+  @async.sleep(100)
+  assert_true((try? w.write("abcd")) is Err(_))
+}


### PR DESCRIPTION
ignore `SIGPIPE`, so that writing to a closed pipe result in `EPIPE` error instead of crashing the program