### PR TITLE
add `exclude` parameter to `@fs.walk`

### DIFF
--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -147,6 +147,13 @@ pub async fn readdir(
 /// `walk(path, f, ..)` recursively walk the directory `path`,
 /// and call `f` on every sub-directory in `path`, including `path` itself.
 ///
+/// If `exclude` is present, it will be invoked with the path of every directory
+/// before traversing them. If `exclude` returns `true`,
+/// the directory and all its children will be skipped.
+/// The path passed to `exclude` has the following format:
+/// - always start with `path`
+/// - does not contain trailing directory separator
+///
 /// The directories are walked in parallel.
 /// Use `max_concurrency` to limit the number of workers spawned in parallel.
 /// For example, setting `max_concurrency=1` result in sequential walking.
@@ -159,6 +166,7 @@ pub async fn readdir(
 pub async fn walk(
   path : StringView,
   f : async (String, Array[String]) -> Unit,
+  exclude? : (String) -> Bool = _ => false,
   max_concurrency? : Int = 1000,
   allow_failure? : Bool = false,
 ) -> Unit {
@@ -166,6 +174,7 @@ pub async fn walk(
   let sem = @async.Semaphore::new(max_concurrency)
   @async.with_task_group(fn(group) {
     fn handle_path(path : String) {
+      guard !exclude(path) else {  }
       group.spawn_bg(allow_failure~, fn() {
         sem.acquire()
         defer sem.release()

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -47,7 +47,7 @@ pub async fn rmdir(StringView, recursive? : Bool) -> Unit
 
 pub async fn symlink(target~ : StringView, StringView) -> Unit
 
-pub async fn walk(StringView, async (String, Array[String]) -> Unit, max_concurrency? : Int, allow_failure? : Bool) -> Unit
+pub async fn walk(StringView, async (String, Array[String]) -> Unit, exclude? : (String) -> Bool, max_concurrency? : Int, allow_failure? : Bool) -> Unit
 
 pub async fn write_file(StringView, &@io.Data, sync? : SyncMode, append? : Bool, create? : Int, truncate? : Bool) -> Unit
 

--- a/src/fs/walk_test.mbt
+++ b/src/fs/walk_test.mbt
@@ -95,3 +95,21 @@ async test "walk allow_failure" {
     ),
   )
 }
+
+///|
+async test "walk exclude 1" {
+  let walked = []
+  @fs.walk("test_directory", exclude=p => p is [.., '1'], (path, _) => walked.push(
+    path,
+  ))
+  @json.inspect(walked, content=["test_directory"])
+}
+
+///|
+async test "walk exclude 2" {
+  let walked = []
+  @fs.walk("test_directory", exclude=p => p is [.., '2'], (path, _) => walked.push(
+    path,
+  ))
+  @json.inspect(walked, content=["test_directory", "test_directory/inner1"])
+}


### PR DESCRIPTION
This PR adds a new optional parameter `exclude` to `@fs.walk`. If `exclude` is present, it will be invoked with the path of every directory being traversed. If `exclude` returns `true`, the directory and all its children will be skipped.