### PR TITLE
deprecate some non poratble API

### DIFF
--- a/src/fs/dir_test.mbt
+++ b/src/fs/dir_test.mbt
@@ -31,6 +31,7 @@ async test "read_all" {
 
 ///|
 #cfg(not(platform="windows"))
+#warnings("-deprecated")
 async test "as_dir" {
   let dir_file = @fs.open("src/fs", mode=ReadOnly)
   guard dir_file.kind() is Directory

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -258,6 +258,7 @@ extern "C" fn Directory::is_null(dir : Directory) -> Bool = "moonbitlang_async_d
 /// result directory object is closed.
 /// If `as_dir` fails, the input file will be closed automatically.
 #cfg(not(platform="windows"))
+#deprecated("`as_dir` is deprecated because it is not portable, use `opendir` instead.")
 pub fn File::as_dir(self : File) -> Directory raise {
   let fd = self.io.detach_from_event_loop()
   let dir = as_dir_ffi(fd)

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -62,6 +62,7 @@ pub fn Directory::close(Self) -> Unit
 pub async fn Directory::read_all(Self, include_hidden? : Bool, include_special? : Bool) -> Array[String]
 
 type File
+#deprecated
 pub fn File::as_dir(Self) -> Directory raise
 pub async fn File::atime(Self) -> (Int64, Int)
 pub fn File::close(Self) -> Unit

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -354,6 +354,7 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::client_from_pair(
 /// `private_key_file`, `private_key_type` specifies the private key of the server.
 /// `certificate_file` and `certificate_type` specifies the certificate of the server.
 #cfg(not(platform="windows"))
+#internal(internal, "do not use, for internal testing only")
 pub async fn[R : @io.Reader, W : @io.Writer] Tls::server_from_pair(
   r : R,
   w : W,
@@ -397,6 +398,7 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::server_from_pair(
 /// `private_key_file`, `private_key_type` specifies the private key of the server.
 /// `certificate_file` and `certificate_type` specifies the certificate of the server.
 #cfg(not(platform="windows"))
+#internal(internal, "do not use, for internal testing only")
 pub async fn[Inner : @io.Reader + @io.Writer] Tls::server(
   inner : Inner,
   private_key_file~ : String,


### PR DESCRIPTION
- `@tls.server_from_pair` and `@tls.server` (for internal testing only)
- `@fs.File::as_dir`