### PR TITLE
enhance `protect_from_cancel`

### DIFF
--- a/src/async.mbt
+++ b/src/async.mbt
@@ -111,10 +111,15 @@ pub async fn[X] with_timeout_opt(time : Int, f : async () -> X) -> X? {
 ///|
 /// `protect_from_cancel(f)` executes `f` and protect `f` from cancellation.
 /// If current task is cancelled while running `protect_from_cancel(f)`,
-/// `f` will be protected from the cancellation and still run to finish,
-/// and the cancellation will be delayed until `f` returns.
+/// `f` will be protected from the cancellation and still run to finish.
 /// Things waiting for current task, such as the task group,
 /// will also wait until `f` finish.
+///
+/// If `resume_on_cancel` is `false` (`false` by default),
+/// cancellation will be delayed until `f` returns.
+/// If `resume_on_cancel` is `true`, the program will resume normally
+/// after `f` returns, even if current task is cancelled.
+/// The next unprotected async operation will still get cancelled, though.
 ///
 /// This function should be use with extra care and only when absolutely necessary,
 /// because it will break other abstraction such as `with_timeout`.

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -162,7 +162,10 @@ pub fn Coroutine::check_error(coro : Coroutine) -> Unit raise {
 }
 
 ///|
-pub async fn protect_from_cancel(f : async () -> Unit) -> Unit {
+pub async fn[X] protect_from_cancel(
+  f : async () -> X,
+  resume_on_cancel? : Bool = false,
+) -> X {
   guard scheduler.curr_coro is Some(coro)
   if coro.shielded {
     // already in a shield, do nothing
@@ -172,9 +175,10 @@ pub async fn protect_from_cancel(f : async () -> Unit) -> Unit {
     defer {
       coro.shielded = false
     }
-    f()
-    if coro.cancelled {
+    let result = f()
+    if !resume_on_cancel && coro.cancelled {
       raise Cancelled
     }
+    result
   }
 }

--- a/src/internal/coroutine/pkg.generated.mbti
+++ b/src/internal/coroutine/pkg.generated.mbti
@@ -12,7 +12,7 @@ pub fn no_more_work() -> Bool
 
 pub async fn pause() -> Unit
 
-pub async fn protect_from_cancel(async () -> Unit) -> Unit
+pub async fn[X] protect_from_cancel(async () -> X, resume_on_cancel? : Bool) -> X
 
 pub fn reschedule() -> Unit
 

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -18,7 +18,7 @@ pub fn now() -> Int64
 
 pub async fn pause() -> Unit
 
-pub async fn protect_from_cancel(async () -> Unit) -> Unit
+pub async fn[X] protect_from_cancel(async () -> X, resume_on_cancel? : Bool) -> X
 
 pub async fn[X] retry(RetryMethod, max_retry? : Int, fatal_error? : (Error) -> Bool, async () -> X) -> X
 

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -136,7 +136,7 @@ async test "protect_from_cancel with_timeout" {
 async test "protect_from_cancel fail" {
   let log = StringBuilder::new()
   log.write_object(
-    try? @async.with_task_group(fn(root) {
+    try? @async.with_task_group(fn(root) -> Unit {
       root.spawn_bg(fn() {
         @async.sleep(200)
         log.write_string("200ms tick\n")


### PR DESCRIPTION
- allow return arbitrary type in `protect_from_cancel`
- add an optional parameter `resume_on_cancel? : Bool = true` to `protect_from_cancel`. If `resume_on_cancel` is `true`, `protect_from_cancel(f)` will return normally after `f` returns, even if it is cancelled. The next unprotected async operation will still get cancelled, though.