### PR TITLE
[breaking] allow closing async queue

### DIFF
--- a/src/aqueue/aqueue.mbt
+++ b/src/aqueue/aqueue.mbt
@@ -57,6 +57,8 @@ struct Queue[X] {
   writers : @deque.Deque[Writer[X]]
   /// invariant: if `buffer` is non-empty, `readers` must be empty
   buffer : @deque.Deque[X]
+  /// `Some(err)` if the queue is already closed
+  mut closed : Error?
 }
 
 ///|
@@ -73,7 +75,13 @@ pub fn[X] Queue::new(kind? : Kind = Unbounded) -> Queue[X] {
         abort("queue size must be positive")
       }
   }
-  { kind, writers: @deque.new(), readers: @deque.new(), buffer: @deque.new() }
+  {
+    kind,
+    writers: @deque.new(),
+    readers: @deque.new(),
+    buffer: @deque.new(),
+    closed: None,
+  }
 }
 
 ///|
@@ -103,7 +111,14 @@ pub fn[X] Queue::new(kind? : Kind = Unbounded) -> Queue[X] {
 /// in this case `put` will fail with a cancellation error.
 /// It is guaranteed that the element will be added to the queue
 /// *if and only if* `put` return normally.
+///
+/// If the queue is already closed, `put` will fail immediately.
+/// If the queue is a blocking queue, and is closed while `put` is blocking,
+/// `put` will also fail immediately.
 pub async fn[X] Queue::put(self : Queue[X], data : X) -> Unit {
+  if self.closed is Some(err) {
+    raise err
+  }
   if !self.try_put(data) {
     match self.kind {
       Unbounded => panic()
@@ -119,6 +134,9 @@ pub async fn[X] Queue::put(self : Queue[X], data : X) -> Unit {
             writer.coro = None
             raise err
           }
+        }
+        if self.closed is Some(err) {
+          raise err
         }
       }
       DiscardOldest(_) => {
@@ -139,7 +157,12 @@ pub async fn[X] Queue::put(self : Queue[X], data : X) -> Unit {
 /// Note that even for `DiscardOldest` or `DiscardLatest` queues,
 /// where `put` never blocks, `try_put` will still return `false` if the queue is full,
 /// instead of discarding the oldest/newest element.
-pub fn[X] Queue::try_put(self : Queue[X], data : X) -> Bool {
+///
+/// If the queue is already closed, `try_put` will fail with error immediately.
+pub fn[X] Queue::try_put(self : Queue[X], data : X) -> Bool raise {
+  if self.closed is Some(err) {
+    raise err
+  }
   loop self.readers.pop_front() {
     None =>
       match self.kind {
@@ -178,6 +201,10 @@ pub fn[X] Queue::try_put(self : Queue[X], data : X) -> Bool {
 /// `get` itself never fail, and will wait indefinitely.
 /// However, since `get` is a blocking point, the task running `get` may be cancelled,
 /// in this case, an cancellation will be raised from `get`.
+///
+/// If the queue is already closed and there is no buffered elements,
+/// `get` will fail immediately.
+/// If the queue is closed while `get` is waiting, `get` will also fail immediately.
 pub async fn[X] Queue::get(self : Queue[X]) -> X {
   if self.try_get() is Some(data) {
     return data
@@ -207,13 +234,19 @@ pub async fn[X] Queue::get(self : Queue[X]) -> X {
       raise err
     }
   }
+  if self.closed is Some(err) {
+    raise err
+  }
   reader.value.unwrap()
 }
 
 ///|
 /// Try to fetch an element from the queue without blocking.
 /// If no element is in the queue at the moment, `None` is returned.
-pub fn[X] Queue::try_get(self : Queue[X]) -> X? {
+///
+/// If the queue is already closed and there is no buffered elements,
+/// `try_get` will fail immediately.
+pub fn[X] Queue::try_get(self : Queue[X]) -> X? raise {
   let result = self.buffer.pop_front()
   if result is Some(_) {
     loop self.writers.pop_front() {
@@ -225,6 +258,47 @@ pub fn[X] Queue::try_get(self : Queue[X]) -> X? {
         writer.coro = None
       }
     }
+  } else if self.closed is Some(err) {
+    raise err
   }
   result
+}
+
+///|
+pub suberror QueueAlreadyClosed derive(Show, ToJson)
+
+///|
+/// Close an async queue. After the queue is closed:
+///
+/// - blocking `put` and `get` operations will fail immediately.
+/// - subsequent `put` and `try_put` operations also fail immediately
+/// - if `clear = false` (`false` by default),
+///   sbusequent `get` and `try_get` operations can still retrieve
+///   buffered elements in the queue before `close`.
+///   After the queue becomes empty,
+///   subsequent `get` and `try_get` operations also fail immediately
+/// - if `clear = true`, buffered elements in the queue will be cleared
+///
+/// By default, writing to or reading from a closed queue
+/// will receive the `QueueAlreadyClosed` error.
+/// But this error can be customized via the `error` parameter.
+pub fn[X] Queue::close(
+  self : Queue[X],
+  error? : Error = QueueAlreadyClosed,
+  clear? : Bool = false,
+) -> Unit {
+  self.closed = Some(error)
+  for writer in self.writers {
+    if writer.coro is Some(coro) {
+      coro.wake()
+    }
+  }
+  for reader in self.readers {
+    if reader.coro is Some(coro) {
+      coro.wake()
+    }
+  }
+  if clear {
+    self.buffer.clear()
+  }
 }

--- a/src/aqueue/close_test.mbt
+++ b/src/aqueue/close_test.mbt
@@ -1,0 +1,88 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "put after closed" {
+  let q = @aqueue.new(kind=Unbounded)
+  q.close()
+  inspect(try? q.put(42), content="Err(QueueAlreadyClosed)")
+  inspect(try? q.try_put(42), content="Err(QueueAlreadyClosed)")
+}
+
+///|
+async test "get after closed" {
+  let q = @aqueue.new(kind=Unbounded)
+  q.put(42)
+  q.close()
+  inspect(try? q.get(), content="Ok(42)")
+  inspect(try? q.get(), content="Err(QueueAlreadyClosed)")
+}
+
+///|
+async test "try_get after closed" {
+  let q = @aqueue.new(kind=Unbounded)
+  q.put(42)
+  q.close()
+  inspect(try? q.try_get(), content="Ok(Some(42))")
+  inspect(try? q.try_get(), content="Err(QueueAlreadyClosed)")
+}
+
+///|
+async test "get after hard close" {
+  let q = @aqueue.new(kind=Unbounded)
+  q.put(42)
+  q.close(clear=true)
+  inspect(try? q.get(), content="Err(QueueAlreadyClosed)")
+}
+
+///|
+async test "try_get after hard close" {
+  let q = @aqueue.new(kind=Unbounded)
+  q.put(42)
+  q.close(clear=true)
+  inspect(try? q.try_get(), content="Err(QueueAlreadyClosed)")
+}
+
+///|
+async test "close with blocking put" {
+  let q = @aqueue.new(kind=Blocking(1))
+  q.put(1)
+  @async.with_task_group(group => {
+    let start = @async.now()
+    group.spawn_bg(() => {
+      @async.sleep(200)
+      q.close()
+    })
+    inspect(try? q.put(2), content="Err(QueueAlreadyClosed)")
+    let now = @async.now()
+    let duration = (now + 10 - start) / 200
+    inspect(duration, content="1")
+  })
+}
+
+///|
+async test "close with blocking get" {
+  let q : @aqueue.Queue[Int] = @aqueue.new(kind=Unbounded)
+  @async.with_task_group(group => {
+    let start = @async.now()
+    group.spawn_bg(() => {
+      @async.sleep(200)
+      q.close()
+    })
+    inspect(try? q.get(), content="Err(QueueAlreadyClosed)")
+    let now = @async.now()
+    let duration = (now + 10 - start) / 200
+    inspect(duration, content="1")
+  })
+}

--- a/src/aqueue/pkg.generated.mbti
+++ b/src/aqueue/pkg.generated.mbti
@@ -4,6 +4,9 @@ package "moonbitlang/async/aqueue"
 // Values
 
 // Errors
+pub suberror QueueAlreadyClosed
+pub impl Show for QueueAlreadyClosed
+pub impl ToJson for QueueAlreadyClosed
 
 // Types and methods
 pub(all) enum Kind {
@@ -14,13 +17,14 @@ pub(all) enum Kind {
 }
 
 type Queue[X]
+pub fn[X] Queue::close(Self[X], error? : Error, clear? : Bool) -> Unit
 pub async fn[X] Queue::get(Self[X]) -> X
 #as_free_fn
 #label_migration(kind, fill=true, msg="specify the kind of queue explicitly via `kind=...`")
 pub fn[X] Queue::new(kind? : Kind) -> Self[X]
 pub async fn[X] Queue::put(Self[X], X) -> Unit
-pub fn[X] Queue::try_get(Self[X]) -> X?
-pub fn[X] Queue::try_put(Self[X], X) -> Bool
+pub fn[X] Queue::try_get(Self[X]) -> X? raise
+pub fn[X] Queue::try_put(Self[X], X) -> Bool raise
 
 // Type aliases
 


### PR DESCRIPTION
This PR add support for closing an async queue. The detailed behavior of `@async.Queue::close` is:

- any blocked `put` or `get` operation will fail immediately after calling `.close()`
- calling `put` or `try_put` on a closed queue will fail immediately
- calling `get` or `try_get` on a closed queue can still retrieve buffered elements in the queue. If the queue is closed and empty, `get` and `try_get` will fail immediately.
    - `.close(clear=true)` (`clear=false` by default) result in a hard close. Buffered elements in the queue will be discarded, and subsequent `get` & `try_get` operations always fail immediately

By default, the error `@aqueue.QueueAlreadyClosed` will be raised for the above scenarios. However, the error can be customized via the `error` optional argument of `.close()`.

This PR is breaking because `try_get` and `try_put` may now raise error.