### PR TITLE
fix Windows process handling

### DIFF
--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -42,7 +42,7 @@ pub async fn remove(StringView, context~ : String) -> Unit
 
 pub async fn rmdir(StringView, context~ : String) -> Unit
 
-pub async fn spawn(@os_string.OsString, FixedArray[@os_string.OsString?], env~ : FixedArray[@os_string.OsString?], stdin~ : Int, stdout~ : Int, stderr~ : Int, cwd~ : @os_string.OsString?, context~ : String) -> Int
+pub async fn spawn(@os_string.OsString, FixedArray[@os_string.OsString?], env~ : FixedArray[@os_string.OsString?], stdin~ : Int, stdout~ : Int, stderr~ : Int, cwd~ : @os_string.OsString?, context~ : String) -> Process
 
 pub let stderr : IoHandle
 
@@ -51,8 +51,6 @@ pub let stdin : IoHandle
 pub let stdout : IoHandle
 
 pub async fn symlink(StringView, StringView, context~ : String) -> Unit
-
-pub async fn wait_pid(Int, context~ : String) -> Int
 
 pub fn with_event_loop(async () -> Unit) -> Unit raise
 
@@ -90,6 +88,12 @@ pub async fn IoHandle::recvfrom(Self, FixedArray[Byte], offset~ : Int, len~ : In
 pub async fn IoHandle::sendto(Self, Bytes, offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 pub async fn IoHandle::write(Self, Bytes, offset~ : Int, len~ : Int, context~ : String) -> Int
 pub async fn IoHandle::write_at(Self, Bytes, offset~ : Int, len~ : Int, position~ : Int64, context~ : String) -> Unit
+
+type Process
+pub fn Process::close(Self) -> Unit
+pub fn Process::from_pid(Int, context~ : String) -> Self
+pub fn Process::pid(Self) -> Int
+pub async fn Process::wait_pid(Self, context~ : String) -> Int
 
 type Timer
 pub fn Timer::cancel(Self) -> Unit

--- a/src/internal/event_loop/process.c
+++ b/src/internal/event_loop/process.c
@@ -25,14 +25,14 @@
 #ifdef _WIN32
 
 MOONBIT_FFI_EXPORT
-int moonbitlang_async_get_process_result(DWORD pid, DWORD *out) {
-  HANDLE handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-  if (handle == INVALID_HANDLE_VALUE)
-    return -1;
-
+int moonbitlang_async_get_process_result(HANDLE handle, DWORD *out) {
   int result = GetExitCodeProcess(handle, out) ? 0 : -1;
-  CloseHandle(handle);
   return result;
+}
+
+MOONBIT_FFI_EXPORT
+HANDLE moonbitlang_async_open_pid_handle(DWORD pid) {
+  return OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
 }
 
 #else

--- a/src/internal/event_loop/process_unix.mbt
+++ b/src/internal/event_loop/process_unix.mbt
@@ -14,6 +14,29 @@
 
 ///|
 #cfg(not(platform="windows"))
+struct Process(Int)
+
+///|
+#cfg(not(platform="windows"))
+pub fn Process::pid(self : Process) -> Int {
+  self.0
+}
+
+///|
+#cfg(not(platform="windows"))
+pub fn Process::from_pid(pid : Int, context~ : String) -> Process {
+  ignore(context)
+  Process(pid)
+}
+
+///|
+#cfg(not(platform="windows"))
+pub fn Process::close(_ : Process) -> Unit {
+
+}
+
+///|
+#cfg(not(platform="windows"))
 pub async fn spawn(
   path : @os_string.OsString,
   args : FixedArray[@os_string.OsString?],
@@ -23,7 +46,7 @@ pub async fn spawn(
   stderr~ : @fd_util.Fd,
   cwd~ : @os_string.OsString?,
   context~ : String,
-) -> Int {
+) -> Process {
   perform_job_in_worker(
     Job::spawn(path, args, env, stdin, stdout, stderr, cwd),
     context~,
@@ -37,7 +60,8 @@ extern "C" fn get_process_result(pid : Int, out : Ref[Int]) -> Int = "moonbitlan
 
 ///|
 #cfg(not(platform="windows"))
-pub async fn wait_pid(pid : Int, context~ : String) -> Int {
+pub async fn Process::wait_pid(self : Process, context~ : String) -> Int {
+  let Process(pid) = self
   guard curr_loop.val is Some(evloop)
   guard support_wait_pid_via_poll else {
     // pidfd not available, fall back to blocking waitpid in worker thread.

--- a/src/internal/event_loop/process_windows.mbt
+++ b/src/internal/event_loop/process_windows.mbt
@@ -32,6 +32,41 @@ fn init_global_job_object() -> Unit raise {
 
 ///|
 #cfg(platform="windows")
+struct Process {
+  pid : Int
+  handle : @fd_util.Fd
+}
+
+///|
+#cfg(platform="windows")
+pub fn Process::pid(self : Process) -> Int {
+  self.pid
+}
+
+///|
+#cfg(platform="windows")
+extern "C" fn open_pid_handle(pid : Int) -> @fd_util.Fd = "moonbitlang_async_open_pid_handle"
+
+///|
+#cfg(platform="windows")
+pub fn Process::from_pid(pid : Int, context~ : String) -> Process raise {
+  let handle = open_pid_handle(pid)
+  if !@fd_util.fd_is_valid(handle) {
+    @os_error.check_errno(context)
+  }
+  { pid, handle }
+}
+
+///|
+#cfg(platform="windows")
+pub fn Process::close(self : Process) -> Unit {
+  @fd_util.close(self.handle, kind=Unknown, context="") catch {
+    _ => ()
+  }
+}
+
+///|
+#cfg(platform="windows")
 pub async fn spawn(
   command_line : @os_string.OsString,
   env~ : @os_string.OsString?,
@@ -41,30 +76,37 @@ pub async fn spawn(
   cwd~ : @os_string.OsString?,
   is_orphan~ : Bool,
   context~ : String,
-) -> Int {
+) -> Process {
   init_global_job_object()
-  perform_job_in_worker(
-    Job::spawn(command_line, env, stdin, stdout, stderr, cwd, is_orphan~),
-    context~,
+  let job = Job::spawn(
+    command_line,
+    env,
+    stdin,
+    stdout,
+    stderr,
+    cwd,
+    is_orphan~,
   )
+  let pid = perform_job_in_worker(job, context~)
+  { pid, handle: job.get_spawn_job_result_handle() }
 }
 
 ///|
 #cfg(platform="windows")
 #borrow(out)
-extern "C" fn get_process_result(pid : Int, out : Ref[Int]) -> Int = "moonbitlang_async_get_process_result"
+extern "C" fn get_process_result(handle : @fd_util.Fd, out : Ref[Int]) -> Int = "moonbitlang_async_get_process_result"
 
 ///|
 #cfg(platform="windows")
-pub async fn wait_pid(pid : Int, context~ : String) -> Int {
-  let job = Job::wait_for_process(pid)
+pub async fn Process::wait_pid(self : Process, context~ : String) -> Int {
+  let job = Job::wait_for_process(self.handle)
   perform_job_in_worker(job, context~, cancel=_ => {
     job.cancel_process_waiter()
     NeedWait
   })
   |> ignore
   let out = Ref::new(0)
-  let ret = get_process_result(pid, out)
+  let ret = get_process_result(self.handle, out)
   if ret < 0 {
     @os_error.check_errno(context)
   }

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -1655,6 +1655,7 @@ struct spawn_job {
   HANDLE stdio[3];
   LPWSTR cwd;
   int32_t is_orphan;
+  HANDLE result;
 };
 
 static
@@ -1665,6 +1666,8 @@ void free_spawn_job(void *obj) {
     moonbit_decref(job->environment);
   if (job->cwd)
     moonbit_decref(job->cwd);
+  if (job->result != INVALID_HANDLE_VALUE)
+    CloseHandle(job->result);
 }
 
 static
@@ -1804,12 +1807,8 @@ void spawn_job_worker(struct job *job) {
     ResumeThread(process_info.hThread);
   }
 
-  // Since process waiting is not performance-critical,
-  // here we discard the handles returned by `CreateProcessW`,
-  // and use `OpenProcess` to obtain another handle later when needed,
-  // so that the API style is closer to UNIX-like systems.
   CloseHandle(process_info.hThread);
-  CloseHandle(process_info.hProcess);
+  spawn_job->result = process_info.hProcess;
 
   job->ret = process_info.dwProcessId;
 }
@@ -1831,7 +1830,14 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   job->stdio[2] = stderr_handle;
   job->cwd = cwd;
   job->is_orphan = is_orphan;
+  job->result = INVALID_HANDLE_VALUE;
   return job;
+}
+
+HANDLE moonbitlang_async_get_spawn_job_result_handle(struct spawn_job *job) {
+  HANDLE result = job->result;
+  job->result = INVALID_HANDLE_VALUE;
+  return result;
 }
 
 // For windows, waiting for process is done via one dedicated thread per process,
@@ -1840,7 +1846,7 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
 
 struct wait_for_process_job {
   struct job job;
-  DWORD pid;
+  HANDLE process;
   HANDLE cancel;
 };
 
@@ -1854,13 +1860,7 @@ static
 void wait_for_process_job_worker(struct job *job) {
   struct wait_for_process_job *wait_for_process_job = (struct wait_for_process_job*)job;
 
-  HANDLE handles[2] = { INVALID_HANDLE_VALUE, wait_for_process_job->cancel };
-
-  handles[0] = OpenProcess(SYNCHRONIZE, FALSE, wait_for_process_job->pid);
-  if (handles[0] == INVALID_HANDLE_VALUE) {
-    job->err = GetLastError();
-    return;
-  }
+  HANDLE handles[2] = { wait_for_process_job->process, wait_for_process_job->cancel };
 
   DWORD result = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
   if (result == WAIT_FAILED)
@@ -1870,10 +1870,10 @@ void wait_for_process_job_worker(struct job *job) {
 }
 
 struct wait_for_process_job *moonbitlang_async_make_wait_for_process_job(
-  DWORD pid
+  HANDLE process
 ) {
   struct wait_for_process_job *job = MAKE_JOB(wait_for_process);
-  job->pid = pid;
+  job->process = process;
   job->cancel = CreateEventA(NULL, FALSE, FALSE, NULL);
   return job;
 }

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -244,7 +244,17 @@ extern "C" fn Job::spawn(
 ) -> Job = "moonbitlang_async_make_spawn_job"
 
 ///|
+#cfg(platform="windows")
+#borrow(job)
+extern "C" fn Job::get_spawn_job_result_handle(job : Job) -> @fd_util.Fd = "moonbitlang_async_get_spawn_job_result_handle"
+
+///|
+#cfg(not(platform="windows"))
 extern "C" fn Job::wait_for_process(pid : Int) -> Job = "moonbitlang_async_make_wait_for_process_job"
+
+///|
+#cfg(platform="windows")
+extern "C" fn Job::wait_for_process(handle : @fd_util.Fd) -> Job = "moonbitlang_async_make_wait_for_process_job"
 
 ///|
 #cfg(platform="windows")

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -52,7 +52,7 @@ pub async fn spawn_orphan(
     cwd~,
     is_orphan=true,
     context="@process.spawn_orphan()",
-  )
+  ).pid()
 }
 
 ///|
@@ -60,7 +60,9 @@ pub async fn spawn_orphan(
 /// and return the exit code of the process.
 pub async fn wait_pid(pid : Int) -> Int {
   let context = "@process.wait_pid()"
-  @event_loop.wait_pid(pid, context~)
+  let process = @event_loop.Process::from_pid(pid, context~)
+  defer process.close()
+  process.wait_pid(context~)
 }
 
 ///|
@@ -117,7 +119,7 @@ pub async fn run(
   cancel_handler? : CancellationHandler = graceful_cancel(timeout=5000),
 ) -> Int {
   let context = "@process.run()"
-  let pid = raw_spawn(
+  let process = raw_spawn(
     cmd,
     args,
     extra_env~,
@@ -129,12 +131,14 @@ pub async fn run(
     is_orphan=false,
     context~,
   )
-  @event_loop.wait_pid(pid, context~) catch {
+  defer process.close()
+  let pid = process.pid()
+  process.wait_pid(context~) catch {
     _ if @coroutine.is_being_cancelled() =>
       @async.protect_from_cancel(() => {
         @async.with_task_group(group => {
           group.spawn_bg(no_wait=true, () => cancel_handler(pid))
-          @event_loop.wait_pid(pid, context~)
+          process.wait_pid(context~)
         })
       })
     err => raise err
@@ -198,7 +202,7 @@ pub async fn[X] spawn(
   no_wait? : Bool,
 ) -> Process {
   let context = "@process.spawn()"
-  let pid = raw_spawn(
+  let process = raw_spawn(
     cmd,
     args,
     extra_env~,
@@ -210,13 +214,15 @@ pub async fn[X] spawn(
     is_orphan=false,
     context~,
   )
+  let pid = process.pid()
   let result = group.spawn(no_wait?, () => {
-    @event_loop.wait_pid(pid, context~) catch {
+    defer process.close()
+    process.wait_pid(context~) catch {
       _ if @coroutine.is_being_cancelled() =>
         @async.protect_from_cancel(() => {
           @async.with_task_group(group => {
             group.spawn_bg(no_wait=true, () => cancel_handler(pid))
-            @event_loop.wait_pid(pid, context~)
+            process.wait_pid(context~)
           })
         })
       err => raise err

--- a/src/process/unix.mbt
+++ b/src/process/unix.mbt
@@ -33,7 +33,7 @@ async fn raw_spawn(
   cwd~ : StringView?,
   is_orphan~ : Bool,
   context~ : String,
-) -> Int {
+) -> @event_loop.Process {
   let cmd = @os_string.encode(cmd)
   let argv = FixedArray::make(args.length() + 2, None)
   let cwd = match cwd {

--- a/src/process/windows.mbt
+++ b/src/process/windows.mbt
@@ -82,7 +82,7 @@ async fn raw_spawn(
   cwd~ : StringView?,
   is_orphan~ : Bool,
   context~ : String,
-) -> Int {
+) -> @event_loop.Process {
   let cmd = match cmd {
     [.., .. ".exe"] => cmd
     _ => cmd + ".exe"


### PR DESCRIPTION
Previously, on Windows, the process handle returned by `CreateProcessW` is not saved. Instead, the handle is re-opened from PID every time we need to do something on the process. This implementation strategy is an attempt to make the API more similar between Windows and Unix-like systems. However, this approach is incorrect. On Windows, the process handle has the extra functionality of keeping the process's record alive after its termination, so that we can retrieve its exit status. If we do not hold the handle all the time, the process may vanish before we actually try to wait for it, resulting in random failure.

This PR refactors the way we handle process waiting. Instead of re-opening the process handle on every wait operation, we now hold the process handle all the way until the exit status is retrieved on Windows. Hopefully this should fix the random `@process.run(): invalid handle` error on Windows CI.