### PR TITLE
handle multiple `Set-Cookie` headers correctly

### DIFF
--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -173,7 +173,12 @@ pub async fn Client::end_request(self : Client) -> Response {
   for entry in js_response.headers().to_array() {
     headers[entry[0].to_lower()] = entry[1]
   }
-  { code: js_response.status(), reason: js_response.status_text(), headers }
+  {
+    code: js_response.status(),
+    reason: js_response.status_text(),
+    headers,
+    cookies: [],
+  }
 }
 
 ///|

--- a/src/http/cookie.mbt
+++ b/src/http/cookie.mbt
@@ -1,0 +1,131 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub fn Cookie::new(
+  name : String,
+  value : String,
+  path? : String,
+  expires_raw? : String,
+  max_age? : Int64,
+  domain? : String,
+  secure? : Bool = false,
+  http_only? : Bool = false,
+  extensions? : Array[String] = [],
+) -> Cookie {
+  {
+    name,
+    value,
+    path,
+    expires_raw,
+    max_age,
+    domain,
+    secure,
+    http_only,
+    extensions,
+  }
+}
+
+///|
+#cfg(target="native")
+fn Cookie::parse(line : StringView) -> Cookie raise {
+  guard line.find("=") is Some(name_end) else { raise BadRequest }
+  let name = line[:name_end].to_string()
+  guard line[name_end + 1:].find(";") is Some(value_end) else {
+    Cookie(name, line[name_end + 1:].to_string())
+  }
+  let value_end = name_end + 1 + value_end
+  let value = line[name_end + 1:value_end].to_string()
+
+  let mut path = None
+  let mut expires_raw = None
+  let mut max_age = None
+  let mut domain = None
+  let mut secure = false
+  let mut http_only = false
+  let extensions = []
+  for parsed = value_end + 1 {
+    let attr_end = if line[parsed:].find(";") is Some(attr_end) {
+      parsed + attr_end
+    } else {
+      line.length()
+    }
+
+    let attr = line[parsed:attr_end].trim()
+    if attr.find("=") is Some(attr_name_end) {
+      let name = attr[:attr_name_end]
+      let value = attr[attr_name_end + 1:]
+      match name.to_lower() {
+        "path" => path = Some(value.to_string())
+        "expires" => expires_raw = Some(value.to_string())
+        "max-age" => {
+          let value = @string.parse_int64(value) catch { _ => raise BadRequest }
+          max_age = Some(value)
+        }
+        "domain" => domain = Some(value.to_string())
+        _ => extensions.push(attr.to_string())
+      }
+    } else {
+      match attr.to_lower() {
+        "secure" => secure = true
+        "httponly" => http_only = true
+        _ => extensions.push(attr.to_string())
+      }
+    }
+
+    if attr_end == line.length() {
+      break
+    } else {
+      continue attr_end + 1
+    }
+  }
+  {
+    name,
+    value,
+    path,
+    expires_raw,
+    max_age,
+    domain,
+    secure,
+    http_only,
+    extensions,
+  }
+}
+
+///|
+#cfg(target="native")
+async fn[W : @io.Writer] Cookie::write_to(cookie : Cookie, w : W) -> Unit {
+  w..write(cookie.name)..write("=").write(cookie.value)
+  if cookie.path is Some(path) {
+    w..write("; Path=").write(path)
+  }
+  if cookie.expires_raw is Some(expires_raw) {
+    w..write("; Expires=").write(expires_raw)
+  }
+  if cookie.max_age is Some(max_age) {
+    w..write("; Max-Age=").write(max_age.to_string())
+  }
+  if cookie.domain is Some(domain) {
+    w..write("; Domain=").write(domain)
+  }
+  if cookie.secure {
+    w.write("; Secure")
+  }
+  if cookie.http_only {
+    w.write("; HttpOnly")
+  }
+  for ext in cookie.extensions {
+    w..write("; ").write(ext)
+  }
+}

--- a/src/http/cookie_wbtest.mbt
+++ b/src/http/cookie_wbtest.mbt
@@ -1,0 +1,85 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "parse cookie success" {
+  debug_inspect(
+    Cookie::parse("Cookie=value"),
+    content=(
+      #|{
+      #|  name: "Cookie",
+      #|  value: "value",
+      #|  path: None,
+      #|  expires_raw: None,
+      #|  max_age: None,
+      #|  domain: None,
+      #|  secure: false,
+      #|  http_only: false,
+      #|  extensions: [],
+      #|}
+    ),
+  )
+  debug_inspect(
+    try? Cookie::parse("Cookie="),
+    content=(
+      #|Ok(
+      #|  {
+      #|    name: "Cookie",
+      #|    value: "",
+      #|    path: None,
+      #|    expires_raw: None,
+      #|    max_age: None,
+      #|    domain: None,
+      #|    secure: false,
+      #|    http_only: false,
+      #|    extensions: [],
+      #|  },
+      #|)
+    ),
+  )
+  debug_inspect(
+    Cookie::parse(
+      "Cookie2=value2;path=/path/to/xxx; EXPIRES=Sun, 06 Nov 1994 08:49:37 GMT;Max-age=420000; domain=example.moonbitlang.com;SECURE; httponly; whatever=whatever",
+    ),
+    content=(
+      #|{
+      #|  name: "Cookie2",
+      #|  value: "value2",
+      #|  path: Some("/path/to/xxx"),
+      #|  expires_raw: Some("Sun, 06 Nov 1994 08:49:37 GMT"),
+      #|  max_age: Some(420000),
+      #|  domain: Some("example.moonbitlang.com"),
+      #|  secure: true,
+      #|  http_only: true,
+      #|  extensions: ["whatever=whatever"],
+      #|}
+    ),
+  )
+}
+
+///|
+test "parse cookie failure" {
+  debug_inspect(
+    try? Cookie::parse("Cookie"),
+    content=(
+      #|Err(BadRequest)
+    ),
+  )
+  debug_inspect(
+    try? Cookie::parse("Cookie=value;Max-Age=xxx"),
+    content=(
+      #|Err(BadRequest)
+    ),
+  )
+}

--- a/src/http/moon.pkg
+++ b/src/http/moon.pkg
@@ -30,6 +30,8 @@ options(
     "client.js.mbt": [ "js" ],
     "client.mbt": [ "native" ],
     "client_test.mbt": [ "native", "js" ],
+    "cookie.mbt": [ "native", "js" ],
+    "cookie_wbtest.mbt": [ "native" ],
     "deprecated.mbt": [ "native", "js" ],
     "parser.mbt": [ "native" ],
     "parser_wbtest.mbt": [ "native" ],
@@ -40,6 +42,7 @@ options(
     "send.mbt": [ "native" ],
     "send_wbtest.mbt": [ "native" ],
     "server.mbt": [ "native" ],
+    "types.mbt": [ "native", "js" ],
     "utils.mbt": [ "native" ],
   },
 )

--- a/src/http/parser.mbt
+++ b/src/http/parser.mbt
@@ -217,8 +217,11 @@ impl @io.Reader for Reader with _get_internal_buffer(self) {
 }
 
 ///|
-async fn Reader::read_headers(self : Reader) -> Map[String, String] {
+async fn Reader::read_headers(
+  self : Reader,
+) -> (Map[String, String], Array[Cookie]) {
   let headers = {}
+  let cookies = []
   for ;; {
     guard self.transport.read_until("\r\n") is Some(header_line) else {
       raise @io.ReaderClosed
@@ -261,6 +264,10 @@ async fn Reader::read_headers(self : Reader) -> Map[String, String] {
         headers.remove("content-length")
         continue
       }
+      "set-cookie" => {
+        cookies.push(Cookie::parse(value))
+        continue
+      }
       _ => ()
     }
     match headers.get(key) {
@@ -268,7 +275,7 @@ async fn Reader::read_headers(self : Reader) -> Map[String, String] {
       Some(value0) => headers[key] = "\{value0},\{value}"
     }
   }
-  headers
+  (headers, cookies)
 }
 
 ///|
@@ -307,7 +314,8 @@ async fn Reader::read_request(self : Reader) -> Request {
     "HTTP/1.1" | "HTTP/1.0" => ()
     protocol => raise HttpVersionNotSupported(protocol.to_string())
   }
-  let headers = self.read_headers()
+  let (headers, cookies) = self.read_headers()
+  guard cookies.length() is 0 else { raise BadRequest }
   { meth, path, headers }
 }
 
@@ -375,7 +383,7 @@ async fn Reader::read_response(
     _ => raise BadRequest
   }
   let reason = response_line[code_len + 1:].to_string()
-  let headers = self.read_headers()
+  let (headers, cookies) = self.read_headers()
 
   // HTTP/1.1 Spec (RFC 7230 Section 3.3.3): Message Body Length Determination
   // Other cases are handled in `read_headers` when parsing the headers, which will set the body kind accordingly.
@@ -383,7 +391,7 @@ async fn Reader::read_response(
     self.body = WaitConnectionClose // Read until connection close
   }
 
-  { code, reason, headers }
+  { code, reason, headers, cookies }
 }
 
 ///|

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -766,3 +766,81 @@ async test "gzip split between chunks" {
     )
   })
 }
+
+///|
+async test "read_response parse cookie" {
+  @async.with_task_group(group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg(() => {
+      defer w.close()
+      w
+      ..write("HTTP/1.1 200 OK\r\n")
+      ..write("Set-Cookie: Cookie1=value1\r\n")
+      ..write(
+        "Set-Cookie: Cookie2=value2; Path=/path/to/xxx; Max-Age=420000; Secure\r\n",
+      )
+      ..write(
+        "Set-Cookie: Cookie3=value3; Expires=Sun, 06 Nov 1994 08:49:37 GMT; Domain=example.moonbitlang.com; HttpOnly\r\n",
+      )
+      ..write("Set-Cookie: Cookie4=value four; ExtNoArg; ExtWithArg=xxx\r\n")
+      .write("Content-Length: 0\r\n\r\n")
+    })
+    defer r.close()
+    let input = Reader::new(r)
+    let response = input.read_response(
+      request_method=None,
+      auto_decompress=true,
+    )
+    debug_inspect(
+      response.cookies,
+      content=(
+        #|[
+        #|  {
+        #|    name: "Cookie1",
+        #|    value: "value1",
+        #|    path: None,
+        #|    expires_raw: None,
+        #|    max_age: None,
+        #|    domain: None,
+        #|    secure: false,
+        #|    http_only: false,
+        #|    extensions: [],
+        #|  },
+        #|  {
+        #|    name: "Cookie2",
+        #|    value: "value2",
+        #|    path: Some("/path/to/xxx"),
+        #|    expires_raw: None,
+        #|    max_age: Some(420000),
+        #|    domain: None,
+        #|    secure: true,
+        #|    http_only: false,
+        #|    extensions: [],
+        #|  },
+        #|  {
+        #|    name: "Cookie3",
+        #|    value: "value3",
+        #|    path: None,
+        #|    expires_raw: Some("Sun, 06 Nov 1994 08:49:37 GMT"),
+        #|    max_age: None,
+        #|    domain: Some("example.moonbitlang.com"),
+        #|    secure: false,
+        #|    http_only: true,
+        #|    extensions: [],
+        #|  },
+        #|  {
+        #|    name: "Cookie4",
+        #|    value: "value four",
+        #|    path: None,
+        #|    expires_raw: None,
+        #|    max_age: None,
+        #|    domain: None,
+        #|    secure: false,
+        #|    http_only: false,
+        #|    extensions: ["ExtNoArg", "ExtWithArg=xxx"],
+        #|  },
+        #|]
+      ),
+    )
+  })
+}

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -60,6 +60,21 @@ pub async fn Client::skip_response_body(Self) -> Unit
 pub impl @io.Reader for Client
 pub impl @io.Writer for Client
 
+pub struct Cookie {
+  name : String
+  value : String
+  path : String?
+  expires_raw : String?
+  max_age : Int64?
+  domain : String?
+  secure : Bool
+  http_only : Bool
+  extensions : Array[String]
+
+  fn new(String, String, path? : String, expires_raw? : String, max_age? : Int64, domain? : String, secure? : Bool, http_only? : Bool, extensions? : Array[String]) -> Cookie
+} derive(ToJson, @debug.Debug)
+pub fn Cookie::new(String, String, path? : String, expires_raw? : String, max_age? : Int64, domain? : String, secure? : Bool, http_only? : Bool, extensions? : Array[String]) -> Self
+
 pub(all) enum Protocol {
   Http
   Https
@@ -91,6 +106,7 @@ pub(all) struct Response {
   code : Int
   reason : String
   headers : Map[String, String]
+  cookies : Array[Cookie]
 } derive(ToJson, @debug.Debug)
 pub impl Show for Response
 
@@ -115,7 +131,7 @@ pub async fn ServerConnection::enter_passthrough_mode(Self) -> Unit
 pub async fn ServerConnection::flush(Self) -> Unit
 pub fn ServerConnection::new(@socket.Tcp, headers? : Map[String, String]) -> Self
 pub async fn ServerConnection::read_request(Self) -> Request
-pub async fn ServerConnection::send_response(Self, Int, String, extra_headers? : Map[String, String]) -> Unit
+pub async fn ServerConnection::send_response(Self, Int, String, extra_headers? : Map[String, String], cookies? : Array[Cookie]) -> Unit
 pub async fn ServerConnection::skip_request_body(Self) -> Unit
 pub impl @io.Reader for ServerConnection
 pub impl @io.Writer for ServerConnection

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -317,6 +317,7 @@ async fn Sender::send_response(
   code : Int,
   reason : String,
   extra_headers~ : Map[String, String],
+  cookies~ : Array[Cookie],
 ) -> Unit {
   guard self.mode is SendingHeader
   let content_length = self
@@ -327,6 +328,11 @@ async fn Sender::send_response(
     ..write("\r\n")
     ..write(self.headers)
     .send_headers(extra_headers)
+  for cookie in cookies {
+    self.write(b"Set-Cookie: ")
+    cookie.write_to(self)
+    self.write("\r\n")
+  }
   if content_length is Some(len) {
     self.write("\r\n")
     self.mode = SendingFixed(remaining=len)

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -625,7 +625,9 @@ async test "sender write incorrect length" {
     })
     defer w.close()
     let sender = Sender::new(w)
-    sender.send_response(200, "OK", extra_headers={ "Content-Length": "39" })
+    sender.send_response(200, "OK", cookies=[], extra_headers={
+      "Content-Length": "39",
+    })
     let data = Bytes::make(20, b'\x00')
     sender.write(data)
     debug_inspect(
@@ -651,7 +653,9 @@ async test "sender write_reader incorrect length" {
     let sender = Sender::new(w)
     let license_file = @fs.open("LICENSE", mode=ReadOnly)
     defer license_file.close()
-    sender.send_response(200, "OK", extra_headers={ "Content-Length": "2048" })
+    sender.send_response(200, "OK", cookies=[], extra_headers={
+      "Content-Length": "2048",
+    })
     debug_inspect(
       try? sender.write_reader(license_file),
       content=(
@@ -673,11 +677,58 @@ async test "sender end_body incorrect length" {
     })
     defer w.close()
     let sender = Sender::new(w)
-    sender.send_response(200, "OK", extra_headers={ "content-length": "1" })
+    sender.send_response(200, "OK", cookies=[], extra_headers={
+      "content-length": "1",
+    })
     debug_inspect(
       try? sender.end_body(),
       content=(
         #|Err(IncorrectBodyLength)
+      ),
+    )
+  })
+}
+
+///|
+async test "send_response cookies" {
+  let cookies = [
+    Cookie("Cookie1", "value1"),
+    Cookie(
+      "Cookie2",
+      "value2",
+      path="/path/to/xxx",
+      max_age=420000,
+      secure=true,
+    ),
+    Cookie(
+      "Cookie3",
+      "value3",
+      expires_raw="Sun, 06 Nov 1994 08:49:37 GMT",
+      domain="example.moonbitlang.com",
+      http_only=true,
+    ),
+    Cookie("Cookie4", "value four", extensions=["ExtNoArg", "ExtWithArg=xxx"]),
+  ]
+  @async.with_task_group(group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg(() => {
+      defer w.close()
+      let sender = Sender::new(w)
+      let _ = sender.send_response(200, "OK", cookies~, extra_headers={})
+      sender.end_body()
+    })
+    defer r.close()
+    inspect(
+      r.read_all().binary() |> @bytes_util.ascii_to_string,
+      content=(
+        #|HTTP/1.1 200 OK\r
+        #|Set-Cookie: Cookie1=value1\r
+        #|Set-Cookie: Cookie2=value2; Path=/path/to/xxx; Max-Age=420000; Secure\r
+        #|Set-Cookie: Cookie3=value3; Expires=Sun, 06 Nov 1994 08:49:37 GMT; Domain=example.moonbitlang.com; HttpOnly\r
+        #|Set-Cookie: Cookie4=value four; ExtNoArg; ExtWithArg=xxx\r
+        #|Content-Length: 0\r
+        #|\r
+        #|
       ),
     )
   })

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -137,6 +137,10 @@ pub async fn ServerConnection::end_response(self : ServerConnection) -> Unit {
 /// After calling `send_response`,
 /// `end_response` must be called before sending the next response.
 ///
+/// `cookies`, if present, specify a list of cookies that the server wish the client to set.
+/// They will be transferred to the client via the `Set-Cookie` HTTP header.
+/// Users should always set cookies via `cookies` instead of filling `Set-Cookie` header directly.
+///
 /// If `Content-Length` is present in `extra_headers`,
 /// it should be the total length of the request body.
 /// This useful for, for example, file servers to allow
@@ -150,8 +154,9 @@ pub async fn ServerConnection::send_response(
   code : Int,
   reason : String,
   extra_headers? : Map[String, String] = {},
+  cookies? : Array[Cookie] = [],
 ) -> Unit {
-  self.sender.send_response(code, reason, extra_headers~)
+  self.sender.send_response(code, reason, extra_headers~, cookies~)
 }
 
 ///|

--- a/src/http/types.mbt
+++ b/src/http/types.mbt
@@ -37,4 +37,34 @@ pub(all) struct Response {
   code : Int
   reason : String
   headers : Map[String, String]
+  /// The list of cookies specified in `Set-Cookie` headers.
+  ///
+  /// JS backend note: browsers forbid JS code from accessing raw cookie values,
+  /// so this field is always empty on JS backend.
+  cookies : Array[Cookie]
+} derive(Debug, ToJson)
+
+///|
+pub struct Cookie {
+  name : String
+  value : String
+  path : String?
+  expires_raw : String?
+  max_age : Int64?
+  domain : String?
+  secure : Bool
+  http_only : Bool
+  extensions : Array[String]
+
+  fn new(
+    name : String,
+    value : String,
+    path? : String,
+    expires_raw? : String,
+    max_age? : Int64,
+    domain? : String,
+    secure? : Bool,
+    http_only? : Bool,
+    extensions? : Array[String],
+  ) -> Cookie
 } derive(Debug, ToJson)


### PR DESCRIPTION
closes  #326

Currently, `moonbitlang/async/http` use `Map` to represent headers. While this is convenient and allows utilizing the map literal syntax, the current scheme cannot handle `Set-Cookie` correctly. According to RFC 7230, repeated header fields in a single message *should* be equivalent to concatenating individual values with `,`. However, in practice, `Set-Cookie` headers cannot be concatenated with comma, and often appear multiple times in a single server response.

This PR makes the handling of cookies separated from normal headers. The `@http.Response` type now has a new field `cookies`, which is an array of cookies. The server can use this field to pass cookies to the client, and client can read cookies sent by server from this field. Some basic parsing is performed on the `Set-Cookie` header line, allowing easy retrieval of cookie name/value/attributes. However, validation & parsing of cookie attributes, including most of the standard ones, is not performed.

On JS backend, since the browser explicitly block frontend JS code from accessing cookie values for security reasons, the `cookies` field is always empty.