### PR TITLE
always use thread pool & synchronous IO for fs on windows

### DIFF
--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -28,7 +28,6 @@ pub async fn open_detached(
   sync~ : Int,
   // permission for file when new file is created
   mode~ : Int,
-  is_async~ : Bool,
   context~ : String,
 ) -> (@fd_util.Fd, Int64) {
   let path_bytes = @os_string.encode(path)
@@ -40,7 +39,6 @@ pub async fn open_detached(
     truncate~,
     sync~,
     mode~,
-    is_async~,
   )
   try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
@@ -73,12 +71,10 @@ pub async fn open(
     truncate~,
     sync~,
     mode~,
-    is_async=true,
     context~,
   )
-  let is_async = @fd_util.FileKind::is_async(kind)
   let kind = @fd_util.FileKind::from_sys_kind(kind)
-  IoHandle::from_fd(fd, kind~, is_async~)
+  IoHandle::from_fd(fd, kind~, is_async=false)
 }
 
 ///|

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -237,25 +237,25 @@ pub async fn IoHandle::read(
   }
   guard curr_loop.val is Some(evloop)
   if !handle.is_async {
-    let job = Job::read(handle.fd, buf, offset, len, position=-1)
+    let job = Job::read(
+      handle.fd,
+      buf,
+      offset,
+      len,
+      position=handle.read_offset,
+    )
     let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
     let n = perform_job_in_worker(job, context~, cancel~) catch {
       @os_error.OSError(errno, ..) if errno_is_read_eof(errno) => 0
       err => raise err
     }
+    handle.read_offset += n.to_int64()
     return n
   }
   let job_id = evloop.job_id
   evloop.job_id += 1
   let result = match handle.kind {
-    Regular =>
-      IoResult::for_file(
-        job_id,
-        buf.unsafe_reinterpret_as_bytes(),
-        offset~,
-        len~,
-        position=handle.read_offset,
-      )
+    Regular => panic()
     Socket =>
       IoResult::for_socket(
         job_id,
@@ -291,17 +291,12 @@ pub async fn IoHandle::read_at(
 ) -> Int {
   guard curr_loop.val is Some(evloop)
   guard handle.kind is Regular
-  let job_id = evloop.job_id
-  evloop.job_id += 1
-  let result = IoResult::for_file(
-    job_id,
-    buf.unsafe_reinterpret_as_bytes(),
-    offset~,
-    len~,
-    position~,
-  )
-  defer result.free()
-  handle.generic_read(job_id, result, context~)
+  let job = Job::read(handle.fd, buf, offset, len, position~)
+  let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
+  perform_job_in_worker(job, context~, cancel~) catch {
+    @os_error.OSError(errno, ..) if errno_is_read_eof(errno) => 0
+    err => raise err
+  }
 }
 
 ///|
@@ -350,21 +345,22 @@ pub async fn IoHandle::write(
   }
   guard curr_loop.val is Some(evloop)
   if !handle.is_async {
-    let job = Job::write(handle.fd, buf, offset, len, position=-1)
+    let job = Job::write(
+      handle.fd,
+      buf,
+      offset,
+      len,
+      position=handle.write_offset,
+    )
     let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
-    return perform_job_in_worker(job, context~, cancel~)
+    let n = perform_job_in_worker(job, context~, cancel~)
+    handle.write_offset += n.to_int64()
+    return n
   }
   let job_id = evloop.job_id
   evloop.job_id += 1
   let result = match handle.kind {
-    Regular =>
-      IoResult::for_file(
-        job_id,
-        buf,
-        offset~,
-        len~,
-        position=handle.write_offset,
-      )
+    Regular => panic()
     Socket => IoResult::for_socket(job_id, buf, offset~, len~, flags=0)
     _ => IoResult::for_file(job_id, buf, offset~, len~, position=0)
   }
@@ -386,9 +382,7 @@ pub async fn IoHandle::write_at(
 ) -> Unit {
   guard curr_loop.val is Some(evloop)
   guard handle.kind is Regular
-  let job_id = evloop.job_id
-  evloop.job_id += 1
-  let result = IoResult::for_file(job_id, buf, offset~, len~, position~)
-  defer result.free()
-  ignore(handle.generic_write(job_id, result, context~))
+  let job = Job::write(handle.fd, buf, offset, len, position~)
+  let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
+  ignore(perform_job_in_worker(job, context~, cancel~))
 }

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -28,7 +28,7 @@ pub async fn mkdir(StringView, mode~ : Int, context~ : String) -> Unit
 
 pub async fn open(StringView, Int, create~ : Bool, append~ : Bool, truncate~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> IoHandle
 
-pub async fn open_detached(StringView, Int, create~ : Bool, append~ : Bool, truncate~ : Bool, sync~ : Int, mode~ : Int, is_async~ : Bool, context~ : String) -> (Int, Int64)
+pub async fn open_detached(StringView, Int, create~ : Bool, append~ : Bool, truncate~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> (Int, Int64)
 
 pub async fn opendir(StringView, context~ : String) -> Directory
 

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -101,7 +101,6 @@ extern "C" fn Job::open(
   sync~ : Int,
   // permission for file when new file is created
   mode~ : Int,
-  is_async~ : Bool,
 ) -> Job = "moonbitlang_async_make_open_job"
 
 ///|

--- a/src/internal/fd_util/pkg.generated.mbti
+++ b/src/internal/fd_util/pkg.generated.mbti
@@ -35,7 +35,6 @@ pub(all) enum FileKind {
 }
 pub fn FileKind::can_poll(Self) -> Bool
 pub fn FileKind::from_sys_kind(Int64) -> Self
-pub fn FileKind::is_async(Int64) -> Bool
 pub impl Eq for FileKind
 pub impl Show for FileKind
 

--- a/src/internal/fd_util/stat.mbt
+++ b/src/internal/fd_util/stat.mbt
@@ -46,9 +46,6 @@ pub fn FileKind::can_poll(self : FileKind) -> Bool {
 }
 
 ///|
-pub extern "C" fn FileKind::is_async(sys_kind : Int64) -> Bool = "moonbitlang_async_file_kind_is_async"
-
-///|
 pub extern "C" fn FileKind::from_sys_kind(sys_kind : Int64) -> FileKind = "moonbitlang_async_file_kind_from_sys_kind"
 
 ///|

--- a/src/internal/fd_util/stub.c
+++ b/src/internal/fd_util/stub.c
@@ -165,27 +165,6 @@ int32_t moonbitlang_async_sizeof_file_time() {
   return sizeof(file_time_t);
 }
 
-MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_file_kind_is_async(int64_t kind) {
-#ifdef _WIN32
-  // https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/asynchronous-disk-io-synchronous
-  return 0 == ((kind >> 32) & (FILE_ATTRIBUTE_COMPRESSED | FILE_ATTRIBUTE_ENCRYPTED));
-#else
-  switch (kind & S_IFMT) {
-  case S_IFSOCK:
-  case S_IFIFO:
-  case S_IFCHR:
-    return 1;
-  case S_IFREG:
-  case S_IFDIR:
-  case S_IFLNK:
-  case S_IFBLK:
-  default:
-    return 0;
-  }
-#endif
-}
-
 // For Windows, determining the kind of file requires two syscalls:
 // directories can only be detected via file attributes,
 // while pipes can only be detected via `GetFileType`.

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -136,7 +136,6 @@ pub async fn redirect_to_file(
     truncate~,
     sync=0,
     mode~,
-    is_async=false,
     context="@process.redirect_to_file()",
   )
   RedirectToFile(fd, @fd_util.FileKind::from_sys_kind(kind))
@@ -153,7 +152,6 @@ pub async fn redirect_from_file(path : String) -> &ProcessInput {
     truncate=false,
     sync=0,
     mode=0,
-    is_async=false,
     context="@process.redirect_to_file()",
   )
   RedirectToFile(fd, @fd_util.FileKind::from_sys_kind(kind))


### PR DESCRIPTION
Due to a lot of complexity such as https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/asynchronous-disk-io-synchronous. This (unconditionally use thread pool for fs IO on Windows) is also the choice made by libuv