### PR TITLE
Add documentation for internal/c_buffer and internal/io_buffer

### DIFF
--- a/src/internal/c_buffer/README.mbt.md
+++ b/src/internal/c_buffer/README.mbt.md
@@ -1,0 +1,38 @@
+# internal/c_buffer
+
+Internal wrapper for C-allocated byte buffers.
+
+## Overview
+
+`@internal/c_buffer` exposes an opaque `Buffer` type and a small set of
+FFI-backed helpers used throughout the async runtime. These APIs are unsafe:
+they operate on raw pointers and assume correct size, lifetime, and
+null-termination guarantees from native code.
+
+This package is **native-only**. The JavaScript backend is not supported.
+
+## API Summary
+
+- `Buffer`: opaque C pointer
+- `blit_from_bytes`: copy MoonBit `Bytes` into a C buffer
+- `blit_to_bytes`: copy C buffer content into a MoonBit `FixedArray[Byte]`
+- `get`: read a single byte by index
+- `strlen`: length of a NUL-terminated C string
+- `null`, `is_null`, `free`
+
+## Safety and Ownership
+
+- `Buffer` values are raw pointers; no bounds checks are performed.
+- `free` must only be called on memory allocated by `malloc` or a compatible
+  allocator. Passing `null` is allowed.
+- `strlen` requires a valid NUL-terminated sequence.
+
+## Examples
+
+```mbt check
+///|
+test "null helpers" {
+  inspect(Buffer::is_null(null), content="true")
+  Buffer::free(null)
+}
+```

--- a/src/internal/c_buffer/c_buffer.mbt
+++ b/src/internal/c_buffer/c_buffer.mbt
@@ -13,10 +13,31 @@
 // limitations under the License.
 
 ///|
+/// Opaque handle to a native C buffer.
+///
+/// `Buffer` represents a raw pointer managed by native code. All functions in
+/// this package assume the pointer is valid and sized appropriately. It is an
+/// internal FFI helper, not a general-purpose memory container.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let ptr : Buffer = null
+///   inspect(Buffer::is_null(ptr), content="true")
+/// }
+/// ```
 #external
 pub type Buffer
 
 ///|
+/// Copy bytes from a MoonBit `Bytes` into a C buffer.
+///
+/// `offset` and `len` select a range within `src`. The destination buffer must
+/// have at least `len` bytes available.
+///
+/// # Safety
+/// `dst` must be a valid writable buffer; `src` must be valid for the requested
+/// range.
 #borrow(src)
 pub extern "C" fn Buffer::blit_from_bytes(
   dst : Buffer,
@@ -26,6 +47,13 @@ pub extern "C" fn Buffer::blit_from_bytes(
 ) = "moonbitlang_async_blit_to_c"
 
 ///|
+/// Copy bytes from a C buffer into a MoonBit fixed array.
+///
+/// The destination array must have enough room for `len` bytes starting at
+/// `offset`.
+///
+/// # Safety
+/// `src` must be a valid readable buffer containing at least `len` bytes.
 #borrow(dst)
 pub extern "C" fn Buffer::blit_to_bytes(
   src : Buffer,
@@ -35,21 +63,51 @@ pub extern "C" fn Buffer::blit_to_bytes(
 ) = "moonbitlang_async_blit_from_c"
 
 ///|
+/// Read a single byte from the buffer at `index`.
+///
+/// # Safety
+/// `buf` must be valid and the index must be within bounds of the allocated
+/// buffer.
 #borrow(buf)
 #alias("_[_]")
 pub extern "C" fn Buffer::get(buf : Buffer, index : Int) -> Byte = "moonbitlang_async_c_buffer_get"
 
 ///|
+/// Measure the length of a NUL-terminated C string.
+///
+/// # Safety
+/// `buf` must point to a valid NUL-terminated byte sequence.
 pub extern "C" fn Buffer::strlen(buf : Buffer) -> Int = "moonbitlang_async_strlen"
 
 ///|
 extern "C" fn Buffer::null() -> Buffer = "moonbitlang_async_null_pointer"
 
 ///|
+/// A null C pointer for use with `Buffer`.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   inspect(Buffer::is_null(null), content="true")
+///   Buffer::free(null)
+/// }
+/// ```
 pub let null : Buffer = Buffer::null()
 
 ///|
+/// Check whether the pointer is null.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let ptr = null
+///   inspect(Buffer::is_null(ptr), content="true")
+/// }
+/// ```
 pub extern "C" fn Buffer::is_null(ptr : Buffer) -> Bool = "moonbitlang_async_pointer_is_null"
 
 ///|
+/// Free a C buffer allocated with `malloc` or compatible APIs.
+///
+/// Passing `null` is allowed and has no effect.
 pub extern "C" fn Buffer::free(buf : Buffer) = "free"

--- a/src/internal/io_buffer/README.mbt.md
+++ b/src/internal/io_buffer/README.mbt.md
@@ -1,0 +1,70 @@
+# internal/io_buffer
+
+Sliding-window buffer used by the async I/O stack.
+
+## Overview
+
+`@internal/io_buffer` provides a small, low-level `Buffer` type used by
+`@io.ReaderBuffer` and other internal readers. The buffer tracks three pieces of
+state:
+
+- `buf`: the underlying `FixedArray[Byte]`
+- `start`: offset of the first valid byte
+- `len`: number of valid bytes
+
+This package is intentionally minimal and does not enforce invariants beyond
+these fields. It is meant for internal use.
+
+## API
+
+- `Buffer::new(size)` creates an empty buffer with the given capacity.
+- `Buffer::clear` drops data and releases storage.
+- `Buffer::enlarge_to(n)` ensures there is space for `n` bytes starting from
+  `start`, compacting or reallocating as needed.
+- `Buffer::drop(n)` consumes `n` bytes from the front.
+
+## Examples
+
+```mbt check
+///|
+test "basic window management" {
+  let buf = @io_buffer.Buffer::new(6)
+  buf.buf[0] = b'a'
+  buf.buf[1] = b'b'
+  buf.buf[2] = b'c'
+  buf.len = 3
+
+  // Consume two bytes.
+  @io_buffer.Buffer::drop(buf, 2)
+  inspect(buf.start, content="2")
+  inspect(buf.len, content="1")
+}
+```
+
+```mbt check
+///|
+test "compaction preserves data" {
+  let buf = @io_buffer.Buffer::new(5)
+  buf.buf[3] = b'x'
+  buf.buf[4] = b'y'
+  buf.start = 3
+  buf.len = 2
+  @io_buffer.Buffer::enlarge_to(buf, 4)
+  let view = buf.buf.unsafe_reinterpret_as_bytes()[:buf.len]
+  inspect(view, content="b\"xy\"")
+}
+```
+
+```mbt check
+///|
+test "resize rounds up to 1024 bytes" {
+  let buf = @io_buffer.Buffer::new(4)
+  @io_buffer.Buffer::enlarge_to(buf, 7)
+  inspect(buf.buf.length(), content="1024")
+}
+```
+
+## Notes
+
+- The reallocation size is rounded up to 1024-byte segments.
+- `clear` releases storage by replacing the internal buffer with an empty array.

--- a/src/internal/io_buffer/read_buffer.mbt
+++ b/src/internal/io_buffer/read_buffer.mbt
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 ///|
+/// Internal byte buffer with a sliding window.
+///
+/// `buf` stores the underlying bytes, `start` is the offset of the first valid
+/// byte, and `len` is the number of valid bytes available. The buffer does not
+/// enforce invariants beyond these fields; callers are responsible for keeping
+/// them consistent.
 pub(all) struct Buffer {
   mut buf : FixedArray[Byte]
   mut start : Int
@@ -20,12 +26,41 @@ pub(all) struct Buffer {
 }
 
 ///|
+/// Create a new buffer with the given capacity.
+///
+/// The buffer starts empty (`start = 0`, `len = 0`).
+///
+/// # Example
+/// ```mbt check
+/// test "new buffer is empty" {
+///   let buf = Buffer::new(8)
+///   inspect(buf.buf.length(), content="8")
+///   inspect(buf.start, content="0")
+///   inspect(buf.len, content="0")
+/// }
+/// ```
 #as_free_fn
 pub fn Buffer::new(size : Int) -> Buffer {
   { buf: FixedArray::make(size, 0), start: 0, len: 0 }
 }
 
 ///|
+/// Clear the buffer and release its storage.
+///
+/// After `clear`, the buffer has zero capacity and no valid bytes.
+///
+/// # Example
+/// ```mbt check
+/// test "clear resets state" {
+///   let buf = Buffer::new(4)
+///   buf.start = 1
+///   buf.len = 2
+///   Buffer::clear(buf)
+///   inspect(buf.buf.length(), content="0")
+///   inspect(buf.start, content="0")
+///   inspect(buf.len, content="0")
+/// }
+/// ```
 pub fn Buffer::clear(buf : Buffer) -> Unit {
   buf.buf = []
   buf.start = 0
@@ -36,6 +71,45 @@ pub fn Buffer::clear(buf : Buffer) -> Unit {
 const SEGMENT_SIZE = 1024
 
 ///|
+/// Ensure the buffer can hold at least `n` bytes starting from `start`.
+///
+/// - If there is enough space after `start`, nothing changes.
+/// - If the capacity is enough but space after `start` is not, the buffer is
+///   compacted so valid bytes start at offset 0.
+/// - If the capacity is insufficient, a new buffer is allocated with size
+///   rounded up to a 1024-byte segment.
+///
+/// # Example
+/// ```mbt check
+/// test "enlarge compacts in-place" {
+///   let buf = Buffer::new(5)
+///   buf.buf[3] = b'x'
+///   buf.buf[4] = b'y'
+///   buf.start = 3
+///   buf.len = 2
+///   Buffer::enlarge_to(buf, 4)
+///   inspect(buf.start, content="0")
+///   inspect(buf.buf.length(), content="5")
+///   inspect(buf.len, content="2")
+///   let view = buf.buf.unsafe_reinterpret_as_bytes()[:buf.len]
+///   inspect(view, content="b\"xy\"")
+/// }
+/// ```
+///
+/// ```mbt check
+/// test "enlarge grows to segment size" {
+///   let buf = Buffer::new(4)
+///   buf.buf[1] = b'a'
+///   buf.buf[2] = b'b'
+///   buf.start = 1
+///   buf.len = 2
+///   Buffer::enlarge_to(buf, 7)
+///   inspect(buf.start, content="0")
+///   inspect(buf.buf.length(), content="1024")
+///   let view = buf.buf.unsafe_reinterpret_as_bytes()[:buf.len]
+///   inspect(view, content="b\"ab\"")
+/// }
+/// ```
 pub fn Buffer::enlarge_to(self : Buffer, n : Int) -> Unit {
   let capacity = self.buf.length()
   if self.start + n <= capacity {
@@ -55,6 +129,32 @@ pub fn Buffer::enlarge_to(self : Buffer, n : Int) -> Unit {
 }
 
 ///|
+/// Drop `n` bytes from the front of the buffer.
+///
+/// If all bytes are dropped, `start` is reset to 0.
+///
+/// # Example
+/// ```mbt check
+/// test "drop advances window" {
+///   let buf = Buffer::new(6)
+///   buf.start = 1
+///   buf.len = 4
+///   Buffer::drop(buf, 2)
+///   inspect(buf.start, content="3")
+///   inspect(buf.len, content="2")
+/// }
+/// ```
+///
+/// ```mbt check
+/// test "drop to empty resets start" {
+///   let buf = Buffer::new(3)
+///   buf.start = 2
+///   buf.len = 1
+///   Buffer::drop(buf, 1)
+///   inspect(buf.start, content="0")
+///   inspect(buf.len, content="0")
+/// }
+/// ```
 pub fn Buffer::drop(self : Buffer, n : Int) -> Unit {
   guard n <= self.len
   self.len -= n


### PR DESCRIPTION
## Summary
- Add README.mbt.md for internal/c_buffer and internal/io_buffer packages
- Add docstrings with `mbt check` examples for public APIs:
  - c_buffer: Buffer type, null, is_null, free
  - io_buffer: Buffer struct, new, clear, enlarge_to, drop

## Test plan
- [x] `moon test src/internal/c_buffer` passes (4/4 tests)
- [x] `moon test src/internal/io_buffer` passes (9/9 tests)
- [x] `moon fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)