### PR TITLE
windows command line escaping: insert quotes only when necessary

### DIFF
--- a/src/process/windows.mbt
+++ b/src/process/windows.mbt
@@ -26,6 +26,20 @@ fn StringBuilder::write_arg_with_windows_escape(
   builder : StringBuilder,
   arg : String,
 ) -> Unit raise {
+  // Do not add double quotes if it is unnecessary to do so.
+  // This help with simple cases when the program is not using C argv syntax,
+  // such as `rundll32.exe`.
+  let need_quote = for char in arg {
+    if char is (' ' | '\t' | '"') {
+      break true
+    }
+  } else {
+    false
+  }
+  if !need_quote {
+    builder.write_string(arg)
+    return
+  }
   let mut segment_start = 0
   let mut index = 0
   let mut trailing_backslash = 0

--- a/src/process/windows_escape_wbtest.mbt
+++ b/src/process/windows_escape_wbtest.mbt
@@ -41,20 +41,10 @@ test "windows command line arg escape" {
   )
   let test_str =
     #|\
-  inspect(
-    test_arg(test_str),
-    content=(
-      #|"\\"
-    ),
-  )
+  inspect(test_arg(test_str), content="\\")
   let test_str =
     #|a\\\c
-  inspect(
-    test_arg(test_str),
-    content=(
-      #|"a\\\c"
-    ),
-  )
+  inspect(test_arg(test_str), content="a\\\\\\c")
   let test_str =
     #|a\"c
   inspect(


### PR DESCRIPTION
#266 

Some Windows program does not use C argv syntax for command line parsing, such as `cmd.exe` and `rundll32.exe`. For `cmd.exe`, due to its extremely complex escaping rule with security problems, we deliberately omit its support. However, for simple cases such as `rundll32.exe`, we can make things work by dropping the double quotes when there is no need to escape the arguments. The result still confronts to the C argv syntax, but is compatible with more other programs.