### PR TITLE
http: fix passthrough mode data loss

### DIFF
--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -169,7 +169,7 @@ pub impl @io.Reader for Client with _direct_read(self, buf, offset~, max_len~) {
 
 ///|
 pub impl @io.Reader for Client with _get_internal_buffer(self) {
-  self.reader.read_buf
+  self.reader._get_internal_buffer()
 }
 
 ///|

--- a/src/http/proxy_test.mbt
+++ b/src/http/proxy_test.mbt
@@ -51,6 +51,30 @@ async test "passthrough mode" {
 }
 
 ///|
+async test "passthrough mode remaining data" {
+  @async.with_task_group(group => {
+    let server = @socket.TcpServer::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server_addr = server.addr()
+    group.spawn_bg(() => {
+      defer server.close()
+      let (conn, _) = server.accept()
+      let conn = @http.ServerConnection::new(conn)
+      defer conn.close()
+      let request = conn.read_request()
+      inspect(request.meth, content="Get")
+      inspect(request.path, content="/")
+      conn.enter_passthrough_mode()
+      inspect(conn.read_all().text(), content="remaining data")
+    })
+    let client = @socket.Tcp::connect(
+      @socket.Addr::parse("127.0.0.1:\{server_addr.port()}"),
+    )
+    defer client.close()
+    client.write("GET / HTTP/1.1\r\n\r\nremaining data")
+  })
+}
+
+///|
 async fn handle_connect(
   log : Array[String],
   request : @http.Request,

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -71,7 +71,7 @@ pub impl @io.Reader for ServerConnection with _direct_read(
 
 ///|
 pub impl @io.Reader for ServerConnection with _get_internal_buffer(self) {
-  self.reader.read_buf
+  self.reader._get_internal_buffer()
 }
 
 ///|


### PR DESCRIPTION
Fix a bug in pass through mode for `@http.Client` and `@http.Server` that may cause data loss when pass-through data arrived together with previous request/response