### PR TITLE
make `.close()` idempotent

### DIFF
--- a/src/fs/fs.mbt
+++ b/src/fs/fs.mbt
@@ -289,10 +289,9 @@ extern "C" fn Directory::is_null(dir : Directory) -> Bool = "moonbitlang_async_d
 /// If the file is not a directory, an error will be raised.
 ///
 /// The ownership of the file will be transferred to `as_dir`.
-/// So the caller MUST NOT use or close the file after calling `as_dir`,
-/// even if `as_dir` fails.
-/// Caller should call `.close()` on the returned directory object instead
-/// (or, if `as_dir` fails, the input file is closed automatically).
+/// The input file will be automatically closed when the
+/// result directory object is closed.
+/// If `as_dir` fails, the input file will be closed automatically.
 pub fn File::as_dir(self : File) -> Directory raise {
   let fd = self.io.detach_from_event_loop()
   let dir = as_dir_ffi(fd)

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -153,6 +153,8 @@ fn ClientTransport::close(self : ClientTransport) -> Unit {
 ///|
 /// Close a HTTP client and release underlying resource.
 /// In particular close the underlying TCP connection.
+/// This function is idempotent: it is safe to call `.close()` multiple times,
+/// only the first `.close()` call takes effect.
 pub fn Client::close(self : Client) -> Unit {
   if self.tls is Some(tls) {
     tls.close()

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -18,6 +18,7 @@ struct ServerConnection {
   reader : Reader
   conn : @socket.Tcp
   sender : Sender
+  mut closed : Bool
 }
 
 ///|
@@ -33,13 +34,23 @@ pub fn ServerConnection::new(
   conn : @socket.Tcp,
   headers? : Map[String, String] = {},
 ) -> ServerConnection {
-  { reader: Reader::new(conn), conn, sender: Sender::new(conn, headers~) }
+  {
+    reader: Reader::new(conn),
+    conn,
+    sender: Sender::new(conn, headers~),
+    closed: false,
+  }
 }
 
 ///|
 /// Close the connection, the underlying TCP connection will be closed as well.
+/// This function is idempotent: it is safe to call `.close()` multiple times,
+/// only the first `.close()` call takes effect.
 pub fn ServerConnection::close(self : ServerConnection) -> Unit {
-  self.conn.close()
+  if !self.closed {
+    self.closed = true
+    self.conn.close()
+  }
 }
 
 ///|
@@ -243,8 +254,11 @@ pub async fn Server::accept(self : Server) -> (ServerConnection, @socket.Addr) {
 /// at most `max_connections` clients are allowed in parallel.
 /// New clients will only get handled after a previous client terminates.
 ///
-/// `run_forever` will close the server and each connection automatically.
-/// So `f` or the caller must not manually close the connections/server.
+/// If `f` fails without closing the connection, 
+/// `run_forever` will close each connection automatically.
+/// If `f` manually closes the connection,
+/// the connection will be dropped after `f` returns.
+/// On error or cancellation, the server will be closed automatically.
 pub async fn Server::run_forever(
   self : Server,
   f : async (Request, &@io.Reader, ServerConnection) -> Unit,
@@ -253,10 +267,13 @@ pub async fn Server::run_forever(
 ) -> Unit {
   self.server.run_forever(allow_failure?, max_connections?, (conn, _) => {
     let conn = ServerConnection::new(conn, headers=self.headers)
+    defer conn.close()
     for {
       let request = conn.read_request()
       f(request, conn, conn)
-      if conn.sender.mode is SendingBody {
+      if conn.closed {
+        break
+      } else if conn.sender.mode is SendingBody {
         conn.end_response()
       }
     }

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -310,7 +310,7 @@ async fn IOHandle::wait_write(handle : IOHandle) -> Unit {
 /// The underlying file descriptor is returned.
 pub fn IOHandle::detach_from_event_loop(handle : IOHandle) -> Int {
   guard curr_loop.val is Some(evloop)
-  guard handle.fd >= 0 else { abort("closing already closed fd") }
+  guard handle.fd >= 0 else { -1 }
   evloop.fds.remove(handle.fd)
   if not(handle.events is NoEvent) {
     evloop.poll.remove(handle.fd, events=handle.events) catch {
@@ -324,10 +324,13 @@ pub fn IOHandle::detach_from_event_loop(handle : IOHandle) -> Int {
 
 ///|
 /// Close a file descriptor and detach it from the event loop.
+/// This function is idempotent: it is safe to call `.close()` multiple times.
 pub fn IOHandle::close(handle : IOHandle) -> Unit {
   let fd = handle.detach_from_event_loop()
-  @fd_util.close(fd, context="") catch {
-    _ => ()
+  if fd >= 0 {
+    @fd_util.close(fd, context="") catch {
+      _ => ()
+    }
   }
 }
 

--- a/src/tls/bio.mbt
+++ b/src/tls/bio.mbt
@@ -213,11 +213,13 @@ fn Endpoint::close(ep : Endpoint) -> Unit {
   if not(ep.state is Error(_)) {
     ep.state = Closed
   }
-  ep.worker.unwrap().cancel()
+  guard ep.worker is Some(worker) else {  }
+  worker.cancel()
   ep.worker = None
   for waiter in ep.waiters {
     waiter.wake()
   }
+  ep.waiters.clear()
 }
 
 ///|

--- a/src/tls/tls.mbt
+++ b/src/tls/tls.mbt
@@ -21,6 +21,7 @@ struct Tls {
   read_end : Endpoint
   write_end : Endpoint
   read_buf : @io.ReaderBuffer
+  mut closed : Bool
 }
 
 ///|
@@ -41,7 +42,14 @@ fn[R : @io.Reader, W : @io.Writer] Tls::from_pair(
   let rbio = create_bio(read_end)
   let wbio = create_bio(write_end)
   let ssl = SSL::new(ctx, rbio, wbio)
-  { ssl, host, read_end, write_end, read_buf: @io.ReaderBuffer::new() }
+  {
+    ssl,
+    host,
+    read_end,
+    write_end,
+    read_buf: @io.ReaderBuffer::new(),
+    closed: false,
+  }
 }
 
 ///|
@@ -236,6 +244,8 @@ pub impl @io.Writer for Tls with write_once(self, buf, offset~, len~) {
 /// Note that this function will not perform the TLS shutdown process,
 /// for graceful shutdown of a TLS connection, see `TLS::shutdown`.
 pub fn Tls::close(self : Tls) -> Unit {
+  guard !self.closed else {  }
+  self.closed = true
   self.read_end.close()
   self.write_end.close()
   self.ssl.free()


### PR DESCRIPTION
Allow calling `.close()` multiple times on everything. Only the first `.close` takes effect. This is particularly useful for wrapper protocols. For example, for a WebSocket server in #176, the life-cycle of a connection is:

- use `read_request` to obtain the initial `Connection: Upgrade` request
- convert a `@http.ServerConnection` to `@websocket.Conn`, the ownership of the HTTP connection is transferred to the WebSocket connection

Here, if error occurs in the first stage, the HTTP connection should be closed. However, if error occurs in the second state, or the connection terminates successfully, the WebSocket connection should be closed, which automatically closes the underlying HTTP connection. Currently, `@http.ServerConnection` can be closed only once, so users must manually handle the two stages above, which is awkward and hard to done right. This issue also prevents #176 from interacting with `@http.Server::run_forever`.

This PR allows `@http.ServerConnection::close()`, and all other `.close()` to be called multiple times. Only the first call takes effect. This makes WebSocket API in #176 easier to use: just add `defer http_conn.close()` at the very beginning, and `defer ws_conn.close()` after the WebSocket connection is successfully created. It also allows using #176 with `@http.Server::run_forever`.

Another side benefit is: the callback of `@http.Server::run_forever` can now manually close the connection.