### PR TITLE
use random port for test to avoid conflict

### DIFF
--- a/examples/tcp_ping_pong/main.mbt
+++ b/examples/tcp_ping_pong/main.mbt
@@ -16,33 +16,27 @@
 suberror ServerTerminate derive(Show)
 
 ///|
-let port = 4201
-
-///|
 pub(all) struct Printer((String) -> Unit)
 
 ///|
-async fn server(println : Printer) -> Unit {
-  @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:\{port}")).run_forever(
-    allow_failure=false,
-    fn(conn, _) {
-      println("received new connection")
-      while conn.read_some() is Some(msg) {
-        @async.sleep(10)
-        println("server received: \{@encoding/utf8.decode(msg)}")
-        let reply = "pong"
-        conn.write(reply)
-        println("server sent: \{reply}")
-        if msg == b"exit" {
-          println("server initiate terminate")
-          @async.sleep(20)
-          raise ServerTerminate
-        }
-      } else {
-        println("server: connection closed by peer")
+async fn server_main(server : @socket.TcpServer, println : Printer) -> Unit {
+  server.run_forever(allow_failure=false, fn(conn, _) {
+    println("received new connection")
+    while conn.read_some() is Some(msg) {
+      @async.sleep(10)
+      println("server received: \{@encoding/utf8.decode(msg)}")
+      let reply = "pong"
+      conn.write(reply)
+      println("server sent: \{reply}")
+      if msg == b"exit" {
+        println("server initiate terminate")
+        @async.sleep(20)
+        raise ServerTerminate
       }
-    },
-  ) catch {
+    } else {
+      println("server: connection closed by peer")
+    }
+  }) catch {
     err => {
       println("server terminate: \{err}")
       raise err
@@ -51,8 +45,13 @@ async fn server(println : Printer) -> Unit {
 }
 
 ///|
-async fn client(println : Printer, id : Int, msg : String) -> Unit {
-  let conn = @socket.Tcp::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+async fn client(
+  addr : @socket.Addr,
+  println : Printer,
+  id : Int,
+  msg : String,
+) -> Unit {
+  let conn = @socket.Tcp::connect(addr)
   defer conn.close()
   // The sleep here is used to make test result stable and portable,
   // because this message is in race condition
@@ -73,16 +72,18 @@ async fn client(println : Printer, id : Int, msg : String) -> Unit {
 ///|
 pub async fn main_prog(println : Printer) -> Unit {
   @async.with_task_group(fn(root) {
-    root.spawn_bg(() => server(println))
+    let server = @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:0"))
+    let addr = server.addr()
+    root.spawn_bg(() => server_main(server, println))
     root.spawn_bg(fn() {
       @async.with_task_group(fn(ctx) {
         for i in 0..<6 {
           let msg = if i % 3 == 1 { "pong" } else { "ping" }
-          ctx.spawn_bg(() => client(println, i, msg))
+          ctx.spawn_bg(() => client(addr, println, i, msg))
           @async.sleep(100)
         }
       })
-      root.spawn_bg(() => client(println, 6, "exit"))
+      root.spawn_bg(() => client(addr, println, 6, "exit"))
     })
   }) catch {
     ServerTerminate => ()

--- a/examples/udp_ping_pong/main.mbt
+++ b/examples/udp_ping_pong/main.mbt
@@ -16,26 +16,20 @@
 suberror ServerTerminate derive(Show)
 
 ///|
-let port = 4201
-
-///|
 pub(all) struct Printer((String) -> Unit)
 
 ///|
-async fn server(println : Printer) -> Unit {
+async fn server_main(server : @socket.UdpServer, println : Printer) -> Unit {
   @async.with_task_group(fn(group) {
-    let server_sock = @socket.UdpServer::new(
-      @socket.Addr::parse("0.0.0.0:\{port}"),
-    )
-    defer server_sock.close()
+    defer server.close()
     let buf = FixedArray::make(1024, b'0')
-    while server_sock.recvfrom(buf) is (n, addr) && n > 0 {
+    while server.recvfrom(buf) is (n, addr) && n > 0 {
       group.spawn_bg(fn() {
         @async.sleep(10)
         let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
         println("server received: \{@encoding/utf8.decode(msg)}")
         let reply = "pong"
-        server_sock.sendto(@encoding/utf8.encode(reply), addr)
+        server.sendto(@encoding/utf8.encode(reply), addr)
         println("server sent: \{reply}")
         if msg == b"exit" {
           println("server initiate terminate")
@@ -54,8 +48,13 @@ async fn server(println : Printer) -> Unit {
 }
 
 ///|
-async fn client(println : Printer, id : Int, msg : String) -> Unit {
-  let conn = @socket.UdpClient::new(@socket.Addr::parse("127.0.0.1:\{port}"))
+async fn client(
+  addr : @socket.Addr,
+  println : Printer,
+  id : Int,
+  msg : String,
+) -> Unit {
+  let conn = @socket.UdpClient::new(addr)
   defer conn.close()
   conn.send(@encoding/utf8.encode(msg))
   println("client \{id} sent: \{msg}")
@@ -72,16 +71,18 @@ async fn client(println : Printer, id : Int, msg : String) -> Unit {
 ///|
 pub async fn main_prog(println : Printer) -> Unit {
   @async.with_task_group(fn(root) {
-    root.spawn_bg(() => server(println))
+    let server = @socket.UdpServer::new(@socket.Addr::parse("0.0.0.0:0"))
+    let addr = server.addr()
+    root.spawn_bg(() => server_main(server, println))
     root.spawn_bg(fn() {
       @async.with_task_group(fn(ctx) {
         for i in 0..<6 {
           let msg = if i % 3 == 1 { "pong" } else { "ping" }
-          ctx.spawn_bg(() => client(println, i, msg))
+          ctx.spawn_bg(() => client(addr, println, i, msg))
           @async.sleep(100)
         }
       })
-      root.spawn_bg(() => client(println, 6, "exit"))
+      root.spawn_bg(() => client(addr, println, 6, "exit"))
     })
   }) catch {
     ServerTerminate => ()

--- a/src/socket/connect_burst_test.mbt
+++ b/src/socket/connect_burst_test.mbt
@@ -16,37 +16,26 @@
 suberror ServerTerminate
 
 ///|
-async fn server(addr : String) -> Int {
-  let server = @socket.TcpServer::new(@socket.Addr::parse(addr))
-  defer server.close()
+async fn server_main(server : @socket.TcpServer) -> Int {
   let mut num_connection = 0
-  try
-    @async.with_task_group(fn(group) {
-      for {
-        let (conn, _) = server.accept()
-        num_connection += 1
-        group.spawn_bg(fn() {
-          defer conn.close()
-          while conn.read_some() is Some(msg) {
-            if msg == b"exit" {
-              @async.sleep(20)
-              raise ServerTerminate
-            }
-          }
-        })
+  server.run_forever(allow_failure=false, (conn, _) => {
+    num_connection += 1
+    while conn.read_some() is Some(msg) {
+      if msg == b"exit" {
+        @async.sleep(20)
+        raise ServerTerminate
       }
-    })
-  catch {
-    ServerTerminate => num_connection
+    }
+  }) catch {
+    ServerTerminate => return num_connection
     err => raise err
-  } noraise {
-    (_ : Unit) => panic()
   }
+  panic()
 }
 
 ///|
-async fn client(msg : Bytes, addr : String) -> Unit {
-  let conn = @socket.Tcp::connect(@socket.Addr::parse(addr))
+async fn client(msg : Bytes, addr : @socket.Addr) -> Unit {
+  let conn = @socket.Tcp::connect(addr)
   defer conn.close()
   conn.write(msg)
 }
@@ -54,16 +43,17 @@ async fn client(msg : Bytes, addr : String) -> Unit {
 ///|
 async test "connection burst" {
   let mut result = 0
-  let port = 4206
   @async.with_task_group(fn(root) {
-    root.spawn_bg(() => result = server("0.0.0.0:\{port}"))
+    let server = @socket.TcpServer::new(@socket.Addr::parse("127.0.0.1:0"))
+    let addr = server.addr()
+    root.spawn_bg(() => result = server_main(server))
     root.spawn_bg(fn() {
       @async.with_task_group(fn(ctx) {
         for _ in 0..<6 {
-          ctx.spawn_bg(() => client(b"ping", "127.0.0.1:\{port}"))
+          ctx.spawn_bg(() => client(b"ping", addr))
         }
       })
-      root.spawn_bg(() => client(b"exit", "127.0.0.1:\{port}"))
+      root.spawn_bg(() => client(b"exit", addr))
     })
   })
   inspect(result, content="7")
@@ -72,16 +62,20 @@ async test "connection burst" {
 ///|
 async test "connection burst with ipv6" {
   let mut result = 0
-  let port = 4207
   @async.with_task_group(fn(root) {
-    root.spawn_bg(() => result = server("[::]:\{port}"))
+    let server = @socket.TcpServer::new(
+      @socket.Addr::parse("[::]:0"),
+      dual_stack=false,
+    )
+    let addr = server.addr()
+    root.spawn_bg(() => result = server_main(server))
     root.spawn_bg(fn() {
       @async.with_task_group(fn(ctx) {
         for _ in 0..<6 {
-          ctx.spawn_bg(() => client(b"ping", "[::1]:\{port}"))
+          ctx.spawn_bg(() => client(b"ping", addr))
         }
       })
-      root.spawn_bg(() => client(b"exit", "[::1]:\{port}"))
+      root.spawn_bg(() => client(b"exit", addr))
     })
   })
   inspect(result, content="7")

--- a/src/socket/dual_stack_test.mbt
+++ b/src/socket/dual_stack_test.mbt
@@ -23,20 +23,17 @@ let all_protocol_preferences : FixedArray[@socket.IpProtocolPreference] = [
 ///|
 async test "Only_V4 server" {
   let log = StringBuilder::new()
-  let port = 4209
   @async.with_task_group(fn(root) {
+    let server = @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:0"))
+    let port = server.addr().port()
     root.spawn_bg(no_wait=true, fn() {
-      @socket.TcpServer::new(@socket.Addr::parse("0.0.0.0:\{port}")).run_forever(fn(
-          conn,
-          addr,
-        ) {
-          let addr_str = addr.to_string()
-          guard addr_str.rev_find(":") is Some(ip_end)
-          let ip = addr_str[:ip_end]
-          let msg = conn.read_all().text()
-          log.write_string("server received \{repr(msg)} from \{ip}\n")
-        },
-      )
+      server.run_forever((conn, addr) => {
+        let addr_str = addr.to_string()
+        guard addr_str.rev_find(":") is Some(ip_end)
+        let ip = addr_str[:ip_end]
+        let msg = conn.read_all().text()
+        log.write_string("server received \{repr(msg)} from \{ip}\n")
+      })
     })
     async fn client(protocol) {
       let conn = @socket.Tcp::connect_to_host("localhost", port~, protocol~)
@@ -70,13 +67,14 @@ async test "Only_V4 server" {
 ///|
 async test "Only_V6 server" {
   let log = StringBuilder::new()
-  let port = 4210
   @async.with_task_group(fn(root) {
+    let server = @socket.TcpServer::new(
+      @socket.Addr::parse("[::]:0"),
+      dual_stack=false,
+    )
+    let port = server.addr().port()
     root.spawn_bg(no_wait=true, fn() {
-      @socket.TcpServer::new(
-        @socket.Addr::parse("[::]:\{port}"),
-        dual_stack=false,
-      ).run_forever(fn(conn, addr) {
+      server.run_forever((conn, addr) => {
         let addr_str = addr.to_string()
         guard addr_str.rev_find(":") is Some(ip_end)
         let ip = addr_str[:ip_end]
@@ -116,13 +114,11 @@ async test "Only_V6 server" {
 ///|
 async test "dual stack server" {
   let log = StringBuilder::new()
-  let port = 4211
   @async.with_task_group(fn(root) {
+    let server = @socket.TcpServer::new(@socket.Addr::parse("[::]:0"))
+    let port = server.addr().port()
     root.spawn_bg(no_wait=true, fn() {
-      @socket.TcpServer::new(@socket.Addr::parse("[::]:\{port}")).run_forever(fn(
-        conn,
-        addr,
-      ) {
+      server.run_forever((conn, addr) => {
         let addr_str = addr.to_string()
         guard addr_str.rev_find(":") is Some(ip_end)
         let ip = addr_str[:ip_end]
@@ -163,12 +159,10 @@ async test "dual stack server" {
 ///|
 async test "Only_V4 UDP server" {
   let log = StringBuilder::new()
-  let port = 4209
   @async.with_task_group(fn(root) {
+    let server = @socket.UdpServer::new(@socket.Addr::parse("0.0.0.0:0"))
+    let port = server.addr().port()
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.UdpServer::new(
-        @socket.Addr::parse("0.0.0.0:\{port}"),
-      )
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for {
@@ -212,13 +206,13 @@ async test "Only_V4 UDP server" {
 ///|
 async test "Only_V6 UDP server" {
   let log = StringBuilder::new()
-  let port = 4210
   @async.with_task_group(fn(root) {
+    let server = @socket.UdpServer::new(
+      @socket.Addr::parse("[::]:0"),
+      dual_stack=false,
+    )
+    let port = server.addr().port()
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.UdpServer::new(
-        @socket.Addr::parse("[::]:\{port}"),
-        dual_stack=false,
-      )
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for {
@@ -262,10 +256,10 @@ async test "Only_V6 UDP server" {
 ///|
 async test "dual stack UDP server" {
   let log = StringBuilder::new()
-  let port = 4211
   @async.with_task_group(fn(root) {
+    let server = @socket.UdpServer::new(@socket.Addr::parse("[::]:0"))
+    let port = server.addr().port()
     root.spawn_bg(no_wait=true, fn() {
-      let server = @socket.UdpServer::new(@socket.Addr::parse("[::]:\{port}"))
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for {

--- a/src/socket/read_exactly_test.mbt
+++ b/src/socket/read_exactly_test.mbt
@@ -14,7 +14,6 @@
 
 ///|
 async test "read_exactly" {
-  let port = 4203
   let buf = StringBuilder::new()
   fn log(msg) {
     buf..write_string(msg).write_char('\n')
@@ -22,10 +21,9 @@ async test "read_exactly" {
 
   @async.with_task_group(fn(root) {
     // server
+    let server = @socket.TcpServer::new(@socket.Addr::parse("127.0.0.1:0"))
+    let addr = server.addr()
     root.spawn_bg(fn() {
-      let server = @socket.TcpServer::new(
-        @socket.Addr::parse("127.0.0.1:\{port}"),
-      )
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -44,7 +42,7 @@ async test "read_exactly" {
     })
     // client
     root.spawn_bg(fn() {
-      let conn = @socket.Tcp::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+      let conn = @socket.Tcp::connect(addr)
       defer conn.close()
       conn.write("abcdef")
       log("first message sent")
@@ -68,7 +66,6 @@ async test "read_exactly" {
 
 ///|
 async test "read_exactly failure" {
-  let port = 4204
   let buf = StringBuilder::new()
   fn log(msg) {
     buf..write_string(msg).write_char('\n')
@@ -76,10 +73,9 @@ async test "read_exactly failure" {
 
   @async.with_task_group(fn(root) {
     // server
+    let server = @socket.TcpServer::new(@socket.Addr::parse("127.0.0.1:0"))
+    let addr = server.addr()
     root.spawn_bg(fn() {
-      let server = @socket.TcpServer::new(
-        @socket.Addr::parse("127.0.0.1:\{port}"),
-      )
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -98,7 +94,7 @@ async test "read_exactly failure" {
     })
     // client
     root.spawn_bg(fn() {
-      let conn = @socket.Tcp::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+      let conn = @socket.Tcp::connect(addr)
       defer conn.close()
       conn.write("abcdef")
       log("first message sent")

--- a/src/tls/shutdown_test.mbt
+++ b/src/tls/shutdown_test.mbt
@@ -14,13 +14,11 @@
 
 ///|
 async test "peer close connection" {
-  let port = 4208
   @async.with_task_group(fn(root) {
     // server
+    let server = @socket.TcpServer::new(@socket.Addr::parse("127.0.0.1:0"))
+    let addr = server.addr()
     root.spawn_bg(fn() {
-      let server = @socket.TcpServer::new(
-        @socket.Addr::parse("127.0.0.1:\{port}"),
-      )
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -38,7 +36,7 @@ async test "peer close connection" {
     })
     // client
     root.spawn_bg(fn() {
-      let conn = @socket.Tcp::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
+      let conn = @socket.Tcp::connect(addr)
       defer conn.close()
       let client = @tls.Tls::client(conn, verify=false)
       defer client.close()


### PR DESCRIPTION
Recent introduction of `.addr()` method for various types in `@socket` has allowed us to use random port assigned by the operating system for testing. This way we can avoid port conflict with local system service, and address-already-in-use due to failed test when debugging.