### PR TITLE
support manually setting `Content-Length` in `@http`

### DIFF
--- a/examples/http_file_server/main.mbt
+++ b/examples/http_file_server/main.mbt
@@ -58,7 +58,10 @@ async fn serve_file(
     _ => "appliaction/octet-stream"
   }
   conn
-  ..send_response(200, "OK", extra_headers={ "Content-Type": content_type })
+  ..send_response(200, "OK", extra_headers={
+    "Content-Type": content_type,
+    "Content-Length": file.size().to_string(),
+  })
   ..write_reader(file)
   .end_response()
 }

--- a/examples/http_file_server/server_wbtest.mbt
+++ b/examples/http_file_server/server_wbtest.mbt
@@ -115,7 +115,7 @@ async test "basic" {
       #|client: GET /examples/moon.mod.json
       #|HTTP/1.1 200 OK
       #|content-type: appliaction/octet-stream
-      #|transfer-encoding: chunked
+      #|content-length: 362
       #|{
       #|  "name": "moonbitlang/async_examples",
       #|  "version": "0.3.0",

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -234,7 +234,13 @@ pub async fn Client::end_request(self : Client) -> Response {
 /// and must not be specified in `extra_headers`:
 ///
 /// - Host
-/// - Content-Length, Transfer-Encoding
+/// - Transfer-Encoding
+///
+/// If `Content-Length` is present in `extra_headers`,
+/// it should be the total length of the request body.
+/// The request body can still be sent incrementally,
+/// but if the actual body being sent is shorter and longer than the provided length,
+/// an error will be raised.
 pub async fn Client::request(
   self : Client,
   meth : RequestMethod,

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -28,6 +28,8 @@ pub suberror HttpProtocolError {
 } derive(ToJson, @debug.Debug)
 pub impl Show for HttpProtocolError
 
+pub suberror IncorrectBodyLength derive(ToJson, @debug.Debug)
+
 pub suberror ProxyError {
   ProxyError(Response)
 } derive(ToJson, @debug.Debug)

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -161,8 +161,8 @@ pub async fn put_stream(
   proxy? : Client,
 ) -> Client {
   let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
-  try client.request(Put, path) catch {
+  let client = Client::connect(host, protocol~, port~, proxy?)
+  try client.request(Put, path, extra_headers=headers) catch {
     err => {
       client.close()
       raise err
@@ -191,8 +191,8 @@ pub async fn post_stream(
   proxy? : Client,
 ) -> Client {
   let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
-  try client.request(Post, path) catch {
+  let client = Client::connect(host, protocol~, port~, proxy?)
+  try client.request(Post, path, extra_headers=headers) catch {
     err => {
       client.close()
       raise err

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -17,6 +17,7 @@ priv enum SenderMode {
   SendingHeader
   WaitingBody
   SendingBody
+  SendingFixed(mut remaining~ : Int64)
   PassThrough
 }
 
@@ -79,6 +80,9 @@ const NON_EMPTY_MESSAGE_HEADER_END : Bytes = "Transfer-Encoding: chunked\r\n\r\n
 const EMPTY_MESSAGE_HEADER_END : Bytes = "Content-Length: 0\r\n\r\n"
 
 ///|
+pub suberror IncorrectBodyLength derive(Debug, ToJson)
+
+///|
 impl @io.Writer for Sender with write_once(self, buf, offset~, len~) {
   match self.mode {
     SendingHeader => {
@@ -88,6 +92,17 @@ impl @io.Writer for Sender with write_once(self, buf, offset~, len~) {
       let len = @cmp.minimum(len, self.send_buf.length() - self.send_len)
       self.send_buf.blit_from_bytes(self.send_len, buf, offset, len)
       self.send_len += len
+      len
+    }
+    SendingFixed(remaining~) as mode => {
+      guard len.to_int64() <= remaining else { raise IncorrectBodyLength }
+      if self.send_len >= self.send_buf.length() {
+        self.flush()
+      }
+      let len = @cmp.minimum(self.send_buf.length() - self.send_len, len)
+      self.send_buf.blit_from_bytes(self.send_len, buf, offset, len)
+      self.send_len += len
+      mode.remaining -= len.to_int64()
       len
     }
     WaitingBody => {
@@ -144,6 +159,24 @@ impl @io.Writer for Sender with write_reader(self, reader) {
           break
         }
       }
+    SendingFixed(remaining~) as mode =>
+      for remaining = remaining {
+        if self.send_len >= self.send_buf.length() {
+          self.flush()
+        }
+        let n = reader.read(self.send_buf, offset=self.send_len)
+        if n == 0 {
+          mode.remaining = remaining
+          break
+        }
+        let remaining = remaining - n.to_int64()
+        if remaining < 0 {
+          raise IncorrectBodyLength
+        }
+        self.send_len += n
+        self.flush()
+        continue remaining
+      }
     WaitingBody => {
       if self.send_len + NON_EMPTY_MESSAGE_HEADER_END.length() >
         self.send_buf.length() {
@@ -188,6 +221,8 @@ async fn Sender::end_body(self : Sender) -> Unit {
   match self.mode {
     SendingHeader | PassThrough =>
       abort("`end_body()` called outside a HTTP message")
+    SendingFixed(remaining=0) => self.flush()
+    SendingFixed(_) => raise IncorrectBodyLength
     WaitingBody =>
       if self.send_len + EMPTY_MESSAGE_HEADER_END.length() >
         self.send_buf.length() {
@@ -220,12 +255,20 @@ async fn Sender::end_body(self : Sender) -> Unit {
 async fn Sender::send_headers(
   self : Sender,
   headers : Map[String, String],
-) -> Unit {
+) -> Int64? {
+  let mut content_length = None
   for pair in headers.to_array() {
     let (k, v) = pair
-    guard !forbidden_headers.contains(k.to_lower()) else {  }
+    let k_lower = k.to_lower()
+    if k_lower is "content-length" {
+      let len = @string.parse_int64(v.trim(), base=10)
+      content_length = Some(len)
+    } else if forbidden_headers.contains(k_lower) {
+      continue
+    }
     self..write(k)..write(": ")..write(v).write("\r\n")
   }
+  content_length
 }
 
 ///|
@@ -248,18 +291,23 @@ async fn Sender::send_request(
     Trace => self.write("TRACE ")
     Patch => self.write("PATCH ")
   }
-  self
-  ..write(path)
-  ..write(" HTTP/1.1\r\n")
-  ..write(self.headers)
-  .send_headers(extra_headers)
+  let content_length = self
+    ..write(path)
+    ..write(" HTTP/1.1\r\n")
+    ..write(self.headers)
+    .send_headers(extra_headers)
   let auto_decompress = !self.has_accept_encoding &&
     extra_headers.keys().find_first(k => k.to_lower() is "accept-encoding")
     is None
   if auto_decompress {
     self.write("Accept-Encoding: gzip,identity\r\n")
   }
-  self.mode = WaitingBody
+  if content_length is Some(len) {
+    self.write("\r\n")
+    self.mode = SendingFixed(remaining=len)
+  } else {
+    self.mode = WaitingBody
+  }
   auto_decompress
 }
 
@@ -271,15 +319,20 @@ async fn Sender::send_response(
   extra_headers~ : Map[String, String],
 ) -> Unit {
   guard self.mode is SendingHeader
-  self
-  ..write("HTTP/1.1 ")
-  ..write(encode_int(code, base=10))
-  ..write(" ")
-  ..write(reason)
-  ..write("\r\n")
-  ..write(self.headers)
-  .send_headers(extra_headers)
-  self.mode = WaitingBody
+  let content_length = self
+    ..write("HTTP/1.1 ")
+    ..write(encode_int(code, base=10))
+    ..write(" ")
+    ..write(reason)
+    ..write("\r\n")
+    ..write(self.headers)
+    .send_headers(extra_headers)
+  if content_length is Some(len) {
+    self.write("\r\n")
+    self.mode = SendingFixed(remaining=len)
+  } else {
+    self.mode = WaitingBody
+  }
 }
 
 ///|

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -348,14 +348,10 @@ async test "send invalid header" {
     let (r, w) = @io.pipe()
     root.spawn_bg(() => {
       defer w.close()
-      let sender = Sender::new(w, headers={
-        "Content-Length": "42",
-        "Content-Encoding": "chunked",
-      })
+      let sender = Sender::new(w, headers={ "Content-Encoding": "chunked" })
       let _ = sender.send_request(Get, "/", extra_headers={
         "Host": "x.y.org",
         "User-Agent": "MoonBit",
-        "Content-Length": "42",
         "Content-Encoding": "chunked",
       })
       sender.end_body()
@@ -371,6 +367,317 @@ async test "send invalid header" {
         #|Content-Length: 0\r
         #|\r
         #|
+      ),
+    )
+  })
+}
+
+///|
+async test "send fixed length" {
+  @async.with_task_group(group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg(() => {
+      defer w.close()
+      let sender = Sender::new(w)
+      let license_file = @fs.open("LICENSE", mode=ReadOnly)
+      defer license_file.close()
+      let header = "===== header =====\n"
+      let trailer = "===== trailer =====\n"
+      let total_size = license_file.size() +
+        header.length().to_int64() +
+        trailer.length().to_int64()
+      let _ = sender.send_request(Get, "/", extra_headers={
+        "Content-Length": total_size.to_string(),
+      })
+      sender
+      ..write(header)
+      ..write_reader(license_file)
+      ..write(trailer)
+      .end_body()
+    })
+    defer r.close()
+    inspect(
+      r.read_all().binary() |> @bytes_util.ascii_to_string,
+      content=(
+        #|GET / HTTP/1.1\r
+        #|Content-Length: 11397\r
+        #|Accept-Encoding: gzip,identity\r
+        #|\r
+        #|===== header =====
+        #|
+        #|                                 Apache License
+        #|                           Version 2.0, January 2004
+        #|                        http://www.apache.org/licenses/
+        #|
+        #|   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+        #|
+        #|   1. Definitions.
+        #|
+        #|      "License" shall mean the terms and conditions for use, reproduction,
+        #|      and distribution as defined by Sections 1 through 9 of this document.
+        #|
+        #|      "Licensor" shall mean the copyright owner or entity authorized by
+        #|      the copyright owner that is granting the License.
+        #|
+        #|      "Legal Entity" shall mean the union of the acting entity and all
+        #|      other entities that control, are controlled by, or are under common
+        #|      control with that entity. For the purposes of this definition,
+        #|      "control" means (i) the power, direct or indirect, to cause the
+        #|      direction or management of such entity, whether by contract or
+        #|      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+        #|      outstanding shares, or (iii) beneficial ownership of such entity.
+        #|
+        #|      "You" (or "Your") shall mean an individual or Legal Entity
+        #|      exercising permissions granted by this License.
+        #|
+        #|      "Source" form shall mean the preferred form for making modifications,
+        #|      including but not limited to software source code, documentation
+        #|      source, and configuration files.
+        #|
+        #|      "Object" form shall mean any form resulting from mechanical
+        #|      transformation or translation of a Source form, including but
+        #|      not limited to compiled object code, generated documentation,
+        #|      and conversions to other media types.
+        #|
+        #|      "Work" shall mean the work of authorship, whether in Source or
+        #|      Object form, made available under the License, as indicated by a
+        #|      copyright notice that is included in or attached to the work
+        #|      (an example is provided in the Appendix below).
+        #|
+        #|      "Derivative Works" shall mean any work, whether in Source or Object
+        #|      form, that is based on (or derived from) the Work and for which the
+        #|      editorial revisions, annotations, elaborations, or other modifications
+        #|      represent, as a whole, an original work of authorship. For the purposes
+        #|      of this License, Derivative Works shall not include works that remain
+        #|      separable from, or merely link (or bind by name) to the interfaces of,
+        #|      the Work and Derivative Works thereof.
+        #|
+        #|      "Contribution" shall mean any work of authorship, including
+        #|      the original version of the Work and any modifications or additions
+        #|      to that Work or Derivative Works thereof, that is intentionally
+        #|      submitted to Licensor for inclusion in the Work by the copyright owner
+        #|      or by an individual or Legal Entity authorized to submit on behalf of
+        #|      the copyright owner. For the purposes of this definition, "submitted"
+        #|      means any form of electronic, verbal, or written communication sent
+        #|      to the Licensor or its representatives, including but not limited to
+        #|      communication on electronic mailing lists, source code control systems,
+        #|      and issue tracking systems that are managed by, or on behalf of, the
+        #|      Licensor for the purpose of discussing and improving the Work, but
+        #|      excluding communication that is conspicuously marked or otherwise
+        #|      designated in writing by the copyright owner as "Not a Contribution."
+        #|
+        #|      "Contributor" shall mean Licensor and any individual or Legal Entity
+        #|      on behalf of whom a Contribution has been received by Licensor and
+        #|      subsequently incorporated within the Work.
+        #|
+        #|   2. Grant of Copyright License. Subject to the terms and conditions of
+        #|      this License, each Contributor hereby grants to You a perpetual,
+        #|      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        #|      copyright license to reproduce, prepare Derivative Works of,
+        #|      publicly display, publicly perform, sublicense, and distribute the
+        #|      Work and such Derivative Works in Source or Object form.
+        #|
+        #|   3. Grant of Patent License. Subject to the terms and conditions of
+        #|      this License, each Contributor hereby grants to You a perpetual,
+        #|      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        #|      (except as stated in this section) patent license to make, have made,
+        #|      use, offer to sell, sell, import, and otherwise transfer the Work,
+        #|      where such license applies only to those patent claims licensable
+        #|      by such Contributor that are necessarily infringed by their
+        #|      Contribution(s) alone or by combination of their Contribution(s)
+        #|      with the Work to which such Contribution(s) was submitted. If You
+        #|      institute patent litigation against any entity (including a
+        #|      cross-claim or counterclaim in a lawsuit) alleging that the Work
+        #|      or a Contribution incorporated within the Work constitutes direct
+        #|      or contributory patent infringement, then any patent licenses
+        #|      granted to You under this License for that Work shall terminate
+        #|      as of the date such litigation is filed.
+        #|
+        #|   4. Redistribution. You may reproduce and distribute copies of the
+        #|      Work or Derivative Works thereof in any medium, with or without
+        #|      modifications, and in Source or Object form, provided that You
+        #|      meet the following conditions:
+        #|
+        #|      (a) You must give any other recipients of the Work or
+        #|          Derivative Works a copy of this License; and
+        #|
+        #|      (b) You must cause any modified files to carry prominent notices
+        #|          stating that You changed the files; and
+        #|
+        #|      (c) You must retain, in the Source form of any Derivative Works
+        #|          that You distribute, all copyright, patent, trademark, and
+        #|          attribution notices from the Source form of the Work,
+        #|          excluding those notices that do not pertain to any part of
+        #|          the Derivative Works; and
+        #|
+        #|      (d) If the Work includes a "NOTICE" text file as part of its
+        #|          distribution, then any Derivative Works that You distribute must
+        #|          include a readable copy of the attribution notices contained
+        #|          within such NOTICE file, excluding those notices that do not
+        #|          pertain to any part of the Derivative Works, in at least one
+        #|          of the following places: within a NOTICE text file distributed
+        #|          as part of the Derivative Works; within the Source form or
+        #|          documentation, if provided along with the Derivative Works; or,
+        #|          within a display generated by the Derivative Works, if and
+        #|          wherever such third-party notices normally appear. The contents
+        #|          of the NOTICE file are for informational purposes only and
+        #|          do not modify the License. You may add Your own attribution
+        #|          notices within Derivative Works that You distribute, alongside
+        #|          or as an addendum to the NOTICE text from the Work, provided
+        #|          that such additional attribution notices cannot be construed
+        #|          as modifying the License.
+        #|
+        #|      You may add Your own copyright statement to Your modifications and
+        #|      may provide additional or different license terms and conditions
+        #|      for use, reproduction, or distribution of Your modifications, or
+        #|      for any such Derivative Works as a whole, provided Your use,
+        #|      reproduction, and distribution of the Work otherwise complies with
+        #|      the conditions stated in this License.
+        #|
+        #|   5. Submission of Contributions. Unless You explicitly state otherwise,
+        #|      any Contribution intentionally submitted for inclusion in the Work
+        #|      by You to the Licensor shall be under the terms and conditions of
+        #|      this License, without any additional terms or conditions.
+        #|      Notwithstanding the above, nothing herein shall supersede or modify
+        #|      the terms of any separate license agreement you may have executed
+        #|      with Licensor regarding such Contributions.
+        #|
+        #|   6. Trademarks. This License does not grant permission to use the trade
+        #|      names, trademarks, service marks, or product names of the Licensor,
+        #|      except as required for reasonable and customary use in describing the
+        #|      origin of the Work and reproducing the content of the NOTICE file.
+        #|
+        #|   7. Disclaimer of Warranty. Unless required by applicable law or
+        #|      agreed to in writing, Licensor provides the Work (and each
+        #|      Contributor provides its Contributions) on an "AS IS" BASIS,
+        #|      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        #|      implied, including, without limitation, any warranties or conditions
+        #|      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+        #|      PARTICULAR PURPOSE. You are solely responsible for determining the
+        #|      appropriateness of using or redistributing the Work and assume any
+        #|      risks associated with Your exercise of permissions under this License.
+        #|
+        #|   8. Limitation of Liability. In no event and under no legal theory,
+        #|      whether in tort (including negligence), contract, or otherwise,
+        #|      unless required by applicable law (such as deliberate and grossly
+        #|      negligent acts) or agreed to in writing, shall any Contributor be
+        #|      liable to You for damages, including any direct, indirect, special,
+        #|      incidental, or consequential damages of any character arising as a
+        #|      result of this License or out of the use or inability to use the
+        #|      Work (including but not limited to damages for loss of goodwill,
+        #|      work stoppage, computer failure or malfunction, or any and all
+        #|      other commercial damages or losses), even if such Contributor
+        #|      has been advised of the possibility of such damages.
+        #|
+        #|   9. Accepting Warranty or Additional Liability. While redistributing
+        #|      the Work or Derivative Works thereof, You may choose to offer,
+        #|      and charge a fee for, acceptance of support, warranty, indemnity,
+        #|      or other liability obligations and/or rights consistent with this
+        #|      License. However, in accepting such obligations, You may act only
+        #|      on Your own behalf and on Your sole responsibility, not on behalf
+        #|      of any other Contributor, and only if You agree to indemnify,
+        #|      defend, and hold each Contributor harmless for any liability
+        #|      incurred by, or claims asserted against, such Contributor by reason
+        #|      of your accepting any such warranty or additional liability.
+        #|
+        #|   END OF TERMS AND CONDITIONS
+        #|
+        #|   APPENDIX: How to apply the Apache License to your work.
+        #|
+        #|      To apply the Apache License to your work, attach the following
+        #|      boilerplate notice, with the fields enclosed by brackets "[]"
+        #|      replaced with your own identifying information. (Don't include
+        #|      the brackets!)  The text should be enclosed in the appropriate
+        #|      comment syntax for the file format. We also recommend that a
+        #|      file or class name and description of purpose be included on the
+        #|      same "printed page" as the copyright notice for easier
+        #|      identification within third-party archives.
+        #|
+        #|   Copyright [yyyy] [name of copyright owner]
+        #|
+        #|   Licensed under the Apache License, Version 2.0 (the "License");
+        #|   you may not use this file except in compliance with the License.
+        #|   You may obtain a copy of the License at
+        #|
+        #|       http://www.apache.org/licenses/LICENSE-2.0
+        #|
+        #|   Unless required by applicable law or agreed to in writing, software
+        #|   distributed under the License is distributed on an "AS IS" BASIS,
+        #|   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        #|   See the License for the specific language governing permissions and
+        #|   limitations under the License.
+        #|===== trailer =====
+        #|
+      ),
+    )
+  })
+}
+
+///|
+async test "sender write incorrect length" {
+  @async.with_task_group(group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg(no_wait=true, () => {
+      defer r.close()
+      while r.read_some() is Some(_) {
+
+      }
+    })
+    defer w.close()
+    let sender = Sender::new(w)
+    sender.send_response(200, "OK", extra_headers={ "Content-Length": "39" })
+    let data = Bytes::make(20, b'\x00')
+    sender.write(data)
+    debug_inspect(
+      try? sender.write(data),
+      content=(
+        #|Err(IncorrectBodyLength)
+      ),
+    )
+  })
+}
+
+///|
+async test "sender write_reader incorrect length" {
+  @async.with_task_group(group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg(no_wait=true, () => {
+      defer r.close()
+      while r.read_some() is Some(_) {
+
+      }
+    })
+    defer w.close()
+    let sender = Sender::new(w)
+    let license_file = @fs.open("LICENSE", mode=ReadOnly)
+    defer license_file.close()
+    sender.send_response(200, "OK", extra_headers={ "Content-Length": "2048" })
+    debug_inspect(
+      try? sender.write_reader(license_file),
+      content=(
+        #|Err(IncorrectBodyLength)
+      ),
+    )
+  })
+}
+
+///|
+async test "sender end_body incorrect length" {
+  @async.with_task_group(group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg(no_wait=true, () => {
+      defer r.close()
+      while r.read_some() is Some(_) {
+
+      }
+    })
+    defer w.close()
+    let sender = Sender::new(w)
+    sender.send_response(200, "OK", extra_headers={ "content-length": "1" })
+    debug_inspect(
+      try? sender.end_body(),
+      content=(
+        #|Err(IncorrectBodyLength)
       ),
     )
   })

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -136,6 +136,15 @@ pub async fn ServerConnection::end_response(self : ServerConnection) -> Unit {
 /// The `ServerConnection` can be used as a `@io.Writer` later for sending response body.
 /// After calling `send_response`,
 /// `end_response` must be called before sending the next response.
+///
+/// If `Content-Length` is present in `extra_headers`,
+/// it should be the total length of the request body.
+/// This useful for, for example, file servers to allow
+/// clients to know the progress of download, perform multipart download etc.
+///
+/// The request body can still be sent incrementally,
+/// but if the actual body being sent is shorter and longer than the provided length,
+/// an error will be raised.
 pub async fn ServerConnection::send_response(
   self : ServerConnection,
   code : Int,


### PR DESCRIPTION
Previously, `Content-Length` can never be set manually by the user in `moonbitlang/async/http`. Request/response body were either empty or chunk encoded. However, explicit `Content-Length` is useful on its own. For example, it allow clients to know the progress when downloading file, enables multipart download, etc.

This PR allows setting `Content-Length` in the `extra_headers` field of `Client::request` and `ServerConnection::send_response`. When the library detects that `Content-Length` is set, it enters fixed length body mode. Under this mode, the content of request/response body can still be sent incrementally and lazily, just like before. However, if the body is longer or shorter than the value of `Content-Length`, an error will be raised.