### PR TITLE
fix unused `async` annotation

### DIFF
--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -145,7 +145,7 @@ pub async fn walk(
   guard max_concurrency > 0
   let sem = @async.Semaphore::new(max_concurrency)
   @async.with_task_group(fn(group) {
-    async fn handle_path(path : String) {
+    fn handle_path(path : String) {
       group.spawn_bg(allow_failure~, fn() {
         sem.acquire()
         defer sem.release()

--- a/src/js_async/unimplemented.mbt
+++ b/src/js_async/unimplemented.mbt
@@ -82,6 +82,7 @@ pub fn AbortController::abort(self : Self) -> Unit {
 ///
 /// If `abort_controller` is absent, `wait` is non-cancellable.
 #internal(unimplemented, "unimplemented in native backend")
+#warnings("-unused_async")
 pub async fn[X] Promise::wait(
   promise : Promise[X],
   abort_controller? : AbortController,
@@ -104,6 +105,7 @@ pub async fn[X] Promise::wait(
 /// (i.e. the promised returned by `f` should properly handle the passed-in abort signal).
 /// For non-cancellable JavaScript code, use `Promise::wait()` directly.
 #internal(unimplemented, "unimplemented in native backend")
+#warnings("-unused_async")
 pub async fn[X] run_promise(f : (AbortSignal) -> Promise[X]) -> X {
   ignore(f)
   abort("unimplemented in native backend")
@@ -124,6 +126,7 @@ pub async fn[X] run_promise(f : (AbortSignal) -> Promise[X]) -> X {
 /// so there is no structured concurrency support for `Promise::from_async`,
 /// and this function should only be used for exporting MoonBit code to JavaScript.
 #internal(unimplemented, "unimplemented in native backend")
+#warnings("-unused_async")
 pub fn[X] Promise::from_async(
   f : async () -> X,
   abort_signal? : AbortSignal,

--- a/src/websocket/conn.mbt
+++ b/src/websocket/conn.mbt
@@ -611,7 +611,7 @@ pub impl @io.Reader for Message with _direct_read(self, buf, offset~, max_len~) 
 /// and use `end_message` to ensure data is actually sent to the server.
 ///
 /// `start_message` must NOT be called before the last message ends.
-pub async fn Conn::start_message(self : Conn, kind : MessageKind) -> Unit {
+pub fn Conn::start_message(self : Conn, kind : MessageKind) -> Unit {
   guard self.write_opcode is None else {
     abort("cannot start a new message before the last message end")
   }

--- a/src/websocket/pkg.generated.mbti
+++ b/src/websocket/pkg.generated.mbti
@@ -47,7 +47,7 @@ pub async fn Conn::recv(Self) -> Message
 pub async fn Conn::send_binary(Self, BytesView) -> Unit
 pub async fn Conn::send_close(Self, code? : CloseCode, reason? : String) -> Unit
 pub async fn Conn::send_text(Self, StringView) -> Unit
-pub async fn Conn::start_message(Self, MessageKind) -> Unit
+pub fn Conn::start_message(Self, MessageKind) -> Unit
 pub impl @io.Writer for Conn
 
 pub struct Message {


### PR DESCRIPTION
The latest MoonBit release now supports reporting warning on useless `async` annotation. This PR fixes those useless `async` warning in `moonbitlang/async`.

There is one public API affected: `@websocket.Conn::start_message`. It is previously marked as `async`, but is in fact synchronous.