### PR TITLE
less dependency using indirect dependency

### DIFF
--- a/examples/cat/moon.pkg.json
+++ b/examples/cat/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "import": [
     "moonbitlang/async",
-    "moonbitlang/async/io",
     "moonbitlang/async/fs",
     "moonbitlang/async/stdio"
   ],

--- a/examples/http_file_server/moon.pkg.json
+++ b/examples/http_file_server/moon.pkg.json
@@ -1,11 +1,9 @@
 {
   "import": [
     "moonbitlang/async",
-    "moonbitlang/async/io",
     "moonbitlang/async/socket",
     "moonbitlang/async/fs",
     "moonbitlang/async/http",
-    "moonbitlang/async/pipe",
     "moonbitlang/async/process"
   ],
   "is-main": true

--- a/examples/http_file_server/server_test.mbt
+++ b/examples/http_file_server/server_test.mbt
@@ -115,11 +115,9 @@ async test "basic" {
       #|{
       #|  "import": [
       #|    "moonbitlang/async",
-      #|    "moonbitlang/async/io",
       #|    "moonbitlang/async/socket",
       #|    "moonbitlang/async/fs",
       #|    "moonbitlang/async/http",
-      #|    "moonbitlang/async/pipe",
       #|    "moonbitlang/async/process"
       #|  ],
       #|  "is-main": true

--- a/examples/tcp_ping_pong/moon.pkg.json
+++ b/examples/tcp_ping_pong/moon.pkg.json
@@ -1,8 +1,7 @@
 {
   "import": [
     "moonbitlang/async",
-    "moonbitlang/async/socket",
-    "moonbitlang/async/io"
+    "moonbitlang/async/socket"
   ],
   "is-main": true
 }

--- a/examples/tcp_server_benchmark/moon.pkg.json
+++ b/examples/tcp_server_benchmark/moon.pkg.json
@@ -2,7 +2,6 @@
   "is-main": true,
   "import": [
     "moonbitlang/async",
-    "moonbitlang/async/io",
     "moonbitlang/async/socket"
   ]
 }

--- a/examples/websocket_client/moon.pkg.json
+++ b/examples/websocket_client/moon.pkg.json
@@ -3,7 +3,6 @@
     "moonbitlang/async/websocket",
     "moonbitlang/async",
     "moonbitlang/async/stdio",
-    "moonbitlang/async/io",
     "moonbitlang/x/sys"
   ],
   "is-main": true

--- a/examples/websocket_echo_server/moon.pkg.json
+++ b/examples/websocket_echo_server/moon.pkg.json
@@ -3,8 +3,7 @@
     "moonbitlang/async/socket",
     "moonbitlang/async/http",
     "moonbitlang/async/websocket",
-    "moonbitlang/async",
-    "moonbitlang/async/io"
+    "moonbitlang/async"
   ],
   "is-main": true
 }

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -152,7 +152,7 @@ pub async fn walk(
   allow_failure? : Bool = false,
 ) -> Unit {
   guard max_concurrency > 0
-  let sem = @semaphore.Semaphore::new(max_concurrency)
+  let sem = @async.Semaphore::new(max_concurrency)
   @async.with_task_group(fn(group) {
     async fn handle_path(path : String) {
       group.spawn_bg(allow_failure~, fn() {

--- a/src/fs/moon.pkg.json
+++ b/src/fs/moon.pkg.json
@@ -6,8 +6,7 @@
     "moonbitlang/async/internal/fd_util",
     "moonbitlang/async/internal/c_buffer",
     "moonbitlang/async/internal/os_string",
-    "moonbitlang/async",
-    "moonbitlang/async/semaphore"
+    "moonbitlang/async"
   ],
   "targets": {
     "access_test.mbt": [ "native" ],

--- a/src/fs/unimplemented.mbt
+++ b/src/fs/unimplemented.mbt
@@ -19,7 +19,6 @@ pub let unimplemented : Unit = {
   ignore(@io.pipe)
   ignore(@async.sleep)
   ignore(@event_loop.sleep)
-  ignore(@semaphore.Semaphore::acquire)
   ignore(@os_error.unimplemented)
   ignore(@fd_util.unimplemented)
   ignore(@c_buffer.unimplemented)

--- a/src/socket/moon.pkg.json
+++ b/src/socket/moon.pkg.json
@@ -5,8 +5,7 @@
     "moonbitlang/async/internal/fd_util",
     "moonbitlang/async/internal/c_buffer",
     "moonbitlang/async/io",
-    "moonbitlang/async",
-    "moonbitlang/async/semaphore"
+    "moonbitlang/async"
   ],
   "targets": {
     "addr.mbt": [ "native" ],

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -115,7 +115,7 @@ pub async fn TcpServer::run_forever(
   defer self.close()
   let conn_limit = match max_connections {
     None => None
-    Some(n) => Some(@semaphore.Semaphore::new(n))
+    Some(n) => Some(@async.Semaphore::new(n))
   }
   @async.with_task_group(fn(group) {
     for {

--- a/src/socket/unimplemented.mbt
+++ b/src/socket/unimplemented.mbt
@@ -19,7 +19,6 @@ pub let unimplemented : Unit = {
   ignore(@io.pipe)
   ignore(@event_loop.sleep)
   ignore(@async.sleep)
-  ignore(@semaphore.Semaphore::acquire)
   ignore(@os_error.unimplemented)
   ignore(@fd_util.unimplemented)
   ignore(@c_buffer.unimplemented)


### PR DESCRIPTION
The latest MoonBit release (v0.6.34) now supports *indirect dependency*.  Only those packages that are explicitly referenced via `@pkg` need to be imported, calling methods/using trait implementations of a package no longer requires explicit import. Utilizing this new feature, some unnecessary import can be removed from this project. For example, typical async program no longer need to explicit import `moonbitlang/async/io`.