### PR TITLE
fix calling convention when importing Windows API

### DIFF
--- a/src/internal/event_loop/io_windows.c
+++ b/src/internal/event_loop/io_windows.c
@@ -23,9 +23,15 @@
 
 #pragma comment(lib, "ws2_32.lib")
 
+MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_init_WSA() {
   WSADATA data;
   return WSAStartup(MAKEWORD(2, 2), &data);
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_cleanup_WSA() {
+  return WSACleanup;
 }
 
 enum IoResultKind {
@@ -468,6 +474,11 @@ int32_t moonbitlang_async_setup_accepted_socket(HANDLE listen_sock, HANDLE accep
     (char*)&listen_sock,
     sizeof(UINT_PTR)
   );
+}
+
+MOONBIT_FFI_EXPORT
+HANDLE moonbitlang_async_get_std_handle(int32_t id) {
+  return GetStdHandle(id);
 }
 
 #endif // #ifdef _WIN32

--- a/src/internal/event_loop/network_windows.mbt
+++ b/src/internal/event_loop/network_windows.mbt
@@ -18,7 +18,7 @@ extern "C" fn init_WSA_ffi() -> Int = "moonbitlang_async_init_WSA"
 
 ///|
 #cfg(platform="windows")
-extern "C" fn cleanup_WSA_ffi() -> Int = "WSACleanup"
+extern "C" fn cleanup_WSA_ffi() -> Int = "moonbitlang_async_cleanup_WSA"
 
 ///|
 #cfg(platform="windows")

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -36,7 +36,7 @@ fn setup_stdio(fd : Int, context~ : String) -> IoHandle {
 
 ///|
 #cfg(platform="windows")
-extern "C" fn get_std_handle(id : Int) -> @fd_util.Fd = "GetStdHandle"
+extern "C" fn get_std_handle(id : Int) -> @fd_util.Fd = "moonbitlang_async_get_std_handle"
 
 ///|
 #cfg(platform="windows")

--- a/src/internal/fd_util/fd_util.mbt
+++ b/src/internal/fd_util/fd_util.mbt
@@ -85,17 +85,12 @@ pub fn close(fd : Fd, kind~ : FileKind, context~ : String) -> Unit raise {
 
 ///|
 #cfg(platform="windows")
-extern "C" fn close_ffi(fd : Fd) -> Int = "CloseHandle"
-
-///|
-#cfg(platform="windows")
-extern "C" fn closesocket_ffi(fd : Fd) -> Int = "moonbitlang_async_closesocket"
+extern "C" fn close_ffi(fd : Fd, is_socket~ : Bool) -> Int = "moonbitlang_async_close_fd"
 
 ///|
 #cfg(platform="windows")
 pub fn close(fd : Fd, kind~ : FileKind, context~ : String) -> Unit raise {
-  let ret = if kind is Socket { closesocket_ffi(fd) } else { close_ffi(fd) }
-  if ret == 0 {
+  if close_ffi(fd, is_socket=kind is Socket) == 0 {
     @os_error.check_errno(context)
   }
 }

--- a/src/internal/fd_util/stub.c
+++ b/src/internal/fd_util/stub.c
@@ -52,8 +52,12 @@ int32_t moonbitlang_async_fd_is_valid(int fd) {
 
 #ifdef _WIN32
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_closesocket(HANDLE handle) {
-  return 0 == closesocket((SOCKET)handle);
+int32_t moonbitlang_async_close_fd(HANDLE handle, int32_t is_socket) {
+  if (is_socket) {
+    return 0 == closesocket((SOCKET)handle);
+  } else {
+    return CloseHandle(handle);
+  }
 }
 #endif
 


### PR DESCRIPTION
On Windows, a few windows API are bound using `extern "C"` from MoonBit directly. However, this would result in incorrect calling convention (the implicit `__cdecl` generated by MoonBit v.s. `WINAPI` aka `__stdcall`). So all Windows API should be bound indirectly via C stub, using the correct prototype in Windows header. This PR fixes the problem.

Not sure why the problem is never triggered on CI & my local development environment, though.