### PR TITLE
fix resource leak & improve worker handling

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -305,6 +305,9 @@ fn EventLoop::cleanup(self : Self) -> Unit raise {
     self.poll.remove_pid(pid)
   }
   self.pids.clear()
+  for worker in self.idle_workers {
+    worker.free()
+  }
 }
 
 ///|
@@ -327,6 +330,9 @@ fn EventLoop::cleanup(self : Self) -> Unit raise {
     coro.cancel()
   }
   self.jobs.clear()
+  for worker in self.idle_workers {
+    worker.free()
+  }
 }
 
 ///|

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 ///|
+#external
 priv type Worker
 
 ///|
@@ -26,16 +27,16 @@ extern "C" fn destroy_thread_pool() = "moonbitlang_async_destroy_thread_pool"
 extern "C" fn Worker::spawn(init_job_id : Int, init_job : Job) -> Worker = "moonbitlang_async_spawn_worker"
 
 ///|
-#borrow(worker)
+extern "C" fn Worker::free(worker : Worker) = "moonbitlang_async_free_worker"
+
+///|
 #owned(job)
 extern "C" fn Worker::wake(worker : Worker, job_id : Int, job : Job) = "moonbitlang_async_wake_worker"
 
 ///|
-#borrow(worker)
 extern "C" fn Worker::enter_idle(worker : Worker) = "moonbitlang_async_worker_enter_idle"
 
 ///|
-#borrow(worker)
 extern "C" fn Worker::cancel_ffi(worker : Worker) -> Int = "moonbitlang_async_cancel_worker"
 
 ///|


### PR DESCRIPTION
- previously, the job object assigned to a worker can only be freed when the worker is assigned a new job, or the whole event loop terminates. This result in resource leak because the job object is living longer than necessary. This PR fixes the issue by dropping the job object as soon as it completes
- previously, the lifetime of thread worker objects are managed automatically using `moonbit_make_external_object`. However this is not the best way, because:
    - dropping a worker object is a "dangerous" operation that involves waiting for a thread. Implicitly doing this kind of stuff in the destructor is scary
    - the lifetime of worker objects are pretty clear, so manual management is not difficult

    so this PR also turn to manual management for worker objects.