### PR TITLE
use blocking IO for stdio on Unix

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -451,7 +451,6 @@ async fn perform_job_in_worker(
 }
 
 ///|
-#cfg(platform="windows")
 fn EventLoop::cancel_job_in_worker(
   evloop : EventLoop,
   job_id : Int,

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -74,7 +74,7 @@ pub async fn open(
     context~,
   )
   let kind = @fd_util.FileKind::from_sys_kind(kind)
-  IoHandle::from_fd(fd, kind~, is_async=false)
+  IoHandle::from_fd(fd, kind~, is_async=!IS_WINDOWS && kind.can_poll())
 }
 
 ///|

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -17,6 +17,7 @@
 struct IoHandle {
   mut fd : @fd_util.Fd
   kind : @fd_util.FileKind
+  is_async : Bool
   mut events : Int
   mut read : @coroutine.Coroutine?
   mut write : @coroutine.Coroutine?
@@ -32,8 +33,7 @@ pub fn IoHandle::from_fd(
 ) -> IoHandle raise {
   guard curr_loop.val is Some(evloop)
   guard evloop.fds.get(fd) is None
-  ignore(is_async)
-  let handle = { fd, kind, read: None, write: None, events: NoEvent }
+  let handle = { fd, kind, is_async, read: None, write: None, events: NoEvent }
   evloop.fds[fd] = handle
   handle
 }
@@ -143,7 +143,7 @@ pub async fn IoHandle::read(
   len~ : Int,
   context~ : String,
 ) -> Int {
-  if handle.kind.can_poll() {
+  if handle.is_async {
     handle.prepare_read()
     let ret = read_ffi(handle.fd, buf, offset~, len~)
     if ret >= 0 {
@@ -161,8 +161,14 @@ pub async fn IoHandle::read(
     }
     ret
   } else {
+    let cancel = if handle.kind.can_poll() {
+      guard curr_loop.val is Some(evloop)
+      Some(job_id => evloop.cancel_job_in_worker(job_id, context~))
+    } else {
+      None
+    }
     let job = Job::read(handle.fd, buf, offset, len, position=-1)
-    perform_job_in_worker(job, context~)
+    perform_job_in_worker(job, context~, cancel?)
   }
 }
 
@@ -200,7 +206,7 @@ pub async fn IoHandle::write(
   len~ : Int,
   context~ : String,
 ) -> Int {
-  if handle.kind.can_poll() {
+  if handle.is_async {
     handle.prepare_write()
     let ret = write_ffi(handle.fd, buf, offset~, len~)
     if ret >= 0 {
@@ -218,8 +224,14 @@ pub async fn IoHandle::write(
     }
     ret
   } else {
+    let cancel = if handle.kind.can_poll() {
+      guard curr_loop.val is Some(evloop)
+      Some(job_id => evloop.cancel_job_in_worker(job_id, context~))
+    } else {
+      None
+    }
     let job = Job::write(handle.fd, buf, offset, len, position=-1)
-    perform_job_in_worker(job, context~)
+    perform_job_in_worker(job, context~, cancel?)
   }
 }
 

--- a/src/internal/event_loop/io_windows.c
+++ b/src/internal/event_loop/io_windows.c
@@ -207,11 +207,6 @@ int32_t moonbitlang_async_io_result_get_job_id(struct IoResult *result) {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_errno_is_cancelled(int32_t err) {
-  return err == ERROR_OPERATION_ABORTED;
-}
-
-MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_io_result_get_status(
   LPOVERLAPPED overlapped,
   HANDLE file

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -14,35 +14,23 @@
 
 ///|
 #cfg(not(platform="windows"))
-fn setup_stdio(
-  fd : Int,
-  context~ : String,
-  restore_context~ : String,
-) -> IoHandle {
+fn setup_stdio(fd : Int, context~ : String) -> IoHandle {
   let kind = @fd_util.get_fd_kind_sync(fd, context~) catch {
     err => abort("\{context}: \{err}")
   }
-  let handle = { fd, kind, events: NoEvent, read: None, write: None }
-  let need_unblock = kind.can_poll() &&
-    not(try! @fd_util.fd_is_nonblocking(fd, context~))
-  fn init() raise {
-    guard curr_loop.val is Some(evloop)
-    guard evloop.fds.get(fd) is None
-    evloop.fds[fd] = handle
-    if need_unblock {
-      @fd_util.set_nonblocking(fd, context~)
-    }
-  }
-
-  fn exit() raise {
-    let _ = handle.detach_from_event_loop()
-    handle.events = NoEvent
-    if need_unblock {
-      @fd_util.set_blocking(fd, context=restore_context)
-    }
-  }
-
-  register_hook(init~, exit~)
+  let is_async = try! @fd_util.fd_is_nonblocking(fd, context~)
+  let handle = { fd, kind, is_async, events: NoEvent, read: None, write: None }
+  register_hook(
+    init=() => {
+      guard curr_loop.val is Some(evloop)
+      guard evloop.fds.get(fd) is None
+      evloop.fds[fd] = handle
+    },
+    exit=() => {
+      let _ = handle.detach_from_event_loop()
+      handle.events = NoEvent
+    },
+  )
   handle
 }
 
@@ -52,11 +40,7 @@ extern "C" fn get_std_handle(id : Int) -> @fd_util.Fd = "GetStdHandle"
 
 ///|
 #cfg(platform="windows")
-fn setup_stdio(
-  id : Int,
-  context~ : String,
-  restore_context~ : String,
-) -> IoHandle {
+fn setup_stdio(id : Int, context~ : String) -> IoHandle {
   // The value comes from https://learn.microsoft.com/en-us/windows/console/getstdhandle
   let fd = get_std_handle(-10 - id)
   if !@fd_util.fd_is_valid(fd) {
@@ -86,31 +70,16 @@ fn setup_stdio(
       guard evloop.fds.get(fd) is None
       evloop.fds[fd] = handle
     },
-    exit=() => {
-      ignore(restore_context)
-      ignore(handle.detach_from_event_loop())
-    },
+    exit=() => ignore(handle.detach_from_event_loop()),
   )
   handle
 }
 
 ///|
-pub let stdin : IoHandle = setup_stdio(
-  0,
-  context="initialize `stdin`",
-  restore_context="restore `stdin`",
-)
+pub let stdin : IoHandle = setup_stdio(0, context="initialize `stdin`")
 
 ///|
-pub let stdout : IoHandle = setup_stdio(
-  1,
-  context="initialize `stdout`",
-  restore_context="restore `stdout`",
-)
+pub let stdout : IoHandle = setup_stdio(1, context="initialize `stdout`")
 
 ///|
-pub let stderr : IoHandle = setup_stdio(
-  2,
-  context="initialize `stderr`",
-  restore_context="restore `stderr`",
-)
+pub let stderr : IoHandle = setup_stdio(2, context="initialize `stderr`")

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -31,12 +31,10 @@ extern "C" fn spawn_worker(init_job_id : Int, init_job : Job) -> Worker = "moonb
 extern "C" fn wake_worker(worker : Worker, job_id : Int, job : Job) = "moonbitlang_async_wake_worker"
 
 ///|
-#cfg(platform="windows")
 #borrow(worker)
 extern "C" fn Worker::cancel_ffi(worker : Worker) -> Int = "moonbitlang_async_cancel_worker"
 
 ///|
-#cfg(platform="windows")
 fn Worker::cancel(
   worker : Worker,
   context~ : String,

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -72,26 +72,6 @@ async test "redirect pipe" {
 }
 
 ///|
-#cfg(not(platform="windows"))
-async test "recover state" {
-  assert_false(@fd_util.fd_is_nonblocking(1, context=""))
-  assert_false(@fd_util.fd_is_nonblocking(2, context=""))
-  let cat = cat.wait()
-  @async.with_task_group(group => {
-    let (cat_read, we_write) = @process.write_to_process()
-    group.spawn_bg(() => {
-      let code = @process.run(cat, [], stdin=cat_read)
-      inspect(code, content="0")
-    })
-    @async.sleep(100)
-    we_write.close()
-  })
-  @async.sleep(100)
-  assert_false(@fd_util.fd_is_nonblocking(1, context=""))
-  assert_false(@fd_util.fd_is_nonblocking(2, context=""))
-}
-
-///|
 async test "stdio cancel" {
   let cat = cat.wait()
   @async.with_task_group(group => {


### PR DESCRIPTION
Previously, stdio channels will be turned into non-blocking mode if poll-able, so that we can process them asynchronously. However, this may cause interaction problem when stdio channels are shared between multiple process. Although the event loop automatically reset stdio channels back to their original state on exit, other process may still get affected while the event loop is running.

This PR changes how we handle stdio channels to avoid touching their state. If the stdio channels are already non blocking, we use non blocking IO. If stdio channels are blocking, we process them using the thread pool, instead of changing their state.

One important concern here is cancellation. If, for example, stdin is a blocking pipe, we must be able to cancel blocking read on it, otherwise the program may hang forever. This is achieved by sending signal to the worker thread. If stdin is a "slow" fd that may hang indefinitely, it will get interrupted by the signal. As in #237, self spinning is used to avoid race condition during cancellation.

TODO: what if the state of stdio channels change in the middle of execution? should we handle this case?