### PR TITLE
do not send `Content-Length: 0` when there should be no message body

### DIFF
--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -30,6 +30,7 @@ priv struct Sender {
   mut send_len : Int
   headers : Bytes
   has_accept_encoding : Bool
+  mut should_have_empty_body : Bool
 }
 
 ///|
@@ -60,6 +61,7 @@ fn[W : @io.Writer] Sender::new(
     send_len: 0,
     headers: header_text.contents(),
     has_accept_encoding,
+    should_have_empty_body: false,
   }
 }
 
@@ -223,6 +225,10 @@ async fn Sender::end_body(self : Sender) -> Unit {
       abort("`end_body()` called outside a HTTP message")
     SendingFixed(remaining=0) => self.flush()
     SendingFixed(_) => raise IncorrectBodyLength
+    WaitingBody if self.should_have_empty_body => {
+      self.mode = SendingHeader
+      self..write(b"\r\n").flush()
+    }
     WaitingBody =>
       if self.send_len + EMPTY_MESSAGE_HEADER_END.length() >
         self.send_buf.length() {
@@ -248,6 +254,7 @@ async fn Sender::end_body(self : Sender) -> Unit {
         self.flush()
       }
   }
+  self.should_have_empty_body = false
   self.mode = SendingHeader
 }
 
@@ -280,6 +287,7 @@ async fn Sender::send_request(
   extra_headers~ : Map[String, String],
 ) -> Bool {
   guard self.mode is SendingHeader
+  self.should_have_empty_body = meth is (Get | Head | Delete | Trace)
   match meth {
     Get => self.write("GET ")
     Head => self.write("HEAD ")
@@ -318,8 +326,14 @@ async fn Sender::send_response(
   reason : String,
   extra_headers~ : Map[String, String],
   cookies~ : Array[Cookie],
+  request_method~ : RequestMethod,
 ) -> Unit {
   guard self.mode is SendingHeader
+  match request_method {
+    Head => self.should_have_empty_body = true
+    Connect => self.should_have_empty_body = code is (100..<300 | 304)
+    _ => self.should_have_empty_body = code is (100..<200 | 204 | 205 | 304)
+  }
   let content_length = self
     ..write("HTTP/1.1 ")
     ..write(encode_int(code, base=10))

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -33,7 +33,6 @@ async test "send_request basic" {
         #|Host: x.y.org\r
         #|User-Agent: MoonBit\r
         #|Accept-Encoding: gzip,identity\r
-        #|Content-Length: 0\r
         #|\r
         #|
       ),
@@ -364,7 +363,6 @@ async test "send invalid header" {
         #|Host: x.y.org\r
         #|User-Agent: MoonBit\r
         #|Accept-Encoding: gzip,identity\r
-        #|Content-Length: 0\r
         #|\r
         #|
       ),
@@ -625,7 +623,7 @@ async test "sender write incorrect length" {
     })
     defer w.close()
     let sender = Sender::new(w)
-    sender.send_response(200, "OK", cookies=[], extra_headers={
+    sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={
       "Content-Length": "39",
     })
     let data = Bytes::make(20, b'\x00')
@@ -653,7 +651,7 @@ async test "sender write_reader incorrect length" {
     let sender = Sender::new(w)
     let license_file = @fs.open("LICENSE", mode=ReadOnly)
     defer license_file.close()
-    sender.send_response(200, "OK", cookies=[], extra_headers={
+    sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={
       "Content-Length": "2048",
     })
     debug_inspect(
@@ -677,7 +675,7 @@ async test "sender end_body incorrect length" {
     })
     defer w.close()
     let sender = Sender::new(w)
-    sender.send_response(200, "OK", cookies=[], extra_headers={
+    sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={
       "content-length": "1",
     })
     debug_inspect(
@@ -714,7 +712,7 @@ async test "send_response cookies" {
     group.spawn_bg(() => {
       defer w.close()
       let sender = Sender::new(w)
-      let _ = sender.send_response(200, "OK", cookies~, extra_headers={})
+      let _ = sender.send_response(200, "OK", cookies~, request_method=Get, extra_headers={})
       sender.end_body()
     })
     defer r.close()
@@ -732,4 +730,77 @@ async test "send_response cookies" {
       ),
     )
   })
+}
+
+///|
+async test "send_request empty body" {
+  @async.with_task_group <| group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg(() => {
+      defer w.close()
+      let sender = Sender::new(w)
+      let _ = sender.send_request(Get, "/", extra_headers={})
+      sender..write("").end_body()
+      let _ = sender.send_request(Head, "/", extra_headers={})
+      sender.end_body()
+      let _ = sender.send_request(Post, "/", extra_headers={})
+      sender.end_body()
+    })
+    defer r.close()
+    inspect(
+      r.read_all().binary() |> @bytes_util.ascii_to_string,
+      content=(
+        #|GET / HTTP/1.1\r
+        #|Accept-Encoding: gzip,identity\r
+        #|\r
+        #|HEAD / HTTP/1.1\r
+        #|Accept-Encoding: gzip,identity\r
+        #|\r
+        #|POST / HTTP/1.1\r
+        #|Accept-Encoding: gzip,identity\r
+        #|Content-Length: 0\r
+        #|\r
+        #|
+      ),
+    )
+  }
+}
+
+///|
+async test "send_response empty body" {
+  @async.with_task_group <| group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg(() => {
+      defer w.close()
+      let sender = Sender::new(w)
+      let _ = sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={})
+      sender.end_body()
+      let _ = sender.send_response(200, "OK", cookies=[], request_method=Head, extra_headers={})
+      sender..write("").end_body()
+      let _ = sender.send_response(102, "OK", cookies=[], request_method=Get, extra_headers={})
+      sender.end_body()
+      let _ = sender.send_response(204, "OK", cookies=[], request_method=Get, extra_headers={})
+      sender..write("").end_body()
+      let _ = sender.send_response(304, "OK", cookies=[], request_method=Get, extra_headers={})
+      sender.end_body()
+    })
+    defer r.close()
+    inspect(
+      r.read_all().binary() |> @bytes_util.ascii_to_string,
+      content=(
+        #|HTTP/1.1 200 OK\r
+        #|Content-Length: 0\r
+        #|\r
+        #|HTTP/1.1 200 OK\r
+        #|\r
+        #|HTTP/1.1 102 OK\r
+        #|\r
+        #|HTTP/1.1 204 OK\r
+        #|\r
+        #|HTTP/1.1 304 OK\r
+        #|\r
+        #|
+      ),
+    )
+  }
 }

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -19,6 +19,7 @@ struct ServerConnection {
   conn : @socket.Tcp
   sender : Sender
   mut closed : Bool
+  mut request_method : RequestMethod
 }
 
 ///|
@@ -39,6 +40,7 @@ pub fn ServerConnection::new(
     conn,
     sender: Sender::new(conn, headers~),
     closed: false,
+    request_method: Get,
   }
 }
 
@@ -84,7 +86,9 @@ pub impl @io.Reader for ServerConnection with _get_internal_buffer(self) {
 /// as a `@io.Reader`.
 pub async fn ServerConnection::read_request(self : ServerConnection) -> Request {
   self.reader.skip_body()
-  self.reader.read_request()
+  let request = self.reader.read_request()
+  self.request_method = request.meth
+  request
 }
 
 ///|
@@ -156,7 +160,13 @@ pub async fn ServerConnection::send_response(
   extra_headers? : Map[String, String] = {},
   cookies? : Array[Cookie] = [],
 ) -> Unit {
-  self.sender.send_response(code, reason, extra_headers~, cookies~)
+  self.sender.send_response(
+    code,
+    reason,
+    extra_headers~,
+    cookies~,
+    request_method=self.request_method,
+  )
 }
 
 ///|


### PR DESCRIPTION
Some HTTP messages, such as `GET` request, are expected to have an empty body. In this case, sending a `Content-Length: 0` header is defined as a "SHOULD NOT" in the RFC. However, in practice, some servers treat this kind of request messages as invalid and reject them.

This PR fixes the problem by not sending any message body related headers when (1) there should be no message body according to the HTTP RFC (2) the user call `.end_request()`/`.end_response()` without actually sending anything.