### PR TITLE
Add documentation for internal/time

### DIFF
--- a/src/internal/time/README.mbt.md
+++ b/src/internal/time/README.mbt.md
@@ -1,0 +1,47 @@
+# internal/time
+
+Internal wall-clock helpers used by the async runtime.
+
+## Overview
+
+`@internal/time` provides a single function, `ms_since_epoch`, used by timers
+and scheduling code. It exposes the platform wall clock in milliseconds. The
+value can jump forwards or backwards if the system clock is adjusted, so it is
+suited for elapsed-time measurement (by subtraction), not for strict monotonic
+ordering.
+
+## API
+
+`ms_since_epoch() -> Int64`
+
+Return the current wall-clock time in milliseconds.
+
+## Platform Behavior
+
+- Unix/macOS: `gettimeofday()` (Unix epoch)
+- Windows: `GetSystemTimeAsFileTime()` (FILETIME epoch, 1601)
+- JavaScript: `Date.getTime()` (Unix epoch)
+
+## Examples
+
+```mbt check
+///|
+test "read timestamp" {
+  let _ : Int64 = @time.ms_since_epoch()
+
+}
+```
+
+```mbt check
+///|
+test "derive a deadline" {
+  let now = @time.ms_since_epoch()
+  let deadline = now + 500
+  guard deadline >= now else { fail("overflow") }
+}
+```
+
+## Notes
+
+- If you need an API with stable absolute meaning, use higher-level functions
+  such as `@async.now` and treat the value as opaque for ordering only.

--- a/src/internal/time/time.mbt
+++ b/src/internal/time/time.mbt
@@ -13,6 +13,24 @@
 // limitations under the License.
 
 ///|
+/// Get the current wall-clock time in milliseconds.
+///
+/// This is the time source used by the async runtime. It is intended for
+/// computing elapsed time by subtraction. The value can jump forwards or
+/// backwards if the system clock is adjusted, so do not assume monotonicity.
+///
+/// Platform notes:
+/// - Unix/macOS: `gettimeofday()` (Unix epoch)
+/// - Windows: `GetSystemTimeAsFileTime()` (FILETIME epoch, 1601)
+/// - JavaScript: `Date.getTime()` (Unix epoch)
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let _ : Int64 = ms_since_epoch()
+///
+/// }
+/// ```
 #cfg(target="native")
 pub extern "C" fn ms_since_epoch() -> Int64 = "moonbitlang_async_get_ms_since_epoch"
 
@@ -22,6 +40,24 @@ extern "js" fn js_now() -> Double =
   #| () => (new Date()).getTime()
 
 ///|
+/// Get the current wall-clock time in milliseconds.
+///
+/// This is the time source used by the async runtime. It is intended for
+/// computing elapsed time by subtraction. The value can jump forwards or
+/// backwards if the system clock is adjusted, so do not assume monotonicity.
+///
+/// Platform notes:
+/// - Unix/macOS: `gettimeofday()` (Unix epoch)
+/// - Windows: `GetSystemTimeAsFileTime()` (FILETIME epoch, 1601)
+/// - JavaScript: `Date.getTime()` (Unix epoch)
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let _ : Int64 = ms_since_epoch()
+///
+/// }
+/// ```
 #cfg(target="js")
 pub fn ms_since_epoch() -> Int64 {
   js_now().to_int64()


### PR DESCRIPTION
## Summary
- Add README.mbt.md for internal/time package
- Add docstrings with `mbt check` examples for `ms_since_epoch` function (both native and JS backends)
- Document platform-specific behavior and non-monotonicity warning

## Test plan
- [x] `moon test src/internal/time` passes (3/3 tests)
- [x] `moon fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)