### PR TITLE
allow cancelling synchronous IO & use blocking IO for stdio on Unix

### DIFF
--- a/src/internal/event_loop/cancel_sync_test.mbt
+++ b/src/internal/event_loop/cancel_sync_test.mbt
@@ -1,0 +1,39 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(not(platform="windows"))
+#borrow(path)
+extern "C" fn mkfifo(path : @os_string.OsString, mode : Int) -> Int = "mkfifo"
+
+///|
+#cfg(not(platform="windows"))
+async test "cancel FIFO open" {
+  @async.with_task_group(group => {
+    let path = "target/cancel_fifo_read"
+    if mkfifo(@os_string.encode(path), 0o644) < 0 {
+      @os_error.check_errno("mkfifo")
+    }
+    group.add_defer(() => @fs.remove(path))
+    let result = @async.with_timeout_opt(500, () => @fs.open(
+      path,
+      mode=ReadOnly,
+    ).close())
+    inspect(result, content="None")
+  })
+}
+
+///|
+#cfg(platform="windows")
+let _unused : Unit = ignore(@fs.File::close)

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -352,7 +352,6 @@ pub async fn sleep(duration : Int) -> Unit {
 }
 
 ///|
-#warnings("-unused_constructor")
 priv enum CancellationStatus {
   NoWait
   NeedWait
@@ -363,7 +362,7 @@ priv enum CancellationStatus {
 async fn EventLoop::wait_for_job(
   evloop : EventLoop,
   job_id : Int,
-  cancel? : (Int) -> CancellationStatus raise,
+  cancel? : () -> CancellationStatus raise,
 ) -> Unit {
   evloop.jobs[job_id] = @coroutine.current_coroutine()
   defer evloop.jobs.remove(job_id)
@@ -373,7 +372,7 @@ async fn EventLoop::wait_for_job(
       @coroutine.suspend() catch {
         err =>
           for {
-            let status = cancel_func(job_id) catch {
+            let status = cancel_func() catch {
               err =>
                 @coroutine.protect_from_cancel(() => {
                   @coroutine.suspend()
@@ -402,36 +401,10 @@ async fn EventLoop::wait_for_job(
 }
 
 ///|
-#cfg(not(platform="windows"))
-fn Job::extract_result(job : Job, context~ : String) -> Int raise {
-  if job.err() is err && err > 0 {
-    raise @os_error.OSError(err, context~)
-  } else {
-    job.ret()
-  }
-}
+extern "C" fn errno_is_cancelled(errno : Int) -> Bool = "moonbitlang_async_errno_is_cancelled"
 
 ///|
-#cfg(platform="windows")
-fn Job::extract_result(job : Job, context~ : String) -> Int raise {
-  if job.err() is err && err > 0 {
-    if errno_is_cancelled(err) {
-      raise @coroutine.Cancelled
-    } else {
-      raise @os_error.OSError(err, context~)
-    }
-  } else {
-    job.ret()
-  }
-}
-
-///|
-async fn perform_job_in_worker(
-  job : Job,
-  context~ : String,
-  cancel? : (Int) -> CancellationStatus raise,
-) -> Int {
-  guard curr_loop.val is Some(evloop)
+fn EventLoop::submit_job_to_worker(evloop : EventLoop, job : Job) -> Int {
   let job_id = evloop.job_id
   evloop.job_id += 1
   match evloop.idle_workers.pop_front() {
@@ -446,12 +419,35 @@ async fn perform_job_in_worker(
       wake_worker(worker, job_id, job)
     }
   }
-  evloop.wait_for_job(job_id, cancel?)
-  job.extract_result(context~)
+  job_id
 }
 
 ///|
-#cfg(platform="windows")
+async fn perform_job_in_worker(
+  job : Job,
+  context~ : String,
+  cancel? : Bool = false,
+) -> Int {
+  guard curr_loop.val is Some(evloop)
+  let job_id = evloop.submit_job_to_worker(job)
+  let cancel = if cancel {
+    Some(() => evloop.cancel_job_in_worker(job_id, context~))
+  } else {
+    None
+  }
+  evloop.wait_for_job(job_id, cancel?)
+  if job.err() is err && err > 0 {
+    if errno_is_cancelled(err) {
+      raise @coroutine.Cancelled
+    } else {
+      raise @os_error.OSError(err, context~)
+    }
+  } else {
+    job.ret()
+  }
+}
+
+///|
 fn EventLoop::cancel_job_in_worker(
   evloop : EventLoop,
   job_id : Int,

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -40,7 +40,7 @@ pub async fn open_detached(
     sync~,
     mode~,
   )
-  try perform_job_in_worker(job, context~) catch {
+  try perform_job_in_worker(job, context~, cancel=true) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{repr(path)}")
     err => raise err
@@ -240,7 +240,7 @@ fn prepare_opendir_path(path : StringView) -> StringView {
 pub async fn opendir(path : StringView, context~ : String) -> Directory {
   let path_bytes = @os_string.encode(prepare_opendir_path(path))
   let job = Job::opendir(path_bytes)
-  let _ = perform_job_in_worker(job, context~) catch {
+  let _ = perform_job_in_worker(job, context~, cancel=true) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{repr(path)}")
     err => raise err
@@ -259,7 +259,7 @@ pub extern "C" fn Directory::close(self : Directory) -> Int = "moonbitlang_async
 ///|
 pub async fn readdir(dir : Directory, context~ : String) -> @c_buffer.Buffer {
   let job = Job::readdir(dir)
-  let _ = perform_job_in_worker(job, context~)
+  let _ = perform_job_in_worker(job, context~, cancel=true)
   job.get_readdir_result()
 }
 

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -162,7 +162,7 @@ pub async fn IoHandle::read(
     ret
   } else {
     let job = Job::read(handle.fd, buf, offset, len, position=-1)
-    perform_job_in_worker(job, context~)
+    perform_job_in_worker(job, context~, cancel=true)
   }
 }
 
@@ -178,7 +178,7 @@ pub async fn IoHandle::read_at(
 ) -> Int {
   guard !handle.kind.can_poll()
   let job = Job::read(handle.fd, buf, offset, len, position~)
-  perform_job_in_worker(job, context~)
+  perform_job_in_worker(job, context~, cancel=true)
 }
 
 ///|
@@ -219,7 +219,7 @@ pub async fn IoHandle::write(
     ret
   } else {
     let job = Job::write(handle.fd, buf, offset, len, position=-1)
-    perform_job_in_worker(job, context~)
+    perform_job_in_worker(job, context~, cancel=true)
   }
 }
 
@@ -235,5 +235,5 @@ pub async fn IoHandle::write_at(
 ) -> Unit {
   guard !handle.kind.can_poll()
   let job = Job::write(handle.fd, buf, offset, len, position~)
-  perform_job_in_worker(job, context~) |> ignore
+  perform_job_in_worker(job, context~, cancel=true) |> ignore
 }

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -17,6 +17,7 @@
 struct IoHandle {
   mut fd : @fd_util.Fd
   kind : @fd_util.FileKind
+  is_async : Bool
   mut events : Int
   mut read : @coroutine.Coroutine?
   mut write : @coroutine.Coroutine?
@@ -33,7 +34,7 @@ pub fn IoHandle::from_fd(
   guard curr_loop.val is Some(evloop)
   guard evloop.fds.get(fd) is None
   ignore(is_async)
-  let handle = { fd, kind, read: None, write: None, events: NoEvent }
+  let handle = { fd, kind, is_async, read: None, write: None, events: NoEvent }
   evloop.fds[fd] = handle
   handle
 }
@@ -143,7 +144,7 @@ pub async fn IoHandle::read(
   len~ : Int,
   context~ : String,
 ) -> Int {
-  if handle.kind.can_poll() {
+  if handle.is_async && handle.kind.can_poll() {
     handle.prepare_read()
     let ret = read_ffi(handle.fd, buf, offset~, len~)
     if ret >= 0 {
@@ -200,7 +201,7 @@ pub async fn IoHandle::write(
   len~ : Int,
   context~ : String,
 ) -> Int {
-  if handle.kind.can_poll() {
+  if handle.is_async && handle.kind.can_poll() {
     handle.prepare_write()
     let ret = write_ffi(handle.fd, buf, offset~, len~)
     if ret >= 0 {

--- a/src/internal/event_loop/io_windows.c
+++ b/src/internal/event_loop/io_windows.c
@@ -207,11 +207,6 @@ int32_t moonbitlang_async_io_result_get_job_id(struct IoResult *result) {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_errno_is_cancelled(int32_t err) {
-  return err == ERROR_OPERATION_ABORTED;
-}
-
-MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_io_result_get_status(
   LPOVERLAPPED overlapped,
   HANDLE file

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -102,10 +102,6 @@ extern "C" fn IoResult::status_ffi(
 
 ///|
 #cfg(platform="windows")
-extern "C" fn errno_is_cancelled(errno : Int) -> Bool = "moonbitlang_async_errno_is_cancelled"
-
-///|
-#cfg(platform="windows")
 fn IoResult::status(
   result : IoResult,
   handle : @fd_util.Fd,
@@ -179,7 +175,7 @@ async fn EventLoop::wait_for_io_result(
   handle : @fd_util.Fd,
   context~ : String,
 ) -> Unit {
-  evloop.wait_for_job(job_id, cancel=_ => io_result.cancel(handle, context~))
+  evloop.wait_for_job(job_id, cancel=() => io_result.cancel(handle, context~))
 }
 
 ///|
@@ -244,8 +240,7 @@ pub async fn IoHandle::read(
       len,
       position=handle.read_offset,
     )
-    let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
-    let n = perform_job_in_worker(job, context~, cancel~) catch {
+    let n = perform_job_in_worker(job, context~, cancel=true) catch {
       @os_error.OSError(errno, ..) if errno_is_read_eof(errno) => 0
       err => raise err
     }
@@ -289,11 +284,9 @@ pub async fn IoHandle::read_at(
   position~ : Int64,
   context~ : String,
 ) -> Int {
-  guard curr_loop.val is Some(evloop)
   guard handle.kind is Regular
   let job = Job::read(handle.fd, buf, offset, len, position~)
-  let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
-  perform_job_in_worker(job, context~, cancel~) catch {
+  perform_job_in_worker(job, context~, cancel=true) catch {
     @os_error.OSError(errno, ..) if errno_is_read_eof(errno) => 0
     err => raise err
   }
@@ -352,8 +345,7 @@ pub async fn IoHandle::write(
       len,
       position=handle.write_offset,
     )
-    let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
-    let n = perform_job_in_worker(job, context~, cancel~)
+    let n = perform_job_in_worker(job, context~, cancel=true)
     handle.write_offset += n.to_int64()
     return n
   }
@@ -380,9 +372,7 @@ pub async fn IoHandle::write_at(
   position~ : Int64,
   context~ : String,
 ) -> Unit {
-  guard curr_loop.val is Some(evloop)
   guard handle.kind is Regular
   let job = Job::write(handle.fd, buf, offset, len, position~)
-  let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
-  ignore(perform_job_in_worker(job, context~, cancel~))
+  ignore(perform_job_in_worker(job, context~, cancel=true))
 }

--- a/src/internal/event_loop/moon.pkg.json
+++ b/src/internal/event_loop/moon.pkg.json
@@ -13,6 +13,7 @@
   "test-import": [
     "moonbitlang/async",
     "moonbitlang/async/pipe",
+    "moonbitlang/async/fs",
     "moonbitlang/async/io"
   ],
   "targets": {
@@ -30,6 +31,7 @@
     "thread_pool.mbt": [ "native" ],
     "timer.mbt": [ "native" ],
     "missing_close_test.mbt": [ "native" ],
+    "cancel_sync_test.mbt": [ "native" ],
     "event_loop.js.mbt": [ "js" ]
   },
   "native-stub": [

--- a/src/internal/event_loop/network.mbt
+++ b/src/internal/event_loop/network.mbt
@@ -39,7 +39,7 @@ pub async fn getaddrinfo(
 ) -> Result[AddrInfo, String] {
   let host_bytes = @os_string.encode(host)
   let job = Job::getaddrinfo(host_bytes)
-  let ret = perform_job_in_worker(job, cancel=_ => NoWait, context~) catch {
+  let ret = perform_job_in_worker(job, cancel=true, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{repr(host)}")
     err => raise err

--- a/src/internal/event_loop/process.mbt
+++ b/src/internal/event_loop/process.mbt
@@ -68,10 +68,12 @@ pub async fn wait_pid(pid : Int, context~ : String) -> Unit {
 ///|
 #cfg(platform="windows")
 pub async fn wait_pid(pid : Int, context~ : String) -> Unit {
+  ignore(context)
+  guard curr_loop.val is Some(evloop)
   let job = Job::wait_for_process(pid)
-  perform_job_in_worker(job, context~, cancel=_ => {
+  let job_id = evloop.submit_job_to_worker(job)
+  evloop.wait_for_job(job_id, cancel=() => {
     job.cancel_process_waiter()
     NeedWait
   })
-  |> ignore
 }

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -14,35 +14,25 @@
 
 ///|
 #cfg(not(platform="windows"))
-fn setup_stdio(
-  fd : Int,
-  context~ : String,
-  restore_context~ : String,
-) -> IoHandle {
+fn setup_stdio(fd : Int, context~ : String) -> IoHandle {
   let kind = @fd_util.get_fd_kind_sync(fd, context~) catch {
-    err => abort("\{context}: \{err}")
+    err => abort(err.to_string())
   }
-  let handle = { fd, kind, events: NoEvent, read: None, write: None }
-  let need_unblock = kind.can_poll() &&
-    not(try! @fd_util.fd_is_nonblocking(fd, context~))
-  fn init() raise {
-    guard curr_loop.val is Some(evloop)
-    guard evloop.fds.get(fd) is None
-    evloop.fds[fd] = handle
-    if need_unblock {
-      @fd_util.set_nonblocking(fd, context~)
-    }
+  let is_async = @fd_util.fd_is_nonblocking(fd, context~) catch {
+    err => abort(err.to_string())
   }
-
-  fn exit() raise {
-    let _ = handle.detach_from_event_loop()
-    handle.events = NoEvent
-    if need_unblock {
-      @fd_util.set_blocking(fd, context=restore_context)
-    }
-  }
-
-  register_hook(init~, exit~)
+  let handle = { fd, kind, is_async, events: NoEvent, read: None, write: None }
+  register_hook(
+    init=() => {
+      guard curr_loop.val is Some(evloop)
+      guard evloop.fds.get(fd) is None
+      evloop.fds[fd] = handle
+    },
+    exit=() => {
+      let _ = handle.detach_from_event_loop()
+      handle.events = NoEvent
+    },
+  )
   handle
 }
 
@@ -52,11 +42,7 @@ extern "C" fn get_std_handle(id : Int) -> @fd_util.Fd = "GetStdHandle"
 
 ///|
 #cfg(platform="windows")
-fn setup_stdio(
-  id : Int,
-  context~ : String,
-  restore_context~ : String,
-) -> IoHandle {
+fn setup_stdio(id : Int, context~ : String) -> IoHandle {
   // The value comes from https://learn.microsoft.com/en-us/windows/console/getstdhandle
   let fd = get_std_handle(-10 - id)
   if !@fd_util.fd_is_valid(fd) {
@@ -86,31 +72,16 @@ fn setup_stdio(
       guard evloop.fds.get(fd) is None
       evloop.fds[fd] = handle
     },
-    exit=() => {
-      ignore(restore_context)
-      ignore(handle.detach_from_event_loop())
-    },
+    exit=() => ignore(handle.detach_from_event_loop()),
   )
   handle
 }
 
 ///|
-pub let stdin : IoHandle = setup_stdio(
-  0,
-  context="initialize `stdin`",
-  restore_context="restore `stdin`",
-)
+pub let stdin : IoHandle = setup_stdio(0, context="initialize `stdin`")
 
 ///|
-pub let stdout : IoHandle = setup_stdio(
-  1,
-  context="initialize `stdout`",
-  restore_context="restore `stdout`",
-)
+pub let stdout : IoHandle = setup_stdio(1, context="initialize `stdout`")
 
 ///|
-pub let stderr : IoHandle = setup_stdio(
-  2,
-  context="initialize `stderr`",
-  restore_context="restore `stderr`",
-)
+pub let stderr : IoHandle = setup_stdio(2, context="initialize `stderr`")

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -186,7 +186,10 @@ thread_worker_result_t worker_loop(void *data) {
       0
     );
 #else
-    write(pool.notify_send, &job_id, sizeof(int));
+    do {
+      if (write(pool.notify_send, &job_id, sizeof(int)) > 0)
+        break;
+    } while (errno == EINTR);
 #endif
 
 #ifdef WAKEUP_METHOD_EVENT
@@ -222,24 +225,33 @@ void moonbitlang_async_wake_worker(
   moonbit_decref(worker->job);
   worker->job_id = job_id;
   worker->job = job;
+
 #ifdef WAKEUP_METHOD_EVENT
+
   worker->waiting = 0;
   SetEvent(worker->event);
+
 #elif defined(WAKEUP_METHOD_SIGNAL)
+
+  worker->waiting = 0;
   pthread_kill(worker->id, SIGUSR1);
+
 #elif defined(WAKEUP_METHOD_COND_VAR)
+
   pthread_mutex_lock(&(worker->mutex));
   worker->waiting = 0;
   pthread_cond_signal(&(worker->cond));
   pthread_mutex_unlock(&(worker->mutex));
+
 #endif
 }
 
-#ifdef _WIN32
 MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_cancel_worker(struct worker *worker) {
   if (worker->waiting)
     return 1;
+
+#ifdef _WIN32
 
   if (CancelSynchronousIo(worker->id)) {
     return 1;
@@ -248,7 +260,18 @@ int32_t moonbitlang_async_cancel_worker(struct worker *worker) {
   } else {
     return -1;
   }
+
+#else
+
+  pthread_kill(worker->id, SIGUSR2);
+  return 0;
+
+#endif
 }
+
+#ifndef _WIN32
+static
+void nop_signal_handler(int signum) {}
 #endif
 
 MOONBIT_FFI_EXPORT
@@ -269,6 +292,12 @@ void moonbitlang_async_init_thread_pool(HANDLE notify_send) {
   pthread_sigmask(SIG_BLOCK, &signals_to_block, 0);
 
   signal(SIGPIPE, SIG_IGN);
+
+  struct sigaction act;
+  act.sa_handler = nop_signal_handler;
+  sigemptyset(&act.sa_mask);
+  act.sa_flags = 0;
+  sigaction(SIGUSR2, &act, NULL);
 #endif
 
   pool.notify_send = notify_send;
@@ -351,6 +380,15 @@ int32_t moonbitlang_async_fetch_completion(int notify_recv) {
   return job_id;
 }
 #endif
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_errno_is_cancelled(int32_t err) {
+#ifdef _WIN32
+  return err == ERROR_OPERATION_ABORTED;
+#else
+  return err == EINTR;
+#endif
+}
 
 // =========================================================
 // ===================== concrete jobs =====================

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -31,12 +31,10 @@ extern "C" fn spawn_worker(init_job_id : Int, init_job : Job) -> Worker = "moonb
 extern "C" fn wake_worker(worker : Worker, job_id : Int, job : Job) = "moonbitlang_async_wake_worker"
 
 ///|
-#cfg(platform="windows")
 #borrow(worker)
 extern "C" fn Worker::cancel_ffi(worker : Worker) -> Int = "moonbitlang_async_cancel_worker"
 
 ///|
-#cfg(platform="windows")
 fn Worker::cancel(
   worker : Worker,
   context~ : String,

--- a/src/internal/event_loop/unimplemented_test.mbt
+++ b/src/internal/event_loop/unimplemented_test.mbt
@@ -18,4 +18,5 @@ let _ignore_unused_import : Unit = {
   ignore(@io.pipe)
   ignore(@async.sleep)
   ignore(@pipe.unimplemented)
+  ignore(@fs.unimplemented)
 }

--- a/src/internal/event_loop/worker_wbtest.mbt
+++ b/src/internal/event_loop/worker_wbtest.mbt
@@ -18,14 +18,18 @@ extern "C" fn Job::sleep(time : Int) -> Job = "moonbitlang_async_make_sleep_job"
 
 ///|
 #cfg(target="native")
-async fn perform_sleep_job(t : Int) -> Unit {
-  perform_job_in_worker(Job::sleep(t), context="") |> ignore
+async fn perform_sleep_job(t : Int, cancel? : Bool = false) -> Unit {
+  perform_job_in_worker(Job::sleep(t), context="", cancel~) |> ignore
 }
 
 ///|
 #cfg(target="js")
-async fn perform_sleep_job(t : Int) -> Unit {
-  @async.protect_from_cancel(() => sleep(t))
+async fn perform_sleep_job(t : Int, cancel? : Bool = false) -> Unit {
+  if cancel {
+    sleep(t)
+  } else {
+    @async.protect_from_cancel(() => sleep(t))
+  }
 }
 
 ///|
@@ -85,7 +89,7 @@ async test "worker multiple" {
 }
 
 ///|
-async test "worker cancel1" {
+async test "worker no cancel1" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {
     root.spawn_bg(fn() {
@@ -123,7 +127,7 @@ async test "worker cancel1" {
 }
 
 ///|
-async test "worker cancel2" {
+async test "worker no cancel2" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {
     root.spawn_bg(fn() {
@@ -155,4 +159,32 @@ async test "worker cancel2" {
       #|
     ),
   )
+}
+
+///|
+// note: on Windows, `CancelSynchronousIo` cannot cancel `sleep`
+#cfg(not(platform="windows"))
+async test "worker cancel" {
+  let t0 = @async.now()
+  let result = @async.with_timeout_opt(400, () => perform_sleep_job(
+    1000,
+    cancel=true,
+  ))
+  let t1 = @async.now()
+  inspect(result, content="None")
+  inspect((t1 - t0) / 200, content="2")
+}
+
+///|
+// note: on Windows, `CancelSynchronousIo` cannot cancel `sleep`
+#cfg(not(platform="windows"))
+async test "worker cancel stress" {
+  @async.with_task_group(group => for _ in 0..<10 {
+    async fn worker() {
+      @async.with_timeout_opt(300, () => perform_sleep_job(300, cancel=true))
+      |> ignore
+    }
+
+    group.spawn_bg(worker)
+  })
 }

--- a/src/socket/resolve_host_test.mbt
+++ b/src/socket/resolve_host_test.mbt
@@ -24,10 +24,10 @@ async test "resolve mooncakes.io" {
 async test "resolve cancel" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {
-    let lock = @async.Semaphore::new(1, initial_value=1)
+    let lock = @async.Semaphore::new(1)
     let task = root.spawn(allow_failure=true, fn() {
       lock.release()
-      log.write_object(@socket.Addr::resolve("does.not.exist", port=443))
+      log.write_object(try? @socket.Addr::resolve("does.not.exist", port=443))
     })
     lock.acquire() // make sure the task already started
     task.cancel()
@@ -37,7 +37,7 @@ async test "resolve cancel" {
     log.to_string(),
     content=(
       #|host resolution cancelled
-      #|
+      #|Err(Cancelled)
     ),
   )
 }

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -72,26 +72,6 @@ async test "redirect pipe" {
 }
 
 ///|
-#cfg(not(platform="windows"))
-async test "recover state" {
-  assert_false(@fd_util.fd_is_nonblocking(1, context=""))
-  assert_false(@fd_util.fd_is_nonblocking(2, context=""))
-  let cat = cat.wait()
-  @async.with_task_group(group => {
-    let (cat_read, we_write) = @process.write_to_process()
-    group.spawn_bg(() => {
-      let code = @process.run(cat, [], stdin=cat_read)
-      inspect(code, content="0")
-    })
-    @async.sleep(100)
-    we_write.close()
-  })
-  @async.sleep(100)
-  assert_false(@fd_util.fd_is_nonblocking(1, context=""))
-  assert_false(@fd_util.fd_is_nonblocking(2, context=""))
-}
-
-///|
 async test "stdio cancel" {
   let cat = cat.wait()
   @async.with_task_group(group => {


### PR DESCRIPTION
This PR:

- add support for cancelling blocking IO operation in the thread pool on Unix. This is achieved by sending `SIGUSR2` signal to the worker thread. A dummy handler is registered for `SIGUSR2` in advance, so the sole effect of this signal is to interrupt any blocking IO syscall via `EINTR`
    - note that this way of cancellation is racy by nature: the signal may arrive before/while/after the syscall. So similar to how we handle `CancelSynchronousIo` on Windows, spinning is necessary for proper cancellation
    - according to the man page, only "slow" syscall can be cancelled with `EINTR`, which is basically those syscall that may hang indefinitely. So regular file IO is still not cancellable.
- with the capability to cancel synchronous IO in the thread pool, we no longer need to turn stdio into non blocking mode. This can avoid some potential issue when stdio channels are shared with other process
- `getaddrinfo` can also be cancelled properly via this method