### PR TITLE
HTTP: do not use chunked encoding for empty body

### DIFF
--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -59,7 +59,6 @@ async test "request streaming" {
       log.write_string("client sending PUT request\n")
       let client = @http.put_stream("http://localhost:\{port}/put")
       defer client.close()
-      client.flush()
       @async.sleep(100)
       log.write_string("client: sending PUT data part 1\n")
       client..write("PUT data part 1\n")..flush()
@@ -74,7 +73,6 @@ async test "request streaming" {
       log.write_string("client sending POST request\n")
       let client = @http.post_stream("http://localhost:\{port}/post")
       defer client.close()
-      client.flush()
       @async.sleep(100)
       log.write_string("client: sending POST data part 1\n")
       client..write("POST data part 1\n")..flush()
@@ -100,8 +98,8 @@ async test "request streaming" {
       #|server: sending Get response part 2
       #|client received: Get response part 2
       #|client sending PUT request
-      #|server received request: Put /put
       #|client: sending PUT data part 1
+      #|server received request: Put /put
       #|server received: PUT data part 1
       #|client: sending PUT data part 2
       #|server received: PUT data part 2
@@ -110,8 +108,8 @@ async test "request streaming" {
       #|server: sending Put response part 2
       #|client received: Put response part 2
       #|client sending POST request
-      #|server received request: Post /post
       #|client: sending POST data part 1
+      #|server received request: Post /post
       #|server received: POST data part 1
       #|client: sending POST data part 2
       #|server received: POST data part 2

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -15,6 +15,7 @@
 ///|
 priv enum SenderMode {
   SendingHeader
+  WaitingBody
   SendingBody
   PassThrough
 }
@@ -65,6 +66,12 @@ async fn Sender::flush(self : Sender) -> Unit {
 }
 
 ///|
+const NON_EMPTY_MESSAGE_HEADER_END : Bytes = "Transfer-Encoding: chunked\r\n\r\n"
+
+///|
+const EMPTY_MESSAGE_HEADER_END : Bytes = "Content-Length: 0\r\n\r\n"
+
+///|
 impl @io.Writer for Sender with write_once(self, buf, offset~, len~) {
   match self.mode {
     SendingHeader => {
@@ -75,6 +82,21 @@ impl @io.Writer for Sender with write_once(self, buf, offset~, len~) {
       self.send_buf.blit_from_bytes(self.send_len, buf, offset, len)
       self.send_len += len
       len
+    }
+    WaitingBody => {
+      if self.send_len + NON_EMPTY_MESSAGE_HEADER_END.length() >
+        self.send_buf.length() {
+        self.flush()
+      }
+      self.send_buf.blit_from_bytes(
+        self.send_len,
+        NON_EMPTY_MESSAGE_HEADER_END,
+        0,
+        NON_EMPTY_MESSAGE_HEADER_END.length(),
+      )
+      self.send_len += NON_EMPTY_MESSAGE_HEADER_END.length()
+      self.mode = SendingBody
+      self.write_once(buf, offset~, len~)
     }
     SendingBody => {
       // Reserve enough space for chunk length and '\r\n' in the buffer,
@@ -115,6 +137,21 @@ impl @io.Writer for Sender with write_reader(self, reader) {
           break
         }
       }
+    WaitingBody => {
+      if self.send_len + NON_EMPTY_MESSAGE_HEADER_END.length() >
+        self.send_buf.length() {
+        self.flush()
+      }
+      self.send_buf.blit_from_bytes(
+        self.send_len,
+        NON_EMPTY_MESSAGE_HEADER_END,
+        0,
+        NON_EMPTY_MESSAGE_HEADER_END.length(),
+      )
+      self.send_len += NON_EMPTY_MESSAGE_HEADER_END.length()
+      self.mode = SendingBody
+      self.write_reader(reader)
+    }
     SendingBody => {
       self.flush()
       self.send_buf[3] = '\r'
@@ -141,13 +178,33 @@ impl @io.Writer for Sender with write_reader(self, reader) {
 
 ///|
 async fn Sender::end_body(self : Sender) -> Unit {
-  if self.send_len + 5 > self.send_buf.length() {
-    self.flush()
-    self.writer.write("0\r\n\r\n")
-  } else {
-    self.send_buf.blit_from_bytes(self.send_len, "0\r\n\r\n", 0, 5)
-    self.send_len += 5
-    self.flush()
+  match self.mode {
+    SendingHeader | PassThrough =>
+      abort("`end_body()` called outside a HTTP message")
+    WaitingBody =>
+      if self.send_len + EMPTY_MESSAGE_HEADER_END.length() >
+        self.send_buf.length() {
+        self.flush()
+        self.writer.write(EMPTY_MESSAGE_HEADER_END)
+      } else {
+        self.send_buf.blit_from_bytes(
+          self.send_len,
+          EMPTY_MESSAGE_HEADER_END,
+          0,
+          EMPTY_MESSAGE_HEADER_END.length(),
+        )
+        self.send_len += EMPTY_MESSAGE_HEADER_END.length()
+        self.flush()
+      }
+    SendingBody =>
+      if self.send_len + 5 > self.send_buf.length() {
+        self.flush()
+        self.writer.write("0\r\n\r\n")
+      } else {
+        self.send_buf.blit_from_bytes(self.send_len, "0\r\n\r\n", 0, 5)
+        self.send_len += 5
+        self.flush()
+      }
   }
   self.mode = SendingHeader
 }
@@ -186,8 +243,7 @@ async fn Sender::send_request(
   self..write(path)..write(" HTTP/1.1\r\n")
   self.write(self.headers)
   self.send_headers(extra_headers)
-  self.write("Transfer-Encoding: chunked\r\n\r\n")
-  self.mode = SendingBody
+  self.mode = WaitingBody
 }
 
 ///|

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -33,9 +33,7 @@ async test "send_request basic" {
         #|GET / HTTP/1.1\r
         #|Host: x.y.org\r
         #|User-Agent: MoonBit\r
-        #|Transfer-Encoding: chunked\r
-        #|\r
-        #|0\r
+        #|Content-Length: 0\r
         #|\r
         #|
       ),
@@ -369,9 +367,7 @@ async test "send invalid header" {
         #|GET / HTTP/1.1\r
         #|Host: x.y.org\r
         #|User-Agent: MoonBit\r
-        #|Transfer-Encoding: chunked\r
-        #|\r
-        #|0\r
+        #|Content-Length: 0\r
         #|\r
         #|
       ),


### PR DESCRIPTION
Current HTTP implementation uses chunked encoding unconditionally, even when the message has an empty body. However, some clients expect an completely empty body for messages without a body, for example the WebSocket client of NodeJS before `v24`. This PR makes `@http` API send completely empty body with `Content-Length: 0` for empty message. This is implemented by defer the sending of `Content-Length`/`Transfer-Encoding` until something is written to the message body, or `.end_body()` is called.