### PR TITLE
fix bug related to the task calling `return_immediately`

### DIFF
--- a/src/return_immediately_test.mbt
+++ b/src/return_immediately_test.mbt
@@ -82,3 +82,37 @@ async test "return_immediately error on cancel" {
     ),
   )
 }
+
+///|
+async test "return_immediately recursive cancel" {
+  let log = []
+  @async.with_task_group(group => {
+    group.spawn_bg(() => {
+      @async.sleep(100)
+      log.push("100ms tick")
+    })
+    @async.with_task_group(group => group.return_immediately(()) catch {
+      _ => @async.sleep(200)
+    }) catch {
+      _ => ()
+    }
+    log.push("inner group finished")
+  })
+  @json.inspect(log, content=["inner group finished", "100ms tick"])
+}
+
+///|
+async test "return_immediately called outside" {
+  let log = []
+  @async.with_task_group(outer => {
+    outer.spawn_bg(() => {
+      @async.sleep(100)
+      log.push("100ms tick")
+    })
+    @async.with_task_group(inner => outer.spawn_bg(() => inner.return_immediately(
+      (),
+    )))
+    log.push("inner group finished")
+  })
+  @json.inspect(log, content=["inner group finished", "100ms tick"])
+}

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -238,14 +238,13 @@ pub fn[X] TaskGroup::return_immediately(
   }
   if self.state is Running {
     self.state = Done
-    let curr_coro = @coroutine.current_coroutine()
     for child in self.children {
-      if child != curr_coro {
-        child.cancel()
-      }
+      child.cancel()
     }
   }
-  raise @coroutine.Cancelled
+  if @coroutine.is_being_cancelled() {
+    raise @coroutine.Cancelled
+  }
 }
 
 ///|


### PR DESCRIPTION
Fix two bugs related to behavior of current task when calling `TaskGroup::return_immediately`:

- the current task previously does not enter "cancelled" state: if the cancellation error raised by `return_immediately` is swallowed, current task will not get cancelled recursively
- if current task is not a member of the receiver of `return_immediately`, current task should not get cancelled