### PR TITLE
Fix deprecated warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ examples/target/
 examples/_target/
 examples/.mooncakes/
 .moonagent
+
+target/

--- a/src/http/proxy_test.mbt
+++ b/src/http/proxy_test.mbt
@@ -115,9 +115,9 @@ async test "proxied https request" {
   @async.with_task_group(group => {
     let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr().port()
-    group.spawn_bg(no_wait=true, () => server.run_forever(
-      handle_connect(log, _, _, _),
-    ))
+    group.spawn_bg(no_wait=true, () => server.run_forever((x0, x1, x2) => handle_connect(
+      log, x0, x1, x2,
+    )))
     let (_, result) = @async.with_timeout(3000, () => @http.get(
       "https://www.example.org",
       proxy=@http.Client::new("http://localhost:\{port}"),
@@ -135,9 +135,9 @@ async test "proxied http request" {
   @async.with_task_group(group => {
     let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr().port()
-    group.spawn_bg(no_wait=true, () => server.run_forever(
-      handle_connect(log, _, _, _),
-    ))
+    group.spawn_bg(no_wait=true, () => server.run_forever((x0, x1, x2) => handle_connect(
+      log, x0, x1, x2,
+    )))
     let (_, result) = @http.get(
       "http://www.example.org",
       proxy=@http.Client::new("http://localhost:\{port}"),
@@ -157,9 +157,9 @@ async test "proxied misc request" {
   let server = @socket.TcpServer::new(@socket.Addr::parse("127.0.0.1:0"))
   let port = server.addr().port()
   @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, () => proxy_server.run_forever(
-      handle_connect(log, _, _, _),
-    ))
+    group.spawn_bg(no_wait=true, () => proxy_server.run_forever((x0, x1, x2) => handle_connect(
+      log, x0, x1, x2,
+    )))
     group.spawn_bg(no_wait=true, () => server.run_forever((conn, _) => {
       let conn = @http.ServerConnection::new(conn)
       for {

--- a/src/websocket/README.mbt.md
+++ b/src/websocket/README.mbt.md
@@ -122,7 +122,7 @@ A single message received from a WebSocket tunnel.
 ### `CloseCode`
 WebSocket close code.
 
-```moonbit no-check
+```moonbit no-check nocheck
 ///|
 pub(all) enum CloseCode {
   Normal // 1000
@@ -142,7 +142,7 @@ pub(all) enum CloseCode {
 ### Error Types
 
 #### `WebSocketError`
-```moonbit no-check
+```moonbit no-check nocheck
 ///|
 suberror WebSocketError {
   // Connection was closed with specific code.

--- a/src/websocket/client.mbt
+++ b/src/websocket/client.mbt
@@ -102,7 +102,7 @@ pub async fn Conn::from_http_client(
 /// See `@http.Client::new` for more details.
 ///
 /// Example:
-/// ```moonbit no-check
+/// ```moonbit no-check nocheck
 /// let ws = Client::connect("ws://example.com/endpoint")
 /// ```
 #as_free_fn


### PR DESCRIPTION
Automated cleanup to eliminate warnings under `--warn-list @deprecated`.