### PR TITLE
enhance process cancellation

### DIFF
--- a/src/process/basic_test.mbt
+++ b/src/process/basic_test.mbt
@@ -40,8 +40,8 @@ async test "basic_ls" {
       "stub.c", "unix.mbt", "README.md", "windows.c", "process.mbt", "windows.mbt",
       "cwd_test.mbt", "env_test.mbt", "redirect.mbt", "README.mbt.md", "moon.pkg.json",
       "test_programs", "wait_test.mbt", "basic_test.mbt", "cancel_test.mbt", "helper_test.mbt",
-      "redirect_test.mbt", "unimplemented.mbt", "pkg.generated.mbti", "commands_for_test.mbt",
-      "unimplemented_test.mbt", "windows_escape_wbtest.mbt",
+      "cancellation.mbt", "redirect_test.mbt", "unimplemented.mbt", "pkg.generated.mbti",
+      "commands_for_test.mbt", "unimplemented_test.mbt", "windows_escape_wbtest.mbt",
     ])
   })
 }

--- a/src/process/cancel_test.mbt
+++ b/src/process/cancel_test.mbt
@@ -38,11 +38,70 @@ async test "cancel process" {
     log.to_string(),
     content=(
       #|cancelling task running process
-      #|process terminates
       #|from process: received termination signal
+      #|process terminates
       #|
     ),
   )
+}
+
+///|
+async test "cancel process timeout" {
+  let test_prog = sleep_prog.wait()
+  @async.with_task_group(fn(root) {
+    let (r, w) = @process.read_from_process()
+    let task = root.spawn(allow_failure=true, fn() {
+      @process.run(
+        test_prog,
+        ["-swallow-cancel-signal", "10000"],
+        stdout=w,
+        cancel_handler=@process.graceful_cancel(timeout=500),
+      )
+    })
+    let t_receive_graceful_termination = root.spawn(() => {
+      defer r.close()
+      guard r.read_some() is Some(data)
+      let data = @encoding/utf8.decode(data).trim_end(chars="\r\n")
+      let t = @async.now()
+      inspect(data, content="received termination signal")
+      t
+    })
+    @async.sleep(500)
+    let t_cancel = @async.now()
+    task.cancel()
+    inspect(try? task.wait(), content="Err(Cancelled)")
+    let t_process_terminates = @async.now()
+    let t1 = t_receive_graceful_termination.wait() - t_cancel
+    let t2 = t_process_terminates - t_cancel
+    inspect(t1 / 250, content="0")
+    inspect(t2 / 250, content="2")
+  })
+}
+
+///|
+async test "cancel process hard" {
+  let test_prog = sleep_prog.wait()
+  @async.with_task_group(fn(root) {
+    let (r, w) = @process.read_from_process()
+    let task = root.spawn(allow_failure=true, fn() {
+      @process.run(
+        test_prog,
+        ["10000"],
+        stdout=w,
+        cancel_handler=@process.hard_cancel(),
+      )
+    })
+    root.spawn_bg(() => {
+      defer r.close()
+      inspect(r.read_all().text(), content="")
+    })
+    @async.sleep(500)
+    let t0 = @async.now()
+    task.cancel()
+    inspect(try? task.wait(), content="Err(Cancelled)")
+    let t1 = @async.now()
+    inspect((t1 - t0) / 250, content="0")
+  })
 }
 
 ///|

--- a/src/process/cancellation.mbt
+++ b/src/process/cancellation.mbt
@@ -1,0 +1,46 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+extern "C" fn terminate_process(pid : Int) = "moonbitlang_async_terminate_process"
+
+///|
+extern "C" fn kill_process(pid : Int) = "moonbitlang_async_kill_process"
+
+///|
+/// A handler function used to stop spawned process on cancellation.
+/// The function receive the PID of the process as input.
+pub(all) struct CancellationHandler(async (Int) -> Unit)
+
+///|
+/// A process cancellation handler that first try to gracefully stop the process,
+/// and if the process is still running after `timeout` milliseconds,
+/// forcefully stop the process.
+///
+/// Graceful process termination is implemented via `SIGTERM` on POSIX-like systems,
+/// and `CTRL_BREAK_EVENT` on Windows.
+pub fn graceful_cancel(timeout~ : Int) -> CancellationHandler {
+  pid => {
+    terminate_process(pid)
+    @async.sleep(timeout)
+    kill_process(pid)
+  }
+}
+
+///|
+/// A process cancellation handler that forcefully stop the process.
+/// Implemented via `SIGKILL` on POSIX-like systems and `TerminateProcess` on Windows.
+pub fn hard_cancel() -> CancellationHandler {
+  pid => kill_process(pid)
+}

--- a/src/process/cwd_test.mbt
+++ b/src/process/cwd_test.mbt
@@ -42,8 +42,8 @@ async test "set cwd" {
       "stub.c", "unix.mbt", "README.md", "windows.c", "process.mbt", "windows.mbt",
       "cwd_test.mbt", "env_test.mbt", "redirect.mbt", "README.mbt.md", "moon.pkg.json",
       "test_programs", "wait_test.mbt", "basic_test.mbt", "cancel_test.mbt", "helper_test.mbt",
-      "redirect_test.mbt", "unimplemented.mbt", "pkg.generated.mbti", "commands_for_test.mbt",
-      "unimplemented_test.mbt", "windows_escape_wbtest.mbt",
+      "cancellation.mbt", "redirect_test.mbt", "unimplemented.mbt", "pkg.generated.mbti",
+      "commands_for_test.mbt", "unimplemented_test.mbt", "windows_escape_wbtest.mbt",
     ])
   })
 }

--- a/src/process/moon.pkg.json
+++ b/src/process/moon.pkg.json
@@ -16,6 +16,7 @@
   "targets": {
     "process.mbt": [ "native" ],
     "redirect.mbt": [ "native" ],
+    "cancellation.mbt": [ "native" ],
     "windows.mbt": [ "native" ],
     "unix.mbt": [ "native" ],
     "basic_test.mbt": [ "native" ],

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -16,13 +16,17 @@ pub async fn collect_stderr(String, Array[String], extra_env? : Map[String, Stri
 
 pub async fn collect_stdout(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stderr? : &ProcessOutput, cwd? : String) -> (Int, &@io.Data)
 
+pub fn graceful_cancel(timeout~ : Int) -> CancellationHandler
+
+pub fn hard_cancel() -> CancellationHandler
+
 pub fn read_from_process() -> (@pipe.PipeRead, &ProcessOutput) raise
 
 pub async fn redirect_from_file(String) -> &ProcessInput
 
 pub async fn redirect_to_file(String, append? : Bool, create? : Int, truncate? : Bool) -> &ProcessOutput
 
-pub async fn run(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : String) -> Int
+pub async fn run(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : String, cancel_handler? : CancellationHandler) -> Int
 
 pub async fn spawn_orphan(String, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : String) -> Int
 
@@ -33,6 +37,9 @@ pub fn write_to_process() -> (&ProcessInput, @pipe.PipeWrite) raise
 // Errors
 
 // Types and methods
+pub(all) struct CancellationHandler(async (Int) -> Unit)
+#deprecated
+pub fn CancellationHandler::inner(Self) -> async (Int) -> Unit
 
 // Type aliases
 

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 ///|
-extern "C" fn terminate_process(pid : Int) = "moonbitlang_async_terminate_process"
-
-///|
 #borrow(out)
 extern "C" fn get_process_result(pid : Int, out : Ref[Int]) -> Int = "moonbitlang_async_get_process_result"
 
@@ -82,8 +79,6 @@ pub async fn wait_pid(pid : Int) -> Int {
 ///
 /// `run` will block until the new process terminates,
 /// and returns the exit status of the process.
-/// If current task is cancelled while blocking,
-/// the spawned process will be terminated via `SIGTERM`.
 /// To run the process in background, use `@async.spawn` or `@async.spawn_bg`.
 ///
 /// If `inherit_env` is `true` (`true` by default),
@@ -109,6 +104,16 @@ pub async fn wait_pid(pid : Int) -> Int {
 ///
 /// If `cwd` is present, the spawned command will be executed
 /// in the directory specified by `cwd`.
+///
+/// If current task is cancelled while blocking,
+/// `cancel_handler` will be used to automatically stop the process.
+/// `@process.run` will not return until the process terminates, even if cancelled.
+/// The default value of `cancel_handler` is `graceful_cancel(timeout=5000)`
+/// (First try to gracefully terminate the process, and if the process is still running
+/// after five seconds, terminate it forcefully).
+///
+/// If `cancel_handler` is still running after the process terminates,
+/// it will be cancelled.
 pub async fn run(
   cmd : String,
   args : Array[String],
@@ -118,6 +123,7 @@ pub async fn run(
   stdout? : &ProcessOutput,
   stderr? : &ProcessOutput,
   cwd? : String,
+  cancel_handler? : CancellationHandler = graceful_cancel(timeout=5000),
 ) -> Int {
   let context = "@process.run()"
   let pid = spawn(
@@ -132,10 +138,11 @@ pub async fn run(
     context~,
   )
   @event_loop.wait_pid(pid, context~) catch {
-    err if @coroutine.is_being_cancelled() => {
-      terminate_process(pid)
-      raise err
-    }
+    _ if @coroutine.is_being_cancelled() =>
+      @async.protect_from_cancel(() => @async.with_task_group(group => {
+        group.spawn_bg(no_wait=true, () => cancel_handler(pid))
+        @event_loop.wait_pid(pid, context~)
+      }))
     err => raise err
   }
   let out = @ref.new(0)

--- a/src/process/stub.c
+++ b/src/process/stub.c
@@ -57,4 +57,8 @@ void moonbitlang_async_terminate_process(pid_t pid) {
   kill(pid, SIGTERM);
 }
 
+void moonbitlang_async_kill_process(pid_t pid) {
+  kill(pid, SIGKILL);
+}
+
 #endif

--- a/src/process/test_programs/sleep/main.mbt
+++ b/src/process/test_programs/sleep/main.mbt
@@ -17,11 +17,13 @@
 extern "C" fn register_termination_handler() = "register_termination_handler"
 
 ///|
+extern "C" fn set_swallow_cancel_signal() = "set_swallow_cancel_signal"
+
+///|
 extern "C" fn exit(code : Int) = "exit"
 
 ///|
 async fn main {
-  register_termination_handler()
   let mut time = 10_000
   let mut exit_code = 0
   loop @env.args()[1:] {
@@ -31,12 +33,17 @@ async fn main {
       exit_code = @strconv.parse_int(code)
       continue rest
     }
+    ["-swallow-cancel-signal", ..rest] => {
+      set_swallow_cancel_signal()
+      continue rest
+    }
     [['-', ..] as flag, ..] => fail("unrecognized argument \{flag}")
     [t, .. rest] => {
       time = @strconv.parse_int(t)
       continue rest
     }
   }
+  register_termination_handler()
   @async.sleep(time)
   exit(exit_code)
 }

--- a/src/process/windows.c
+++ b/src/process/windows.c
@@ -47,4 +47,13 @@ void moonbitlang_async_terminate_process(DWORD pid) {
   GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid);
 }
 
+void moonbitlang_async_kill_process(DWORD pid) {
+  HANDLE handle = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
+  if (handle == INVALID_HANDLE_VALUE)
+    return;
+
+  TerminateProcess(handle, 1);
+  CloseHandle(handle);
+}
+
 #endif


### PR DESCRIPTION
This PR enhance automatic cancellation feature of `@process.run`, allow users to configure how the process should be terminated when `@process.run` is cancelled. Process termination is implemented via a callback function of type `async (Int) -> Unit`. The parameter is the PID of the process.

Two pre-defined cancellation handlers are provided. `@process.hard_cancel()` terminate the process forcefully. `@process.graceful_cancel(timeout~)` first try to terminate the process gracefully (via `SIGTERM` on POSIX-like or `CTRL_BREAK_EVENT` on Windows), and if the process does not terminate after `timeout` milliseconds, stop the process forcefully.

The default cancellation handler is `@process.graceful_cancel(timeout=5000)`.

[behavior change] Previously, `@process.run` will return immediately after the graceful termination signal is sent. After this PR, `@process.run` will return if and only if the process actually terminates.