### PR TITLE
allow cancellation of `open` to handle named pipe

### DIFF
--- a/src/internal/event_loop/cancel_open_test.mbt
+++ b/src/internal/event_loop/cancel_open_test.mbt
@@ -1,0 +1,54 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(not(platform="windows"))
+#borrow(path)
+extern "C" fn mkfifo(path : @os_string.OsString, mode : Int) -> Int = "mkfifo"
+
+///|
+#cfg(not(platform="windows"))
+async test "cancel FIFO open" {
+  @async.with_task_group(group => {
+    let path = "_build/cancel_fifo_read"
+    if mkfifo(@os_string.encode(path), 0o644) < 0 {
+      @os_error.check_errno("mkfifo")
+    }
+    group.add_defer(() => @fs.remove(path))
+    let result = @async.with_timeout_opt(500, () => @fs.open(
+      path,
+      mode=ReadOnly,
+    ).close())
+    inspect(result, content="None")
+  })
+}
+
+///|
+#cfg(platform="windows")
+async test "cancel named pipe open" {
+  let context = "cancel named pipe open test"
+  let path = "\\\\.\\pipe\\moonbitlang_async_cancel_open_test"
+  let server = @fd_util.create_named_pipe_server(
+    @os_string.encode(path),
+    is_async=false,
+  )
+  if !@fd_util.fd_is_valid(server) {
+    @os_error.check_errno(context)
+  }
+  defer (try! @fd_util.close(server, kind=Pipe, context~))
+  let client1 = @fs.open(path, mode=WriteOnly)
+  defer client1.close()
+  let result = @async.with_timeout_opt(500, () => @fs.open(path, mode=WriteOnly).close())
+  inspect(result, content="None")
+}

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -40,7 +40,12 @@ pub async fn open_detached(
     sync~,
     mode~,
   )
-  try perform_job_in_worker(job, context~) catch {
+  fn cancel(job_id) raise {
+    guard curr_loop.val is Some(evloop)
+    evloop.cancel_job_in_worker(job_id, context~)
+  }
+
+  try perform_job_in_worker(job, context~, cancel~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{repr(path)}")
     err => raise err

--- a/src/internal/event_loop/moon.pkg.json
+++ b/src/internal/event_loop/moon.pkg.json
@@ -13,6 +13,7 @@
   "test-import": [
     "moonbitlang/async",
     "moonbitlang/async/pipe",
+    "moonbitlang/async/fs",
     "moonbitlang/async/io"
   ],
   "targets": {
@@ -30,6 +31,7 @@
     "thread_pool.mbt": [ "native" ],
     "timer.mbt": [ "native" ],
     "missing_close_test.mbt": [ "native" ],
+    "cancel_open_test.mbt": [ "native" ],
     "event_loop.js.mbt": [ "js" ]
   },
   "native-stub": [

--- a/src/internal/event_loop/unimplemented_test.mbt
+++ b/src/internal/event_loop/unimplemented_test.mbt
@@ -18,4 +18,5 @@ let _ignore_unused_import : Unit = {
   ignore(@io.pipe)
   ignore(@async.sleep)
   ignore(@pipe.unimplemented)
+  ignore(@fs.unimplemented)
 }

--- a/src/internal/fd_util/pipe.mbt
+++ b/src/internal/fd_util/pipe.mbt
@@ -64,7 +64,7 @@ let current_process_id : UInt = get_current_process_id()
 ///|
 #cfg(platform="windows")
 #borrow(name)
-extern "C" fn create_named_pipe_server(
+pub extern "C" fn create_named_pipe_server(
   name : @os_string.OsString,
   is_async~ : Bool,
 ) -> Fd = "moonbitlang_async_create_named_pipe_server"


### PR DESCRIPTION
`open` may hang indefinitely if the target is a named fifo (unix) or named pipe (Windows). In this case, we should make `open` cancellable. Fortunately, the usual way to cancel blocking IO in thread pool (`pthread_kill` on unix and `CancelSynchronousIo` on Windows) can handle this case properly. This PR implemented cancellation for `open` to handle the named pipe case.

Previously, `open` cannot handle named pipe properly on Windows. This PR makes `open` call `WaitNamedPipe` automatically if the target is a named pipe and no instance is available. `WaitNamedPipe` may hang forever, but can be canceled via `CancelSynchronousIo`.