### PR TITLE
move job id management to MoonBit

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -19,7 +19,8 @@ priv struct EventLoop {
   pids : Map[Int, @coroutine.Coroutine]
   notify_recv : Int
   max_worker_count : Int
-  job_queue : @deque.Deque[Job]
+  mut job_id : Int
+  job_queue : @deque.Deque[QueuedJob]
   idle_workers : @deque.Deque[Worker]
   running_workers : Map[Int, Worker]
   jobs : Map[Int, @coroutine.Coroutine]
@@ -33,6 +34,12 @@ struct IoHandle {
   mut events : Int
   mut read : @coroutine.Coroutine?
   mut write : @coroutine.Coroutine?
+}
+
+///|
+priv struct QueuedJob {
+  job_id : Int
+  job : Job
 }
 
 ///|
@@ -82,6 +89,7 @@ pub fn with_event_loop(f : async () -> Unit) -> Unit raise {
     pids: {},
     notify_recv,
     max_worker_count: 1024,
+    job_id: 0,
     job_queue: @deque.new(),
     idle_workers: @deque.new(),
     running_workers: {},
@@ -142,8 +150,8 @@ fn EventLoop::poll(self : Self) -> Unit raise {
         match self.job_queue.pop_front() {
           None => self.idle_workers.push_back(worker)
           Some(job) => {
-            self.running_workers[job.id()] = worker
-            wake_worker(worker, job)
+            self.running_workers[job.job_id] = worker
+            wake_worker(worker, job.job_id, job.job)
           }
         }
         if self.jobs.get(job_id) is Some(coro) {
@@ -341,20 +349,22 @@ async fn perform_job_in_worker(
   allow_cancel? : Bool = false,
 ) -> Int {
   guard curr_loop.val is Some(evloop)
+  let job_id = evloop.job_id
+  evloop.job_id += 1
   match evloop.idle_workers.pop_front() {
     None if evloop.running_workers.length() > evloop.max_worker_count =>
-      evloop.job_queue.push_back(job)
+      evloop.job_queue.push_back({ job_id, job })
     None => {
-      let worker = spawn_worker(job)
-      evloop.running_workers[job.id()] = worker
+      let worker = spawn_worker(job_id, job)
+      evloop.running_workers[job_id] = worker
     }
     Some(worker) => {
-      evloop.running_workers[job.id()] = worker
-      wake_worker(worker, job)
+      evloop.running_workers[job_id] = worker
+      wake_worker(worker, job_id, job)
     }
   }
-  evloop.jobs[job.id()] = @coroutine.current_coroutine()
-  defer evloop.jobs.remove(job.id())
+  evloop.jobs[job_id] = @coroutine.current_coroutine()
+  defer evloop.jobs.remove(job_id)
   if allow_cancel {
     @coroutine.suspend()
   } else {

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -23,22 +23,18 @@ extern "C" fn destroy_thread_pool() = "moonbitlang_async_destroy_thread_pool"
 
 ///|
 #owned(init_job)
-extern "C" fn spawn_worker(init_job : Job) -> Worker = "moonbitlang_async_spawn_worker"
+extern "C" fn spawn_worker(init_job_id : Int, init_job : Job) -> Worker = "moonbitlang_async_spawn_worker"
 
 ///|
 #borrow(worker)
 #owned(job)
-extern "C" fn wake_worker(worker : Worker, job : Job) = "moonbitlang_async_wake_worker"
+extern "C" fn wake_worker(worker : Worker, job_id : Int, job : Job) = "moonbitlang_async_wake_worker"
 
 ///|
 extern "C" fn fetch_completion_ffi(notify_recv : Int) -> Int = "moonbitlang_async_fetch_completion"
 
 ///|
 priv type Job
-
-///|
-#borrow(self)
-extern "C" fn Job::id(self : Job) -> Int = "moonbitlang_async_job_get_id"
 
 ///|
 #borrow(self)


### PR DESCRIPTION
Refactor event loop, move job id management to MoonBit. In the Windows backend under development, I plan to use job id to uniformly handle thread pool tasks and IOCP operations.