### PR TITLE
feat(http): pass verify parameter through HTTP Client to TLS layer

### DIFF
--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -96,7 +96,7 @@ fn Client::connect(
   protocol? : Protocol = Https,
   port? : Int = protocol.default_port(),
   proxy? : Client,
-  verify~ : Bool = true,
+  verify? : Bool = true,
 ) -> Client {
   ignore(proxy)
   ignore(verify)
@@ -124,7 +124,7 @@ pub async fn Client::new(
   uri : String,
   headers? : Map[String, String] = {},
   proxy? : Client,
-  verify~ : Bool = true,
+  verify? : Bool = true,
 ) -> Client {
   ignore(proxy)
   let (protocol, port, host, path) = resolve_url(uri)

--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -96,10 +96,8 @@ fn Client::connect(
   protocol? : Protocol = Https,
   port? : Int = protocol.default_port(),
   proxy? : Client,
-  verify? : Bool = true,
 ) -> Client {
   ignore(proxy)
-  ignore(verify)
   { host, headers, protocol, port, request: None, response_body: None }
 }
 
@@ -119,6 +117,8 @@ fn Client::connect(
 /// The HTTP client make requests using native fetch API.
 ///
 /// The `proxy` argument is not supported on JavaScript backend and has no effect.
+///
+/// `verify` is ignored on JS backend
 #warnings("-unused_async")
 pub async fn Client::new(
   uri : String,
@@ -127,9 +127,10 @@ pub async fn Client::new(
   verify? : Bool = true,
 ) -> Client {
   ignore(proxy)
+  ignore(verify)
   let (protocol, port, host, path) = resolve_url(uri)
   guard path is "/" else { raise InvalidFormat }
-  Client::connect(host, protocol~, port~, headers~, proxy?, verify~)
+  Client::connect(host, protocol~, port~, headers~, proxy?)
 }
 
 ///|

--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -74,6 +74,7 @@ pub struct Client {
     uri : String,
     headers? : Map[String, String],
     proxy? : Client,
+    verify? : Bool,
   ) -> Client
 }
 
@@ -95,8 +96,10 @@ fn Client::connect(
   protocol? : Protocol = Https,
   port? : Int = protocol.default_port(),
   proxy? : Client,
+  verify~ : Bool = true,
 ) -> Client {
   ignore(proxy)
+  ignore(verify)
   { host, headers, protocol, port, request: None, response_body: None }
 }
 
@@ -121,11 +124,12 @@ pub async fn Client::new(
   uri : String,
   headers? : Map[String, String] = {},
   proxy? : Client,
+  verify~ : Bool = true,
 ) -> Client {
   ignore(proxy)
   let (protocol, port, host, path) = resolve_url(uri)
   guard path is "/" else { raise InvalidFormat }
-  Client::connect(host, protocol~, port~, headers~, proxy?)
+  Client::connect(host, protocol~, port~, headers~, proxy?, verify~)
 }
 
 ///|

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -101,6 +101,9 @@ async fn Client::connect(
 /// If `protocol` is `https`, a TLS connection will be established,
 /// and the certificate of the remote peer will be verified.
 ///
+/// If the protocol is `https` and `verify` is `false` (`true` by default), certificate validation will be skipped.
+/// `verify=false` should be used for testing only.
+///
 /// `headers` can be used to specify persistent headers for the client,
 /// i.e. all requests made from this client will share these headers.
 /// The ownership of `headers` will be transferred to the new client,

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -48,7 +48,7 @@ async fn Client::connect(
   protocol? : Protocol = Https,
   port? : Int = protocol.default_port(),
   proxy? : Client,
-  verify~ : Bool = true,
+  verify? : Bool = true,
 ) -> Client {
   let transport = if proxy is Some(proxy) {
     let path = "\{host}:\{port}"
@@ -123,7 +123,7 @@ pub async fn Client::new(
   uri : String,
   headers? : Map[String, String] = {},
   proxy? : Client,
-  verify~ : Bool = true,
+  verify? : Bool = true,
 ) -> Client {
   let (protocol, port, host, path) = resolve_url(uri)
   guard path is "/" else { raise InvalidFormat }

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -31,6 +31,7 @@ pub struct Client {
     uri : String,
     headers? : Map[String, String],
     proxy? : Client,
+    verify? : Bool,
   ) -> Client
 }
 
@@ -47,6 +48,7 @@ async fn Client::connect(
   protocol? : Protocol = Https,
   port? : Int = protocol.default_port(),
   proxy? : Client,
+  verify~ : Bool = true,
 ) -> Client {
   let transport = if proxy is Some(proxy) {
     let path = "\{host}:\{port}"
@@ -69,7 +71,7 @@ async fn Client::connect(
     (Http, Plain(conn)) =>
       (None, Reader::new(conn), Sender::new(conn, headers~))
     (Https, Plain(conn)) => {
-      let tls = @tls.Tls::client(conn, host~) catch {
+      let tls = @tls.Tls::client(conn, host~, verify~) catch {
         err => {
           transport.close()
           raise err
@@ -80,7 +82,7 @@ async fn Client::connect(
     (Http, Proxy(proxy)) =>
       (None, Reader::new(proxy), Sender::new(proxy, headers~))
     (Https, Proxy(proxy)) => {
-      let tls = @tls.Tls::client(proxy, host~) catch {
+      let tls = @tls.Tls::client(proxy, host~, verify~) catch {
         err => {
           transport.close()
           raise err
@@ -121,10 +123,11 @@ pub async fn Client::new(
   uri : String,
   headers? : Map[String, String] = {},
   proxy? : Client,
+  verify~ : Bool = true,
 ) -> Client {
   let (protocol, port, host, path) = resolve_url(uri)
   guard path is "/" else { raise InvalidFormat }
-  Client::connect(host, protocol~, port~, headers~, proxy?)
+  Client::connect(host, protocol~, port~, headers~, proxy?, verify~)
 }
 
 ///|

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -43,14 +43,14 @@ pub impl Show for URIParseError
 pub struct Client {
   // private fields
 
-  async fn new(String, headers? : Map[String, String], proxy? : Client) -> Client
+  async fn new(String, headers? : Map[String, String], proxy? : Client, verify? : Bool) -> Client
 }
 pub fn Client::close(Self) -> Unit
 pub async fn Client::end_request(Self) -> Response
 pub async fn Client::enter_passthrough_mode(Self) -> Unit
 pub async fn Client::flush(Self) -> Unit
 pub async fn Client::get(Self, String, extra_headers? : Map[String, String], body? : &@io.Data) -> Response
-pub async fn Client::new(String, headers? : Map[String, String], proxy? : Self) -> Self
+pub async fn Client::new(String, headers? : Map[String, String], proxy? : Self, verify? : Bool) -> Self
 pub async fn Client::post(Self, String, &@io.Data, extra_headers? : Map[String, String]) -> Response
 pub async fn Client::put(Self, String, &@io.Data, extra_headers? : Map[String, String]) -> Response
 pub async fn Client::request(Self, RequestMethod, String, extra_headers? : Map[String, String]) -> Unit


### PR DESCRIPTION
Add `verify~ : Bool = true` to `Client::new` and `Client::connect`, forwarded to `@tls.Tls::client`. On JS backend the parameter is accepted but ignored.

Closes #329