### PR TITLE
make permission optional in fs API & refactor `@fs.open` create mode

### DIFF
--- a/examples/curl/main.mbt
+++ b/examples/curl/main.mbt
@@ -78,7 +78,7 @@ async fn main {
   match output {
     None => download(url, proxy~, output=@stdio.stdout)
     Some(output) => {
-      let file = @fs.open(output, mode=WriteOnly, create=0o644, truncate=true)
+      let file = @fs.open(output, mode=WriteOnly, create_mode=CreateOrTruncate)
       defer file.close()
       download(url, proxy~, output=file)
     }

--- a/src/fs/README.mbt.md
+++ b/src/fs/README.mbt.md
@@ -32,7 +32,7 @@ The `open` function provides flexible file opening with various modes and option
 #cfg(target="native")
 async test "open file for reading" {
   let test_file = "_build/test_open_read.txt"
-  @fs.write_file(test_file, b"Hello, MoonBit!", create=0o644)
+  @fs.write_file(test_file, b"Hello, MoonBit!", create_mode=CreateOrTruncate)
   let file = @fs.open(test_file, mode=ReadOnly)
   defer file.close()
   let content = file.read_all().text()
@@ -44,7 +44,7 @@ async test "open file for reading" {
 #cfg(target="native")
 async test "open file for writing" {
   let test_file = "_build/test_open_write.txt"
-  let file = @fs.open(test_file, mode=WriteOnly, create=0o644, truncate=true)
+  let file = @fs.open(test_file, mode=WriteOnly, create_mode=CreateOrTruncate)
   defer file.close()
   file.write(b"Hello, World!")
   @fs.remove(test_file)
@@ -55,7 +55,7 @@ async test "open file for writing" {
 async test "open with append mode" {
   let test_file = "_build/test_append.txt"
   // Create initial file
-  @fs.write_file(test_file, b"First line\n", create=0o644)
+  @fs.write_file(test_file, b"First line\n", create_mode=CreateOrTruncate)
 
   // Append to existing file
   let file = @fs.open(test_file, mode=WriteOnly, append=true)
@@ -74,7 +74,7 @@ The `create` function is a convenience wrapper for creating new files:
 #cfg(target="native")
 async test "create new file" {
   let test_file = "_build/test_create.txt"
-  let file = @fs.create(test_file, permission=0o644)
+  let file = @fs.create(test_file)
   file.write(b"New file content")
   file.close()
   let exists = @fs.exists(test_file)
@@ -92,7 +92,7 @@ Read entire files or read data in chunks:
 #cfg(target="native")
 async test "read_file - read entire file" {
   let test_file = "_build/test_read_file.txt"
-  @fs.write_file(test_file, b"Hello, MoonBit!", create=0o644)
+  @fs.write_file(test_file, b"Hello, MoonBit!", create_mode=CreateOrTruncate)
   let content = @fs.read_file(test_file)
   @fs.remove(test_file)
   inspect(content.text(), content="Hello, MoonBit!")
@@ -102,7 +102,7 @@ async test "read_file - read entire file" {
 #cfg(target="native")
 async test "read in chunks using File" {
   let test_file = "_build/test_chunk_read.txt"
-  @fs.write_file(test_file, b"0123456789", create=0o644)
+  @fs.write_file(test_file, b"0123456789", create_mode=CreateOrTruncate)
   let file = @fs.open(test_file, mode=ReadOnly)
   defer file.close()
   let buf = FixedArray::make(5, b'0')
@@ -116,7 +116,7 @@ async test "read in chunks using File" {
 #cfg(target="native")
 async test "read_all from file" {
   let test_file = "_build/test_read_all.txt"
-  @fs.write_file(test_file, b"Complete content", create=0o644)
+  @fs.write_file(test_file, b"Complete content", create_mode=CreateOrTruncate)
   let file = @fs.open(test_file, mode=ReadOnly)
   let data = file.read_all()
   file.close()
@@ -128,7 +128,7 @@ async test "read_all from file" {
 #cfg(target="native")
 async test "read_exactly specific bytes" {
   let test_file = "_build/test_read_exact.txt"
-  @fs.write_file(test_file, b"1234567890", create=0o644)
+  @fs.write_file(test_file, b"1234567890", create_mode=CreateOrTruncate)
   let file = @fs.open(test_file, mode=ReadOnly)
   let bytes = file.read_exactly(5)
   file.close()
@@ -146,7 +146,7 @@ Write data to files using various methods:
 #cfg(target="native")
 async test "write_file - write entire file" {
   let test_file = "_build/test_write.txt"
-  @fs.write_file(test_file, b"File content", create=0o644)
+  @fs.write_file(test_file, b"File content", create_mode=CreateOrTruncate)
   let content = @fs.read_file(test_file).text()
   @fs.remove(test_file)
   inspect(content, content="File content")
@@ -157,7 +157,12 @@ async test "write_file - write entire file" {
 async test "write with sync modes" {
   let test_file = "_build/test_sync.txt"
   // Write with data sync
-  @fs.write_file(test_file, b"Synced data", sync=Data, create=0o644)
+  @fs.write_file(
+    test_file,
+    b"Synced data",
+    sync=Data,
+    create_mode=CreateOrTruncate,
+  )
   let content = @fs.read_file(test_file).text()
   @fs.remove(test_file)
   inspect(content, content="Synced data")
@@ -167,7 +172,7 @@ async test "write with sync modes" {
 #cfg(target="native")
 async test "write using File methods" {
   let test_file = "_build/test_file_write.txt"
-  let file = @fs.create(test_file, permission=0o644)
+  let file = @fs.create(test_file)
   file.write(b"Line 1\n")
   file.write(b"Line 2\n")
   file.close()
@@ -180,7 +185,7 @@ async test "write using File methods" {
 #cfg(target="native")
 async test "write_once for single write operation" {
   let test_file = "_build/test_write_once.txt"
-  let file = @fs.create(test_file, permission=0o644)
+  let file = @fs.create(test_file)
   let data : Bytes = b"Single write"
   let written = file.write_once(data, offset=0, len=data.length())
   file.close()
@@ -198,7 +203,7 @@ Read and write file from specified position:
 #cfg(target="native")
 async test "read at specific position" {
   let test_file = "_build/read_at_test.txt"
-  @fs.write_file(test_file, b"0123456789", create=0o644)
+  @fs.write_file(test_file, b"0123456789", create_mode=CreateOrTruncate)
   {
     let file = @fs.open(test_file, mode=ReadOnly)
     defer file.close()
@@ -220,7 +225,7 @@ async test "read at specific position" {
 async test "write at specific position" {
   let test_file = "_build/write_at_test.txt"
   {
-    let file = @fs.open(test_file, mode=WriteOnly, create=0o644)
+    let file = @fs.open(test_file, mode=WriteOnly, create_mode=CreateOrTruncate)
     defer file.close()
     file.write("abcdef")
     file.write_at("CD", position=2)
@@ -235,7 +240,7 @@ async test "write at specific position" {
 #cfg(target="native")
 async test "size - get file size" {
   let test_file = "_build/test_size.txt"
-  @fs.write_file(test_file, b"Hello", create=0o644)
+  @fs.write_file(test_file, b"Hello", create_mode=CreateOrTruncate)
   let file = @fs.open(test_file, mode=ReadOnly)
   let size = file.size()
   file.close()
@@ -284,8 +289,8 @@ async test "mkdir - create with custom permissions" {
 async test "readdir - read directory entries" {
   let dir_path = "_build/test_readdir"
   @fs.mkdir(dir_path, permission=0o755)
-  @fs.write_file("\{dir_path}/test1.txt", b"", create=0o644)
-  @fs.write_file("\{dir_path}/test2.txt", b"", create=0o644)
+  @fs.write_file("\{dir_path}/test1.txt", b"", create_mode=CreateOrTruncate)
+  @fs.write_file("\{dir_path}/test2.txt", b"", create_mode=CreateOrTruncate)
   let entries = @fs.readdir(
     dir_path,
     include_hidden=false,
@@ -302,9 +307,9 @@ async test "readdir - read directory entries" {
 async test "readdir with sorting" {
   let dir_path = "_build/test_readdir_sort"
   @fs.mkdir(dir_path, permission=0o755)
-  @fs.write_file("\{dir_path}/c.txt", b"", create=0o644)
-  @fs.write_file("\{dir_path}/a.txt", b"", create=0o644)
-  @fs.write_file("\{dir_path}/b.txt", b"", create=0o644)
+  @fs.write_file("\{dir_path}/c.txt", b"", create_mode=CreateOrTruncate)
+  @fs.write_file("\{dir_path}/a.txt", b"", create_mode=CreateOrTruncate)
+  @fs.write_file("\{dir_path}/b.txt", b"", create_mode=CreateOrTruncate)
   let entries = @fs.readdir(dir_path, sort=true)
   @fs.remove("\{dir_path}/a.txt")
   @fs.remove("\{dir_path}/b.txt")
@@ -320,8 +325,8 @@ async test "readdir with sorting" {
 async test "opendir and Directory::read_all" {
   let dir_path = "_build/test_opendir"
   @fs.mkdir(dir_path, permission=0o755)
-  @fs.write_file("\{dir_path}/file1.txt", b"test", create=0o644)
-  @fs.write_file("\{dir_path}/file2.txt", b"test", create=0o644)
+  @fs.write_file("\{dir_path}/file1.txt", b"test", create_mode=CreateOrTruncate)
+  @fs.write_file("\{dir_path}/file2.txt", b"test", create_mode=CreateOrTruncate)
   let dir = @fs.opendir(dir_path)
   let entries = dir.read_all(include_hidden=false, include_special=false)
   dir.close()
@@ -343,11 +348,11 @@ Recursively traverse directory hierarchies:
 #cfg(target="native")
 async test "walk directory tree" {
   let base = "_build/test_walk"
-  @fs.mkdir(base, permission=0o755)
-  @fs.mkdir("\{base}/sub1", permission=0o755)
-  @fs.mkdir("\{base}/sub2", permission=0o755)
-  @fs.write_file("\{base}/file.txt", b"", create=0o644)
-  @fs.write_file("\{base}/sub1/file1.txt", b"", create=0o644)
+  @fs.mkdir(base)
+  @fs.mkdir("\{base}/sub1")
+  @fs.mkdir("\{base}/sub2")
+  @fs.write_file("\{base}/file.txt", b"", create_mode=CreateOrTruncate)
+  @fs.write_file("\{base}/sub1/file1.txt", b"", create_mode=CreateOrTruncate)
   let visited : Ref[Int] = Ref::new(0)
   @fs.walk(base, fn(_path, _files) { visited.val = visited.val + 1 })
   @fs.remove("\{base}/file.txt")
@@ -385,7 +390,7 @@ async test "walk with max_concurrency" {
 #cfg(target="native")
 async test "rmdir - remove empty directory" {
   let dir_path = "_build/test_rmdir"
-  @fs.mkdir(dir_path, permission=0o755)
+  @fs.mkdir(dir_path)
   @fs.rmdir(dir_path)
   let exists = @fs.exists(dir_path)
   inspect(exists, content="false")
@@ -395,10 +400,14 @@ async test "rmdir - remove empty directory" {
 #cfg(target="native")
 async test "rmdir recursive - remove directory tree" {
   let base = "_build/test_rmdir_recursive"
-  @fs.mkdir(base, permission=0o755)
-  @fs.mkdir("\{base}/subdir", permission=0o755)
-  @fs.write_file("\{base}/file.txt", b"test", create=0o644)
-  @fs.write_file("\{base}/subdir/nested.txt", b"test", create=0o644)
+  @fs.mkdir(base)
+  @fs.mkdir("\{base}/subdir")
+  @fs.write_file("\{base}/file.txt", b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(
+    "\{base}/subdir/nested.txt",
+    b"test",
+    create_mode=CreateOrTruncate,
+  )
   @fs.rmdir(base, recursive=true)
   let exists = @fs.exists(base)
   inspect(exists, content="false")
@@ -416,7 +425,7 @@ Determine the type of file system entries:
 #cfg(target="native")
 async test "kind - regular file" {
   let test_file = "_build/test_kind_file.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   let kind = @fs.kind(test_file)
   @fs.remove(test_file)
   debug_inspect(kind, content="Regular")
@@ -436,7 +445,7 @@ async test "kind - directory" {
 #cfg(target="native")
 async test "File::kind method" {
   let test_file = "_build/test_file_kind.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   let file = @fs.open(test_file, mode=ReadOnly)
   let kind = file.kind()
   file.close()
@@ -454,7 +463,7 @@ Access file timestamps (atime, mtime, ctime):
 #cfg(all(target="native", not(platform="windows")))
 async test "atime - access time" {
   let test_file = "_build/test_atime.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   let (seconds, nanoseconds) = @fs.atime(test_file)
   @fs.remove(test_file)
   inspect(seconds > 0, content="true")
@@ -465,7 +474,7 @@ async test "atime - access time" {
 #cfg(target="native")
 async test "mtime - modification time" {
   let test_file = "_build/test_mtime.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   let (seconds, nanoseconds) = @fs.mtime(test_file)
   @fs.remove(test_file)
   inspect(seconds > 0, content="true")
@@ -476,7 +485,7 @@ async test "mtime - modification time" {
 #cfg(target="native")
 async test "ctime - status change time" {
   let test_file = "_build/test_ctime.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   let (seconds, nanoseconds) = @fs.ctime(test_file)
   @fs.remove(test_file)
   inspect(seconds > 0, content="true")
@@ -487,7 +496,7 @@ async test "ctime - status change time" {
 #cfg(target="native")
 async test "File timestamp methods" {
   let test_file = "_build/test_file_times.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   let file = @fs.open(test_file, mode=ReadOnly)
   let (atime_s, _) = file.atime()
   let (mtime_s, _) = file.mtime()
@@ -509,7 +518,7 @@ Check file access permissions:
 #cfg(target="native")
 async test "exists - check file existence" {
   let test_file = "_build/test_exists.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   let exists = @fs.exists(test_file)
   @fs.remove(test_file)
   inspect(exists, content="true")
@@ -526,7 +535,7 @@ async test "exists - non-existent file" {
 #cfg(target="native")
 async test "can_read - check read permission" {
   let test_file = "_build/test_can_read.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   let can_read = @fs.can_read(test_file)
   @fs.remove(test_file)
   inspect(can_read, content="true")
@@ -536,7 +545,7 @@ async test "can_read - check read permission" {
 #cfg(target="native")
 async test "can_write - check write permission" {
   let test_file = "_build/test_can_write.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   let can_write = @fs.can_write(test_file)
   @fs.remove(test_file)
   inspect(can_write, content="true")
@@ -546,7 +555,7 @@ async test "can_write - check write permission" {
 #cfg(target="native")
 async test "can_execute - check execute permission" {
   let test_file = "_build/test_can_execute.txt"
-  @fs.write_file(test_file, b"test", create=0o755)
+  @fs.write_file(test_file, b"test", create_mode=CreateNew, permission=0o755)
   let can_execute = @fs.can_execute(test_file)
   @fs.remove(test_file)
   inspect(can_execute, content="true")
@@ -560,7 +569,7 @@ async test "can_execute - check execute permission" {
 #cfg(target="native")
 async test "realpath - resolve absolute path" {
   let test_dir = "_build/test_realpath"
-  @fs.mkdir(test_dir, permission=0o755)
+  @fs.mkdir(test_dir)
   let real_path = @fs.realpath(test_dir)
   @fs.rmdir(test_dir)
   guard @env.current_dir() is Some(cwd)
@@ -580,7 +589,7 @@ async test "realpath - resolve absolute path" {
 #cfg(target="native")
 async test "remove - delete file" {
   let test_file = "_build/test_remove.txt"
-  @fs.write_file(test_file, b"test", create=0o644)
+  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
   @fs.remove(test_file)
   let exists = @fs.exists(test_file)
   inspect(exists, content="false")

--- a/src/fs/access_test.mbt
+++ b/src/fs/access_test.mbt
@@ -49,7 +49,7 @@ async test "can_execute" {
 async test "chmod" {
   let path = "_build/chmod_test"
   @async.with_task_group(group => {
-    @fs.write_file(path, "abcd", create=0o444)
+    @fs.write_file(path, "abcd", create_mode=CreateNew, permission=0o444)
     group.add_defer(() => @fs.remove(path))
     inspect(@fs.can_read(path), content="true")
     inspect(@fs.can_write(path), content="false")

--- a/src/fs/create_test.mbt
+++ b/src/fs/create_test.mbt
@@ -16,7 +16,7 @@
 async test "basic create" {
   let path = "_build/basic_create_test"
   {
-    let w = @fs.create(path, permission=0o644, sync=Full)
+    let w = @fs.create(path, sync=Full)
     defer w.close()
     w.write(b"abcd\n")
   }
@@ -39,7 +39,13 @@ async test "basic create" {
 async test "create or append" {
   let path = "_build/create_append_test"
   async fn add_data(data) {
-    let w = @fs.open(path, mode=WriteOnly, create=0o644, sync=Full, append=true)
+    let w = @fs.open(
+      path,
+      mode=WriteOnly,
+      create_mode=OpenOrCreate,
+      sync=Full,
+      append=true,
+    )
     defer w.close()
     w.write(data)
   }
@@ -58,7 +64,7 @@ async test "create or append" {
 ///|
 async test "wrapper test" {
   let path = "_build/fs_wrapper_test"
-  @fs.write_file(path, b"abcd", create=0o644)
+  @fs.write_file(path, b"abcd", create_mode=CreateOrTruncate)
   let result = @fs.read_file(path).text()
   @fs.remove(path)
   inspect(result, content="abcd")

--- a/src/fs/create_test.mbt
+++ b/src/fs/create_test.mbt
@@ -69,3 +69,48 @@ async test "wrapper test" {
   @fs.remove(path)
   inspect(result, content="abcd")
 }
+
+///|
+async test "create_mode test" {
+  let path = "_build/create_exclusive_test"
+  @async.with_task_group(group => {
+    for create_mode in [@fs.OpenExisting, @fs.TruncateExisting] {
+      assert_true((try? @fs.open(path, mode=WriteOnly, create_mode~)) is Err(_))
+    }
+    {
+      let file = @fs.create(path, allow_existing=false)
+      defer file.close()
+      group.add_defer(() => @fs.remove(path))
+      file.write("abcd")
+    }
+    inspect(@fs.read_file(path).text(), content="abcd")
+    assert_true((try? @fs.create(path, allow_existing=false)) is Err(_))
+    assert_true(
+      (try? @fs.open(path, mode=WriteOnly, create_mode=CreateNew)) is Err(_),
+    )
+    {
+      let file = @fs.open(path, mode=WriteOnly, create_mode=OpenExisting)
+      defer file.close()
+      file.write("AB")
+    }
+    inspect(@fs.read_file(path).text(), content="ABcd")
+    {
+      let file = @fs.open(path, mode=WriteOnly, create_mode=OpenOrCreate)
+      defer file.close()
+      file.write("XY")
+    }
+    inspect(@fs.read_file(path).text(), content="XYcd")
+    {
+      let file = @fs.open(path, mode=WriteOnly, create_mode=CreateOrTruncate)
+      defer file.close()
+      file.write("12")
+    }
+    inspect(@fs.read_file(path).text(), content="12")
+    {
+      let file = @fs.open(path, mode=WriteOnly, create_mode=TruncateExisting)
+      defer file.close()
+      file.write("34")
+    }
+    inspect(@fs.read_file(path).text(), content="34")
+  })
+}

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -14,10 +14,16 @@
 
 ///|
 /// Create a directory at `path`.
-/// The permission of the created directory must be set in `permission`.
+///
+/// The Unix-style permission of the created directory can be set in `permission`,
+/// the default value is `0o755` (anyone can read and traverse, only owner can write).
+/// The `permission` parameter is currently ignored on Windows.
+///
+/// If `recursive=true` (`false` by default), non-existing parent directories
+/// of `path` will be recursively created, too.
 pub async fn mkdir(
   path : StringView,
-  permission~ : Int,
+  permission? : Int = 0o755,
   recursive? : Bool = false,
 ) -> Unit {
   let context = "@fs.mkdir()"

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -55,6 +55,30 @@ pub(all) enum SyncMode {
 }
 
 ///|
+/// Specify how to handle file creation in `@fs.open()`.
+///
+/// - `OpenExisting`: open an existing file, fail if the file does not exist
+/// - `TruncateExisting`: open an existing file and truncate it, fail if the file does not exist
+/// - `OpenOrCreate`: if the file exists, open it without truncation. Otherwise create a new file
+/// - `CreateOrTruncate`: if the file exists, open it and truncate it. Otherwise create a new file
+/// - `CreateNew`: create a new file, fail if the file already exists
+pub(all) enum CreateMode {
+  /// open an existing file, fail if the file does not exist
+  OpenExisting = 0
+  /// open an existing file and truncate it, fail if the file does not exist
+  TruncateExisting = 1
+  /// if the file exists, open it without truncation. Otherwise create a new file
+  OpenOrCreate = 2
+  /// if the file exists, open it and truncate it. Otherwise create a new file
+  CreateOrTruncate = 3
+  /// create a new file, fail if the file already exists
+  CreateNew = 4
+}
+
+///|
+fn CreateMode::to_int(self : CreateMode) -> Int = "%identity"
+
+///|
 /// Open a file. `filename` will be encoded using UTF8.
 ///
 /// - `mode` determines what operations (read/write) are permitted for the file.
@@ -64,21 +88,30 @@ pub(all) enum SyncMode {
 ///
 /// - if `append` is `true` (`false` by default), the file will be opened in append mode.
 ///
-/// - if `create` is present and the file is not present,
-///   the file will be created, with its user permission set to value of `create`.
-///   User permission is represented as an integer in UNIX permission style.
+/// - `create_mode` specify how to handle file creation, truncation, etc.
+///   See the type `CreateMode` for more details.
+///   The default value is `OpenExisting`.
+///
+/// - `permission` specifies the user permission of the new file,
+///   if a new file is created by `@fs.open`.
+///   The permission is represented as an integer in UNIX permission style.
 ///   For example, `0o640` means:
+///
 ///   - the owner of the file can read and write the file (`6`)
 ///   - users in the owner group of the file can read the file (`4`)
 ///   - other users can do nothing to the file
 ///
-/// - if `truncate` is `true` (`false` by default), and the file exists,
-///   it will be truncated to zero length after opening.
+///   The default value is `0o644` (anyone can read, only owner can write, not executable).
+///   `permission` is currently ignored on Windows.
+#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
+#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
 pub async fn open(
   filename : StringView,
   mode~ : Mode,
   sync? : SyncMode = NoSync,
   append? : Bool = false,
+  create_mode? : CreateMode,
+  permission? : Int,
   create? : Int,
   truncate? : Bool = false,
 ) -> File {
@@ -87,9 +120,20 @@ pub async fn open(
     WriteOnly => 1
     ReadWrite => 2
   }
-  let (create, user_mode) = match create {
-    None => (false, 0)
-    Some(mode) => (true, mode)
+  let create_mode = match create_mode {
+    Some(mode) => mode
+    None =>
+      match (create is Some(_), truncate) {
+        (true, true) => CreateOrTruncate
+        (true, false) => OpenOrCreate
+        (false, true) => TruncateExisting
+        (false, false) => OpenExisting
+      }
+  }
+  let permission = match permission {
+    Some(perm) => perm
+    None if create is Some(perm) => perm
+    None => 0o644
   }
   let sync = match sync {
     NoSync => 0
@@ -99,11 +143,10 @@ pub async fn open(
   let io = @event_loop.open(
     filename,
     access,
-    create~,
+    create=create_mode.to_int(),
     append~,
-    truncate~,
     sync~,
-    mode=user_mode,
+    mode=permission,
     context="@fs.open()",
   )
   { io, read_buf: @io.ReaderBuffer::new() }
@@ -112,20 +155,28 @@ pub async fn open(
 ///|
 /// Create a new file at `pathname`. `pathname` will be encoded using UTF8.
 ///
+/// - If the file already exists and `allow_existing` is `true` (`true` by default),
+///   the existing file will be truncated and opened.
+///   If the file already exists and `allow_existing` is `fale`, this function will fail.
+///
 /// - User permission of the new file would be set to `permission`,
 ///   which is an integer in UNIX style. For example, `0o640` means:
 ///     - the owner of the file can read and write the file (`6`)
 ///     - users in the owner group of the file can read the file (`4`)
 ///     - other users can do nothing to the file
+///   The default value is `0o644` (anyone can read, only owner can write, not executable).
+///   `permission` is currently ignored on Windows.
 ///
 /// - `sync` determines how data will be synchronized to disk after writing,
 ///   see `SyncMode` for more details. The default is `NoSync`
 pub async fn create(
   filename : StringView,
-  permission~ : Int,
+  allow_existing? : Bool = true,
+  permission? : Int = 0o644,
   sync? : SyncMode = NoSync,
 ) -> File {
-  open(filename, mode=WriteOnly, sync~, create=permission, truncate=true)
+  let create_mode = if allow_existing { CreateOrTruncate } else { CreateNew }
+  open(filename, mode=WriteOnly, sync~, create_mode~, permission~)
 }
 
 ///|
@@ -395,18 +446,44 @@ pub async fn read_file(
 
 ///|
 /// Write data to a file located at `path`.
-/// The meaning of `sync`, `append`, `create`, and `truncate`,
+/// The meaning of `sync`, `append`, `create_mode` and `permission`,
 /// is the same as `open`, except that `truncate` is `true` by default.
 /// See `open` for more details.
+#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
+#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
 pub async fn write_file(
   path : StringView,
   content : &@io.Data,
+  create_mode? : CreateMode,
+  permission? : Int,
   sync? : SyncMode = Data,
   append? : Bool = false,
   create? : Int,
   truncate? : Bool = true,
 ) -> Unit {
-  let file = open(path, mode=WriteOnly, sync~, append~, create?, truncate~)
+  let create_mode = match create_mode {
+    Some(mode) => mode
+    None =>
+      match (create is Some(_), truncate) {
+        (true, true) => CreateOrTruncate
+        (true, false) => OpenOrCreate
+        (false, true) => TruncateExisting
+        (false, false) => OpenExisting
+      }
+  }
+  let permission = match permission {
+    Some(perm) => perm
+    None if create is Some(perm) => perm
+    None => 0o644
+  }
+  let file = open(
+    path,
+    mode=WriteOnly,
+    sync~,
+    append~,
+    create_mode~,
+    permission~,
+  )
   defer file.close()
   file.write(content.binary())
 }

--- a/src/fs/lock_test.mbt
+++ b/src/fs/lock_test.mbt
@@ -55,7 +55,7 @@ async test "flock exclusive vs exclusive" {
   let log = []
   let file_name = "_build/flock_ex_ex"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log)
@@ -74,7 +74,7 @@ async test "flock exclusive vs exclusive blocking" {
   let log = []
   let file_name = "_build/flock_ex_ex_blocking"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
@@ -96,7 +96,7 @@ async test "flock shared vs exclusive" {
   let log = []
   let file_name = "_build/flock_sh_ex"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log)
@@ -115,7 +115,7 @@ async test "flock shared vs exclusive blocking" {
   let log = []
   let file_name = "_build/flock_sh_ex_blocking"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log, prefix="child: ")
@@ -137,7 +137,7 @@ async test "flock exclusive vs shared" {
   let log = []
   let file_name = "_build/flock_ex_sh"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log)
@@ -156,7 +156,7 @@ async test "flock exclusive vs shared blocking" {
   let log = []
   let file_name = "_build/flock_ex_sh_blocking"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
@@ -178,7 +178,7 @@ async test "flock shared vs shared" {
   let log = []
   let file_name = "_build/flock_sh_sh"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log)
@@ -195,7 +195,7 @@ async test "flock shared vs shared blocking" {
   let log = []
   let file_name = "_build/flock_sh_sh_blocking"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log, prefix="child: ")
@@ -216,7 +216,7 @@ async test "flock shared vs shared vs exclusive" {
   let log = []
   let file_name = "_build/flock_sh_sh_ex"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #1: ")
@@ -241,7 +241,7 @@ async test "flock shared vs shared vs exclusive blocking" {
   let log = []
   let file_name = "_build/flock_sh_sh_ex_blocking"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #1: ")
@@ -265,7 +265,7 @@ async test "flock cancelled" {
   let log = []
   let file_name = "_build/flock_cancel"
   @async.with_task_group(group => {
-    let file = @fs.open(file_name, create=0o644, mode=ReadWrite)
+    let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
@@ -288,7 +288,7 @@ async test "flock advisory" {
   let log = []
   let file_name = "_build/flock_advisory"
   @async.with_task_group(group => {
-    @fs.write_file(file_name, create=0o644, "abcd")
+    @fs.write_file(file_name, create_mode=CreateOrTruncate, "abcd")
     let file = @fs.open(file_name, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))

--- a/src/fs/mkdir_test.mbt
+++ b/src/fs/mkdir_test.mbt
@@ -15,8 +15,8 @@
 ///|
 async test "mkdir" {
   let path = "_build/mkdir_test"
-  @fs.mkdir(path, permission=0o755)
-  @fs.write_file("\{path}/file", "", create=0o644)
+  @fs.mkdir(path)
+  @fs.write_file("\{path}/file", "", create_mode=CreateOrTruncate)
   let result = @fs.readdir(path, sort=true)
   @fs.remove("\{path}/file")
   @fs.rmdir(path)
@@ -28,9 +28,9 @@ async test "mkdir" {
 async test "rmdir recursive" {
   let path = "_build/rmdir_test"
   @fs.mkdir(path, permission=0o755)
-  @fs.write_file("\{path}/file", "", create=0o644)
-  @fs.mkdir("\{path}/inner", permission=0o755)
-  @fs.write_file("\{path}/inner/file", "", create=0o644)
+  @fs.write_file("\{path}/file", "", create_mode=CreateOrTruncate)
+  @fs.mkdir("\{path}/inner")
+  @fs.write_file("\{path}/inner/file", "", create_mode=CreateOrTruncate)
   @fs.symlink("\{path}/symlink", target="../../target")
   let result = try? @fs.rmdir(path)
   @fs.rmdir(path, recursive=true)
@@ -42,7 +42,7 @@ async test "mkdir recursive" {
   @async.with_task_group(group => {
     let base_path = "_build/recursive_mkdir"
     let path = "\{base_path}/test//directory"
-    @fs.mkdir(path, permission=0o755, recursive=true)
+    @fs.mkdir(path, recursive=true)
     group.add_defer(() => @fs.rmdir(base_path, recursive=true))
     json_inspect(@fs.readdir(base_path), content=["test"])
     json_inspect(@fs.readdir("\{base_path}/test"), content=["directory"])
@@ -56,7 +56,7 @@ async test "mkdir recursive windows" {
   @async.with_task_group(group => {
     let base_path = "target\\recursive_mkdir_windows"
     let path = "\{base_path}\\test\\\\directory"
-    @fs.mkdir(path, permission=0o755, recursive=true)
+    @fs.mkdir(path, recursive=true)
     group.add_defer(() => @fs.rmdir(base_path, recursive=true))
     json_inspect(@fs.readdir(base_path), content=["test"])
     json_inspect(@fs.readdir("\{base_path}\\test"), content=["directory"])

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -17,7 +17,7 @@ pub async fn can_write(StringView) -> Bool
 
 pub async fn chmod(StringView, Int) -> Unit
 
-pub async fn create(StringView, permission~ : Int, sync? : SyncMode) -> File
+pub async fn create(StringView, allow_existing? : Bool, permission? : Int, sync? : SyncMode) -> File
 
 pub async fn ctime(StringView, follow_symlink? : Bool) -> (Int64, Int)
 
@@ -25,11 +25,13 @@ pub async fn exists(StringView) -> Bool
 
 pub async fn kind(StringView, follow_symlink? : Bool) -> FileKind
 
-pub async fn mkdir(StringView, permission~ : Int, recursive? : Bool) -> Unit
+pub async fn mkdir(StringView, permission? : Int, recursive? : Bool) -> Unit
 
 pub async fn mtime(StringView, follow_symlink? : Bool) -> (Int64, Int)
 
-pub async fn open(StringView, mode~ : Mode, sync? : SyncMode, append? : Bool, create? : Int, truncate? : Bool) -> File
+#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
+#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
+pub async fn open(StringView, mode~ : Mode, sync? : SyncMode, append? : Bool, create_mode? : CreateMode, permission? : Int, create? : Int, truncate? : Bool) -> File
 
 pub async fn opendir(StringView) -> Directory
 
@@ -49,11 +51,21 @@ pub async fn tmpdir(prefix~ : StringView) -> String
 
 pub async fn walk(StringView, async (String, Array[String]) -> Unit, exclude? : (String) -> Bool, max_concurrency? : Int, allow_failure? : Bool) -> Unit
 
-pub async fn write_file(StringView, &@io.Data, sync? : SyncMode, append? : Bool, create? : Int, truncate? : Bool) -> Unit
+#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
+#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
+pub async fn write_file(StringView, &@io.Data, create_mode? : CreateMode, permission? : Int, sync? : SyncMode, append? : Bool, create? : Int, truncate? : Bool) -> Unit
 
 // Errors
 
 // Types and methods
+pub(all) enum CreateMode {
+  OpenExisting
+  TruncateExisting
+  OpenOrCreate
+  CreateOrTruncate
+  CreateNew
+}
+
 type Directory
 pub fn Directory::close(Self) -> Unit
 pub async fn Directory::read_all(Self, include_hidden? : Bool, include_special? : Bool) -> Array[String]

--- a/src/fs/random_access_test.mbt
+++ b/src/fs/random_access_test.mbt
@@ -16,7 +16,7 @@
 async test "write_at" {
   let path = "_build/write_at_test"
   // initialize
-  @fs.write_file(path, "abcdef", create=0o644, sync=Full)
+  @fs.write_file(path, "abcdef", create_mode=CreateOrTruncate, sync=Full)
   // first read
   inspect(@fs.read_file(path).text(), content="abcdef")
   // update content
@@ -39,7 +39,7 @@ async test "write_at" {
 ///|
 async test "read_at" {
   let path = "_build/read_at_test"
-  @fs.write_file(path, "abcdef", create=0o644, sync=Full)
+  @fs.write_file(path, "abcdef", create_mode=CreateOrTruncate, sync=Full)
   {
     let r = @fs.open(path, mode=ReadOnly)
     defer r.close()

--- a/src/fs/text_file_test.mbt
+++ b/src/fs/text_file_test.mbt
@@ -17,7 +17,7 @@ async test "text file" {
   @async.with_task_group(root => {
     let path = "_build/basic_text_file_test"
     root.add_defer(() => @fs.remove(path))
-    @fs.write_file(path, "abcd", create=0o644)
+    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate)
     inspect(@fs.read_file(path).text(), content="abcd")
   })
 }

--- a/src/fs/timestamp_test.mbt
+++ b/src/fs/timestamp_test.mbt
@@ -24,7 +24,7 @@ fn diff_timestamp(t1 : (Int64, Int), t2 : (Int64, Int)) -> Int64 {
 async test "timestamp for path" {
   let path = "/tmp/timestamp_test"
   @async.with_task_group(group => {
-    @fs.write_file(path, "abcd", create=0o644, sync=Full)
+    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
     group.add_defer(() => @fs.remove(path))
     let mtime_1 = @fs.mtime(path)
     let ctime_1 = @fs.ctime(path)
@@ -58,7 +58,7 @@ async test "timestamp for path" {
 async test "mtime for path" {
   let path = "_build/timestamp_test"
   @async.with_task_group(group => {
-    @fs.write_file(path, "abcd", create=0o644, sync=Full)
+    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
     group.add_defer(() => @fs.remove(path))
     let mtime_1 = @fs.mtime(path)
     let ctime_1 = @fs.ctime(path)
@@ -76,7 +76,7 @@ async test "mtime for path" {
 async test "timestamp for opened file" {
   let path = "/tmp/opened_file_timestamp_test"
   @async.with_task_group(group => {
-    @fs.write_file(path, "abcd", create=0o644, sync=Full)
+    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
     group.add_defer(() => @fs.remove(path))
     let file = @fs.open(path, mode=ReadWrite, sync=Full)
     defer file.close()
@@ -113,7 +113,7 @@ async test "timestamp for opened file" {
 async test "mtime for opened file" {
   let path = "_build/opened_file_timestamp_test"
   @async.with_task_group(group => {
-    @fs.write_file(path, "abcd", create=0o644, sync=Full)
+    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
     group.add_defer(() => @fs.remove(path))
     let file = @fs.open(path, mode=ReadWrite, sync=Full)
     defer file.close()

--- a/src/fs/tmpdir_test.mbt
+++ b/src/fs/tmpdir_test.mbt
@@ -26,7 +26,12 @@ async test "tmpdir" {
     assert_not_eq(t1, t2)
     assert_true(@fs.exists(t1))
     assert_true(@fs.exists(t2))
-    @fs.write_file("\{t1}/file.txt", "abcd", create=0o600)
+    @fs.write_file(
+      "\{t1}/file.txt",
+      "abcd",
+      create_mode=CreateNew,
+      permission=0o600,
+    )
     json_inspect(@fs.readdir(t1), content=["file.txt"])
   })
 }

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -21,9 +21,9 @@ pub async fn open_detached(
   path : StringView,
   // 0 => read only, 1 => write only, 2 => read write
   access : Int,
-  create~ : Bool,
+  // See `@fs.CreateMode` for more details
+  create~ : Int,
   append~ : Bool,
-  truncate~ : Bool,
   // 0 => no sync, 1 => data sync, 2 => full sync
   sync~ : Int,
   // permission for file when new file is created
@@ -31,15 +31,7 @@ pub async fn open_detached(
   context~ : String,
 ) -> (@fd_util.Fd, @fd_util.FileKind) {
   let path_bytes = @os_string.encode(path)
-  let job = Job::open(
-    path_bytes,
-    access,
-    create~,
-    append~,
-    truncate~,
-    sync~,
-    mode~,
-  )
+  let job = Job::open(path_bytes, access, create~, append~, sync~, mode~)
   fn cancel(job_id) raise {
     guard curr_loop.val is Some(evloop)
     evloop.cancel_job_in_worker(job_id, context~)
@@ -59,9 +51,9 @@ pub async fn open(
   path : StringView,
   // 0 => read only, 1 => write only, 2 => read write
   access : Int,
-  create~ : Bool,
+  // See `@fs.CreateMode` for more details
+  create~ : Int,
   append~ : Bool,
-  truncate~ : Bool,
   // 0 => no sync, 1 => data sync, 2 => full sync
   sync~ : Int,
   // permission for file when new file is created
@@ -73,7 +65,6 @@ pub async fn open(
     access,
     create~,
     append~,
-    truncate~,
     sync~,
     mode~,
     context~,

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -28,9 +28,9 @@ pub async fn kind_of_fd(Int, context~ : String) -> @fd_util.FileKind
 
 pub async fn mkdir(StringView, mode~ : Int, context~ : String) -> Unit
 
-pub async fn open(StringView, Int, create~ : Bool, append~ : Bool, truncate~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> IoHandle
+pub async fn open(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> IoHandle
 
-pub async fn open_detached(StringView, Int, create~ : Bool, append~ : Bool, truncate~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> (Int, @fd_util.FileKind)
+pub async fn open_detached(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> (Int, @fd_util.FileKind)
 
 pub async fn opendir(StringView, context~ : String) -> Directory
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -644,9 +644,8 @@ struct open_job {
   struct job job;
   char *filename;
   int access;
-  int create;
+  int create_mode;
   int append;
-  int truncate;
   int sync;
   int mode;
   HANDLE result;
@@ -663,19 +662,22 @@ static
 void open_job_worker(struct job *job) {
 #ifdef _WIN32
   static int access_flags[] = { GENERIC_READ, GENERIC_WRITE, GENERIC_READ | GENERIC_WRITE };
+  static int create_modes[] = { OPEN_EXISTING, TRUNCATE_EXISTING, OPEN_ALWAYS, CREATE_ALWAYS, CREATE_NEW };
 #else
   static int access_flags[] = { O_RDONLY, O_WRONLY, O_RDWR };
+  static int create_modes[] = {
+    0,
+    O_TRUNC,
+    O_CREAT,
+    O_CREAT | O_TRUNC,
+    O_CREAT | O_EXCL
+  };
   static int sync_flags[] = { 0, O_DSYNC, O_SYNC };
 #endif
 
   struct open_job *open_job = (struct open_job*)job;
 
 #ifdef _WIN32
-  DWORD create_flags =
-    open_job->create
-    ? (open_job->truncate ? CREATE_ALWAYS : OPEN_ALWAYS)
-    : (open_job->truncate ? TRUNCATE_EXISTING : OPEN_EXISTING);
-
   DWORD flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS;
 
   DWORD access_flag = access_flags[open_job->access];
@@ -688,7 +690,7 @@ void open_job_worker(struct job *job) {
       access_flag, // desired access
       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, // shared mode
       NULL, // security attributes
-      create_flags, // creation
+      create_modes[open_job->create_mode], // creation
       flags, // flags and attributes. Note that we open files in synchronous mode
       NULL // template file
     );
@@ -719,10 +721,11 @@ void open_job_worker(struct job *job) {
 
 #else
 
-  int flags = access_flags[open_job->access] | sync_flags[open_job->sync];
-  if (open_job->create) flags |= O_CREAT;
+  int flags =
+    access_flags[open_job->access]
+    | sync_flags[open_job->sync]
+    | create_modes[open_job->create_mode];
   if (open_job->append) flags |= O_APPEND;
-  if (open_job->truncate) flags |= O_TRUNC;
 
   open_job->result = open(
     open_job->filename,
@@ -747,9 +750,8 @@ MOONBIT_FFI_EXPORT
 struct open_job *moonbitlang_async_make_open_job(
   char *filename,
   int access,
-  int create,
+  int create_mode,
   int append,
-  int truncate,
   int sync,
   int mode
 ) {
@@ -757,9 +759,8 @@ struct open_job *moonbitlang_async_make_open_job(
   struct open_job *job = MAKE_JOB(open);
   job->filename = filename;
   job->access = access;
-  job->create = create;
+  job->create_mode = create_mode;
   job->append = append;
-  job->truncate = truncate;
   job->sync = sync;
   job->mode = mode;
   return job;

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -101,9 +101,9 @@ extern "C" fn Job::open(
   filename : @os_string.OsString,
   // 0 => read only, 1 => write only, 2 => read write
   access : Int,
-  create~ : Bool,
+  // See `@fs.CreateMode` for more details
+  create~ : Int,
   append~ : Bool,
-  truncate~ : Bool,
   // 0 => no sync, 1 => data sync, 2 => full sync
   sync~ : Int,
   // permission for file when new file is created

--- a/src/process/README.mbt.md
+++ b/src/process/README.mbt.md
@@ -191,7 +191,7 @@ Use a file as process input:
 async test "redirect input from file" {
   @async.with_task_group(root => {
     let input_file = "_build/process_test_input.txt"
-    @fs.write_file(input_file, "file content", create=0o644)
+    @fs.write_file(input_file, "file content", create_mode=CreateOrTruncate)
     root.add_defer(() => @fs.remove(input_file))
     let (code, output) = @process.collect_stdout(
       "cat",
@@ -218,7 +218,10 @@ async test "redirect output to file" {
     let code = @process.run(
       "echo",
       ["test output"],
-      stdout=@process.redirect_to_file(output_file, create=0o644),
+      stdout=@process.redirect_to_file(
+        output_file,
+        create_mode=CreateOrTruncate,
+      ),
     )
     inspect(code, content="0")
     let content = @fs.read_file(output_file).text()
@@ -238,14 +241,17 @@ async test "file to file redirection" {
   @async.with_task_group(root => {
     let input_file = "_build/process_redirect_in.txt"
     let output_file = "_build/process_redirect_out.txt"
-    @fs.write_file(input_file, "redirect test", create=0o644)
+    @fs.write_file(input_file, "redirect test", create_mode=CreateOrTruncate)
     root.add_defer(() => @fs.remove(input_file))
     root.add_defer(() => @fs.remove(output_file))
     let _ = @process.run(
       "cat",
       [],
       stdin=@process.redirect_from_file(input_file),
-      stdout=@process.redirect_to_file(output_file, create=0o644),
+      stdout=@process.redirect_to_file(
+        output_file,
+        create_mode=CreateOrTruncate,
+      ),
     )
     inspect(@fs.read_file(output_file).text(), content="redirect test")
   })

--- a/src/process/moon.pkg
+++ b/src/process/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbitlang/async/stdio",
   "moonbitlang/async",
   "moonbitlang/async/io",
+  "moonbitlang/async/fs",
 }
 
 import {

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/async/process"
 
 import {
   "moonbitlang/async",
+  "moonbitlang/async/fs",
   "moonbitlang/async/io",
   "moonbitlang/async/pipe",
   "moonbitlang/async/stdio",
@@ -25,7 +26,9 @@ pub fn read_from_process() -> (ReadFromProcess, &ProcessOutput) raise
 
 pub async fn redirect_from_file(String) -> &ProcessInput
 
-pub async fn redirect_to_file(String, append? : Bool, create? : Int, truncate? : Bool) -> &ProcessOutput
+#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
+#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
+pub async fn redirect_to_file(String, append? : Bool, create_mode? : @fs.CreateMode, permission? : Int, create? : Int, truncate? : Bool) -> &ProcessOutput
 
 pub async fn run(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : StringView, cancel_handler? : CancellationHandler) -> Int
 

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -115,27 +115,44 @@ pub impl @io.Writer for WriteToProcess with write_once(self, buf, offset~, len~)
 }
 
 ///|
+fn @fs.CreateMode::to_int(self : @fs.CreateMode) -> Int = "%identity"
+
+///|
 /// Redirect the output of a process to the file at `path`.
-/// The meaning of `append`, `create` and `truncate` is the same as `@fs.open`,
+/// The meaning of `append`, `create_mode` and `permission` is the same as `@fs.open`,
 /// see the document of `@fs.open` for more details.
+#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
+#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
 pub async fn redirect_to_file(
   path : String,
   append? : Bool = false,
+  create_mode? : @fs.CreateMode,
+  permission? : Int,
   create? : Int,
   truncate? : Bool = false,
 ) -> &ProcessOutput {
-  let (create, mode) = match create {
-    Some(mode) => (true, mode)
-    None => (false, 0)
+  let create_mode = match create_mode {
+    Some(mode) => mode
+    None =>
+      match (create is Some(_), truncate) {
+        (true, true) => CreateOrTruncate
+        (true, false) => OpenOrCreate
+        (false, true) => TruncateExisting
+        (false, false) => OpenExisting
+      }
+  }
+  let permission = match permission {
+    Some(perm) => perm
+    None if create is Some(perm) => perm
+    None => 0o644
   }
   let (fd, kind) = @event_loop.open_detached(
     path,
     1, // write only
-    create~,
+    create=create_mode.to_int(),
     append~,
-    truncate~,
     sync=0,
-    mode~,
+    mode=permission,
     context="@process.redirect_to_file()",
   )
   RedirectToFile(fd, kind)
@@ -147,9 +164,8 @@ pub async fn redirect_from_file(path : String) -> &ProcessInput {
   let (fd, kind) = @event_loop.open_detached(
     path,
     0, // read only
-    create=false,
+    create=0, // `OpenExisting`
     append=false,
-    truncate=false,
     sync=0,
     mode=0,
     context="@process.redirect_to_file()",

--- a/src/process/redirect_test.mbt
+++ b/src/process/redirect_test.mbt
@@ -50,12 +50,15 @@ async test "redirect to file" {
     let output_file = "_build/process_redirect_test_out.txt"
     root.add_defer(() => @fs.remove(input_file))
     root.add_defer(() => @fs.remove(output_file))
-    @fs.write_file(input_file, "abcd", create=0o644)
+    @fs.write_file(input_file, "abcd", create_mode=CreateOrTruncate)
     let _ = @process.run(
       cat,
       [],
       stdin=@process.redirect_from_file(input_file),
-      stdout=@process.redirect_to_file(output_file, create=0o644),
+      stdout=@process.redirect_to_file(
+        output_file,
+        create_mode=CreateOrTruncate,
+      ),
     )
     inspect(@fs.read_file(output_file).text(), content="abcd")
   })

--- a/src/process/unimplemented.mbt
+++ b/src/process/unimplemented.mbt
@@ -25,4 +25,5 @@ pub let unimplemented : Unit = {
   ignore(@stdio.unimplemented)
   ignore(@fd_util.unimplemented)
   ignore(@os_string.unimplemented)
+  ignore(@fs.unimplemented)
 }

--- a/src/raw_fd/raw_fd_test.mbt
+++ b/src/raw_fd/raw_fd_test.mbt
@@ -60,9 +60,8 @@ async test "file as raw fd" {
   let (fd, _) = @event_loop.open_detached(
     "LICENSE",
     0,
-    create=false,
+    create=0,
     append=false,
-    truncate=false,
     sync=0,
     mode=0,
     context="file as raw fd test",

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -35,7 +35,7 @@ async test "redirect_file" {
     cat,
     [],
     stdin=@process.redirect_from_file("moon.mod.json"),
-    stdout=@process.redirect_to_file(out_file, create=0o644),
+    stdout=@process.redirect_to_file(out_file, create_mode=CreateOrTruncate),
   )
   inspect(code, content="0")
   assert_eq(


### PR DESCRIPTION
- make the `permission` optional for various fs API. For new files the default permission is `0o644`. For directories, the default permission is `0o755`
- refactor `@fs.open` for how create mode is specified. Previously, the API follows UNIX style: `create`, `truncate` and `exclusive` (not implemented) are independent options. The new API style follows Windows `CreateFile` style: an enum `@fs.CreateMode` and a new option `create_mode? : CreateMode = OpenExisting` is used to specify all creation/truncation related behavior. The motivation is:
    - previously `create`, when present, requires the permission of the new file. By introducing a new option `create_mode`, the migration to optional permission would be easier
    - the Windows style API is actually cleaner, as it rules out several invalid combinations, such as `create=false, exclusive=true`. There are 5 valid options out of 8 possible combinations:
        - `OpenExisting`: the default. `create=false, truncate=false, exclusive=<does not matter>`
        - `TruncateExisting`: `create=false, truncate=true, exclusive=<does not matter>`
        - `OpenOrCreate`: `create=true, truncate=false, exclusive=false`
        - `CreateOrTruncate`: `create=true, truncate=true, exclusive=false`
        - `CreateNew`: `create=true, truncate=<doen not matter>, exclusive=true`
 
   in addition to `create_mode`, a new option `permission` is also introduced for file permission, and defaults to `0o644`. The old `create` and `truncate` flags are not removed, just deprecated. So this PR is a non-breaking change.