### PR TITLE
do not treat cancelled task as failing in task group

### DIFF
--- a/src/aqueue/aqueue_test.mbt
+++ b/src/aqueue/aqueue_test.mbt
@@ -126,9 +126,7 @@ async test "aqueue cancellation no_swallow" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(group) {
     let q = @aqueue.Queue::new(kind=Unbounded)
-    let get_task = group.spawn(allow_failure=true, fn() {
-      log.write_string("get() => \{q.get()}\n")
-    })
+    let get_task = group.spawn(() => log.write_string("get() => \{q.get()}\n"))
     @async.sleep(100)
     q.put(42)
     get_task.cancel()

--- a/src/aqueue/blocking_test.mbt
+++ b/src/aqueue/blocking_test.mbt
@@ -146,7 +146,7 @@ async test "blocking immediate cancellation" {
   @async.with_task_group(group => {
     let q = @async.Queue::new(kind=Blocking(1))
     q.put(0)
-    let put_task = group.spawn(allow_failure=true, () => {
+    let put_task = group.spawn(() => {
       q.put(1) catch {
         err => {
           log.push("put() cancelled")

--- a/src/cancellation_test.mbt
+++ b/src/cancellation_test.mbt
@@ -16,15 +16,13 @@
 async test "manual cancel" {
   let buf = StringBuilder::new()
   let result = try? @async.with_task_group(fn(root) {
-    let task = root.spawn(allow_failure=true, fn() {
-      try {
-        @async.sleep(300)
-        buf.write_string("task finished\n")
-      } catch {
-        err => {
-          buf.write_string("cancelled by error \{err}\n")
-          raise err
-        }
+    let task = root.spawn(() => try {
+      @async.sleep(300)
+      buf.write_string("task finished\n")
+    } catch {
+      err => {
+        buf.write_string("cancelled by error \{err}\n")
+        raise err
       }
     })
     @async.sleep(100)
@@ -157,7 +155,7 @@ async test "recursive cancel" {
           buf.write_string("tick\n")
         }
       })
-      let task = root.spawn(allow_failure=true, fn() {
+      let task = root.spawn(() => {
         @async.sleep(1000) catch {
           err => buf.write_string("first sleep cancelled with \{err}\n")
         }
@@ -240,7 +238,7 @@ async test "error in cancellation" {
 async test "immediately cancelled" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {
-    let task = root.spawn(allow_failure=true, fn() {
+    let task = root.spawn(() => {
       defer log.write_string("task terminated\n")
       log.write_string("task started\n")
       @async.sleep(100)

--- a/src/cond_var/cond_var_test.mbt
+++ b/src/cond_var/cond_var_test.mbt
@@ -32,7 +32,7 @@ async test "cond var cancellation no_swallow" {
   let log = StringBuilder::new()
   @async.with_task_group(root => {
     let cond = @cond_var.Cond::new()
-    let wait_task = root.spawn(allow_failure=true, () => {
+    let wait_task = root.spawn(() => {
       cond.wait()
       log.write_string("waiter 1 succeed\n")
     })

--- a/src/internal/event_loop/worker_wbtest.mbt
+++ b/src/internal/event_loop/worker_wbtest.mbt
@@ -94,15 +94,13 @@ async test "worker cancel1" {
         log.write_string("tick\n")
       }
     })
-    let task = root.spawn(allow_failure=true, fn() {
-      try perform_sleep_job(1000) catch {
-        err => {
-          log.write_string("sleep cancelled with \{err}\n")
-          raise err
-        }
-      } noraise {
-        _ => log.write_string("done\n")
+    let task = root.spawn(() => try perform_sleep_job(1000) catch {
+      err => {
+        log.write_string("sleep cancelled with \{err}\n")
+        raise err
       }
+    } noraise {
+      _ => log.write_string("done\n")
     })
     @async.sleep(500)
     log.write_string("trying to cancel\n")

--- a/src/process/cancel_test.mbt
+++ b/src/process/cancel_test.mbt
@@ -19,7 +19,7 @@ async test "cancel process" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn(allow_failure=true, fn() {
+    let task = root.spawn(() => {
       defer log.write_string("process terminates\n")
       @process.run(test_prog, ["10000"], stdout=w)
     })
@@ -50,14 +50,12 @@ async test "cancel process timeout" {
   let test_prog = sleep_prog.wait()
   @async.with_task_group(fn(root) {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn(allow_failure=true, fn() {
-      @process.run(
-        test_prog,
-        ["-swallow-cancel-signal", "10000"],
-        stdout=w,
-        cancel_handler=@process.graceful_cancel(timeout=500),
-      )
-    })
+    let task = root.spawn(() => @process.run(
+      test_prog,
+      ["-swallow-cancel-signal", "10000"],
+      stdout=w,
+      cancel_handler=@process.graceful_cancel(timeout=500),
+    ))
     let t_receive_graceful_termination = root.spawn(() => {
       defer r.close()
       guard r.read_some() is Some(data)
@@ -83,14 +81,12 @@ async test "cancel process hard" {
   let test_prog = sleep_prog.wait()
   @async.with_task_group(fn(root) {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn(allow_failure=true, fn() {
-      @process.run(
-        test_prog,
-        ["10000"],
-        stdout=w,
-        cancel_handler=@process.hard_cancel(),
-      )
-    })
+    let task = root.spawn(() => @process.run(
+      test_prog,
+      ["10000"],
+      stdout=w,
+      cancel_handler=@process.hard_cancel(),
+    ))
     root.spawn_bg(() => {
       defer r.close()
       inspect(r.read_all().text(), content="")
@@ -109,7 +105,7 @@ async test "orphan process" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn(allow_failure=true, fn() {
+    let task = root.spawn(() => {
       defer log.write_string("process terminates\n")
       let pid = @process.spawn_orphan(
         shell,

--- a/src/process/spawn_in_group_test.mbt
+++ b/src/process/spawn_in_group_test.mbt
@@ -84,13 +84,7 @@ async test "Process:cancel" {
       defer r.close()
       inspect(r.read_all().text().trim(), content="received termination signal")
     })
-    let child = @process.spawn(
-      group,
-      sleep,
-      ["10000"],
-      stdout=w,
-      allow_failure=true,
-    )
+    let child = @process.spawn(group, sleep, ["10000"], stdout=w)
     t0 = @async.now()
     @async.sleep(500)
     child.cancel()

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -277,23 +277,22 @@ async test "cancel while scheduled" {
         log.write_string("tick\n")
       }
     })
-    let task1 = root.spawn(allow_failure=true, fn() {
-      // after calling `pause`, current coroutine would be in `run_later`,
-      // and it will receive cancellation in this situation
-      @async.pause() catch {
-        err => {
-          log.write_string("`pause` cancelled with \{err}\n")
-          @async.protect_from_cancel(fn() {
-            // Now, due to `protect_from_cancel`,
-            // we are allowed to suspend inside cancellation handler.
-            // However, since current coroutine is still in `run_later`,
-            // the scheduler will wakeup current coroutine immediately,
-            // before the timer expires.
-            @async.sleep(300)
-            log.write_string("async cleanup finished\n")
-          })
-          raise err
-        }
+    let task1 = root.spawn((
+    // after calling `pause`, current coroutine would be in `run_later`,
+    // and it will receive cancellation in this situation
+    ) => @async.pause() catch {
+      err => {
+        log.write_string("`pause` cancelled with \{err}\n")
+        @async.protect_from_cancel(fn() {
+          // Now, due to `protect_from_cancel`,
+          // we are allowed to suspend inside cancellation handler.
+          // However, since current coroutine is still in `run_later`,
+          // the scheduler will wakeup current coroutine immediately,
+          // before the timer expires.
+          @async.sleep(300)
+          log.write_string("async cleanup finished\n")
+        })
+        raise err
       }
     })
     root.spawn_bg(fn() { task1.cancel() })

--- a/src/semaphore/semaphore_test.mbt
+++ b/src/semaphore/semaphore_test.mbt
@@ -105,7 +105,7 @@ async test "semaphore cancellation no_swallow" {
   @async.with_task_group(fn(root) {
     let semaphore = @semaphore.Semaphore::new(1)
     semaphore.acquire()
-    let acquire_taskire_task = root.spawn(allow_failure=true, fn() {
+    let acquire_taskire_task = root.spawn(() => {
       semaphore.acquire()
       log.write_string("acquire() succeed\n")
     })

--- a/src/socket/resolve_host_test.mbt
+++ b/src/socket/resolve_host_test.mbt
@@ -25,7 +25,7 @@ async test "resolve cancel" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {
     let lock = @async.Semaphore::new(1, initial_value=1)
-    let task = root.spawn(allow_failure=true, fn() {
+    let task = root.spawn(() => {
       lock.release()
       log.write_object(@socket.Addr::resolve("does.not.exist", port=443))
     })

--- a/src/task.mbt
+++ b/src/task.mbt
@@ -43,8 +43,6 @@ pub fn[X] Task::try_wait(self : Task[X]) -> X? raise {
 
 ///|
 /// Cancel a task. Subsequent attempt to wait for the task will receive error.
-/// Note that if the task is *not* spawned with `allow_failure=true`,
-/// the whole task group will fail too.
 pub fn[X] Task::cancel(self : Task[X]) -> Unit {
   self.coro.cancel()
 }

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -76,13 +76,15 @@ fn[X] TaskGroup::spawn_coroutine(
     }
     f() catch {
       err if allow_failure => raise err
+      @coroutine.Cancelled as err if @coroutine.is_being_cancelled() =>
+        raise err
       err => {
         if self.state is Running {
           for child in self.children {
             child.cancel()
           }
           self.state = Fail(err)
-        } else if not(err is @coroutine.Cancelled) {
+        } else {
           self.state = Fail(err)
         }
         raise err
@@ -105,8 +107,13 @@ fn[X] TaskGroup::spawn_coroutine(
 /// the whole task group will only exit after this child task terminates.
 ///
 /// Unless `allow_failure` (`false` by default) is `true`,
-/// Ithe whole task group will also fail if the spawned task fails, 
+/// the whole task group will also fail if the spawned task fails, 
 /// other tasks in the group will be cancelled in this case.
+///
+/// Cancelled task (either cancelled by the group or manually cancelled via `Task::cancel`)
+/// are not consider failing, although they raise a cancellation error.
+/// However, if the task raise some other error during cancellation handling,
+/// it will be considered failing.
 ///
 /// If the task group is already cancelled, but `with_task_group` is still running
 /// (i.e. there are still other running child task in the group),
@@ -141,6 +148,11 @@ pub fn[X] TaskGroup::spawn_bg(
 /// Unless `allow_failure` (`false` by default) is `true`,
 /// Ithe whole task group will also fail if the spawned task fails, 
 /// other tasks in the group will be cancelled in this case.
+///
+/// Cancelled task (either cancelled by the group or manually cancelled via `Task::cancel`)
+/// are not consider failing, although they raise a cancellation error.
+/// However, if the task raise some other error during cancellation handling,
+/// it will be considered failing.
 ///
 /// If the task group is already cancelled, but `with_task_group` is still running
 /// (i.e. there are still other running child task in the group),


### PR DESCRIPTION
Consider a task spawned with `allow_failure=false` (the default). If the task is cancelled, should it be considered failing (and hence fail the whole task group)? Previously, such cancelled task is considered non-failing only if the cancellation come from the task group itself (i.e. the task group is already performing cleanup). Tasks manually cancelled via `Task::cancel` are considered failing. This semantic is inconsistent and surprising (if users want to manually cancel task, they must pass `allow_failure=true` to `@async.spawn`).

This PR refines the semantic by *not* treating cancelled task as failing unconditionally in task groups. This should simplify the semantic and improve user experience for manual task cancellation. Note that if the task raise another error during cancellation handling, it is still treated as failing.