### PR TITLE
add gzip compression/decompression support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -271,7 +271,6 @@ jobs:
 
       - name: run test with address sanitizer
         run: |
-          export ASAN_OPTIONS=fast_unwind_on_malloc=0
           moon test
 
   sanitizer-check-windows:

--- a/src/gzip/decoder.mbt
+++ b/src/gzip/decoder.mbt
@@ -1,0 +1,87 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let decoder_buffer_size = 4096
+
+///|
+fn @io.ReaderBuffer::repr(buf : Self) -> @io_buffer.Buffer = "%identity"
+
+///|
+pub struct Decoder[R] {
+  priv inner : R
+  priv core : @gzip_internal.Decoder
+  priv read_buf : @io.ReaderBuffer
+
+  fn[R : @io.Reader] new(inner : R) -> Decoder[R]
+}
+
+///|
+pub fn[R : @io.Reader] Decoder::new(inner : R) -> Decoder[R] {
+  let decoder = {
+    inner,
+    core: @gzip_internal.Decoder::new(),
+    read_buf: @io.ReaderBuffer::new(),
+  }
+  decoder.inner._get_internal_buffer().repr().enlarge_to(decoder_buffer_size)
+  decoder
+}
+
+///|
+async fn[R : @io.Reader] Decoder::read_more_input(self : Decoder[R]) -> Unit {
+  let input = self.inner._get_internal_buffer().repr()
+  let need = @cmp.maximum(self.core.minimum_input_size(), 1)
+  input.enlarge_to(input.len + @cmp.maximum(need, decoder_buffer_size))
+  let end = input.start + input.len
+  let max_len = input.buf.length() - end
+  let n = self.inner._direct_read(input.buf, offset=end, max_len~)
+  guard n > 0 else { raise @io.ReaderClosed }
+  input.len += n
+}
+
+///|
+pub impl[R : @io.Reader] @io.Reader for Decoder[R] with _get_internal_buffer(
+  self,
+) {
+  self.read_buf
+}
+
+///|
+pub impl[R : @io.Reader] @io.Reader for Decoder[R] with _direct_read(
+  self,
+  dst,
+  offset~,
+  max_len~,
+) {
+  let input = self.inner._get_internal_buffer().repr()
+  while !self.core.is_finished() {
+    while input.len < self.core.minimum_input_size() {
+      self.read_more_input()
+    }
+    let (consumed, produced) = self.core.write(
+      input.buf.unsafe_reinterpret_as_bytes(),
+      dst,
+      input_offset=input.start,
+      input_len=input.len,
+      output_offset=offset,
+      output_len=max_len,
+    )
+    input.drop(consumed)
+    if produced > 0 {
+      return produced
+    }
+  } nobreak {
+    0
+  }
+}

--- a/src/gzip/encoder.mbt
+++ b/src/gzip/encoder.mbt
@@ -1,0 +1,96 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let encoder_buffer_size = 4096
+
+///|
+pub struct Encoder[W] {
+  priv inner : W
+  priv buf : FixedArray[Byte]
+  priv mut buf_len : Int
+  priv core : @gzip_internal.Encoder
+
+  fn[W] new(
+    inner : W,
+    mtime? : UInt,
+    extra_flags? : Byte,
+    operating_system? : Byte,
+  ) -> Encoder[W]
+}
+
+///|
+pub fn[W] Encoder::new(
+  inner : W,
+  mtime? : UInt = 0U,
+  extra_flags? : Byte = b'\x00',
+  operating_system? : Byte = b'\xff',
+) -> Encoder[W] {
+  let buf = FixedArray::make(encoder_buffer_size, b'\x00')
+  {
+    inner,
+    buf,
+    buf_len: 0,
+    core: @gzip_internal.Encoder::new(mtime~, extra_flags~, operating_system~),
+  }
+}
+
+///|
+async fn[W : @io.Writer] Encoder::flush_output(self : Encoder[W]) -> Unit {
+  if self.buf_len > 0 {
+    self.inner.write(self.buf.unsafe_reinterpret_as_bytes()[:self.buf_len])
+    self.buf_len = 0
+  }
+}
+
+///|
+pub async fn[W : @io.Writer] Encoder::flush(self : Encoder[W]) -> Unit {
+  self.flush_output()
+}
+
+///|
+pub async fn[W : @io.Writer] Encoder::end(self : Encoder[W]) -> Unit {
+  if self.core.minimum_output_space(end=true) > self.buf.length() - self.buf_len {
+    self.flush_output()
+  }
+  self.buf_len += self.core.end(
+    self.buf,
+    output_offset=self.buf_len,
+    output_len=self.buf.length() - self.buf_len,
+  )
+  self.flush_output()
+}
+
+///|
+pub impl[W : @io.Writer] @io.Writer for Encoder[W] with write_once(
+  self,
+  buf,
+  offset~,
+  len~,
+) {
+  if self.core.minimum_output_space(end=false) >
+    self.buf.length() - self.buf_len {
+    self.flush_output()
+  }
+  let (written, produced) = self.core.write(
+    buf,
+    self.buf,
+    input_offset=offset,
+    input_len=len,
+    output_offset=self.buf_len,
+    output_len=self.buf.length() - self.buf_len,
+  )
+  self.buf_len += produced
+  written
+}

--- a/src/gzip/gzip_test.mbt
+++ b/src/gzip/gzip_test.mbt
@@ -1,0 +1,233 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(target="native")
+async fn node_gzip(mode : String, input : Bytes) -> Bytes {
+  @async.with_task_group(group => {
+    let (stdin, we_write) = @process.write_to_process()
+    let runner = group.spawn(() => {
+      @process.collect_output("node", ["src/gzip/node_gzip.js", mode], stdin~)
+    })
+    group.spawn_bg(() => {
+      defer we_write.close()
+      we_write.write(input)
+    })
+    let (code, stdout, stderr) = runner.wait()
+    assert_eq(code, 0)
+    assert_eq(stderr.binary().length(), 0)
+    stdout.binary()
+  })
+}
+
+///|
+#cfg(target="native")
+async fn encode_with_moonbit(input : Bytes) -> Bytes {
+  let (r, w) = @io.pipe()
+  @async.with_task_group(group => {
+    group.spawn_bg(() => {
+      defer w.close()
+      Encoder::new(w)..write(input).end()
+    })
+    defer r.close()
+    r.read_all().binary()
+  })
+}
+
+///|
+#cfg(target="native")
+async fn decode_with_moonbit(input : Bytes) -> Bytes {
+  let (r, w) = @io.pipe()
+  @async.with_task_group(group => {
+    group.spawn_bg(() => {
+      defer w.close()
+      w.write(input)
+    })
+    defer r.close()
+    Decoder::new(r).read_all().binary()
+  })
+}
+
+///|
+#cfg(target="native")
+async fn assert_node_compatibility(input : Bytes) -> Unit {
+  let node_encoded = node_gzip("compress", input)
+  assert_true(decode_with_moonbit(node_encoded) == input)
+
+  let moonbit_encoded = encode_with_moonbit(input)
+  assert_true(node_gzip("decompress", moonbit_encoded) == input)
+}
+
+///|
+async test "encode decode roundtrip" {
+  @async.with_task_group(root => {
+    let source_chunks = ["hello ", "gzip ", "world"]
+    let (compressed_r, compressed_w) = @io.pipe()
+    root.spawn_bg(() => {
+      defer compressed_w.close()
+      let encoder = Encoder::new(
+        compressed_w,
+        mtime=123456789U,
+        operating_system=b'\x03',
+      )
+      for chunk in source_chunks {
+        encoder.write(chunk)
+        @async.sleep(10)
+      }
+      encoder.end()
+    })
+
+    let decoder = Decoder::new(compressed_r)
+    inspect(decoder.read_all().text(), content="hello gzip world")
+    compressed_r.close()
+  })
+}
+
+///|
+async test "encoder uses valid blocks across large writes" {
+  @async.with_task_group(root => {
+    let payload = Bytes::makei(70000, i => (i % 251).to_byte())
+    let (compressed_r, compressed_w) = @io.pipe()
+    root.spawn_bg(() => {
+      defer compressed_w.close()
+      let encoder = Encoder::new(compressed_w)
+      encoder.write(payload)
+      encoder.end()
+    })
+
+    let decoder = Decoder::new(compressed_r)
+    inspect(decoder.read_all().binary() == payload, content="true")
+    compressed_r.close()
+  })
+}
+
+///|
+async test "encoder emits output when flushed" {
+  let log : Array[String] = []
+  @async.with_task_group(root => {
+    let (r, w) = @io.pipe()
+    root.spawn_bg(() => {
+      defer w.close()
+      log.push("start init")
+      let encoder = Encoder::new(w)
+      log.push("encoder ready")
+      log.push("write plain ab")
+      encoder.write("ab")
+      encoder.flush()
+      @async.sleep(60)
+      log.push("write plain cd")
+      encoder.write("cd")
+      encoder.flush()
+      @async.sleep(60)
+      log.push("end")
+      encoder.end()
+    })
+    root.spawn_bg(() => {
+      defer r.close()
+      while r.read_some() is Some(chunk) {
+        log.push("receive compressed \{chunk.length()}")
+      }
+    })
+  })
+  json_inspect(log, content=[
+    "start init", "encoder ready", "write plain ab", "receive compressed 13", "write plain cd",
+    "receive compressed 3", "end", "receive compressed 10",
+  ])
+}
+
+///|
+async test "decoder yields plain chunks lazily across delayed chunks" {
+  let log : Array[String] = []
+  @async.with_task_group(root => {
+    let (compressed_r, compressed_w) = @io.pipe()
+    root.spawn_bg(() => {
+      defer compressed_w.close()
+      compressed_w.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff")
+      @async.sleep(20)
+      log.push("write plain ab")
+      compressed_w.write(b"\x00\x02\x00\xfd\xffab")
+      @async.sleep(200)
+      log.push("write plain cd")
+      compressed_w.write(b"\x00\x02\x00\xfd\xffcd")
+      @async.sleep(200)
+      log.push("write plain ef")
+      compressed_w.write(b"\x00\x02\x00\xfd\xffef")
+      @async.sleep(200)
+      log.push("finish")
+      compressed_w.write(b"\x01\x00\x00\xff\xff")
+      compressed_w.write(b"\xef\x39\x8e\x4b\x06\x00\x00\x00")
+    })
+    let decoder = Decoder::new(compressed_r)
+    match decoder.read_some(max_len=2) {
+      Some(chunk) => log.push("read plain \{@utf8.decode(chunk)}")
+      None => assert_true(false)
+    }
+    match decoder.read_some(max_len=2) {
+      Some(chunk) => log.push("read plain \{@utf8.decode(chunk)}")
+      None => assert_true(false)
+    }
+    match decoder.read_some(max_len=2) {
+      Some(chunk) => log.push("read plain \{@utf8.decode(chunk)}")
+      None => assert_true(false)
+    }
+    inspect(decoder.read_some(max_len=2), content="None")
+  })
+  json_inspect(log, content=[
+    "write plain ab", "read plain ab", "write plain cd", "read plain cd", "write plain ef",
+    "read plain ef", "finish",
+  ])
+}
+
+///|
+async test "decoder supports reads smaller than writer chunks" {
+  @async.with_task_group(root => {
+    let (compressed_r, compressed_w) = @io.pipe()
+    root.spawn_bg(() => {
+      defer compressed_w.close()
+      compressed_w.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff")
+      compressed_w.write(b"\x00\x04\x00\xfb\xffabcd")
+      @async.sleep(200)
+      compressed_w.write(b"\x00\x04\x00\xfb\xffefgh")
+      compressed_w.write(b"\x01\x00\x00\xff\xff")
+      compressed_w.write(b"\x50\x2a\xef\xae\x08\x00\x00\x00")
+    })
+    let decoder = Decoder::new(compressed_r)
+    inspect(decoder.read_some(max_len=2), content="Some(b\"ab\")")
+    inspect(decoder.read_some(max_len=2), content="Some(b\"cd\")")
+    inspect(decoder.read_some(max_len=2), content="Some(b\"ef\")")
+    inspect(decoder.read_some(max_len=2), content="Some(b\"gh\")")
+    inspect(decoder.read_some(max_len=2), content="None")
+  })
+}
+
+///|
+#cfg(target="native")
+async test "node compatibility on source text file" {
+  let input = @fs.read_file("src/internal/gzip_internal/decoder.mbt").binary()
+  assert_node_compatibility(input)
+}
+
+///|
+#cfg(target="native")
+async test "node compatibility on generated binary data" {
+  let input = Bytes::makei(65536 + 257, i => ((i * 73 + 19) & 0xff).to_byte())
+  assert_node_compatibility(input)
+}
+
+///|
+#cfg(not(target="native"))
+let _unused : Unit = {
+  ignore(@fs.unimplemented)
+  ignore(@process.unimplemented)
+}

--- a/src/gzip/moon.pkg
+++ b/src/gzip/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/core/cmp",
+  "moonbitlang/async/io",
+  "moonbitlang/async/internal/gzip_internal",
+  "moonbitlang/async/internal/io_buffer",
+}
+
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/io",
+  "moonbitlang/async/process",
+  "moonbitlang/core/encoding/utf8",
+} for "test"

--- a/src/gzip/node_gzip.js
+++ b/src/gzip/node_gzip.js
@@ -1,0 +1,33 @@
+const { gzipSync, gunzipSync } = require("node:zlib");
+
+const mode = process.argv[2];
+
+const chunks = [];
+process.stdin.on("data", (chunk) => {
+  chunks.push(chunk);
+});
+
+process.stdin.on("end", () => {
+  const input = Buffer.concat(chunks);
+  try {
+    const output =
+      mode === "compress"
+        ? gzipSync(input, { mtime: 0 })
+        : mode === "decompress"
+          ? gunzipSync(input)
+          : null;
+    if (output === null) {
+      process.stderr.write(`unknown mode: ${mode}\n`);
+      process.exitCode = 2;
+      return;
+    }
+    process.stdout.write(output);
+  } catch (err) {
+    const message = err && err.stack ? err.stack : String(err);
+    process.stderr.write(message);
+    if (!message.endsWith("\n")) {
+      process.stderr.write("\n");
+    }
+    process.exitCode = 1;
+  }
+});

--- a/src/gzip/pkg.generated.mbti
+++ b/src/gzip/pkg.generated.mbti
@@ -1,0 +1,34 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/async/gzip"
+
+import {
+  "moonbitlang/async/io",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct Decoder[R] {
+  // private fields
+
+  fn[R : @io.Reader] new(R) -> Decoder[R]
+}
+pub fn[R : @io.Reader] Decoder::new(R) -> Self[R]
+pub impl[R : @io.Reader] @io.Reader for Decoder[R]
+
+pub struct Encoder[W] {
+  // private fields
+
+  fn[W] new(W, mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Encoder[W]
+}
+pub async fn[W : @io.Writer] Encoder::end(Self[W]) -> Unit
+pub async fn[W : @io.Writer] Encoder::flush(Self[W]) -> Unit
+pub fn[W] Encoder::new(W, mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Self[W]
+pub impl[W : @io.Writer] @io.Writer for Encoder[W]
+
+// Type aliases
+
+// Traits
+

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -26,6 +26,8 @@ pub struct Client {
   priv tls : @tls.Tls?
   priv sender : Sender
   priv mut request_method : RequestMethod?
+  /// whether automatic decompression should be enabled for current request
+  priv mut auto_decompress : Bool
 
   async fn new(
     uri : String,
@@ -91,7 +93,14 @@ async fn Client::connect(
       (Some(tls), Reader::new(tls), Sender::new(tls, headers~))
     }
   }
-  { transport, tls, reader, sender, request_method: None }
+  {
+    transport,
+    tls,
+    reader,
+    sender,
+    request_method: None,
+    auto_decompress: false,
+  }
 }
 
 ///|
@@ -200,8 +209,12 @@ pub async fn Client::flush(self : Client) -> Unit {
 pub async fn Client::end_request(self : Client) -> Response {
   self.sender.end_body()
   self.reader.skip_body()
-  let response = self.reader.read_response(request_method=self.request_method)
+  let response = self.reader.read_response(
+    request_method=self.request_method,
+    auto_decompress=self.auto_decompress,
+  )
   self.request_method = None
+  self.auto_decompress = false
   response
 }
 
@@ -228,7 +241,7 @@ pub async fn Client::request(
   path : String,
   extra_headers? : Map[String, String] = {},
 ) -> Unit {
-  self.sender.send_request(meth, path, extra_headers~)
+  self.auto_decompress = self.sender.send_request(meth, path, extra_headers~)
   self.request_method = Some(meth)
 }
 

--- a/src/http/moon.pkg
+++ b/src/http/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbitlang/async/tls",
   "moonbitlang/async/internal/io_buffer",
   "moonbitlang/async/js_async",
+  "moonbitlang/async/internal/gzip_internal" @gzip,
 }
 
 import {
@@ -21,6 +22,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/internal/bytes_util",
+  "moonbitlang/async/gzip" @gzip_stream,
 } for "wbtest"
 
 options(

--- a/src/http/parser.mbt
+++ b/src/http/parser.mbt
@@ -27,13 +27,21 @@ priv struct Reader {
   mut body : BodyKind
   transport : &@io.Reader
   read_buf : @io.ReaderBuffer
+  mut auto_decompress : Bool
+  mut gzip : @gzip.Decoder?
 }
 
 ///|
 /// Create a new HTTP reader wrapping around existing reader `transport`.
 /// The HTTP reader will read data from `transport`.
 fn[R : @io.Reader] Reader::new(transport : R) -> Reader {
-  { body: Empty, transport, read_buf: @io.ReaderBuffer::new() }
+  {
+    body: Empty,
+    transport,
+    read_buf: @io.ReaderBuffer::new(),
+    auto_decompress: false,
+    gzip: None,
+  }
 }
 
 ///|
@@ -42,6 +50,78 @@ pub suberror HttpProtocolError {
   HttpVersionNotSupported(String)
   NotImplemented
 } derive(Debug, ToJson)
+
+///|
+/// Decode some data from current chunk, perform gzip decompression if necessary.
+/// At most `limit` bytes of data will be read from the underlying transport,
+/// and decoded into `buf[offset:offset+max_len]`.
+async fn Reader::decode_chunk(
+  self : Reader,
+  buf : FixedArray[Byte],
+  offset~ : Int,
+  max_len~ : Int,
+  limit~ : Int,
+) -> (Int, Int) {
+  guard self.gzip is Some(gzip) else {
+    let max_len = @cmp.minimum(max_len, limit)
+    let n = self.transport.read(buf, offset~, max_len~)
+    (n, n)
+  }
+  let inner_buf = self.transport._get_internal_buffer().get_repr()
+  for consumed = 0; !gzip.is_finished(); {
+    let limit = limit - consumed
+    let min_len = gzip.minimum_input_size()
+    let target = @cmp.minimum(min_len, limit)
+
+    // Read from underlying transport until we have enough data to make progress
+    inner_buf.enlarge_to(target)
+    let available = for available = @cmp.minimum(inner_buf.len, limit); available <
+                       target; {
+      let end = inner_buf.start + inner_buf.len
+      let delta = self.transport._direct_read(
+        inner_buf.buf,
+        offset=end,
+        max_len=@cmp.minimum(inner_buf.buf.length() - end, target - available),
+      )
+      guard delta > 0 else { raise BadRequest }
+      inner_buf.len += delta
+      continue available + delta
+    } nobreak {
+      available
+    }
+
+    if limit < min_len {
+      gzip.write_partial_data(
+        inner_buf.buf.unsafe_reinterpret_as_bytes(),
+        input_offset=inner_buf.start,
+        input_len=available,
+      )
+      inner_buf.drop(available)
+      let consumed = consumed + available
+      break (consumed, 0)
+    }
+
+    // Perform the decoding
+    let (new_consumed, produced) = gzip.write(
+      inner_buf.buf.unsafe_reinterpret_as_bytes(),
+      input_offset=inner_buf.start,
+      input_len=@cmp.minimum(available, limit),
+      buf,
+      output_offset=offset,
+      output_len=max_len,
+    )
+    inner_buf.drop(new_consumed)
+    let consumed = consumed + new_consumed
+    if produced > 0 {
+      break (consumed, produced)
+    } else {
+      continue consumed
+    }
+  } nobreak {
+    guard consumed > 0 else { raise BadRequest }
+    (consumed, 0)
+  }
+}
 
 ///|
 /// Read from the body of the HTTP request/response
@@ -53,11 +133,23 @@ impl @io.Reader for Reader with _direct_read(self, buf, offset~, max_len~) {
   match self.body {
     Empty => 0
     Fixed(remaining) => {
-      let max_len = @cmp.minimum(max_len, remaining)
-      let n = self.transport.read(buf, offset~, max_len~)
-      let remaining = remaining - n
-      self.body = if remaining == 0 { Empty } else { Fixed(remaining) }
-      n
+      let (consumed, produced) = self.decode_chunk(
+        buf,
+        offset~,
+        max_len~,
+        limit=remaining,
+      )
+      let remaining = remaining - consumed
+      self.body = if remaining == 0 {
+        if self.gzip is Some(gzip) {
+          guard gzip.is_finished() else { raise BadRequest }
+          self.gzip = None
+        }
+        Empty
+      } else {
+        Fixed(remaining)
+      }
+      produced
     }
     Chunked(0) => {
       guard self.transport.read_until("\r\n") is Some(len_str) else {
@@ -68,27 +160,47 @@ impl @io.Reader for Reader with _direct_read(self, buf, offset~, max_len~) {
       }
       guard next_chunk_len > 0 else {
         guard self.transport.read_exactly(2) == "\r\n" else { raise BadRequest }
+        if self.gzip is Some(gzip) {
+          guard gzip.is_finished() else { raise BadRequest }
+          self.gzip = None
+        }
         self.body = Empty
         return 0
       }
-      let max_len = @cmp.minimum(next_chunk_len, max_len)
-      let n = self.transport.read(buf, offset~, max_len~)
-      let remaining = next_chunk_len - n
+      let (consumed, produced) = self.decode_chunk(
+        buf,
+        offset~,
+        max_len~,
+        limit=next_chunk_len,
+      )
+      let remaining = next_chunk_len - consumed
       if remaining == 0 {
         guard self.transport.read_exactly(2) == "\r\n" else { raise BadRequest }
       }
       self.body = Chunked(remaining)
-      n
+      if produced == 0 {
+        self._direct_read(buf, offset~, max_len~)
+      } else {
+        produced
+      }
     }
-    Chunked(first_chunk_remaining) => {
-      let max_len = @cmp.minimum(first_chunk_remaining, max_len)
-      let n = self.transport.read(buf, offset~, max_len~)
-      let remaining = first_chunk_remaining - n
+    Chunked(curr_chunk_remaining) => {
+      let (consumed, produced) = self.decode_chunk(
+        buf,
+        offset~,
+        max_len~,
+        limit=curr_chunk_remaining,
+      )
+      let remaining = curr_chunk_remaining - consumed
       if remaining == 0 {
         guard self.transport.read_exactly(2) == "\r\n" else { raise BadRequest }
       }
       self.body = Chunked(remaining)
-      n
+      if produced == 0 {
+        self._direct_read(buf, offset~, max_len~)
+      } else {
+        produced
+      }
     }
     PassThrough => self.transport._direct_read(buf, offset~, max_len~)
     WaitConnectionClose => self.transport._direct_read(buf, offset~, max_len~)
@@ -124,10 +236,6 @@ async fn Reader::read_headers(self : Reader) -> Map[String, String] {
       colon_index + 1
     }
     let value = header_line[value_start:].to_string()
-    match headers.get(key) {
-      None => headers[key] = value
-      Some(value0) => headers[key] = "\{value0},\{value}"
-    }
     match key {
       "content-length" => {
         guard !(self.body is Fixed(_)) else { raise BadRequest }
@@ -135,13 +243,29 @@ async fn Reader::read_headers(self : Reader) -> Map[String, String] {
         if self.body is Empty && len > 0 {
           self.body = Fixed(len)
         }
+        // if automatic decompression is enabled, avoid reporting a wrong content-length value
+        if self.gzip is Some(_) {
+          continue
+        }
       }
       "transfer-encoding" => {
         guard !(self.body is Chunked(_)) else { raise BadRequest }
         guard value.to_lower() is "chunked" else { raise NotImplemented }
         self.body = Chunked(0)
       }
+      "content-encoding" if self.auto_decompress => {
+        guard self.gzip is None else { raise BadRequest }
+        guard value.to_lower() is "gzip" else { raise NotImplemented }
+        self.gzip = Some(@gzip.Decoder())
+        // if automatic decompression is enabled, avoid reporting a wrong content-length value
+        headers.remove("content-length")
+        continue
+      }
       _ => ()
+    }
+    match headers.get(key) {
+      None => headers[key] = value
+      Some(value0) => headers[key] = "\{value0},\{value}"
     }
   }
   headers
@@ -232,8 +356,10 @@ fn should_read_body_until_close(
 /// In the result of `read_response`, all header fields will be in lower case.
 async fn Reader::read_response(
   self : Reader,
+  auto_decompress~ : Bool,
   request_method~ : RequestMethod?,
 ) -> Response {
+  self.auto_decompress = auto_decompress
   guard self.body is Empty
   guard self.transport.read_until("\r\n") is Some(response_line) else {
     raise @io.ReaderClosed

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -254,7 +254,10 @@ async test "read_response basic" {
     })
     defer r.close()
     let input = Reader::new(r)
-    let response = input.read_response(request_method=None)
+    let response = input.read_response(
+      request_method=None,
+      auto_decompress=true,
+    )
     log_response(response, log)
     log.write_string(input.read_all().text())
   })
@@ -285,7 +288,10 @@ async test "read_response passthrough fallback (no length headers)" {
     })
     defer r.close()
     let input = Reader::new(r)
-    let response = input.read_response(request_method=None)
+    let response = input.read_response(
+      request_method=None,
+      auto_decompress=true,
+    )
     log_response(response, log)
 
     // Read body via PassThrough fallback (reads until EOF/connection close)
@@ -318,7 +324,10 @@ async test "read_response 204 No Content (no body)" {
     })
     defer r.close()
     let input = Reader::new(r)
-    let response = input.read_response(request_method=None)
+    let response = input.read_response(
+      request_method=None,
+      auto_decompress=true,
+    )
     log_response(response, log)
     // Body should be Empty, not PassThrough
     let body_text = input.read_all().text()
@@ -352,7 +361,10 @@ async test "read_response 205 Reset Content (no body)" {
     })
     defer r.close()
     let input = Reader::new(r)
-    let response = input.read_response(request_method=None)
+    let response = input.read_response(
+      request_method=None,
+      auto_decompress=true,
+    )
     log_response(response, log)
     // Body should be Empty, not WaitConnectionClose
     let body_text = input.read_all().text()
@@ -386,7 +398,10 @@ async test "read_response 304 Not Modified (no body)" {
     })
     defer r.close()
     let input = Reader::new(r)
-    let response = input.read_response(request_method=None)
+    let response = input.read_response(
+      request_method=None,
+      auto_decompress=true,
+    )
     log_response(response, log)
     let body_text = input.read_all().text()
     log.write_string("body: ")
@@ -418,7 +433,10 @@ async test "read_response 100 Continue (no body)" {
     })
     defer r.close()
     let input = Reader::new(r)
-    let response = input.read_response(request_method=None)
+    let response = input.read_response(
+      request_method=None,
+      auto_decompress=true,
+    )
     log_response(response, log)
     let body_text = input.read_all().text()
     log.write_string("body: ")
@@ -448,7 +466,10 @@ async test "read_response CONNECT 200 (no body, tunnel mode)" {
     })
     defer r.close()
     let input = Reader::new(r)
-    let response = input.read_response(request_method=Some(Connect))
+    let response = input.read_response(
+      request_method=Some(Connect),
+      auto_decompress=true,
+    )
     log_response(response, log)
     // Body should be Empty, not WaitConnectionClose
     let body_text = input.read_all().text()
@@ -481,7 +502,10 @@ async test "read_response HEAD 200 (no body)" {
     })
     defer r.close()
     let input = Reader::new(r)
-    let response = input.read_response(request_method=Some(Head))
+    let response = input.read_response(
+      request_method=Some(Head),
+      auto_decompress=true,
+    )
     log_response(response, log)
     // Body should be Empty, not Fixed(1234)
     let body_text = input.read_all().text()
@@ -701,4 +725,44 @@ test "should_read_body_until_close - false cases (HEAD requests)" {
     should_read_body_until_close(200, headers_with_length, Empty, Some(Head)),
     content="false",
   )
+}
+
+///|
+async test "gzip split between chunks" {
+  let compressed = @async.with_task_group(group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg(() => {
+      defer w.close()
+      @gzip_stream.Encoder(w)..write("A simple message to compress").end()
+    })
+    defer r.close()
+    r.read_all().binary()
+  })
+  let (r, w) = @io.pipe()
+  @async.with_task_group(group => {
+    group.spawn_bg(() => {
+      defer w.close()
+      w
+      ..write("HTTP/1.1 200 OK\r\n")
+      ..write("Transfer-Encoding: Chunked\r\n")
+      .write("Content-Encoding: gzip\r\n\r\n")
+      for i in 0..<compressed.length() {
+        w..write("1\r\n")..write(compressed[i:i + 1]).write("\r\n")
+      }
+      w.write("0\r\n\r\n")
+    })
+    defer r.close()
+    let r = Reader::new(r)
+    let response = r.read_response(
+      request_method=Some(Get),
+      auto_decompress=true,
+    )
+    inspect(response.code, content="200")
+    inspect(
+      r.read_all().text(),
+      content=(
+        #|A simple message to compress
+      ),
+    )
+  })
 }

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -35,3 +35,13 @@ async test "request cancel" {
   let end = @async.now()
   assert_true((end - start).to_int() < 250)
 }
+
+///|
+#cfg(target="native")
+async test "manual Accept-Encoding" {
+  let (_, result1) = @http.get("https://www.moonbitlang.com")
+  let (_, result2) = @http.get("https://www.moonbitlang.com", headers={
+    "Accept-Encoding": "gzip",
+  })
+  assert_not_eq(result1.binary().length(), result2.binary().length())
+}

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -28,6 +28,7 @@ priv struct Sender {
   mut send_buf : FixedArray[Byte]
   mut send_len : Int
   headers : Bytes
+  has_accept_encoding : Bool
 }
 
 ///|
@@ -41,8 +42,13 @@ fn[W : @io.Writer] Sender::new(
   headers? : Map[String, String] = {},
 ) -> Sender {
   let header_text = @buffer.new()
+  let mut has_accept_encoding = false
   for k, v in headers {
-    if !forbidden_headers.contains(k.to_lower()) {
+    let k_lower = k.to_lower()
+    if !forbidden_headers.contains(k_lower) {
+      if k_lower is "accept-encoding" {
+        has_accept_encoding = true
+      }
       header_text.write_string_utf8("\{k}: \{v}\r\n")
     }
   }
@@ -52,6 +58,7 @@ fn[W : @io.Writer] Sender::new(
     send_buf: FixedArray::make(1024, 0),
     send_len: 0,
     headers: header_text.contents(),
+    has_accept_encoding,
   }
 }
 
@@ -222,12 +229,13 @@ async fn Sender::send_headers(
 }
 
 ///|
+/// Return value indicate if automatic decompression should be enabled for the response of this request
 async fn Sender::send_request(
   self : Sender,
   meth : RequestMethod,
   path : String,
   extra_headers~ : Map[String, String],
-) -> Unit {
+) -> Bool {
   guard self.mode is SendingHeader
   match meth {
     Get => self.write("GET ")
@@ -245,7 +253,14 @@ async fn Sender::send_request(
   ..write(" HTTP/1.1\r\n")
   ..write(self.headers)
   .send_headers(extra_headers)
+  let auto_decompress = !self.has_accept_encoding &&
+    extra_headers.keys().find_first(k => k.to_lower() is "accept-encoding")
+    is None
+  if auto_decompress {
+    self.write("Accept-Encoding: gzip,identity\r\n")
+  }
   self.mode = WaitingBody
+  auto_decompress
 }
 
 ///|

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -19,12 +19,11 @@ async test "send_request basic" {
     root.spawn_bg(() => {
       defer w.close()
       let sender = Sender::new(w)
-      sender
-      ..send_request(Get, "/", extra_headers={
+      let _ = sender.send_request(Get, "/", extra_headers={
         "Host": "x.y.org",
         "User-Agent": "MoonBit",
       })
-      .end_body()
+      sender.end_body()
     })
     defer r.close()
     inspect(
@@ -33,6 +32,7 @@ async test "send_request basic" {
         #|GET / HTTP/1.1\r
         #|Host: x.y.org\r
         #|User-Agent: MoonBit\r
+        #|Accept-Encoding: gzip,identity\r
         #|Content-Length: 0\r
         #|\r
         #|
@@ -50,13 +50,11 @@ async test "send_request stream" {
       let sender = Sender::new(w)
       let file = @fs.open("LICENSE", mode=ReadOnly)
       defer file.close()
-      sender
-      ..send_request(Get, "/", extra_headers={
+      let _ = sender.send_request(Get, "/", extra_headers={
         "Host": "x.y.org",
         "User-Agent": "MoonBit",
       })
-      ..write_reader(file)
-      .end_body()
+      sender..write_reader(file).end_body()
     })
     defer r.close()
     inspect(
@@ -65,6 +63,7 @@ async test "send_request stream" {
         #|GET / HTTP/1.1\r
         #|Host: x.y.org\r
         #|User-Agent: MoonBit\r
+        #|Accept-Encoding: gzip,identity\r
         #|Transfer-Encoding: chunked\r
         #|\r
         #|3f9\r
@@ -308,7 +307,7 @@ async test "send_request stream2" {
     root.spawn_bg(() => {
       defer w.close()
       let sender = Sender::new(w)
-      sender.send_request(Get, "/", extra_headers={
+      let _ = sender.send_request(Get, "/", extra_headers={
         "Host": "x.y.org",
         "User-Agent": "MoonBit",
       })
@@ -326,6 +325,7 @@ async test "send_request stream2" {
         #|GET / HTTP/1.1\r
         #|Host: x.y.org\r
         #|User-Agent: MoonBit\r
+        #|Accept-Encoding: gzip,identity\r
         #|Transfer-Encoding: chunked\r
         #|\r
         #|4\r
@@ -352,7 +352,7 @@ async test "send invalid header" {
         "Content-Length": "42",
         "Content-Encoding": "chunked",
       })
-      sender.send_request(Get, "/", extra_headers={
+      let _ = sender.send_request(Get, "/", extra_headers={
         "Host": "x.y.org",
         "User-Agent": "MoonBit",
         "Content-Length": "42",
@@ -367,6 +367,7 @@ async test "send invalid header" {
         #|GET / HTTP/1.1\r
         #|Host: x.y.org\r
         #|User-Agent: MoonBit\r
+        #|Accept-Encoding: gzip,identity\r
         #|Content-Length: 0\r
         #|\r
         #|

--- a/src/http/unimplemented.mbt
+++ b/src/http/unimplemented.mbt
@@ -21,6 +21,7 @@ pub let unimplemented : Unit = {
   ignore(@socket.unimplemented)
   ignore(@tls.unimplemented)
   ignore(@io_buffer.new)
+  ignore(@gzip.Decoder::new)
 }
 
 ///|

--- a/src/http/unimplemented_wbtest.mbt
+++ b/src/http/unimplemented_wbtest.mbt
@@ -15,6 +15,7 @@
 ///|
 #cfg(not(target="native"))
 fn _ignore_unused_import() -> Unit {
+  let _ : (&@io.Reader) -> _ = @gzip_stream.Decoder::new
   ignore(@async.sleep)
   ignore(@fs.unimplemented)
   ignore(@bytes_util.ascii_to_string)

--- a/src/internal/gzip_internal/crc32.mbt
+++ b/src/internal/gzip_internal/crc32.mbt
@@ -1,0 +1,32 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let crc32_table : FixedArray[UInt] = FixedArray::makei(256, i => {
+  let mut crc = i.reinterpret_as_uint()
+  for _ in 0..<8 {
+    crc = if (crc & 1U) == 0U { crc >> 1 } else { (crc >> 1) ^ 0xedb88320U }
+  }
+  crc
+})
+
+///|
+fn crc32_update(current : UInt, chunk : BytesView) -> UInt {
+  for byte in chunk; crc = current {
+    let index = ((crc ^ byte.to_uint()) & 0xffU).reinterpret_as_int()
+    continue crc32_table[index] ^ (crc >> 8)
+  } nobreak {
+    crc
+  }
+}

--- a/src/internal/gzip_internal/decoder.mbt
+++ b/src/internal/gzip_internal/decoder.mbt
@@ -1,0 +1,1033 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+priv enum DecodeMode {
+  Header
+  Blocks
+  DynamicHeader(is_final~ : Bool)
+  DynamicCodeLengths(
+    is_final~ : Bool,
+    hlit~ : Int,
+    hdist~ : Int,
+    hclen~ : Int,
+    index~ : Int,
+    code_lengths~ : FixedArray[Int]
+  )
+  DynamicLengths(
+    is_final~ : Bool,
+    hlit~ : Int,
+    hdist~ : Int,
+    code_tree~ : HuffmanTree,
+    index~ : Int,
+    previous~ : Int,
+    lengths~ : FixedArray[Int]
+  )
+  StoredLengths(is_final~ : Bool)
+  StoredBlock(is_final~ : Bool, remaining~ : Int)
+  HuffmanBlock(
+    is_final~ : Bool,
+    literal_tree~ : HuffmanTree,
+    distance_tree~ : HuffmanTree
+  )
+  Trailer
+  Finished
+}
+
+///|
+pub struct Decoder {
+  priv trailer_state : TrailerState
+  priv mut mode : DecodeMode
+  priv mut bit_buffer : UInt
+  priv mut bit_count : Int
+  priv mut copy_remaining : Int
+  priv mut copy_distance : Int
+  priv mut pending_buf : FixedArray[Byte]
+  priv mut pending_len : Int
+  priv history : FixedArray[Byte]
+  priv mut history_pos : Int
+  priv mut history_len : Int
+
+  fn new() -> Decoder
+}
+
+///|
+/// Create a decoder state machine.
+/// The gzip header is consumed by the first successful `write` call.
+pub fn Decoder::new() -> Decoder {
+  {
+    trailer_state: TrailerState::new(),
+    mode: Header,
+    bit_buffer: 0U,
+    bit_count: 0,
+    copy_remaining: 0,
+    copy_distance: 0,
+    pending_buf: [],
+    pending_len: 0,
+    history: FixedArray::make(32768, b'\x00'),
+    history_pos: 0,
+    history_len: 0,
+  }
+}
+
+///|
+pub fn Decoder::is_finished(self : Decoder) -> Bool {
+  self.mode is Finished
+}
+
+///|
+/// Return the minimum compressed input required for
+/// the next `write` call to make any progress.
+/// The caller may provide more than this amount.
+pub fn Decoder::minimum_input_size(self : Decoder) -> Int {
+  @cmp.maximum(0, self.raw_minimum_input_size() - self.pending_len)
+}
+
+///|
+fn Decoder::raw_minimum_input_size(self : Decoder) -> Int {
+  match self.mode {
+    Header => HEADER_SIZE
+    DynamicHeader(_) => @cmp.maximum(0, (14 - self.bit_count + 7) / 8)
+    DynamicCodeLengths(hclen~, index~, ..) => {
+      let remaining = hclen - index
+      @cmp.maximum(0, (remaining * 3 - self.bit_count + 7) / 8)
+    }
+    DynamicLengths(hlit~, hdist~, code_tree~, index~, ..) =>
+      if index < hlit + hdist {
+        @cmp.maximum(0, (code_tree.max_bits + 7 - self.bit_count + 7) / 8)
+      } else {
+        0
+      }
+    StoredLengths(_) => 4
+    StoredBlock(remaining~, ..) => if remaining > 0 { 1 } else { 0 }
+    HuffmanBlock(..) =>
+      if self.copy_remaining != 0 {
+        0
+      } else {
+        self.minimum_huffman_input_size()
+      }
+    Trailer => @cmp.maximum(0, 8 - self.bit_count / 8)
+    Finished => 0
+    Blocks => 1
+  }
+}
+
+///|
+fn Decoder::ensure_pending_capacity(self : Decoder, len : Int) -> Unit {
+  guard len > self.pending_buf.length() else { return }
+  let new_buf = FixedArray::make(len, b'\x00')
+  if self.pending_len > 0 {
+    self.pending_buf.blit_to(new_buf, len=self.pending_len)
+  }
+  self.pending_buf = new_buf
+}
+
+///|
+fn Decoder::drop_pending(self : Decoder, len : Int) -> Unit {
+  guard len > 0 else { return }
+  self.pending_len -= len
+  if self.pending_len > 0 {
+    self.pending_buf.blit_to(
+      self.pending_buf,
+      src_offset=len,
+      dst_offset=0,
+      len=self.pending_len,
+    )
+  }
+}
+
+///|
+fn Decoder::copy_to_pending(
+  self : Decoder,
+  input : Bytes,
+  input_offset : Int,
+  len : Int,
+) -> Unit {
+  guard len > 0 else { return }
+  self.ensure_pending_capacity(self.pending_len + len)
+  self.pending_buf.blit_from_bytes(self.pending_len, input, input_offset, len)
+  self.pending_len += len
+}
+
+///|
+/// Buffer compressed input that is smaller than `minimum_input_size()`.
+/// `input_len` must be smaller than `minimum_input_size`.
+pub fn Decoder::write_partial_data(
+  self : Decoder,
+  input : Bytes,
+  input_offset? : Int = 0,
+  input_len? : Int = input.length() - input_offset,
+) -> Unit {
+  guard input_len < self.minimum_input_size()
+  self.ensure_pending_capacity(self.raw_minimum_input_size())
+  self.copy_to_pending(input, input_offset, input_len)
+}
+
+///|
+fn Decoder::finish_dynamic_header(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  is_final~ : Bool,
+) -> Int raise {
+  let (index, hlit) = self.read_bits(input, start, end, 5)
+  let (index, hdist) = self.read_bits(input, index, end, 5)
+  let (index, hclen) = self.read_bits(input, index, end, 4)
+  let hlit = hlit.reinterpret_as_int() + 257
+  let hdist = hdist.reinterpret_as_int() + 1
+  let hclen = hclen.reinterpret_as_int() + 4
+  self.mode = DynamicCodeLengths(
+    is_final~,
+    hlit~,
+    hdist~,
+    hclen~,
+    index=0,
+    code_lengths=FixedArray::make(19, 0),
+  )
+  index
+}
+
+///|
+fn Decoder::finish_dynamic_code_lengths(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  is_final~ : Bool,
+  hlit~ : Int,
+  hdist~ : Int,
+  hclen~ : Int,
+  code_lengths : FixedArray[Int],
+  length_index~ : Int,
+) -> Int raise {
+  let mut index = start
+  for i in length_index..<hclen {
+    let (next, bits) = self.read_bits(input, index, end, 3)
+    index = next
+    code_lengths[code_length_order[i]] = bits.reinterpret_as_int()
+  }
+  self.mode = DynamicLengths(
+    is_final~,
+    hlit~,
+    hdist~,
+    code_tree=build_huffman_tree(code_lengths),
+    index=0,
+    previous=0,
+    lengths=FixedArray::make(320, 0),
+  )
+  index
+}
+
+///|
+fn Decoder::finish_dynamic_trees(
+  self : Decoder,
+  is_final~ : Bool,
+  hlit~ : Int,
+  hdist~ : Int,
+  lengths : FixedArray[Int],
+) -> Unit raise {
+  let literal_lengths = FixedArray::make(hlit, 0)
+  for i in 0..<hlit {
+    literal_lengths[i] = lengths[i]
+  }
+  guard hlit > 256 && literal_lengths[256] > 0 else {
+    raise InvalidBlock("invalid code -- missing end-of-block")
+  }
+  let distance_lengths = FixedArray::make(hdist, 0)
+  for i in 0..<hdist {
+    distance_lengths[i] = lengths[hlit + i]
+  }
+  self.mode = HuffmanBlock(
+    is_final~,
+    literal_tree=build_huffman_tree(literal_lengths),
+    distance_tree=build_huffman_tree(distance_lengths),
+  )
+}
+
+///|
+fn Decoder::decode_dynamic_length_step(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  is_final~ : Bool,
+  hlit~ : Int,
+  hdist~ : Int,
+  code_tree~ : HuffmanTree,
+  lengths : FixedArray[Int],
+  length_index~ : Int,
+  previous~ : Int,
+) -> Int raise {
+  let total = hlit + hdist
+  guard length_index < total else {
+    self.finish_dynamic_trees(is_final~, hlit~, hdist~, lengths)
+    return start
+  }
+  let (next, symbol) = self.decode_symbol(input, start, end, code_tree)
+  let mut index = next
+  let mut length_index = length_index
+  let mut previous = previous
+  match symbol {
+    0..=15 => {
+      lengths[length_index] = symbol
+      previous = symbol
+      length_index += 1
+    }
+    16 => {
+      guard length_index > 0 else {
+        raise InvalidBlock("invalid bit length repeat")
+      }
+      let (next, bits) = self.read_bits(input, index, end, 2)
+      index = next
+      let repeat = bits.reinterpret_as_int() + 3
+      guard length_index + repeat <= total else {
+        raise InvalidBlock("invalid bit length repeat")
+      }
+      for _ in 0..<repeat {
+        lengths[length_index] = previous
+        length_index += 1
+      }
+    }
+    17 => {
+      let (next, bits) = self.read_bits(input, index, end, 3)
+      index = next
+      let repeat = bits.reinterpret_as_int() + 3
+      guard length_index + repeat <= total else {
+        raise InvalidBlock("invalid bit length repeat")
+      }
+      for _ in 0..<repeat {
+        lengths[length_index] = 0
+        length_index += 1
+      }
+      previous = 0
+    }
+    18 => {
+      let (next, bits) = self.read_bits(input, index, end, 7)
+      index = next
+      let repeat = bits.reinterpret_as_int() + 11
+      guard length_index + repeat <= total else {
+        raise InvalidBlock("invalid bit length repeat")
+      }
+      for _ in 0..<repeat {
+        lengths[length_index] = 0
+        length_index += 1
+      }
+      previous = 0
+    }
+    _ => raise InvalidBlock("invalid code lengths set")
+  }
+  if length_index == total {
+    self.finish_dynamic_trees(is_final~, hlit~, hdist~, lengths)
+  } else {
+    self.mode = DynamicLengths(
+      is_final~,
+      hlit~,
+      hdist~,
+      code_tree~,
+      index=length_index,
+      previous~,
+      lengths~,
+    )
+  }
+  index
+}
+
+///|
+fn Decoder::finish_header(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+) -> Int raise {
+  ignore(Header::from_bytes(input[start:start + HEADER_SIZE]))
+  self.mode = Blocks
+  start + HEADER_SIZE
+}
+
+///|
+fn Decoder::available_output(output_capacity : Int, produced : Int) -> Int {
+  output_capacity - produced
+}
+
+///|
+fn Decoder::minimum_huffman_input_size(self : Decoder) -> Int {
+  let needed_bits = 48 - self.bit_count
+  if needed_bits <= 0 {
+    0
+  } else {
+    (needed_bits + 7) / 8
+  }
+}
+
+///|
+fn Decoder::append_history(self : Decoder, byte : Byte) -> Unit {
+  self.history[self.history_pos] = byte
+  self.history_pos = (self.history_pos + 1) & 0x7fff
+  if self.history_len < 32768 {
+    self.history_len += 1
+  }
+}
+
+///|
+fn Decoder::append_history_bytes(
+  self : Decoder,
+  src : FixedArray[Byte],
+  src_offset : Int,
+  len : Int,
+) -> Unit {
+  guard len > 0 else { return }
+  let first_len = @cmp.minimum(len, 32768 - self.history_pos)
+  src.blit_to(
+    self.history,
+    src_offset~,
+    dst_offset=self.history_pos,
+    len=first_len,
+  )
+  if first_len < len {
+    src.blit_to(
+      self.history,
+      src_offset=src_offset + first_len,
+      dst_offset=0,
+      len=len - first_len,
+    )
+  }
+  self.history_pos = (self.history_pos + len) & 0x7fff
+  self.history_len = @cmp.minimum(32768, self.history_len + len)
+}
+
+///|
+fn Decoder::history_index(self : Decoder, distance : Int) -> Int raise {
+  guard distance >= 1 && distance <= self.history_len else {
+    raise InvalidBlock("invalid distance too far back")
+  }
+  let mut index = self.history_pos - distance
+  if index < 0 {
+    index += 32768
+  }
+  index
+}
+
+///|
+fn Decoder::write_output_byte(
+  self : Decoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  byte : Byte,
+) -> Int {
+  output[output_offset + produced] = byte
+  self.trailer_state.update(
+    output.unsafe_reinterpret_as_bytes()[output_offset + produced:output_offset +
+    produced +
+    1],
+  )
+  self.append_history(byte)
+  produced + 1
+}
+
+///|
+fn Decoder::align_to_byte(self : Decoder) -> Unit {
+  self.bit_buffer = 0U
+  self.bit_count = 0
+}
+
+///|
+fn Decoder::begin_trailer(self : Decoder) -> Unit {
+  let discard = self.bit_count & 7
+  if discard > 0 {
+    self.bit_buffer = self.bit_buffer >> discard
+    self.bit_count -= discard
+  }
+  self.mode = Trailer
+}
+
+///|
+fn Decoder::finish_stored_header(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  is_final~ : Bool,
+) -> Int raise {
+  guard input[start:] is [u16le(len), u16le(nlen), ..]
+  guard (len ^ nlen) == 0xffff else {
+    raise InvalidBlock("stored block length checksum mismatch")
+  }
+  if len == 0 {
+    if is_final {
+      self.begin_trailer()
+    } else {
+      self.mode = Blocks
+    }
+  } else {
+    self.mode = StoredBlock(is_final~, remaining=len.reinterpret_as_int())
+  }
+  start + 4
+}
+
+///|
+fn Decoder::read_aligned_byte(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+) -> (Int, Byte) {
+  guard (self.bit_count & 7) == 0 else { abort("unreachable") }
+  if self.bit_count >= 8 {
+    let byte = (self.bit_buffer & 0xffU).to_byte()
+    self.bit_buffer = self.bit_buffer >> 8
+    self.bit_count -= 8
+    (start, byte)
+  } else {
+    (start + 1, input[start])
+  }
+}
+
+///|
+fn Decoder::read_aligned_uint32_le(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+) -> (Int, UInt) {
+  let (index, b0) = self.read_aligned_byte(input, start)
+  let (index, b1) = self.read_aligned_byte(input, index)
+  let (index, b2) = self.read_aligned_byte(input, index)
+  let (index, b3) = self.read_aligned_byte(input, index)
+  let value = b0.to_uint() |
+    (b1.to_uint() << 8) |
+    (b2.to_uint() << 16) |
+    (b3.to_uint() << 24)
+  (index, value)
+}
+
+///|
+fn Decoder::finish_trailer(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+) -> Int raise {
+  let (index, crc32) = self.read_aligned_uint32_le(input, start)
+  let (index, input_size) = self.read_aligned_uint32_le(input, index)
+  let expected = self.trailer_state.snapshot()
+  guard crc32 == expected.crc32 else {
+    raise InvalidTrailer("gzip trailer CRC32 mismatch")
+  }
+  guard input_size == expected.input_size else {
+    raise InvalidTrailer("gzip trailer input size mismatch")
+  }
+  self.mode = Finished
+  index
+}
+
+///|
+fn Decoder::ensure_bits(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  count : Int,
+  allow_eof~ : Bool,
+) -> (Int, Bool) raise {
+  let mut index = start
+  while self.bit_count < count {
+    if index >= end {
+      guard allow_eof else {
+        raise InvalidBlock("unexpected EOF in compressed data")
+      }
+      return (index, false)
+    }
+    self.bit_buffer = self.bit_buffer |
+      (input[index].to_uint() << self.bit_count)
+    self.bit_count += 8
+    index += 1
+  }
+  (index, true)
+}
+
+///|
+fn Decoder::read_bits(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  count : Int,
+) -> (Int, UInt) raise {
+  let (index, _) = self.ensure_bits(input, start, end, count, allow_eof=false)
+  let mask = if count == 32 { 0xffffffffU } else { (1U << count) - 1U }
+  let bits = self.bit_buffer & mask
+  self.bit_buffer = self.bit_buffer >> count
+  self.bit_count -= count
+  (index, bits)
+}
+
+///|
+fn Decoder::start_next_block(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+) -> Int raise {
+  let (index, header) = self.read_bits(input, start, end, 3)
+  let is_final = (header & 1U) == 1U
+  let block_type = (header >> 1).reinterpret_as_int()
+  match block_type {
+    0 => {
+      self.align_to_byte()
+      self.mode = StoredLengths(is_final~)
+      index
+    }
+    1 => {
+      self.mode = HuffmanBlock(
+        is_final~,
+        literal_tree=fixed_literal_tree,
+        distance_tree=fixed_distance_tree,
+      )
+      index
+    }
+    2 => {
+      self.mode = DynamicHeader(is_final~)
+      index
+    }
+    _ => raise InvalidBlock("invalid block type")
+  }
+}
+
+///|
+fn Decoder::continue_copy(
+  self : Decoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  output_len : Int,
+) -> Int raise {
+  ignore(self.history_index(self.copy_distance))
+  let max_len = @cmp.minimum(
+    Decoder::available_output(output_len, produced),
+    self.copy_remaining,
+  )
+  for written = 0; written < max_len && self.copy_remaining > 0; {
+    let src_index = self.history_index(self.copy_distance)
+    let chunk = @cmp.minimum(
+      @cmp.minimum(max_len - written, self.copy_remaining),
+      @cmp.minimum(self.copy_distance, 32768 - src_index),
+    )
+    self.history.blit_to(
+      output,
+      src_offset=src_index,
+      dst_offset=output_offset + produced + written,
+      len=chunk,
+    )
+    self.append_history_bytes(output, output_offset + produced + written, chunk)
+    self.copy_remaining -= chunk
+    continue written + chunk
+  } nobreak {
+    if written > 0 {
+      self.trailer_state.update(
+        output.unsafe_reinterpret_as_bytes()[output_offset + produced:output_offset +
+        produced +
+        written],
+      )
+    }
+    if self.copy_remaining == 0 {
+      self.copy_distance = 0
+    }
+    written
+  }
+}
+
+///|
+fn Decoder::decode_symbol(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  tree : HuffmanTree,
+) -> (Int, Int) raise {
+  let mut index = start
+  for ;; {
+    let (next_index, _) = self.ensure_bits(
+      input,
+      index,
+      end,
+      tree.max_bits,
+      allow_eof=true,
+    )
+    index = next_index
+    let lookup = (self.bit_buffer & ((1U << tree.max_bits) - 1U)).reinterpret_as_int()
+    let packed = tree.table[lookup]
+    let bit_len = packed & 0x1f
+    if bit_len > 0 && bit_len <= self.bit_count {
+      self.bit_buffer = self.bit_buffer >> bit_len
+      self.bit_count -= bit_len
+      return (index, packed >> 5)
+    }
+    guard self.bit_count < tree.max_bits else {
+      raise InvalidBlock("invalid huffman code")
+    }
+    let prev_bits = self.bit_count
+    let (next_index, has_more) = self.ensure_bits(
+      input,
+      index,
+      end,
+      prev_bits + 1,
+      allow_eof=true,
+    )
+    index = next_index
+    if !has_more && self.bit_count <= prev_bits {
+      raise InvalidBlock("unexpected EOF in huffman block")
+    }
+  }
+}
+
+///|
+fn Decoder::read_length(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  symbol : Int,
+) -> (Int, Int) raise {
+  let index = symbol - 257
+  guard index >= 0 && index < length_bases.length() else {
+    raise InvalidBlock("invalid literal/length code")
+  }
+  let extra_bits = length_extras[index]
+  if extra_bits == 0 {
+    (start, length_bases[index])
+  } else {
+    let (next, extra) = self.read_bits(input, start, end, extra_bits)
+    (next, length_bases[index] + extra.reinterpret_as_int())
+  }
+}
+
+///|
+fn Decoder::read_distance(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  symbol : Int,
+) -> (Int, Int) raise {
+  guard symbol >= 0 && symbol < distance_bases.length() else {
+    raise InvalidBlock("invalid distance code")
+  }
+  let extra_bits = distance_extras[symbol]
+  if extra_bits == 0 {
+    (start, distance_bases[symbol])
+  } else {
+    let (next, extra) = self.read_bits(input, start, end, extra_bits)
+    (next, distance_bases[symbol] + extra.reinterpret_as_int())
+  }
+}
+
+///|
+fn Decoder::decode_huffman_step(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  is_final~ : Bool,
+  literal_tree~ : HuffmanTree,
+  distance_tree~ : HuffmanTree,
+) -> Int raise {
+  let (index, symbol) = self.decode_symbol(input, start, end, literal_tree)
+  match symbol {
+    0..=255 => {
+      self.copy_remaining = -symbol - 1
+      self.copy_distance = 0
+      index
+    }
+    256 => {
+      if is_final {
+        self.begin_trailer()
+      } else {
+        self.mode = Blocks
+      }
+      index
+    }
+    _ => {
+      let (index, length) = self.read_length(input, index, end, symbol)
+      let (index, distance_symbol) = self.decode_symbol(
+        input, index, end, distance_tree,
+      )
+      let (index, distance) = self.read_distance(
+        input, index, end, distance_symbol,
+      )
+      self.copy_remaining = length
+      self.copy_distance = distance
+      index
+    }
+  }
+}
+
+///|
+fn Decoder::read_stored_from_input(
+  self : Decoder,
+  input : Bytes,
+  start : Int,
+  end : Int,
+  is_final~ : Bool,
+  remaining~ : Int,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  output_len : Int,
+) -> (Int, Int) {
+  let len = @cmp.minimum(
+    @cmp.minimum(Decoder::available_output(output_len, produced), remaining),
+    end - start,
+  )
+  guard len > 0 else { return (start, 0) }
+  output.blit_from_bytes(output_offset + produced, input, start, len)
+  self.append_history_bytes(output, output_offset + produced, len)
+  self.trailer_state.update(
+    output.unsafe_reinterpret_as_bytes()[output_offset + produced:output_offset +
+    produced +
+    len],
+  )
+  let remaining = remaining - len
+  if remaining == 0 {
+    if is_final {
+      self.begin_trailer()
+    } else {
+      self.mode = Blocks
+    }
+  } else {
+    self.mode = StoredBlock(is_final~, remaining~)
+  }
+  (start + len, len)
+}
+
+///|
+/// Decode compressed input into `output`.
+/// The caller must provide at least `minimum_input_size()` bytes of input and a
+/// non-empty output buffer. The result is `(consumed, produced)`,
+/// where `consumed` is the number of bytes consumed from the input
+/// and `produced` is the number of bytes written to the output.
+/// `produced == 0` is allowed: it means the call only advanced decoder state,
+/// for example by reading a block header, stored lengths, or the trailer.
+/// EOF should be checked explicitly via `is_finished`.
+fn Decoder::write_direct(
+  self : Decoder,
+  input : Bytes,
+  output : FixedArray[Byte],
+  input_offset? : Int = 0,
+  input_len? : Int = input.length() - input_offset,
+  output_offset? : Int = 0,
+  output_len? : Int = output.length() - output_offset,
+) -> (Int, Int) raise {
+  let end = input_offset + input_len
+  let mut index = input_offset
+  let mut produced = 0
+  for ;; {
+    if Decoder::available_output(output_len, produced) == 0 {
+      break
+    }
+    match self.mode {
+      Header => {
+        if end - index < self.raw_minimum_input_size() {
+          break
+        }
+        index = self.finish_header(input, index)
+        if self.mode is Header || index >= end {
+          break
+        }
+      }
+      DynamicHeader(is_final~) => {
+        if end - index < self.raw_minimum_input_size() {
+          break
+        }
+        index = self.finish_dynamic_header(input, index, end, is_final~)
+        if self.mode is DynamicHeader(_) || index >= end {
+          break
+        }
+      }
+      DynamicCodeLengths(
+        is_final~,
+        hlit~,
+        hdist~,
+        hclen~,
+        index=length_index,
+        code_lengths~
+      ) => {
+        if end - index < self.raw_minimum_input_size() {
+          break
+        }
+        index = self.finish_dynamic_code_lengths(
+          input,
+          index,
+          end,
+          is_final~,
+          hlit~,
+          hdist~,
+          hclen~,
+          code_lengths,
+          length_index~,
+        )
+        if self.mode is DynamicCodeLengths(..) || index >= end {
+          break
+        }
+      }
+      DynamicLengths(
+        is_final~,
+        hlit~,
+        hdist~,
+        code_tree~,
+        index=length_index,
+        previous~,
+        lengths~
+      ) => {
+        if end - index < self.raw_minimum_input_size() {
+          break
+        }
+        index = self.decode_dynamic_length_step(
+          input,
+          index,
+          end,
+          is_final~,
+          hlit~,
+          hdist~,
+          code_tree~,
+          lengths,
+          length_index~,
+          previous~,
+        )
+        if self.mode is DynamicLengths(..) || index >= end {
+          break
+        }
+      }
+      StoredLengths(is_final~) => {
+        if end - index < self.raw_minimum_input_size() {
+          break
+        }
+        index = self.finish_stored_header(input, index, is_final~)
+        if self.mode is StoredLengths(_) || index >= end {
+          break
+        }
+      }
+      StoredBlock(is_final~, remaining~) => {
+        let (next, written) = self.read_stored_from_input(
+          input,
+          index,
+          end,
+          is_final~,
+          remaining~,
+          output,
+          output_offset,
+          produced,
+          output_len,
+        )
+        if next == index {
+          break
+        }
+        index = next
+        produced += written
+        continue
+      }
+      HuffmanBlock(is_final~, literal_tree~, distance_tree~) => {
+        if self.copy_remaining > 0 {
+          let written = self.continue_copy(
+            output, output_offset, produced, output_len,
+          )
+          if written == 0 {
+            break
+          }
+          produced += written
+          continue
+        }
+        if self.copy_remaining < 0 {
+          produced = self.write_output_byte(
+            output,
+            output_offset,
+            produced,
+            (-self.copy_remaining - 1).to_byte(),
+          )
+          self.copy_remaining = 0
+          continue
+        }
+        if end - index < self.minimum_huffman_input_size() {
+          break
+        }
+        index = self.decode_huffman_step(
+          input,
+          index,
+          end,
+          is_final~,
+          literal_tree~,
+          distance_tree~,
+        )
+      }
+      Trailer => {
+        if end - index < self.raw_minimum_input_size() {
+          break
+        }
+        index = self.finish_trailer(input, index)
+        if self.mode is Trailer || index >= end {
+          break
+        }
+      }
+      Finished => break
+      Blocks => {
+        if index >= end {
+          break
+        }
+        index = self.start_next_block(input, index, end)
+      }
+    }
+  }
+  (index - input_offset, produced)
+}
+
+///|
+/// Decode compressed input into `output`.
+/// The caller must provide at least `minimum_input_size()` bytes of input and a
+/// non-empty output buffer. The result is `(consumed, produced)`,
+/// where `consumed` is the number of bytes consumed from the input
+/// and `produced` is the number of bytes written to the output.
+/// `produced == 0` is allowed: it means the call only advanced decoder state,
+/// for example by reading a block header, stored lengths, or the trailer.
+/// EOF should be checked explicitly via `is_finished`.
+pub fn Decoder::write(
+  self : Decoder,
+  input : Bytes,
+  output : FixedArray[Byte],
+  input_offset? : Int = 0,
+  input_len? : Int = input.length() - input_offset,
+  output_offset? : Int = 0,
+  output_len? : Int = output.length() - output_offset,
+) -> (Int, Int) raise {
+  if self.pending_len == 0 {
+    return self.write_direct(
+      input,
+      output,
+      input_offset~,
+      input_len~,
+      output_offset~,
+      output_len~,
+    )
+  }
+  let needed = self.raw_minimum_input_size()
+  let copied = @cmp.maximum(0, needed - self.pending_len)
+  if copied > 0 {
+    self.copy_to_pending(input, input_offset, copied)
+  }
+  let (pending_consumed, produced) = self.write_direct(
+    self.pending_buf.unsafe_reinterpret_as_bytes(),
+    output,
+    input_offset=0,
+    input_len=self.pending_len,
+    output_offset~,
+    output_len~,
+  )
+  self.drop_pending(pending_consumed)
+  (copied, produced)
+}

--- a/src/internal/gzip_internal/encoder.mbt
+++ b/src/internal/gzip_internal/encoder.mbt
@@ -1,0 +1,483 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let encoder_block_overhead_bits = 10
+
+///|
+let encoder_window_size = 1024
+
+///|
+let encoder_max_match_len = 64
+
+///|
+let encoder_min_match_len = 3
+
+///|
+pub struct Encoder {
+  priv header : Header
+  priv trailer_state : TrailerState
+  priv mut bit_buffer : UInt
+  priv mut bit_count : Int
+  priv mut finished : Bool
+  priv mut started : Bool
+  priv history : FixedArray[Byte]
+  priv mut history_pos : Int
+  priv mut history_len : Int
+
+  fn new(
+    mtime? : UInt,
+    extra_flags? : Byte,
+    operating_system? : Byte,
+  ) -> Encoder
+}
+
+///|
+/// Create an encoder state machine.
+/// The gzip header is written by the first successful `write` or `end` call.
+pub fn Encoder::new(
+  mtime? : UInt = 0U,
+  extra_flags? : Byte = b'\x00',
+  operating_system? : Byte = b'\xff',
+) -> Encoder {
+  {
+    header: Header::new(mtime~, extra_flags~, operating_system~),
+    trailer_state: TrailerState::new(),
+    bit_buffer: 0U,
+    bit_count: 0,
+    finished: false,
+    started: false,
+    history: FixedArray::make(32768, b'\x00'),
+    history_pos: 0,
+    history_len: 0,
+  }
+}
+
+///|
+fn fixed_literal_code(symbol : Int) -> (UInt, Int) {
+  if symbol <= 143 {
+    (reverse_bits(symbol + 0x30, 8).reinterpret_as_uint(), 8)
+  } else if symbol <= 255 {
+    (reverse_bits(symbol - 144 + 0x190, 9).reinterpret_as_uint(), 9)
+  } else if symbol <= 279 {
+    (reverse_bits(symbol - 256, 7).reinterpret_as_uint(), 7)
+  } else {
+    (reverse_bits(symbol - 280 + 0xc0, 8).reinterpret_as_uint(), 8)
+  }
+}
+
+///|
+fn Encoder::push_byte(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  byte : Byte,
+) -> Int {
+  ignore(self)
+  output[output_offset + produced] = byte
+  produced + 1
+}
+
+///|
+fn Encoder::push_bytes(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  bytes : Bytes,
+) -> Int {
+  ignore(self)
+  output.blit_from_bytes(output_offset + produced, bytes, 0, bytes.length())
+  produced + bytes.length()
+}
+
+///|
+fn Encoder::write_bits(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  bits : UInt,
+  count : Int,
+) -> Int {
+  self.bit_buffer = self.bit_buffer | (bits << self.bit_count)
+  self.bit_count += count
+  let mut produced = produced
+  while self.bit_count >= 8 {
+    produced = self.push_byte(
+      output,
+      output_offset,
+      produced,
+      (self.bit_buffer & 0xffU).to_byte(),
+    )
+    self.bit_buffer = self.bit_buffer >> 8
+    self.bit_count -= 8
+  }
+  produced
+}
+
+///|
+fn Encoder::write_header(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+) -> Int {
+  let produced = self.push_bytes(
+    output,
+    output_offset,
+    produced,
+    self.header.to_bytes(),
+  )
+  self.started = true
+  produced
+}
+
+///|
+fn Encoder::write_literal(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  literal : Byte,
+) -> Int {
+  let (code, bit_len) = fixed_literal_code(literal.to_int())
+  self.write_bits(output, output_offset, produced, code, bit_len)
+}
+
+///|
+fn Encoder::write_end_of_block(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+) -> Int {
+  let (code, bit_len) = fixed_literal_code(256)
+  self.write_bits(output, output_offset, produced, code, bit_len)
+}
+
+///|
+fn fixed_distance_code(symbol : Int) -> (UInt, Int) {
+  (reverse_bits(symbol, 5).reinterpret_as_uint(), 5)
+}
+
+///|
+fn find_length_code(length : Int) -> (Int, Int, Int) {
+  for i in 0..<length_bases.length() {
+    let base = length_bases[i]
+    let extra_bits = length_extras[i]
+    let end = if extra_bits == 0 { base } else { base + (1 << extra_bits) - 1 }
+    if length <= end {
+      return (257 + i, extra_bits, length - base)
+    }
+  }
+  abort("unreachable")
+}
+
+///|
+fn find_distance_code(distance : Int) -> (Int, Int, Int) {
+  for i in 0..<distance_bases.length() {
+    let base = distance_bases[i]
+    let extra_bits = distance_extras[i]
+    let end = if extra_bits == 0 { base } else { base + (1 << extra_bits) - 1 }
+    if distance <= end {
+      return (i, extra_bits, distance - base)
+    }
+  }
+  abort("unreachable")
+}
+
+///|
+fn Encoder::write_match(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  length : Int,
+  distance : Int,
+) -> Int {
+  let (length_symbol, length_extra_bits, length_extra) = find_length_code(
+    length,
+  )
+  let (length_code, length_bit_len) = fixed_literal_code(length_symbol)
+  let mut produced = self.write_bits(
+    output, output_offset, produced, length_code, length_bit_len,
+  )
+  if length_extra_bits > 0 {
+    produced = self.write_bits(
+      output,
+      output_offset,
+      produced,
+      length_extra.reinterpret_as_uint(),
+      length_extra_bits,
+    )
+  }
+  let (distance_symbol, distance_extra_bits, distance_extra) = find_distance_code(
+    distance,
+  )
+  let (distance_code, distance_bit_len) = fixed_distance_code(distance_symbol)
+  produced = self.write_bits(
+    output, output_offset, produced, distance_code, distance_bit_len,
+  )
+  if distance_extra_bits > 0 {
+    produced = self.write_bits(
+      output,
+      output_offset,
+      produced,
+      distance_extra.reinterpret_as_uint(),
+      distance_extra_bits,
+    )
+  }
+  produced
+}
+
+///|
+fn Encoder::append_history_byte(self : Encoder, byte : Byte) -> Unit {
+  self.history[self.history_pos] = byte
+  self.history_pos = (self.history_pos + 1) & 0x7fff
+  if self.history_len < 32768 {
+    self.history_len += 1
+  }
+}
+
+///|
+fn Encoder::append_history_bytes(
+  self : Encoder,
+  input : Bytes,
+  input_offset : Int,
+  input_len : Int,
+) -> Unit {
+  for i in 0..<input_len {
+    self.append_history_byte(input[input_offset + i])
+  }
+}
+
+///|
+fn Encoder::match_byte(
+  self : Encoder,
+  input : Bytes,
+  input_offset : Int,
+  pos : Int,
+  distance : Int,
+  matched : Int,
+) -> Byte {
+  if matched < distance {
+    let mut history_index = self.history_pos - distance + matched
+    if history_index < 0 {
+      history_index += 32768
+    } else if history_index >= 32768 {
+      history_index -= 32768
+    }
+    self.history[history_index]
+  } else {
+    input[input_offset + pos + matched - distance]
+  }
+}
+
+///|
+fn Encoder::find_match(
+  self : Encoder,
+  input : Bytes,
+  input_offset : Int,
+  input_len : Int,
+  pos : Int,
+) -> (Int, Int) {
+  let max_distance = @cmp.minimum(self.history_len, encoder_window_size)
+  let max_match_len = @cmp.minimum(input_len - pos, encoder_max_match_len)
+  if max_distance <= 0 || max_match_len < encoder_min_match_len {
+    return (0, 0)
+  }
+  let mut best_len = 0
+  let mut best_distance = 0
+  for distance in 1..<=max_distance {
+    let mut matched = 0
+    while matched < max_match_len &&
+          input[input_offset + pos + matched] ==
+          self.match_byte(input, input_offset, pos, distance, matched) {
+      matched += 1
+    }
+    if matched >= encoder_min_match_len &&
+      (matched > best_len || (matched == best_len && distance < best_distance)) {
+      best_len = matched
+      best_distance = distance
+      if matched == max_match_len {
+        break
+      }
+    }
+  }
+  (best_len, best_distance)
+}
+
+///|
+fn Encoder::write_fixed_block_header(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  is_final : Bool,
+) -> Int {
+  self.write_bits(
+    output,
+    output_offset,
+    produced,
+    if is_final {
+      3U
+    } else {
+      2U
+    },
+    3,
+  )
+}
+
+///|
+fn Encoder::encode_chunk(
+  self : Encoder,
+  input : Bytes,
+  input_offset : Int,
+  input_len : Int,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+  is_final : Bool,
+) -> Int {
+  let mut produced = self.write_fixed_block_header(
+    output, output_offset, produced, is_final,
+  )
+  let mut i = 0
+  while i < input_len {
+    let (match_len, match_distance) = self.find_match(
+      input, input_offset, input_len, i,
+    )
+    if match_len >= encoder_min_match_len {
+      produced = self.write_match(
+        output, output_offset, produced, match_len, match_distance,
+      )
+      self.append_history_bytes(input, input_offset + i, match_len)
+      i += match_len
+    } else {
+      produced = self.write_literal(
+        output,
+        output_offset,
+        produced,
+        input[input_offset + i],
+      )
+      self.append_history_byte(input[input_offset + i])
+      i += 1
+    }
+  }
+  self.write_end_of_block(output, output_offset, produced)
+}
+
+///|
+fn Encoder::flush_partial_byte(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset : Int,
+  produced : Int,
+) -> Int {
+  if self.bit_count > 0 {
+    let produced = self.push_byte(
+      output,
+      output_offset,
+      produced,
+      (self.bit_buffer & 0xffU).to_byte(),
+    )
+    self.bit_buffer = 0U
+    self.bit_count = 0
+    produced
+  } else {
+    produced
+  }
+}
+
+///|
+/// Return the minimum output space required for the next successful call.
+/// `end=true` means the caller wants to terminate the stream now, so this
+/// includes the final block and trailer.
+pub fn Encoder::minimum_output_space(self : Encoder, end~ : Bool) -> Int {
+  guard !self.finished else { return 0 }
+  let header = if self.started { 0 } else { HEADER_SIZE }
+  if end {
+    header + (self.bit_count + encoder_block_overhead_bits + 7) / 8 + 8
+  } else {
+    header + (self.bit_count + 19 + 7) / 8
+  }
+}
+
+///|
+/// Encode plain input into `output`.
+/// The caller must provide at least `minimum_output_space(end=false)` bytes of
+/// output space, and the input buffer must be non-empty.
+/// The result is `(consumed, produced)`,
+/// where `consumed` is the number of bytes consumed from the input
+/// and `produced` is the number of bytes written to the output.
+/// `write` must not be called on a stream where `.end()` is already called.
+pub fn Encoder::write(
+  self : Encoder,
+  input : Bytes,
+  output : FixedArray[Byte],
+  input_offset? : Int = 0,
+  input_len? : Int = input.length() - input_offset,
+  output_offset? : Int = 0,
+  output_len? : Int = output.length() - output_offset,
+) -> (Int, Int) {
+  guard !self.finished
+  guard input_len > 0 else { return (0, 0) }
+  let mut produced = 0
+  if !self.started {
+    produced = self.write_header(output, output_offset, produced)
+  }
+  let available_bits = (output_len - produced) * 8 -
+    self.bit_count -
+    encoder_block_overhead_bits
+  let max_len = available_bits / 9
+  guard max_len > 0 else { return (0, produced) }
+  let consumed = @cmp.minimum(input_len, max_len)
+  self.trailer_state.update(input[input_offset:input_offset + consumed])
+  produced = self.encode_chunk(
+    input, input_offset, consumed, output, output_offset, produced, false,
+  )
+  (consumed, produced)
+}
+
+///|
+/// Finish the gzip stream by writing the final block and trailer into `output`.
+/// The caller must provide at least `minimum_output_space(end=true)` bytes.
+/// Returns the number of bytes written to `output`.
+/// The encoder must not be finished (i.e. `.end()` can be called only once).
+pub fn Encoder::end(
+  self : Encoder,
+  output : FixedArray[Byte],
+  output_offset? : Int = 0,
+  output_len? : Int = output.length() - output_offset,
+) -> Int {
+  guard !self.finished else { return 0 }
+  let mut produced = 0
+  let trailer = self.trailer_state.snapshot()
+  guard self.minimum_output_space(end=true) <= output_len
+  if !self.started {
+    produced = self.write_header(output, output_offset, produced)
+  }
+  produced = self.encode_chunk(b"", 0, 0, output, output_offset, produced, true)
+  produced = self.flush_partial_byte(output, output_offset, produced)
+  produced = self.push_bytes(
+    output,
+    output_offset,
+    produced,
+    Trailer::new(trailer.crc32, trailer.input_size).to_bytes(),
+  )
+  self.finished = true
+  produced
+}

--- a/src/internal/gzip_internal/gzip_internal_test.mbt
+++ b/src/internal/gzip_internal/gzip_internal_test.mbt
@@ -1,0 +1,323 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+enum Step {
+  Min
+  Max
+}
+
+///|
+fn encode(
+  data : Bytes,
+  input_step? : Step = Max,
+  output_step? : Step = Max,
+) -> Bytes raise {
+  let output = FixedArray::make(data.length() * 4 + 256, b'\x00')
+  let encoder = Encoder::new()
+  let mut input_offset = 0
+  let mut output_offset = 0
+  let mut step = 0
+  while input_offset < data.length() {
+    step += 1
+    let input_len = match input_step {
+      Min => 1
+      Max => data.length() - input_offset
+    }
+    let output_len = match output_step {
+      Min => encoder.minimum_output_space(end=false)
+      Max => output.length() - output_offset
+    }
+    guard input_len > 0 && output_len > 0
+    let (consumed, produced) = encoder.write(
+      data,
+      input_offset~,
+      input_len~,
+      output,
+      output_offset~,
+      output_len~,
+    )
+    guard consumed < input_len + 1
+    guard produced < output_len + 1
+    input_offset += consumed
+    output_offset += produced
+    if step > data.length() * 2 {
+      raise Failure::Failure("too many steps")
+    }
+  }
+  output_offset += encoder.end(
+    output,
+    output_offset~,
+    output_len=output.length() - output_offset,
+  )
+  output.unsafe_reinterpret_as_bytes()[:output_offset].to_bytes()
+}
+
+///|
+fn decode(
+  compressed : Bytes,
+  expected_len~ : Int,
+  input_step? : Step = Max,
+  output_step? : Step = Max,
+) -> Bytes raise {
+  let output = FixedArray::make(
+    if expected_len > 0 {
+      expected_len * 2
+    } else {
+      1
+    },
+    b'\x00',
+  )
+  let decoder = Decoder::new()
+  let mut input_offset = 0
+  let mut output_offset = 0
+  let mut step = 0
+  let max_steps = compressed.length() * 2 + output.length() + 1
+  while !decoder.is_finished() {
+    step += 1
+    let input_len = match input_step {
+      Min => decoder.minimum_input_size()
+      Max => compressed.length() - input_offset
+    }
+    let output_len = match output_step {
+      Min => 1
+      Max => output.length() - output_offset
+    }
+    guard input_len > 0 && output_len > 0
+    let (consumed, produced) = decoder.write(
+      compressed,
+      input_offset~,
+      input_len~,
+      output,
+      output_offset~,
+      output_len~,
+    )
+    guard consumed < input_len + 1
+    guard produced < output_len + 1
+    input_offset += consumed
+    output_offset += produced
+    if step > max_steps {
+      raise Failure::Failure("too many steps")
+    }
+  }
+  guard input_offset == compressed.length()
+  output.unsafe_reinterpret_as_bytes()[:output_offset].to_bytes()
+}
+
+///|
+test "gzip decode one byte partial chunks" {
+  let data = b"A simple message to compress"
+  let compressed = encode(data)
+  let output = FixedArray::make(data.length() * 2, b'\x00')
+  let decoder = Decoder::new()
+  let mut input_offset = 0
+  let mut output_offset = 0
+  while !decoder.is_finished() {
+    let min_len = decoder.minimum_input_size()
+    if min_len > 1 {
+      decoder.write_partial_data(compressed, input_offset~, input_len=1)
+      input_offset += 1
+    } else {
+      let (consumed, produced) = decoder.write(
+        compressed,
+        input_offset~,
+        input_len=1,
+        output,
+        output_offset~,
+        output_len=output.length() - output_offset,
+      )
+      input_offset += consumed
+      output_offset += produced
+    }
+  }
+  inspect(input_offset, content="48")
+  inspect(compressed.length(), content="48")
+  inspect(
+    output.unsafe_reinterpret_as_bytes()[:output_offset],
+    content=(
+      #|b"A simple message to compress"
+    ),
+  )
+}
+
+///|
+test "gzip encode min input 1" {
+  let data = b"hello_gzip_world"
+  let compressed = encode(data, input_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip encode min output 1" {
+  let data = b"hello_gzip_world"
+  let compressed = encode(data, output_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip decode min input 1" {
+  let data = b"hello_gzip_world"
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), input_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip decode min output 1" {
+  let data = b"hello_gzip_world"
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), output_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip encode min input abcdef" {
+  let data = b"abcdef"
+  let compressed = encode(data, input_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip encode min output abcdef" {
+  let data = b"abcdef"
+  let compressed = encode(data, output_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip decode min input abcdef" {
+  let data = b"abcdef"
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), input_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip decode min output abcdef" {
+  let data = b"abcdef"
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), output_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip encode min input abcdefgh" {
+  let data = b"abcdefgh"
+  let compressed = encode(data, input_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip encode min output abcdefgh" {
+  let data = b"abcdefgh"
+  let compressed = encode(data, output_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip decode min input abcdefgh" {
+  let data = b"abcdefgh"
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), input_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip decode min output abcdefgh" {
+  let data = b"abcdefgh"
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), output_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip encode min input hello node huffman" {
+  let data = b"hello from node huffman stream"
+  let compressed = encode(data, input_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip encode min output hello node huffman" {
+  let data = b"hello from node huffman stream"
+  let compressed = encode(data, output_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip decode min input hello node huffman" {
+  let data = b"hello from node huffman stream"
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), input_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+test "gzip decode min output hello node huffman" {
+  let data = b"hello from node huffman stream"
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), output_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+#cfg(target="native")
+async test "gzip encode min input source file" {
+  let data = @fs.read_file("src/internal/gzip_internal/decoder.mbt").binary()
+  let compressed = encode(data, input_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+#cfg(target="native")
+async test "gzip encode min output source file" {
+  let data = @fs.read_file("src/internal/gzip_internal/decoder.mbt").binary()
+  let compressed = encode(data, output_step=Min)
+  let data2 = decode(compressed, expected_len=data.length())
+  assert_eq(data, data2)
+}
+
+///|
+#cfg(target="native")
+async test "gzip decode min input source file" {
+  let data = @fs.read_file("src/internal/gzip_internal/decoder.mbt").binary()
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), input_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+#cfg(target="native")
+async test "gzip decode min output source file" {
+  let data = @fs.read_file("src/internal/gzip_internal/decoder.mbt").binary()
+  let compressed = encode(data)
+  let data2 = decode(compressed, expected_len=data.length(), output_step=Min)
+  assert_eq(data, data2)
+}
+
+///|
+#cfg(not(target="native"))
+let _unused : Unit = {
+  ignore(@async.sleep)
+  ignore(@fs.unimplemented)
+}

--- a/src/internal/gzip_internal/huffman.mbt
+++ b/src/internal/gzip_internal/huffman.mbt
@@ -1,0 +1,140 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let max_huffman_bits = 15
+
+///|
+priv struct HuffmanTree {
+  table : FixedArray[Int]
+  max_bits : Int
+}
+
+///|
+fn reverse_bits(code : Int, bit_len : Int) -> Int {
+  let mut reversed = 0
+  for i in 0..<bit_len {
+    reversed = (reversed << 1) | ((code >> i) & 1)
+  }
+  reversed
+}
+
+///|
+fn build_huffman_tree(lengths : FixedArray[Int]) -> HuffmanTree raise {
+  let counts = FixedArray::make(max_huffman_bits + 1, 0)
+  let mut max_bits = 0
+  let mut num_codes = 0
+  for bit_len in lengths {
+    guard bit_len >= 0 && bit_len <= max_huffman_bits else {
+      raise InvalidBlock("invalid huffman code length")
+    }
+    if bit_len > 0 {
+      counts[bit_len] += 1
+      num_codes += 1
+      if bit_len > max_bits {
+        max_bits = bit_len
+      }
+    }
+  }
+  guard num_codes > 0 else { raise InvalidBlock("empty huffman tree") }
+
+  let mut left = 1
+  for bit_len in 1..<=max_huffman_bits {
+    left = (left << 1) - counts[bit_len]
+    guard left >= 0 else { raise InvalidBlock("oversubscribed huffman tree") }
+  }
+
+  let next_code = FixedArray::make(max_huffman_bits + 1, 0)
+  let mut code = 0
+  for bit_len in 1..<=max_huffman_bits {
+    code = (code + counts[bit_len - 1]) << 1
+    next_code[bit_len] = code
+  }
+
+  let table = FixedArray::make(1 << max_bits, 0)
+  for symbol, bit_len in lengths {
+    if bit_len == 0 {
+      continue
+    }
+    let code = next_code[bit_len]
+    next_code[bit_len] = code + 1
+    let reversed = reverse_bits(code, bit_len)
+    let packed = (symbol << 5) | bit_len
+    let num_suffixes = 1 << (max_bits - bit_len)
+    for suffix in 0..<num_suffixes {
+      let index = reversed | (suffix << bit_len)
+      guard table[index] == 0 else {
+        raise InvalidBlock("duplicate huffman code")
+      }
+      table[index] = packed
+    }
+  }
+  { table, max_bits }
+}
+
+///|
+fn build_huffman_tree_or_abort(lengths : FixedArray[Int]) -> HuffmanTree {
+  build_huffman_tree(lengths) catch {
+    err => abort(err.to_string())
+  }
+}
+
+///|
+let fixed_literal_tree : HuffmanTree = build_huffman_tree_or_abort(
+  FixedArray::makei(288, i => {
+    if i < 144 {
+      8
+    } else if i < 256 {
+      9
+    } else if i < 280 {
+      7
+    } else {
+      8
+    }
+  }),
+)
+
+///|
+let fixed_distance_tree : HuffmanTree = build_huffman_tree_or_abort(
+  FixedArray::make(32, 5),
+)
+
+///|
+let code_length_order : FixedArray[Int] = [
+  16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15,
+]
+
+///|
+let length_bases : FixedArray[Int] = [
+  3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83,
+  99, 115, 131, 163, 195, 227, 258,
+]
+
+///|
+let length_extras : FixedArray[Int] = [
+  0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5,
+  5, 0,
+]
+
+///|
+let distance_bases : FixedArray[Int] = [
+  1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513, 769,
+  1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577,
+]
+
+///|
+let distance_extras : FixedArray[Int] = [
+  0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11,
+  12, 12, 13, 13,
+]

--- a/src/internal/gzip_internal/invalid_test.mbt
+++ b/src/internal/gzip_internal/invalid_test.mbt
@@ -1,0 +1,31 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "decoder rejects invalid gzip header" {
+  let result = try? decode(
+    b"\x1f\x8b\x08\x02\x00\x00\x00\x00\x00\x00\x1d\x26\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+    expected_len=0,
+  )
+  assert_true(result is Err(_))
+}
+
+///|
+test "decoder verifies trailer automatically" {
+  let encoded = encode(b"\x00")
+  let corrupted = encoded[:encoded.length() - 8].to_bytes() +
+    b"\x00\x00\x00\x00\x01\x00\x00\x00"
+  let result = try? decode(corrupted, expected_len=1)
+  assert_true(result is Err(_))
+}

--- a/src/internal/gzip_internal/metadata.mbt
+++ b/src/internal/gzip_internal/metadata.mbt
@@ -1,0 +1,119 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+priv suberror FormatError {
+  InvalidHeader(String)
+  InvalidTrailer(String)
+  InvalidBlock(String)
+} derive(Debug, ToJson)
+
+///|
+pub const HEADER_SIZE : Int = 10
+
+///|
+priv struct Header {
+  mtime : UInt
+  extra_flags : Byte
+  operating_system : Byte
+}
+
+///|
+fn Header::new(
+  mtime? : UInt = 0U,
+  extra_flags? : Byte = b'\x00',
+  operating_system? : Byte = b'\xff',
+) -> Header {
+  { mtime, extra_flags, operating_system }
+}
+
+///|
+fn Header::to_bytes(self : Header) -> Bytes {
+  let buf = FixedArray::make(10, b'\x00')
+  buf[0] = b'\x1f'
+  buf[1] = b'\x8b'
+  buf[2] = b'\x08'
+  buf[3] = b'\x00'
+  buf.unsafe_write_uint32_le(4, self.mtime)
+  buf[8] = self.extra_flags
+  buf[9] = self.operating_system
+  buf.unsafe_reinterpret_as_bytes()
+}
+
+///|
+fn Header::from_bytes(buf : BytesView) -> Header raise {
+  guard buf
+    is [
+      '\x1f',
+      '\x8b',
+      compression_method,
+      flags,
+      u32le(mtime),
+      extra_flags,
+      operating_system,
+    ] else {
+    raise InvalidHeader("invalid gzip magic")
+  }
+  guard compression_method is '\x08' else {
+    raise InvalidHeader("unsupported compression method")
+  }
+  guard flags is '\x00' else {
+    raise InvalidHeader("gzip optional header fields are not supported")
+  }
+  { mtime, extra_flags, operating_system }
+}
+
+///|
+priv struct Trailer {
+  crc32 : UInt
+  input_size : UInt
+}
+
+///|
+fn Trailer::new(crc32 : UInt, input_size : UInt) -> Trailer {
+  { crc32, input_size }
+}
+
+///|
+fn Trailer::to_bytes(self : Trailer) -> Bytes {
+  let buf = FixedArray::make(8, b'\x00')
+  buf.unsafe_write_uint32_le(0, self.crc32)
+  buf.unsafe_write_uint32_le(4, self.input_size)
+  buf.unsafe_reinterpret_as_bytes()
+}
+
+///|
+priv struct TrailerState {
+  mut crc32 : UInt
+  mut input_size : UInt
+}
+
+///|
+fn TrailerState::new(
+  crc32? : UInt = 0xffffffffU,
+  input_size? : UInt = 0U,
+) -> TrailerState {
+  { crc32, input_size }
+}
+
+///|
+fn TrailerState::update(self : TrailerState, chunk : BytesView) -> Unit {
+  self.crc32 = crc32_update(self.crc32, chunk)
+  self.input_size += chunk.length().reinterpret_as_uint()
+}
+
+///|
+fn TrailerState::snapshot(self : TrailerState) -> Trailer {
+  { crc32: self.crc32 ^ 0xffffffffU, input_size: self.input_size }
+}

--- a/src/internal/gzip_internal/moon.pkg
+++ b/src/internal/gzip_internal/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "moonbitlang/core/cmp",
+}
+
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+} for "test"

--- a/src/internal/gzip_internal/pkg.generated.mbti
+++ b/src/internal/gzip_internal/pkg.generated.mbti
@@ -1,0 +1,34 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/async/internal/gzip_internal"
+
+// Values
+pub const HEADER_SIZE : Int = 10
+
+// Errors
+
+// Types and methods
+pub struct Decoder {
+  // private fields
+
+  fn new() -> Decoder
+}
+pub fn Decoder::is_finished(Self) -> Bool
+pub fn Decoder::minimum_input_size(Self) -> Int
+pub fn Decoder::new() -> Self
+pub fn Decoder::write(Self, Bytes, FixedArray[Byte], input_offset? : Int, input_len? : Int, output_offset? : Int, output_len? : Int) -> (Int, Int) raise
+pub fn Decoder::write_partial_data(Self, Bytes, input_offset? : Int, input_len? : Int) -> Unit
+
+pub struct Encoder {
+  // private fields
+
+  fn new(mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Encoder
+}
+pub fn Encoder::end(Self, FixedArray[Byte], output_offset? : Int, output_len? : Int) -> Int
+pub fn Encoder::minimum_output_space(Self, end~ : Bool) -> Int
+pub fn Encoder::new(mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Self
+pub fn Encoder::write(Self, Bytes, FixedArray[Byte], input_offset? : Int, input_len? : Int, output_offset? : Int, output_len? : Int) -> (Int, Int)
+
+// Type aliases
+
+// Traits
+

--- a/src/internal/gzip_internal/spec_test.mbt
+++ b/src/internal/gzip_internal/spec_test.mbt
@@ -1,0 +1,102 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Public gzip/deflate vectors in this file come from zlib's `test/infcover.c`
+/// in the `madler/zlib` repository.
+
+///|
+fn add_metadata(deflate : Bytes, crc32 : UInt, input_size : UInt) -> Bytes {
+  let trailer = FixedArray::make(8, b'\x00')
+  trailer.unsafe_write_uint32_le(0, crc32)
+  trailer.unsafe_write_uint32_le(4, input_size)
+  b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff" +
+  deflate +
+  trailer.unsafe_reinterpret_as_bytes()
+}
+
+///|
+test "zlib infcover stored block" {
+  let compressed = add_metadata(b"\x01\x01\x00\xfe\xff\x00", 3523407757U, 1U)
+  let decoded = decode(compressed, expected_len=1)
+  let decoded_min = decode(compressed, expected_len=1, input_step=Min)
+  assert_eq(decoded, b"\x00")
+  assert_eq(decoded_min, b"\x00")
+  assert_eq(decode(encode(decoded), expected_len=1), decoded)
+}
+
+///|
+test "zlib infcover fixed huffman block" {
+  let compressed = add_metadata(b"\x03\x00", 0U, 0U)
+  let decoded = decode(compressed, expected_len=0)
+  let decoded_min = decode(compressed, expected_len=0, input_step=Min)
+  assert_eq(decoded, b"")
+  assert_eq(decoded_min, b"")
+  assert_eq(decode(encode(decoded), expected_len=0), decoded)
+}
+
+///|
+test "zlib infcover invalid stored block lengths" {
+  let compressed = add_metadata(b"\x00\x00\x00\x00\x00", 0U, 0U)
+  let result = try? decode(compressed, expected_len=0)
+  let result_min = try? decode(compressed, expected_len=0, input_step=Min)
+  assert_true(result is Err(_))
+  assert_true(result_min is Err(_))
+}
+
+///|
+test "zlib infcover invalid block type" {
+  let compressed = add_metadata(b"\x06", 0U, 0U)
+  let result = try? decode(compressed, expected_len=0)
+  let result_min = try? decode(compressed, expected_len=0, input_step=Min)
+  assert_true(result is Err(_))
+  assert_true(result_min is Err(_))
+}
+
+///|
+test "zlib infcover gzip optional header fields rejected" {
+  let compressed = b"\x1f\x8b\x08\x02\x00\x00\x00\x00\x00\x00\x1d\x26\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+  let result = try? decode(compressed, expected_len=0)
+  let result_min = try? decode(compressed, expected_len=0, input_step=Min)
+  assert_true(result is Err(_))
+  assert_true(result_min is Err(_))
+}
+
+///|
+test "zlib infcover dynamic huffman length extra" {
+  let compressed = add_metadata(
+    b"\xed\xc0\x01\x01\x00\x00\x00\x40\x20\xff\x57\x1b\x42\x2c\x4f", 2893183767U,
+    516U,
+  )
+  let decoded = decode(compressed, expected_len=516)
+  let decoded_min = decode(compressed, expected_len=516, input_step=Min)
+  inspect(decoded.length(), content="516")
+  assert_eq(decoded_min.length(), 516)
+  assert_eq(decoded_min, decoded)
+  assert_eq(decode(encode(decoded), expected_len=516), decoded)
+}
+
+///|
+test "zlib infcover dynamic huffman window end" {
+  let compressed = add_metadata(
+    b"\xed\xc0\x81\x00\x00\x00\x00\x80\xa0\xfd\xa9\x17\xa9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06",
+    4130011695U, 33025U,
+  )
+  let decoded = decode(compressed, expected_len=33025)
+  let decoded_min = decode(compressed, expected_len=33025, input_step=Min)
+  inspect(decoded.length(), content="33025")
+  assert_eq(decoded_min.length(), 33025)
+  assert_eq(decoded_min, decoded)
+  assert_eq(decode(encode(decoded), expected_len=33025), decoded)
+}


### PR DESCRIPTION
This PR introduces `gzip` compression/decompression support for `moonbitlang/async`:

- an internal package `moonbitlang/async/internal/gzip_internal` provides state-machine style, IO-independent gzip encoding/decoding support
- a public package `moonbitlang/async/gzip` provides streaming gzip encoding/decoding support in the form of `@io.Reader`/`@io.Writer` transformer
- `@http.Client` can now automatically utilize HTTP gzip compression. It works as follows:
    - if the user explicitly supplied `Accept-Encoding`, automatic decompression will be skipped, the user get raw, encoded traffic when reading the response, and must manually decode the traffic
    - if the user did not supply `Accept-Encoding`, `@http.Client` will set `Accept-Encoding: gzip,identity` as a default. In this case, if the `Content-Encoding` is `gzip` from the server response, the client will perform automatic decompression, so the user still get uncompressed result, as intended
        - note that when automatic decompression happens, the `Content-Length` field will no longer be visible to the user (even if it is present) to avoid confusion, because it stores length of compressed content