### PR TITLE
simplify `@async.any`

### DIFF
--- a/src/all_any_test.mbt
+++ b/src/all_any_test.mbt
@@ -282,7 +282,7 @@ async test "any single task" {
 async test "any empty fails" {
   @json.inspect(try? (@async.any([]) : Unit), content={
     "Err": [
-      "Failure", "async.mbt:292:5-292:39@moonbitlang/async FAILED: no tasks provided to any()",
+      "Failure", "all_any_test.mbt:283:23-283:37@moonbitlang/async_blackbox_test FAILED: no tasks provided to any()",
     ],
   })
 }

--- a/src/async.mbt
+++ b/src/async.mbt
@@ -278,10 +278,12 @@ pub async fn[X] all(
 /// If not specified, all tasks run at once.
 ///
 /// `any` requires at least one task and will fail if the array is empty.
+#callsite(autofill(loc))
 pub async fn[X] any(
   tasks : ArrayView[async () -> X],
   max_concurrent? : Int,
   allow_failure? : Bool = false,
+  loc~ : SourceLoc,
 ) -> X {
   let semaphore = if max_concurrent is Some(p) {
     Some(@semaphore.Semaphore::new(p))
@@ -289,7 +291,7 @@ pub async fn[X] any(
     None
   }
   if tasks.is_empty() {
-    fail("no tasks provided to any()")
+    fail("no tasks provided to any()", loc~)
   }
   let mut result = None
   let mut last_err = None

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -10,7 +10,8 @@ import(
 // Values
 pub async fn[X] all(ArrayView[async () -> X], max_concurrent? : Int) -> Array[X]
 
-pub async fn[X] any(ArrayView[async () -> X], max_concurrent? : Int, allow_failure? : Bool) -> X
+#callsite(autofill(loc))
+pub async fn[X] any(ArrayView[async () -> X], max_concurrent? : Int, allow_failure? : Bool, loc~ : SourceLoc) -> X
 
 pub fn is_being_cancelled() -> Bool
 


### PR DESCRIPTION
- simplify code for `@async.any`
- use location of call site in error message for `@async.any([])`, for easier trouble shooting
- simplify tests for `@async.all` and `@async.any`, add check for event timing & use `@json.inspect` more
- add test for `@async.all`/`@async.any` being cancelled