### PR TITLE
fix TLS shutdown handling

### DIFF
--- a/src/tls/shutdown_test.mbt
+++ b/src/tls/shutdown_test.mbt
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 ///|
-#cfg(not(platform="windows"))
 async test "peer close connection" {
   @async.with_task_group(fn(root) {
     // server
@@ -25,23 +24,24 @@ async test "peer close connection" {
       defer conn.close()
       let server = test_server(conn, conn)
       defer server.close()
+      server.write("1234")
       inspect(server.read_all().text(), content="abcd")
-      // close the underlying connection directly
     })
     // client
-    root.spawn_bg(fn() {
-      let conn = @socket.Tcp::connect(addr)
-      defer conn.close()
-      let client = @tls.Tls::client(conn, verify=false)
-      defer client.close()
-      client.write("abcd")
-      @async.sleep(100)
-      // the server already closed the connection
-      client.shutdown()
-    })
+    let conn = @socket.Tcp::connect(addr)
+    defer conn.close()
+    let client = @tls.Tls::client(conn, verify=false)
+    defer client.close()
+    // It is necessary to perform a `read` first here.
+    // OpenSSL and Windows schannel will send a TLS v1.3 session ticket
+    // immediately after handshake.
+    //
+    // If we close the connection without reading any data (i.e. a one-way connection),
+    // the underlying TCP connection will be reset,
+    // due to pending data in the recv buffer.
+    // Read something before closing the connection solves the problem.
+    inspect(@encoding/utf8.decode(client.read_exactly(4)), content="1234")
+    client.write("abcd")
+    // close the underlying connection directly
   })
 }
-
-///|
-#cfg(platform="windows")
-let _unused : Unit = ignore(@socket.Addr::parse)

--- a/src/tls/tls.mbt
+++ b/src/tls/tls.mbt
@@ -21,6 +21,7 @@ struct Tls {
   host : String?
   bio : Endpoint
   read_buf : @io.ReaderBuffer
+  mut shutdown : Bool
   mut closed : Bool
 }
 
@@ -42,7 +43,14 @@ fn[R : @io.Reader, W : @io.Writer] Tls::from_pair(
   let rbio = create_bio(bio)
   let wbio = create_bio(bio)
   let ssl = SSL::new(ctx, rbio, wbio)
-  { ssl, host, bio, read_buf: @io.ReaderBuffer::new(), closed: false }
+  {
+    ssl,
+    host,
+    bio,
+    read_buf: @io.ReaderBuffer::new(),
+    shutdown: false,
+    closed: false,
+  }
 }
 
 ///|
@@ -211,7 +219,17 @@ pub impl @io.Reader for Tls with _direct_read(self, buf, offset~, max_len~) {
       break ret
     }
     let err = self.ssl.get_error(ret)
-    if err is SSL_ERROR_ZERO_RETURN || self.bio.state is Closed {
+    if err is SSL_ERROR_ZERO_RETURN {
+      // the peer initiates closure
+      self.shutdown()
+      break 0
+    }
+    if self.bio.state is Closed &&
+      self.bio.reader._get_internal_buffer().repr().len is 0 {
+      // Not all TLS client/servers close the connection properly.
+      // Some peers just close the underlying TCP connection
+      // without performing a TLS closure.
+      // So we treat this case as normal here.
       break 0
     }
     self.handle_error(err)
@@ -268,35 +286,31 @@ pub fn Tls::close(self : Tls) -> Unit {
 /// This function MUST be called before `close`,
 /// and MUST NOT be called if the TLS connection fail with other error.
 ///
+/// `shutdown` is used to initiate the closure of a TLS connection.
+/// So there is no need to call `shutdown` if you receive EOF from the peer.
+///
+/// When calling `shutdown`,
+/// there may still be pending data sent by the peer on the wire.
+/// So to close a TLS connection cleanly,
+/// make sure you read from the connection until EOF after calling `shutdown`.
+///
 /// Note that the main purpose of TLS shutdown is to ensure integrity
 /// before closing the underlying transport.
 /// So if your application protocol has its own way of ensuring integrity
 /// (e.g. `Content-Length` in HTTP/1.1),
 /// it is not necessary to call `shutdown`.
-///
-/// Shutting down a TLS connection involves communicating with remote peer,
-/// which may die unexpectedly or become irresponsive.
-/// Furthermore, some servers may not response correctly to TLS shutdown.
-/// So it is highly recommended to add a timeout when calling this function,
-/// to prevent the program from haning indefinitely.
 #cfg(not(platform="windows"))
 pub async fn Tls::shutdown(self : Tls) -> Unit {
+  guard !self.shutdown else {  }
+  self.shutdown = true
   match self.bio.state {
     Normal => ()
-    Closed => return
+    Closed => raise ConnectionClosed
     Error(err) => raise err
   }
-  while self.ssl.shutdown() is ret && ret <= 0 {
-    let err = if ret == 0 {
-      SSL_ERROR_WANT_READ
-    } else {
-      self.ssl.get_error(ret)
-    }
-    match err {
-      SSL_ERROR_WANT_READ | SSL_ERROR_WANT_WRITE if self.bio.state is Closed =>
-        break
-      _ => self.handle_error(err)
-    }
+  while self.ssl.shutdown() is ret && ret < 0 {
+    let err = self.ssl.get_error(ret)
+    self.handle_error(err)
   } else {
     self.bio.flush_write(flush_all=true)
   }


### PR DESCRIPTION
Previously, TLS shutdown is implemented incorrectly for Linux/MacOS. This PR fixes the problem. To close a TLS connection properly:

- if the closure is initiated by us, `@tls.Tls::shutdown` should be called, which send a TLS CLOSE_NOTIFY message to the peer. After that, we should continue reading from the TLS connection until EOF, so that no data is lost and the CLOSE_NOTIFY reply from the peer is properly notified
- if the closure is initiated by the remote peer, we should reply with a CLOSE_NOTIFY message immediately after receiving CLOSE_NOTIFY from the peer. In this PR, this is done automatically by `impl @io.Reader for @tls.Tls`

In practice, if the application protocol has its own way of identifying end of data (e.g. HTTP), TLS closure is not necessary. And many real-world HTTPS server does not perform TLS closure. Since HTTPS is currently the most important use case for `moonbitlang/async/tls`, currently, if the peer closes underlying connection without sending `CLOSE_NOTIFY`, `@tls.Tls::read` will return zero normally instead of failing. This can be problematic when the application protocol is just a byte stream, though. Closing the underlying connection directly is vulnerable to truncation attack, so maybe we should add a configuration option for whether TLS closure is required in the future.

There is another TLS 1.3 specific issue that arise annoyingly in tests. In TLS 1.3, server may send session tickets to clients after the TLS connection is established. OpenSSL and schannel will send a session ticket immediately after handshake. However, if the connection is one-way (i.e. the client only send data and never receive data), the session ticket will never get read. This is problematic for testing because:

- if the underlying transport has no buffer, the server will stuck at sending session ticket
- if the client closes the underlying TCP connection directly, it will be a hard close due to unread data (session ticket) in the socket

Fortunately, both cases are rare, in real world usage. HTTPS, for example, is a two-way protocol, so the session ticket will always get processed when client read HTTP response from the server. For custom protocol, performing a proper TLS shutdown (call `shutdown` and then read until EOF) can avoid the problem. See more discussions at https://github.com/openssl/openssl/issues/7948