### PR TITLE
add `.ping()` method for WebSocket connection

### DIFF
--- a/src/tls/ffi.mbt
+++ b/src/tls/ffi.mbt
@@ -145,11 +145,20 @@ fn err_get_error() -> String {
 }
 
 ///|
+#borrow(buf)
+extern "C" fn rand_bytes_ffi(buf : FixedArray[Byte], num : Int) -> Int = "moonbitlang_async_tls_rand_bytes"
+
+///|
 /// Generate cryptographically secure random bytes using OpenSSL's RAND_bytes
 /// Returns 1 on success, 0 on failure
-#borrow(buf)
 #internal(internal, "for internal use only")
-pub extern "C" fn rand_bytes(buf : FixedArray[Byte], num : Int) -> Int = "moonbitlang_async_tls_rand_bytes"
+pub fn rand_bytes(num : Int) -> Bytes raise {
+  let result = FixedArray::make(num, b'\x00')
+  if rand_bytes_ffi(result, num) != 1 {
+    raise Failure(err_get_error())
+  }
+  result.unsafe_reinterpret_as_bytes()
+}
 
 ///|
 #borrow(src, dst)

--- a/src/tls/pkg.generated.mbti
+++ b/src/tls/pkg.generated.mbti
@@ -6,7 +6,7 @@ import(
 )
 
 // Values
-pub fn rand_bytes(FixedArray[Byte], Int) -> Int
+pub fn rand_bytes(Int) -> Bytes raise
 
 pub fn sha1(Bytes) -> Bytes
 

--- a/src/websocket/client.mbt
+++ b/src/websocket/client.mbt
@@ -35,11 +35,8 @@ pub async fn Conn::from_http_client(
   extra_headers? : Map[String, String] = {},
 ) -> Conn {
   // Ref : https://datatracker.ietf.org/doc/html/rfc6455#section-4.1
-  let seed = FixedArray::make(32, b'\x00')
-  if @tls.rand_bytes(seed, 32) != 1 {
-    fail("Failed to get random bytes for WebSocket client")
-  }
-  let rand = @random.Rand::chacha8(seed=seed.unsafe_reinterpret_as_bytes())
+  let seed = @tls.rand_bytes(32)
+  let rand = @random.Rand::chacha8(seed~)
 
   // Send WebSocket handshake request
   let nonce = FixedArray::make(16, b'\x00')

--- a/src/websocket/conn.mbt
+++ b/src/websocket/conn.mbt
@@ -120,6 +120,13 @@ struct Conn {
 
   // the length of *payload* currently buffered in `write_buf`
   mut write_len : Int
+
+  // The set of PING requests that are sent but not yet acknowledged.
+  // According to the WebSocket protocol,
+  // PING should be replied with a PONG with exactly the same payload,
+  // so here we use the payload of PING frames to identify
+  // different PING requests.
+  pings : Map[Bytes, @coroutine.Coroutine]
 }
 
 ///|
@@ -165,6 +172,7 @@ fn Conn::new(
     is_first_frame: true,
     write_buf: FixedArray::make(max_frame_size, 0),
     write_len: 0,
+    pings: {},
   }
 }
 
@@ -391,8 +399,18 @@ async fn Conn::handle_ping(self : Conn, frame : FrameHeader) -> Unit {
 async fn Conn::handle_pong(self : Conn, frame : FrameHeader) -> Unit {
   // the protocol requires `payload_len <= 125`
   let len = frame.payload_len.to_int()
-  guard self.transport.drop(len) == len else {
-    self.protocol_error("Unexpected EOF")
+  let msg = FixedArray::make(len, b'\x00')
+  for received = 0; received < len; {
+    let n = self.transport.read(msg, offset=received, max_len=len - received)
+    guard n > 0 else { self.protocol_error("Unexpected EOF") }
+    continue received + n
+  }
+  if self.read_mask is Some(mask) {
+    mask_payload(msg, mask, offset=0, len~)
+  }
+  let msg = msg.unsafe_reinterpret_as_bytes()
+  if self.pings.get(msg) is Some(coro) {
+    coro.wake()
   }
 }
 
@@ -673,4 +691,55 @@ pub async fn Conn::send_text(self : Conn, text : StringView) -> Unit {
 /// To send large message lazily, see `start_message`.
 pub async fn Conn::send_binary(self : Conn, data : BytesView) -> Unit {
   self..start_message(Binary)..write(data)..end_message()
+}
+
+///|
+/// Send a PING frame to the peer, and wait for PONG reply.
+/// If `msg` is provided, its content will become the body of the PING message.
+/// Otherwise, `ping()` automatically generate random bytes as message body.
+///
+/// The PONG reply may not come immediately.
+/// In particular, it may arrive after several other messages already on the wire.
+/// To avoid data loss and race condition,
+/// `.ping()` itself will not wait for the PONG reply directly.
+/// User must receive data from the same WebSocket connection somewhere else,
+/// in order to get the PONG reply of a PING request.
+/// Calling `.ping()` without another task running `.recv()` on parallel
+/// WILL RESULT IN DEAD LOCK.
+///
+/// If a PING request with the same message body is still waiting for reply,
+/// `.ping()` will fail immediately with error.
+pub async fn Conn::ping(self : Conn, msg? : BytesView) -> Unit {
+  let msg = match msg {
+    Some(msg) => msg
+    None => @tls.rand_bytes(64)
+  }
+  let len = msg.length()
+  guard len <= 125
+  let payload_start = if self.write_mask is Some(_) { 2 + MASK_SIZE } else { 2 }
+  let frame = FixedArray::make(payload_start + len, b'\x00')
+  frame[0] = 0x89
+  frame[1] = if self.write_mask is Some(_) {
+    0x80 | len.to_byte()
+  } else {
+    len.to_byte()
+  }
+  frame.blit_from_bytesview(payload_start, msg)
+  if self.write_mask is Some(rand) {
+    frame.unsafe_write_uint32_be(2, rand.uint())
+    let mask = frame.unsafe_reinterpret_as_bytes()[2:2 + MASK_SIZE]
+    mask_payload(frame, mask, offset=payload_start, len~)
+  }
+  {
+    self.write_lock.acquire()
+    defer self.write_lock.release()
+    self.transport.write(frame.unsafe_reinterpret_as_bytes())
+  }
+  let msg = msg.to_bytes()
+  guard !self.pings.contains(msg) else {
+    raise Failure("A PING request with the same payload is already pending")
+  }
+  self.pings[msg] = @coroutine.current_coroutine()
+  defer self.pings.remove(msg)
+  @coroutine.suspend()
 }

--- a/src/websocket/control_test.mbt
+++ b/src/websocket/control_test.mbt
@@ -139,3 +139,155 @@ async test "close test" {
     inspect(@encoding/utf8.decode(http_client.read_exactly(4)), content="abcd")
   })
 }
+
+///|
+async test "send ping" {
+  @async.with_task_group(group => {
+    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let port = server.addr().port()
+    group.spawn_bg(() => {
+      defer server.close()
+      let (conn, _) = server.accept()
+      defer conn.close()
+      let request = conn.read_request()
+      let ws = @websocket.from_http_server(request, conn)
+      defer ws.close()
+      inspect(ws.recv().read_all().text(), content="1234")
+      ws.send_text("abcd")
+    })
+    let ws = @websocket.connect("ws://localhost:\{port}")
+    defer ws.close()
+    @async.with_task_group(group => {
+      group.spawn_bg(() => {
+        ws.ping()
+        ws.send_text("1234")
+      })
+      inspect(ws.recv().read_all().text(), content="abcd")
+    })
+  })
+}
+
+///|
+async test "ping inside message" {
+  @async.with_task_group(group => {
+    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let port = server.addr().port()
+    group.spawn_bg(() => {
+      defer server.close()
+      let (conn, _) = server.accept()
+      defer conn.close()
+      let request = conn.read_request()
+      let ws = @websocket.from_http_server(request, conn)
+      defer ws.close()
+      inspect(ws.recv().read_all().text(), content="1234")
+      ws.send_text("abcd")
+    })
+    let ws = @websocket.connect("ws://localhost:\{port}")
+    defer ws.close()
+    @async.with_task_group(group => {
+      group.spawn_bg(() => ws
+        ..start_message(Text)
+        ..ping()
+        ..write("1234")
+        ..end_message())
+      inspect(ws.recv().read_all().text(), content="abcd")
+    })
+  })
+}
+
+///|
+async test "multiple ping" {
+  @async.with_task_group(group => {
+    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let port = server.addr().port()
+    group.spawn_bg(() => {
+      defer server.close()
+      let (conn, _) = server.accept()
+      defer conn.close()
+      let request = conn.read_request()
+      let ws = @websocket.from_http_server(request, conn)
+      defer ws.close()
+      @async.sleep(100)
+      inspect(ws.recv().read_all().text(), content="1234")
+      ws.send_text("abcd")
+    })
+    let ws = @websocket.connect("ws://localhost:\{port}")
+    defer ws.close()
+    @async.with_task_group(group => {
+      group.spawn_bg(() => {
+        @async.with_task_group(inner => {
+          inner.spawn_bg(() => ws.ping())
+          inner.spawn_bg(() => ws.ping())
+        })
+        ws.send_text("1234")
+      })
+      inspect(ws.recv().read_all().text(), content="abcd")
+    })
+  })
+}
+
+///|
+async test "ping cancelled" {
+  @async.with_task_group(group => {
+    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let port = server.addr().port()
+    group.spawn_bg(() => {
+      defer server.close()
+      let (conn, _) = server.accept()
+      defer conn.close()
+      let request = conn.read_request()
+      let ws = @websocket.from_http_server(request, conn)
+      defer ws.close()
+      @async.sleep(200)
+      inspect(ws.recv().read_all().text(), content="1234")
+      ws.send_text("abcd")
+    })
+    let ws = @websocket.connect("ws://localhost:\{port}")
+    defer ws.close()
+    @async.with_task_group(group => {
+      group.spawn_bg(() => inspect(ws.recv().read_all().text(), content="abcd"))
+      inspect(
+        @async.with_timeout_opt(100, () => ws.ping(msg="1")),
+        content="None",
+      )
+      ws.ping(msg="1")
+      ws.send_text("1234")
+    })
+  })
+}
+
+///|
+async test "duplicated ping" {
+  @async.with_task_group(group => {
+    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let port = server.addr().port()
+    group.spawn_bg(() => {
+      defer server.close()
+      let (conn, _) = server.accept()
+      defer conn.close()
+      let request = conn.read_request()
+      let ws = @websocket.from_http_server(request, conn)
+      defer ws.close()
+      @async.sleep(100)
+      inspect(ws.recv().read_all().text(), content="1234")
+      ws.send_text("abcd")
+    })
+    let ws = @websocket.connect("ws://localhost:\{port}")
+    defer ws.close()
+    @async.with_task_group(group => {
+      group.spawn_bg(() => {
+        @async.with_task_group(inner => {
+          inner.spawn_bg(() => ws.ping(msg="1"))
+          inner.spawn_bg(() => inspect(
+            try? ws.ping(msg="1"),
+            content=(
+              #|Err(Failure("A PING request with the same payload is already pending"))
+            ),
+          ))
+        })
+        ws.send_text("1234")
+      })
+      inspect(ws.recv().read_all().text(), content="abcd")
+    })
+  })
+}

--- a/src/websocket/moon.pkg.json
+++ b/src/websocket/moon.pkg.json
@@ -3,7 +3,8 @@
     "moonbitlang/async/io",
     "moonbitlang/async/tls",
     "moonbitlang/async/http",
-    "moonbitlang/async/semaphore"
+    "moonbitlang/async/semaphore",
+    "moonbitlang/async/internal/coroutine"
   ],
   "test-import": [
     "moonbitlang/async",

--- a/src/websocket/pkg.generated.mbti
+++ b/src/websocket/pkg.generated.mbti
@@ -42,6 +42,7 @@ pub async fn Conn::end_message(Self) -> Unit
 pub async fn Conn::from_http_client(@http.Client, String, extra_headers? : Map[String, String]) -> Self
 #as_free_fn
 pub async fn Conn::from_http_server(@http.Request, @http.ServerConnection) -> Self
+pub async fn Conn::ping(Self, msg? : BytesView) -> Unit
 pub async fn Conn::recv(Self) -> Message
 pub async fn Conn::send_binary(Self, BytesView) -> Unit
 pub async fn Conn::send_close(Self, code? : CloseCode, reason? : String) -> Unit


### PR DESCRIPTION
Add `.ping()` method for actively sending PING to remote peer in a WebSocket tunnel. `.ping()` will then wait for the corresponding PONG reply automatically.

The PONG reply may not arrive immediately, so `.ping()` must be used with care. In particular, there must be another task receiving data from the tunnel running in parallel, otherwise `.ping()` will hang forever. Check the docstring of `.ping()` for more details.