### PR TITLE
refactor open job, leave flag handling to C code

### DIFF
--- a/src/fs/constants.mbt
+++ b/src/fs/constants.mbt
@@ -42,30 +42,6 @@ let const_W_OK : Int = get_W_OK()
 let const_X_OK : Int = get_X_OK()
 
 ///|
-let const_O_RDONLY : Int = get_O_RDONLY()
-
-///|
-let const_O_WRONLY : Int = get_O_WRONLY()
-
-///|
-let const_O_RDWR : Int = get_O_RDWR()
-
-///|
-let const_O_SYNC : Int = get_O_SYNC()
-
-///|
-let const_O_DSYNC : Int = get_O_DSYNC()
-
-///|
-let const_O_APPEND : Int = get_O_APPEND()
-
-///|
-let const_O_TRUNC : Int = get_O_TRUNC()
-
-///|
-let const_O_CREAT : Int = get_O_CREAT()
-
-///|
 extern "C" fn get_F_OK() -> Int = "moonbitlang_async_get_F_OK"
 
 ///|
@@ -76,27 +52,3 @@ extern "C" fn get_W_OK() -> Int = "moonbitlang_async_get_W_OK"
 
 ///|
 extern "C" fn get_X_OK() -> Int = "moonbitlang_async_get_X_OK"
-
-///|
-extern "C" fn get_O_RDONLY() -> Int = "moonbitlang_async_get_O_RDONLY"
-
-///|
-extern "C" fn get_O_WRONLY() -> Int = "moonbitlang_async_get_O_WRONLY"
-
-///|
-extern "C" fn get_O_RDWR() -> Int = "moonbitlang_async_get_O_RDWR"
-
-///|
-extern "C" fn get_O_SYNC() -> Int = "moonbitlang_async_get_O_SYNC"
-
-///|
-extern "C" fn get_O_DSYNC() -> Int = "moonbitlang_async_get_O_DSYNC"
-
-///|
-extern "C" fn get_O_APPEND() -> Int = "moonbitlang_async_get_O_APPEND"
-
-///|
-extern "C" fn get_O_TRUNC() -> Int = "moonbitlang_async_get_O_TRUNC"
-
-///|
-extern "C" fn get_O_CREAT() -> Int = "moonbitlang_async_get_O_CREAT"

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -82,32 +82,27 @@ pub async fn open(
   create? : Int,
   truncate? : Bool = false,
 ) -> File {
-  let mut flags = match mode {
-    ReadOnly => const_O_RDONLY
-    WriteOnly => const_O_WRONLY
-    ReadWrite => const_O_RDWR
+  let access = match mode {
+    ReadOnly => 0
+    WriteOnly => 1
+    ReadWrite => 2
   }
-  let user_mode = match create {
-    None => 0
-    Some(mode) => {
-      flags = flags | const_O_CREAT
-      mode
-    }
+  let (create, user_mode) = match create {
+    None => (false, 0)
+    Some(mode) => (true, mode)
   }
-  if append {
-    flags = flags | const_O_APPEND
-  }
-  if truncate {
-    flags = flags | const_O_TRUNC
-  }
-  match sync {
-    NoSync => ()
-    Data => flags = flags | const_O_DSYNC
-    Full => flags = flags | const_O_SYNC
+  let sync = match sync {
+    NoSync => 0
+    Data => 1
+    Full => 2
   }
   let io = @event_loop.open(
     filename,
-    flags~,
+    access,
+    create~,
+    append~,
+    truncate~,
+    sync~,
     mode=user_mode,
     context="@fs.open()",
   )

--- a/src/fs/stub.c
+++ b/src/fs/stub.c
@@ -50,35 +50,3 @@ int moonbitlang_async_get_X_OK() {
 int moonbitlang_async_get_F_OK() {
   return F_OK;
 }
-
-int moonbitlang_async_get_O_RDONLY() {
-  return O_RDONLY;
-}
-
-int moonbitlang_async_get_O_WRONLY() {
-  return O_WRONLY;
-}
-
-int moonbitlang_async_get_O_RDWR() {
-  return O_RDWR;
-}
-
-int moonbitlang_async_get_O_SYNC() {
-  return O_SYNC;
-}
-
-int moonbitlang_async_get_O_DSYNC() {
-  return O_DSYNC;
-}
-
-int moonbitlang_async_get_O_APPEND() {
-  return O_APPEND;
-}
-
-int moonbitlang_async_get_O_TRUNC() {
-  return O_TRUNC;
-}
-
-int moonbitlang_async_get_O_CREAT() {
-  return O_CREAT;
-}

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -23,12 +23,27 @@ pub type DirectoryEntry
 ///|
 pub async fn open(
   path : StringView,
-  flags~ : Int,
+  // 0 => read only, 1 => write only, 2 => read write
+  access : Int,
+  create~ : Bool,
+  append~ : Bool,
+  truncate~ : Bool,
+  // 0 => no sync, 1 => data sync, 2 => full sync
+  sync~ : Int,
+  // permission for file when new file is created
   mode~ : Int,
   context~ : String,
 ) -> IoHandle {
   let path_bytes = @os_string.encode(path)
-  let job = Job::open(path_bytes, flags, mode)
+  let job = Job::open(
+    path_bytes,
+    access,
+    create~,
+    append~,
+    truncate~,
+    sync~,
+    mode~,
+  )
   try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{repr(path)}")

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -23,7 +23,7 @@ pub async fn getaddrinfo(StringView, context~ : String) -> Result[AddrInfo, Stri
 
 pub async fn mkdir(StringView, mode~ : Int, context~ : String) -> Unit
 
-pub async fn open(StringView, flags~ : Int, mode~ : Int, context~ : String) -> IoHandle
+pub async fn open(StringView, Int, create~ : Bool, append~ : Bool, truncate~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> IoHandle
 
 pub async fn opendir(StringView, context~ : String) -> Directory
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -439,12 +439,22 @@ void open_job_worker(struct job *job) {
 
 struct open_job *moonbitlang_async_make_open_job(
   char *filename,
-  int flags,
+  int access,
+  int create,
+  int append,
+  int truncate,
+  int sync,
   int mode
 ) {
+  static int access_flags[] = { O_RDONLY, O_WRONLY, O_RDWR };
+  static int sync_flags[] = { 0, O_DSYNC, O_SYNC };
+
   struct open_job *job = MAKE_JOB(open);
   job->filename = filename;
-  job->flags = flags;
+  job->flags = access_flags[access] | sync_flags[sync];
+  if (create) job->flags |= O_CREAT;
+  if (append) job->flags |= O_APPEND;
+  if (truncate) job->flags |= O_TRUNC;
   job->mode = mode;
   return job;
 }

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -74,8 +74,15 @@ extern "C" fn Job::write(
 #owned(filename)
 extern "C" fn Job::open(
   filename : @os_string.OsString,
-  flags : Int,
-  mode : Int,
+  // 0 => read only, 1 => write only, 2 => read write
+  access : Int,
+  create~ : Bool,
+  append~ : Bool,
+  truncate~ : Bool,
+  // 0 => no sync, 1 => data sync, 2 => full sync
+  sync~ : Int,
+  // permission for file when new file is created
+  mode~ : Int,
 ) -> Job = "moonbitlang_async_make_open_job"
 
 ///|


### PR DESCRIPTION
Previously, handling of open flag is done using MoonBit code, at `fs/file.mbt`. However, open flags and the shape of file opening API differs a lot in Unix/Windows. This PR leave handling of open flags to C code in `event_loop/thread_pool.c`, and pass all individual open options directly on the C/MoonBit interface. This makes future Windows support easier.