### PR TITLE
add signal based global cancellation

### DIFF
--- a/src/integration.mbt
+++ b/src/integration.mbt
@@ -20,6 +20,7 @@
 #doc(hidden)
 pub fn run_async_main(main : async () -> Unit) -> Unit {
   @event_loop.with_event_loop(() => main()) catch {
+    @event_loop.KilledBySignal(signal) => exit(128 + signal)
     err => {
       // TODO: output the error to stderr
       println(err)

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -218,6 +218,13 @@ fn EventLoop::wait_for_event(self : EventLoop) -> Int raise {
 
 ///|
 fn EventLoop::handle_completed_job(self : Self, job_id : Int) -> Unit {
+  guard (job_id & (1 << 31)) == 0 else {
+    // signal
+    if self.main is Some(main) {
+      main.cancel()
+    }
+    self.killed_by_signal = Some(job_id ^ (1 << 31))
+  }
   guard self.running_workers.get(job_id) is Some(worker)
   self.running_workers.remove(job_id)
   match self.job_queue.pop_front() {
@@ -258,15 +265,7 @@ fn EventLoop::poll(self : Self) -> Unit raise {
         }
         let n = bytes_transferred / 4
         for i in 0..<n {
-          let job_id = self.completed_jobs_buffer[i]
-          if (job_id & (1 << 31)) != 0 {
-            if self.main is Some(main) {
-              main.cancel()
-            }
-            self.killed_by_signal = Some(job_id ^ (1 << 31))
-          } else {
-            self.handle_completed_job(job_id)
-          }
+          self.handle_completed_job(self.completed_jobs_buffer[i])
         }
         if n < self.completed_jobs_buffer.length() {
           break

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -36,6 +36,8 @@ priv struct EventLoop {
   completed_jobs_buffer : FixedArray[Int]
   jobs : Map[Int, @coroutine.Coroutine]
   timers : @sorted_set.SortedSet[Timer]
+  mut main : @coroutine.Coroutine?
+  mut killed_by_signal : Int?
 }
 
 ///|
@@ -50,6 +52,8 @@ priv struct EventLoop {
   running_workers : Map[Int, Worker]
   jobs : Map[Int, @coroutine.Coroutine]
   timers : @sorted_set.SortedSet[Timer]
+  mut main : @coroutine.Coroutine?
+  mut killed_by_signal : Int?
 }
 
 ///|
@@ -106,6 +110,8 @@ fn EventLoop::new() -> EventLoop raise {
     completed_jobs_buffer: FixedArray::make(1024, 0),
     jobs: {},
     timers: @sorted_set.new(),
+    main: None,
+    killed_by_signal: None,
   }
 }
 
@@ -127,6 +133,8 @@ fn EventLoop::new() -> EventLoop raise {
     running_workers: {},
     jobs: {},
     timers: @sorted_set.new(),
+    main: None,
+    killed_by_signal: None,
   }
 }
 
@@ -168,7 +176,18 @@ pub fn with_event_loop(f : async () -> Unit) -> Unit raise {
       init()
     }
   }
-  let main = @coroutine.spawn(f)
+  let signal_handler = setup_signal_handler()
+  let main = @coroutine.spawn(() => {
+    try f() catch {
+      err => {
+        evloop.terminate_signal_handler(signal_handler)
+        raise err
+      }
+    } noraise {
+      _ => evloop.terminate_signal_handler(signal_handler)
+    }
+  })
+  evloop.main = Some(main)
   evloop.run_forever()
   main.unwrap()
 }
@@ -239,7 +258,15 @@ fn EventLoop::poll(self : Self) -> Unit raise {
         }
         let n = bytes_transferred / 4
         for i in 0..<n {
-          self.handle_completed_job(self.completed_jobs_buffer[i])
+          let job_id = self.completed_jobs_buffer[i]
+          if (job_id & (1 << 31)) != 0 {
+            if self.main is Some(main) {
+              main.cancel()
+            }
+            self.killed_by_signal = Some(job_id ^ (1 << 31))
+          } else {
+            self.handle_completed_job(job_id)
+          }
         }
         if n < self.completed_jobs_buffer.length() {
           break

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -218,6 +218,8 @@ fn EventLoop::wait_for_event(self : EventLoop) -> Int raise {
 
 ///|
 fn EventLoop::handle_completed_job(self : Self, job_id : Int) -> Unit {
+  // The thread pool pipe may receive job completion event or signal events.
+  // Here we encode signal events by setting the most significant bit to one.
   guard (job_id & (1 << 31)) == 0 else {
     // signal
     if self.main is Some(main) {

--- a/src/internal/event_loop/moon.pkg
+++ b/src/internal/event_loop/moon.pkg
@@ -32,6 +32,7 @@ options(
     "io_windows.c",
     "process.c",
     "detect_file_kind.c",
+    "signal.c",
   ],
   targets: {
     "cancel_before_submit_test.mbt": [ "native" ],
@@ -48,6 +49,7 @@ options(
     "poll.mbt": [ "native" ],
     "process_unix.mbt": [ "native" ],
     "process_windows.mbt": [ "native" ],
+    "signal.mbt": [ "native" ],
     "stdio.mbt": [ "native" ],
     "thread_pool.mbt": [ "native" ],
     "timer.mbt": [ "native" ],

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -10,6 +10,14 @@ import {
 // Values
 pub const IS_WINDOWS : Bool = false
 
+pub let _SIGBREAK : Int
+
+pub let _SIGHUP : Int
+
+pub let _SIGINT : Int
+
+pub let _SIGTERM : Int
+
 pub async fn access(StringView, Access, context~ : String) -> Int
 
 pub async fn chmod(StringView, Int, context~ : String) -> Unit
@@ -42,6 +50,8 @@ pub async fn remove(StringView, context~ : String) -> Unit
 
 pub async fn rmdir(StringView, context~ : String) -> Unit
 
+pub fn set_global_cancellation_signals(ReadOnlyArray[Int]) -> Unit
+
 pub async fn spawn(@os_string.OsString, FixedArray[@os_string.OsString?], env~ : FixedArray[@os_string.OsString?], stdin~ : Int, stdout~ : Int, stderr~ : Int, cwd~ : @os_string.OsString?, context~ : String) -> Process
 
 pub let stderr : IoHandle
@@ -55,6 +65,9 @@ pub async fn symlink(StringView, StringView, context~ : String) -> Unit
 pub fn with_event_loop(async () -> Unit) -> Unit raise
 
 // Errors
+pub suberror KilledBySignal {
+  KilledBySignal(Int)
+}
 
 // Types and methods
 pub(all) enum Access {

--- a/src/internal/event_loop/signal.c
+++ b/src/internal/event_loop/signal.c
@@ -18,6 +18,9 @@
 
 #ifdef _WIN32
 
+#include <windows.h>
+#include <string.h>
+
 #else
 
 #include <signal.h>
@@ -26,6 +29,44 @@
 #endif
 
 #ifdef _WIN32
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_get_signal_by_name(const char *name) {
+  if (0 == strcmp(name, "SIGINT")) {
+    return CTRL_C_EVENT;
+  } else if (0 == strcmp(name, "SIGBREAK")) {
+    return CTRL_BREAK_EVENT;
+  } else if (0 == strcmp(name, "SIGHUP")) {
+    return CTRL_CLOSE_EVENT;
+  } else {
+    return -1;
+  }
+}
+
+// The range of console control events is pretty small
+// according to https://learn.microsoft.com/en-us/windows/console/handlerroutine,
+// and a set of console contron events can easily fix into a single byte.
+// So there is no need for atomic integer here
+extern int interested_console_ctrl_event;
+
+// the actual console control handler is in `thread_pool.c`,
+// because it need to refer to the event loop's IO completion port
+BOOL WINAPI moonbitlang_async_console_control_handler(DWORD ctrl_type);
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_set_global_cancellation_signals(int *all_signals, int *signals) {
+  int new_mask = 0;
+  for (int i = 0; i < Moonbit_array_length(signals); ++i) {
+    if (signals[i] < 0) continue;
+    new_mask |= 1 << signals[i];
+  }
+  interested_console_ctrl_event = new_mask;
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_set_console_control_handler(int32_t add) {
+  return SetConsoleCtrlHandler(moonbitlang_async_console_control_handler, add);
+}
 
 #else // #ifdef _WIN32
 

--- a/src/internal/event_loop/signal.c
+++ b/src/internal/event_loop/signal.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "moonbit.h"
+
+#ifdef _WIN32
+
+#else
+
+#include <signal.h>
+#include <string.h>
+
+#endif
+
+#ifdef _WIN32
+
+#else // #ifdef _WIN32
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_get_signal_by_name(const char *name) {
+  if (0 == strcmp(name, "SIGINT")) {
+    return SIGINT;
+  } else if (0 == strcmp(name, "SIGTERM")) {
+    return SIGTERM;
+  } else if (0 == strcmp(name, "SIGHUP")) {
+    return SIGHUP;
+  } else {
+    return -1;
+  }
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_set_global_cancellation_signals(int *all_signals, int *signals) {
+  sigset_t set;
+  pthread_sigmask(SIG_SETMASK, 0, &set);
+  for (int i = 0; i < Moonbit_array_length(all_signals); ++i) {
+    if (all_signals[i] < 0) continue;
+    sigdelset(&set, all_signals[i]);
+  }
+  for (int i = 0; i < Moonbit_array_length(signals); ++i) {
+    if (signals[i] < 0) continue;
+    sigaddset(&set, signals[i]);
+  }
+  pthread_sigmask(SIG_SETMASK, &set, 0);
+}
+
+#endif // #ifndef _WIN32

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -83,3 +83,32 @@ async fn EventLoop::terminate_signal_handler(
     raise KilledBySignal(signal)
   }
 }
+
+///|
+#cfg(platform="windows")
+extern "C" fn set_console_control_handler(add : Int) -> Int = "moonbitlang_async_set_console_control_handler"
+
+///|
+#cfg(platform="windows")
+fn setup_signal_handler() -> Unit raise {
+  if !global_signal_handler_initialized.val {
+    set_global_cancellation_signals(all_signals)
+  }
+  if set_console_control_handler(1) is 0 {
+    @os_error.check_errno("setup_signal_handler()")
+  }
+}
+
+///|
+#cfg(platform="windows")
+fn EventLoop::terminate_signal_handler(
+  evloop : EventLoop,
+  _ : Unit,
+) -> Unit raise {
+  if set_console_control_handler(0) is 0 {
+    @os_error.check_errno("terminate_signal_handler()")
+  }
+  if evloop.killed_by_signal is Some(signal) {
+    raise KilledBySignal(signal)
+  }
+}

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -1,0 +1,85 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#borrow(name)
+extern "C" fn get_signal_by_name(name : Bytes) -> Int = "moonbitlang_async_get_signal_by_name"
+
+///|
+pub let _SIGINT : Int = get_signal_by_name("SIGINT")
+
+///|
+pub let _SIGTERM : Int = get_signal_by_name("SIGTERM")
+
+///|
+pub let _SIGHUP : Int = get_signal_by_name("SIGHUP")
+
+///|
+pub let _SIGBREAK : Int = get_signal_by_name("SIGBREAK")
+
+///|
+let all_signals : ReadOnlyArray[Int] = [_SIGINT, _SIGTERM, _SIGHUP, _SIGBREAK]
+
+///|
+pub suberror KilledBySignal {
+  KilledBySignal(Int)
+}
+
+///|
+#borrow(all_signals, signals)
+extern "C" fn set_global_cancellation_signals_ffi(
+  all_signals : ReadOnlyArray[Int],
+  signals : ReadOnlyArray[Int],
+) -> Unit = "moonbitlang_async_set_global_cancellation_signals"
+
+///|
+let global_signal_handler_initialized : Ref[Bool] = Ref(false)
+
+///|
+pub fn set_global_cancellation_signals(signals : ReadOnlyArray[Int]) -> Unit {
+  global_signal_handler_initialized.val = true
+  set_global_cancellation_signals_ffi(all_signals, signals)
+}
+
+///|
+#cfg(not(platform="windows"))
+fn setup_signal_handler() -> @coroutine.Coroutine {
+  if !global_signal_handler_initialized.val {
+    set_global_cancellation_signals(all_signals)
+  }
+  @coroutine.spawn(() => {
+    let context = "sigwait thread"
+    fn cancel(job_id) raise {
+      guard curr_loop.val is Some(evloop)
+      evloop.cancel_job_in_worker(job_id, context~)
+    }
+    let _ = perform_job_in_worker(Job::sigwait(all_signals), context~, cancel~)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async fn EventLoop::terminate_signal_handler(
+  evloop : EventLoop,
+  sigwait_task : @coroutine.Coroutine,
+) -> Unit {
+  sigwait_task.cancel()
+  @coroutine.protect_from_cancel(() => sigwait_task.wait()) catch {
+    @coroutine.Cancelled => ()
+    err => raise err
+  }
+  if evloop.killed_by_signal is Some(signal) {
+    raise KilledBySignal(signal)
+  }
+}

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -2161,7 +2161,26 @@ addrinfo_t *moonbitlang_async_get_getaddrinfo_result(struct getaddrinfo_job *job
   return job->result;
 }
 
-#ifndef _WIN32
+#ifdef _WIN32
+
+int interested_console_ctrl_event = 0;
+
+BOOL WINAPI moonbitlang_async_console_control_handler(DWORD ctrl_type) {
+  if (interested_console_ctrl_event & (1 << ctrl_type)) {
+    PostQueuedCompletionStatus(
+      pool.notify_send,
+      ctrl_type | (1 << 31),
+      (ULONG_PTR)INVALID_HANDLE_VALUE,
+      0
+    );
+    return TRUE;
+  } else {
+    return FALSE;
+  }
+}
+
+#else // #ifdef _WIN32
+
 // ===== sigwait job, wait for specific signal =====
 struct sigwait_job {
   struct job job;
@@ -2208,4 +2227,4 @@ struct sigwait_job *moonbitlang_async_make_sigwait_job(int *signals) {
   return job;
 }
 
-#endif
+#endif // #ifndef _WIN32, sigwait job

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -127,9 +127,12 @@ struct {
 
   HANDLE notify_send;
 
+#ifndef _WIN32
+  sigset_t worker_sigmask;
+  sigset_t old_sigmask;
+#endif
 #ifdef WAKEUP_METHOD_SIGNAL
   sigset_t wakeup_signal;
-  sigset_t old_sigmask;
 #endif
 } pool;
 
@@ -320,17 +323,22 @@ void moonbitlang_async_init_thread_pool(HANDLE notify_send) {
   if (pool.initialized)
     abort();
 
-#ifdef WAKEUP_METHOD_SIGNAL
-  sigemptyset(&pool.wakeup_signal);
-  sigaddset(&pool.wakeup_signal, SIGUSR1);
-  pthread_sigmask(SIG_BLOCK, &pool.wakeup_signal, &pool.old_sigmask);
-#endif
-
 #ifndef _WIN32
+  sigfillset(&pool.worker_sigmask); 
+  // used for cancelling blocking IO in worker thread
+  sigdelset(&pool.worker_sigmask, SIGUSR2);
+
   sigset_t signals_to_block;
   sigemptyset(&signals_to_block);
   sigaddset(&signals_to_block, SIGCHLD);
-  pthread_sigmask(SIG_BLOCK, &signals_to_block, 0);
+
+#ifdef WAKEUP_METHOD_SIGNAL
+  sigemptyset(&pool.wakeup_signal);
+  sigaddset(&pool.wakeup_signal, SIGUSR1);
+  sigaddset(&signals_to_block, SIGUSR1);
+#endif
+
+  pthread_sigmask(SIG_BLOCK, &signals_to_block, &pool.old_sigmask);
 
   signal(SIGPIPE, SIG_IGN);
 
@@ -356,7 +364,7 @@ void moonbitlang_async_destroy_thread_pool() {
 
   pool.initialized = 0;
 
-#ifdef WAKEUP_METHOD_SIGNAL
+#ifndef _WIN32
   pthread_sigmask(SIG_SETMASK, &pool.old_sigmask, 0);
 #endif
 }
@@ -389,7 +397,14 @@ struct worker *moonbitlang_async_spawn_worker(
   pthread_attr_setstacksize(&attr, 512);
 #endif
 
+  // make sure the worker thread has correct sigmask immediately
+  sigset_t curr_sigmask;
+  pthread_sigmask(SIG_SETMASK, &pool.worker_sigmask, &curr_sigmask);
+
   pthread_create(&(worker->id), &attr, &worker_loop, worker);
+
+  pthread_sigmask(SIG_SETMASK, &curr_sigmask, 0);
+
   pthread_attr_destroy(&attr);
 #endif
 
@@ -1919,24 +1934,16 @@ void spawn_job_worker(struct job *job) {
 static
 void spawn_job_worker(struct job *job) {
   struct spawn_job *spawn_job = (struct spawn_job *)job;
+
   posix_spawnattr_t attr;
   posix_spawnattr_init(&attr);
-#ifdef WAKEUP_METHOD_SIGNAL
   posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF);
-  posix_spawnattr_setsigmask(&attr, &pool.old_sigmask);
-#else
-  posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSIGDEF);
-#endif
 
-  sigset_t sigdefault_set;
-  sigemptyset(&sigdefault_set);
-  sigaddset(&sigdefault_set, SIGCHLD);
-  sigaddset(&sigdefault_set, SIGHUP);
-  sigaddset(&sigdefault_set, SIGINT);
-  sigaddset(&sigdefault_set, SIGQUIT);
-  sigaddset(&sigdefault_set, SIGTERM);
-  sigaddset(&sigdefault_set, SIGALRM);
-  posix_spawnattr_setsigdefault(&attr, &sigdefault_set);
+  posix_spawnattr_setsigmask(&attr, &pool.old_sigmask);
+
+  sigset_t all_signals;
+  sigfillset(&all_signals);
+  posix_spawnattr_setsigdefault(&attr, &all_signals);
 
   posix_spawn_file_actions_t file_actions;
   posix_spawn_file_actions_init(&file_actions);

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -136,7 +136,6 @@ struct {
 #endif
 } pool;
 
-
 // The type for a worker thread
 struct worker {
 #ifdef _WIN32
@@ -2161,3 +2160,52 @@ addrinfo_t *moonbitlang_async_get_getaddrinfo_result(struct getaddrinfo_job *job
   job->result_fetched = 1;
   return job->result;
 }
+
+#ifndef _WIN32
+// ===== sigwait job, wait for specific signal =====
+struct sigwait_job {
+  struct job job;
+  sigset_t signals;
+};
+
+static
+void free_sigwait_job(void *obj) {}
+
+static
+void sigwait_job_worker(struct job *job) {
+  struct sigwait_job *sigwait_job = (struct sigwait_job*)job;
+
+  siginfo_t info;
+  while (1) {
+    int sig;
+    int err = sigwait(&sigwait_job->signals, &sig);
+    if (err > 0) {
+      job->err = err;
+      return;
+    }
+
+    if (sig == SIGUSR2)
+      break;
+
+    sig |= 1 << 31;
+    do {
+      if (write(pool.notify_send, &sig, sizeof(int)) > 0)
+        break;
+    } while (errno == EINTR);
+  }
+}
+
+MOONBIT_FFI_EXPORT
+struct sigwait_job *moonbitlang_async_make_sigwait_job(int *signals) {
+  struct sigwait_job *job = MAKE_JOB(sigwait);
+
+  sigemptyset(&job->signals);
+  for (int i = 0; i < Moonbit_array_length(signals); ++i)
+    sigaddset(&job->signals, signals[i]);
+
+  sigaddset(&job->signals, SIGUSR2);
+
+  return job;
+}
+
+#endif

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -272,3 +272,8 @@ extern "C" fn Job::getaddrinfo(host : @os_string.OsString) -> Job = "moonbitlang
 ///|
 #borrow(job)
 extern "C" fn Job::get_getaddrinfo_result(job : Job) -> AddrInfo = "moonbitlang_async_get_getaddrinfo_result"
+
+///|
+#cfg(not(platform="windows"))
+#borrow(signals)
+extern "C" fn Job::sigwait(signals : ReadOnlyArray[Int]) -> Job = "moonbitlang_async_make_sigwait_job"

--- a/src/process/cancellation.mbt
+++ b/src/process/cancellation.mbt
@@ -39,12 +39,16 @@ let default_signal : @signal.Signal = SIGTERM
 /// Graceful process termination is implemented by sendig `signal` to the process.
 /// The default signal is `SIGTERM` on POSIX-like systems
 /// and `SIGBREAK` (aka `CTRL_BREAK_EVENT`) on Windows.
+///
+/// Note that on Windows, `SIGBREAK` is the only signal allowed to be be sent.
 pub fn graceful_cancel(
   timeout~ : Int,
   signal? : @signal.Signal = default_signal,
 ) -> CancellationHandler {
   pid => {
-    terminate_process(pid, signal.to_int())
+    if signal.to_int() is code && code >= 0 {
+      terminate_process(pid, signal.to_int())
+    }
     @async.sleep(timeout)
     kill_process(pid)
   }

--- a/src/process/cancellation.mbt
+++ b/src/process/cancellation.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-extern "C" fn terminate_process(pid : Int) = "moonbitlang_async_terminate_process"
+extern "C" fn terminate_process(pid : Int, signal : Int) = "moonbitlang_async_terminate_process"
 
 ///|
 extern "C" fn kill_process(pid : Int) = "moonbitlang_async_kill_process"
@@ -24,15 +24,27 @@ extern "C" fn kill_process(pid : Int) = "moonbitlang_async_kill_process"
 pub(all) struct CancellationHandler(async (Int) -> Unit)
 
 ///|
+#cfg(platform="windows")
+let default_signal : @signal.Signal = SIGBREAK
+
+///|
+#cfg(not(platform="windows"))
+let default_signal : @signal.Signal = SIGTERM
+
+///|
 /// A process cancellation handler that first try to gracefully stop the process,
 /// and if the process is still running after `timeout` milliseconds,
 /// forcefully stop the process.
 ///
-/// Graceful process termination is implemented via `SIGTERM` on POSIX-like systems,
-/// and `CTRL_BREAK_EVENT` on Windows.
-pub fn graceful_cancel(timeout~ : Int) -> CancellationHandler {
+/// Graceful process termination is implemented by sendig `signal` to the process.
+/// The default signal is `SIGTERM` on POSIX-like systems
+/// and `SIGBREAK` (aka `CTRL_BREAK_EVENT`) on Windows.
+pub fn graceful_cancel(
+  timeout~ : Int,
+  signal? : @signal.Signal = default_signal,
+) -> CancellationHandler {
   pid => {
-    terminate_process(pid)
+    terminate_process(pid, signal.to_int())
     @async.sleep(timeout)
     kill_process(pid)
   }

--- a/src/process/moon.pkg
+++ b/src/process/moon.pkg
@@ -8,6 +8,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/io",
   "moonbitlang/async/fs",
+  "moonbitlang/async/signal",
 }
 
 import {

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -6,6 +6,7 @@ import {
   "moonbitlang/async/fs",
   "moonbitlang/async/io",
   "moonbitlang/async/pipe",
+  "moonbitlang/async/signal",
   "moonbitlang/async/stdio",
 }
 
@@ -18,7 +19,7 @@ pub async fn collect_stderr(StringView, ArrayView[String], extra_env? : Map[Stri
 
 pub async fn collect_stdout(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stderr? : &ProcessOutput, cwd? : StringView) -> (Int, &@io.Data)
 
-pub fn graceful_cancel(timeout~ : Int) -> CancellationHandler
+pub fn graceful_cancel(timeout~ : Int, signal? : @signal.Signal) -> CancellationHandler
 
 pub fn hard_cancel() -> CancellationHandler
 

--- a/src/process/stub.c
+++ b/src/process/stub.c
@@ -42,8 +42,8 @@ moonbit_bytes_t *moonbitlang_async_get_curr_env() {
   return result;
 }
 
-void moonbitlang_async_terminate_process(pid_t pid) {
-  kill(pid, SIGTERM);
+void moonbitlang_async_terminate_process(pid_t pid, int signal) {
+  kill(pid, signal);
 }
 
 void moonbitlang_async_kill_process(pid_t pid) {

--- a/src/process/test_programs/sleep/main.mbt
+++ b/src/process/test_programs/sleep/main.mbt
@@ -27,6 +27,8 @@ async fn main {
   let mut time = 10_000
   let mut exit_code = 0
   let mut msg_after_sleep = None
+  let mut msg_finally = None
+  let mut use_default_handler = false
   for args = @env.args()[1:] {
     match args {
       [] => break
@@ -44,6 +46,15 @@ async fn main {
         msg_after_sleep = Some(msg)
         continue rest
       }
+      ["-print-finally", ..rest] => {
+        guard rest is [msg, ..rest] else { fail("invalid arguments") }
+        msg_finally = Some(msg)
+        continue rest
+      }
+      ["-use-default-handler", ..rest] => {
+        use_default_handler = true
+        continue rest
+      }
       [['-', ..] as flag, ..] => fail("unrecognized argument \{flag}")
       [t, .. rest] => {
         time = @string.parse_int(t)
@@ -51,8 +62,18 @@ async fn main {
       }
     }
   }
-  register_termination_handler()
-  @async.sleep(time)
+  if !use_default_handler {
+    @signal.set_global_cancellation_signals([])
+    register_termination_handler()
+  }
+  {
+    defer {
+      if msg_finally is Some(msg) {
+        println(msg)
+      }
+    }
+    @async.sleep(time)
+  }
   if msg_after_sleep is Some(msg) {
     println(msg)
   }

--- a/src/process/test_programs/sleep/moon.pkg
+++ b/src/process/test_programs/sleep/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbitlang/core/string",
   "moonbitlang/core/env",
   "moonbitlang/async",
+  "moonbitlang/async/signal",
 }
 
 options(

--- a/src/process/windows.c
+++ b/src/process/windows.c
@@ -33,8 +33,8 @@ moonbit_string_t moonbitlang_async_get_curr_env() {
   return result;
 }
 
-void moonbitlang_async_terminate_process(DWORD pid) {
-  GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid);
+void moonbitlang_async_terminate_process(DWORD pid, int signal) {
+  GenerateConsoleCtrlEvent(signal, pid);
 }
 
 void moonbitlang_async_kill_process(DWORD pid) {

--- a/src/signal/moon.pkg
+++ b/src/signal/moon.pkg
@@ -1,0 +1,13 @@
+import {
+  "moonbitlang/async/internal/event_loop",
+}
+
+import {
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/async",
+  "moonbitlang/async/process",
+} for "test"
+
+options(
+  targets: { "signal.mbt": [ "native" ], "signal_test.mbt": [ "native" ] },
+)

--- a/src/signal/pkg.generated.mbti
+++ b/src/signal/pkg.generated.mbti
@@ -1,0 +1,25 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/async/signal"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn set_global_cancellation_signals(ReadOnlyArray[Signal]) -> Unit
+
+// Errors
+
+// Types and methods
+pub(all) enum Signal {
+  SIGINT
+  SIGTERM
+  SIGHUP
+  SIGBREAK
+} derive(@debug.Debug)
+pub fn Signal::to_int(Self) -> Int
+
+// Type aliases
+
+// Traits
+

--- a/src/signal/signal.mbt
+++ b/src/signal/signal.mbt
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 ///|
+/// The set of currently supported signals.
+/// - `SIGINT`: `SIGINT` on Unix, `CTRL_C_EVENT` on Windows
+/// - `SIGTERM`: `SIGTERM` on Unix, unavailable on Windows
+/// - `SIGHUP`: `SIGHUP` on Unix, `CTRL_CLOSE_EVENT` on Windows
+/// - `SIGBREAK`: unavailable on Unix, `CTRL_BREAK_EVENT` on Windows
 pub(all) enum Signal {
   SIGINT = 0
   SIGTERM = 1
@@ -21,6 +26,8 @@ pub(all) enum Signal {
 } derive(Debug)
 
 ///|
+/// Convert a signal to its underlying signal code in the OS.
+/// The result of this function is platform-dependent.
 pub fn Signal::to_int(signal : Signal) -> Int {
   match signal {
     SIGINT => @event_loop._SIGINT
@@ -31,6 +38,13 @@ pub fn Signal::to_int(signal : Signal) -> Int {
 }
 
 ///|
+/// Set the list of signals that are used as global cancellation signal.
+/// When a global cancellation signal is received, the whole program will be cancelled gracefully,
+/// using the native cancellation mechanism of `moonbitlang/async`.
+///
+/// Signals unavailable on current platform will be silently ignored.
+///
+/// The default list is all supported signals.
 pub fn set_global_cancellation_signals(signals : ReadOnlyArray[Signal]) -> Unit {
   @event_loop.set_global_cancellation_signals(signals.map(sig => sig.to_int()))
 }

--- a/src/signal/signal.mbt
+++ b/src/signal/signal.mbt
@@ -13,18 +13,24 @@
 // limitations under the License.
 
 ///|
-/// This package currently does not support JavaScript backend
-#cfg(not(target="native"))
-#coverage.skip
-pub let unimplemented : Unit = {
-  ignore(@io.pipe)
-  ignore(@async.sleep)
-  ignore(@event_loop.Timer::new)
-  ignore(@coroutine.spawn)
-  ignore(@pipe.unimplemented)
-  ignore(@stdio.unimplemented)
-  ignore(@fd_util.unimplemented)
-  ignore(@os_string.unimplemented)
-  ignore(@fs.unimplemented)
-  ignore(@signal.unimplemented)
+pub(all) enum Signal {
+  SIGINT = 0
+  SIGTERM = 1
+  SIGHUP = 2
+  SIGBREAK = 3
+} derive(Debug)
+
+///|
+pub fn Signal::to_int(signal : Signal) -> Int {
+  match signal {
+    SIGINT => @event_loop._SIGINT
+    SIGTERM => @event_loop._SIGTERM
+    SIGHUP => @event_loop._SIGHUP
+    SIGBREAK => @event_loop._SIGBREAK
+  }
+}
+
+///|
+pub fn set_global_cancellation_signals(signals : ReadOnlyArray[Signal]) -> Unit {
+  @event_loop.set_global_cancellation_signals(signals.map(sig => sig.to_int()))
 }

--- a/src/signal/signal_test.mbt
+++ b/src/signal/signal_test.mbt
@@ -62,6 +62,8 @@ async test "cancel with default signal" {
 }
 
 ///|
+// On Windows, `CTRL_C_EVENT` cannot be sent to a single process
+#cfg(not(platform="windows"))
 async test "cancel with ctrl+c" {
   let test_prog = sleep_prog.wait()
   let log = []
@@ -95,6 +97,8 @@ async test "cancel with ctrl+c" {
 }
 
 ///|
+// On Windows, `CTRL_CLOSE_EVENT` cannot be sent programmatically
+#cfg(not(platform="windows"))
 async test "cancel with SIGHUP" {
   let test_prog = sleep_prog.wait()
   let log = []

--- a/src/signal/signal_test.mbt
+++ b/src/signal/signal_test.mbt
@@ -1,0 +1,128 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn make_test_prog(name : String) -> @async.Lazy[String] {
+  @async.Lazy(() => {
+    let code = @process.run("moon", [
+      "build",
+      "--manifest-path",
+      "src/process/test_programs/moon.mod.json",
+      "src/process/test_programs/\{name}",
+      "--debug",
+    ])
+    if code != 0 {
+      fail("failed to build test program `\{name}`: \{code}")
+    }
+    "src/process/test_programs/_build/native/debug/build/\{name}/\{name}.exe"
+  })
+}
+
+///|
+let sleep_prog : @async.Lazy[String] = make_test_prog("sleep")
+
+///|
+async test "cancel with default signal" {
+  let test_prog = sleep_prog.wait()
+  let log = []
+  @async.with_task_group(group => {
+    let (r, w) = @process.read_from_process()
+    let task = group.spawn(() => {
+      defer log.push("process terminates")
+      @process.run(test_prog, stdout=w, [
+        "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
+        "before exit",
+      ])
+    })
+    group.spawn_bg(() => {
+      defer r.close()
+      while r.read_some() is Some(data) {
+        let data = @utf8.decode(data).replace_all(old="\r\n", new="\n").trim()
+        log.push("from process: \{data}")
+      }
+    })
+    @async.sleep(500)
+    task.cancel()
+    log.push("cancelling task running process")
+  })
+  json_inspect(log, content=[
+    "cancelling task running process", "from process: before exit", "process terminates",
+  ])
+}
+
+///|
+async test "cancel with ctrl+c" {
+  let test_prog = sleep_prog.wait()
+  let log = []
+  @async.with_task_group(group => {
+    let (r, w) = @process.read_from_process()
+    let task = group.spawn(() => {
+      defer log.push("process terminates")
+      let cancel_handler = @process.graceful_cancel(
+        timeout=5000,
+        signal=@signal.SIGINT,
+      )
+      @process.run(test_prog, stdout=w, cancel_handler~, [
+        "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
+        "before exit",
+      ])
+    })
+    group.spawn_bg(() => {
+      defer r.close()
+      while r.read_some() is Some(data) {
+        let data = @utf8.decode(data).replace_all(old="\r\n", new="\n").trim()
+        log.push("from process: \{data}")
+      }
+    })
+    @async.sleep(500)
+    task.cancel()
+    log.push("cancelling task running process")
+  })
+  json_inspect(log, content=[
+    "cancelling task running process", "from process: before exit", "process terminates",
+  ])
+}
+
+///|
+async test "cancel with SIGHUP" {
+  let test_prog = sleep_prog.wait()
+  let log = []
+  @async.with_task_group(group => {
+    let (r, w) = @process.read_from_process()
+    let task = group.spawn(() => {
+      defer log.push("process terminates")
+      let cancel_handler = @process.graceful_cancel(
+        timeout=5000,
+        signal=@signal.SIGHUP,
+      )
+      @process.run(test_prog, stdout=w, cancel_handler~, [
+        "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
+        "before exit",
+      ])
+    })
+    group.spawn_bg(() => {
+      defer r.close()
+      while r.read_some() is Some(data) {
+        let data = @utf8.decode(data).replace_all(old="\r\n", new="\n").trim()
+        log.push("from process: \{data}")
+      }
+    })
+    @async.sleep(500)
+    task.cancel()
+    log.push("cancelling task running process")
+  })
+  json_inspect(log, content=[
+    "cancelling task running process", "from process: before exit", "process terminates",
+  ])
+}

--- a/src/signal/unimplemented.mbt
+++ b/src/signal/unimplemented.mbt
@@ -16,15 +16,4 @@
 /// This package currently does not support JavaScript backend
 #cfg(not(target="native"))
 #coverage.skip
-pub let unimplemented : Unit = {
-  ignore(@io.pipe)
-  ignore(@async.sleep)
-  ignore(@event_loop.Timer::new)
-  ignore(@coroutine.spawn)
-  ignore(@pipe.unimplemented)
-  ignore(@stdio.unimplemented)
-  ignore(@fd_util.unimplemented)
-  ignore(@os_string.unimplemented)
-  ignore(@fs.unimplemented)
-  ignore(@signal.unimplemented)
-}
+pub let unimplemented : Unit = ignore(@event_loop.Timer::new)

--- a/src/signal/unimplemented_test.mbt
+++ b/src/signal/unimplemented_test.mbt
@@ -13,18 +13,9 @@
 // limitations under the License.
 
 ///|
-/// This package currently does not support JavaScript backend
 #cfg(not(target="native"))
-#coverage.skip
-pub let unimplemented : Unit = {
-  ignore(@io.pipe)
+let _ignore_unused_import : Unit = {
+  ignore(@utf8.encode(""))
   ignore(@async.sleep)
-  ignore(@event_loop.Timer::new)
-  ignore(@coroutine.spawn)
-  ignore(@pipe.unimplemented)
-  ignore(@stdio.unimplemented)
-  ignore(@fd_util.unimplemented)
-  ignore(@os_string.unimplemented)
-  ignore(@fs.unimplemented)
-  ignore(@signal.unimplemented)
+  ignore(@process.unimplemented)
 }


### PR DESCRIPTION
This PR add signal handling support to `moonbitlang/async`, in the form of a set of global cancellation signals. When a registered signal is received, the whole program will be cancelled, using `moonbitlang/async`'s native cancellation mechanism. This covers the graceful termination scenario nicely, while avoiding most of the troubles of Unix signal handling.

The set of supported signals are listed in `@moonbitlang/async/signal.Signal`, and the list of signals used for global cancellation can be set via `@signal.set_global_cancellation_signals`. The default is all supported signals. On Windows, console control event is used as the alternative of signals. If a signal is explicitly excluded from the list, its default behavior is recovered (usually force-terminating the program, but although not recommended, users may manually handle it through FFI).

The implementation uses a dedicated thread running `sigwait`. This avoids all the async-signal-safe problems of signal handlers. On all other threads, including the main thread, the global cancellation signals are blocked, so those signals are always captured by the `sigwait` thread. The `sigwait` thread also waits for `SIGUSR2`. On normal program termination, the event loop will send `SIGUSR2` to the `sigwait` thread, and the `sigwait` thread will terminate itself upon receiving the `SIGUSR2` cancellation signal.
