### PR TITLE
[breaking] improve error message for WebSocket client handshake failure

### DIFF
--- a/src/websocket/client.mbt
+++ b/src/websocket/client.mbt
@@ -52,27 +52,29 @@ pub async fn Conn::from_http_client(
   try {
     let response = conn..request(Get, path, extra_headers~).end_request()
     guard response.code is 101 else {
-      raise InvalidHandshake(
+      raise HandshakeRejected(
         "Server did not respond with 101 Switching Protocols: \{response.code} \{response.reason}",
+        response,
       )
     }
 
     // Validate WebSocket handshake headers
     guard response.headers.get("upgrade") is Some(upgrade) &&
       upgrade.to_lower() == "websocket" else {
-      raise InvalidHandshake("Missing or invalid Upgrade header")
+      raise HandshakeRejected("Missing or invalid Upgrade header", response)
     }
     guard response.headers.get("connection") is Some(connection) &&
       connection.to_lower().contains("upgrade") else {
-      raise InvalidHandshake("Missing or invalid Connection header")
+      raise HandshakeRejected("Missing or invalid Connection header", response)
     }
     guard response.headers.get("sec-websocket-accept") is Some(accept_key) else {
-      raise InvalidHandshake("Missing Sec-WebSocket-Accept header")
+      raise HandshakeRejected("Missing Sec-WebSocket-Accept header", response)
     }
     let expected_accept_key = generate_accept_key(key)
     guard accept_key == expected_accept_key else {
-      raise InvalidHandshake(
+      raise HandshakeRejected(
         "Invalid Sec-WebSocket-Accept value: \{accept_key} != \{expected_accept_key}",
+        response,
       )
     }
     conn.enter_passthrough_mode()

--- a/src/websocket/deprecated.mbt
+++ b/src/websocket/deprecated.mbt
@@ -68,6 +68,15 @@ pub impl Show for WebSocketError with output(self, logger) {
       ..write_string("InvalidHandshake(")
       ..write_object(msg)
       .write_string(")")
+    HandshakeRejected(msg, response) =>
+      logger
+      ..write_string("HandshakeRejected(")
+      ..write_object(msg)
+      ..write_string(", ")
+      ..write_object(response.code)
+      ..write_string(", ")
+      ..write_object(response.reason)
+      .write_string(")")
     ProtocolError(msg) =>
       logger
       ..write_string("ProtocolError(")

--- a/src/websocket/pkg.generated.mbti
+++ b/src/websocket/pkg.generated.mbti
@@ -13,6 +13,7 @@ import {
 pub suberror WebSocketError {
   ConnectionClosed(CloseCode, String?)
   InvalidHandshake(String)
+  HandshakeRejected(String, @http.Response)
   ProtocolError(String)
 } derive(@debug.Debug)
 pub impl Show for WebSocketError

--- a/src/websocket/types.mbt
+++ b/src/websocket/types.mbt
@@ -117,5 +117,6 @@ fn CloseCode::from_uint(code : UInt) -> CloseCode {
 pub suberror WebSocketError {
   ConnectionClosed(CloseCode, String?) // Connection was closed
   InvalidHandshake(String) // Handshake failed with specific reason
+  HandshakeRejected(String, @http.Response) // Server rejected handshake
   ProtocolError(String)
 } derive(Debug)


### PR DESCRIPTION
Currently, when the server rejected a WebSocket client's handshake request, the response from server is discarded from the error message. This PR add a new `HandshakeRejected` error constructor to `@websocket.WebSocketError` and attach the whole server response header to handshake rejected error constructor.