### PR TITLE
add `get_peer_certificate` for `@tls.Tls`

### DIFF
--- a/src/tls/certificate_test.mbt
+++ b/src/tls/certificate_test.mbt
@@ -1,0 +1,54 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "get_peer_certificate" {
+  @async.with_task_group(group => {
+    let (client_read_from_server, server_write_to_client) = @pipe.pipe()
+    let (server_read_from_client, client_write_to_server) = @pipe.pipe()
+    // server
+    group.spawn_bg(() => {
+      defer {
+        server_read_from_client.close()
+        server_write_to_client.close()
+      }
+      let server = test_server(server_read_from_client, server_write_to_client)
+      defer server.close()
+      debug_inspect(
+        server.get_peer_certificate().map(cert => cert.length()),
+        content="None",
+      )
+    })
+    // client
+    group.spawn_bg(() => {
+      defer {
+        client_read_from_server.close()
+        client_write_to_server.close()
+      }
+      let client = @tls.Tls::client_from_pair(
+        client_read_from_server,
+        client_write_to_server,
+        verify=false,
+      )
+      defer client.close()
+      debug_inspect(
+        client.get_peer_certificate().map(cert => cert.length()),
+        content=(
+          #|Some(1447)
+        ),
+      )
+      client.shutdown()
+    })
+  })
+}

--- a/src/tls/moon.pkg
+++ b/src/tls/moon.pkg
@@ -19,6 +19,7 @@ import {
 options(
   "native-stub": [ "openssl.c", "schannel.c" ],
   targets: {
+    "certificate_test.mbt": [ "native" ],
     "crypto_util.mbt": [ "native" ],
     "deprecated.mbt": [ "native" ],
     "openssl.mbt": [ "native" ],

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -18,6 +18,7 @@
 
 #include <dlfcn.h>
 #include <string.h>
+#include <stdio.h>
 #include <moonbit.h>
 
 // TODO: are these stable?
@@ -35,6 +36,7 @@ typedef struct BIO BIO;
 typedef struct SSL SSL;
 typedef struct SSL_CTX SSL_CTX;
 typedef struct SSL_METHOD SSL_METHOD;
+typedef struct X509 X509;
 
 #define IMPORTED_OPEN_SSL_FUNCTIONS\
   IMPORT_FUNC(BIO_METHOD*, BIO_meth_new, (int type, const char *name))\
@@ -70,13 +72,19 @@ typedef struct SSL_METHOD SSL_METHOD;
   IMPORT_FUNC(void, SSL_CTX_set_verify, (SSL_CTX *ctx, int mode, int (*verify_cb)(int, void*)))\
   IMPORT_FUNC(int, SSL_CTX_set_default_verify_paths, (SSL_CTX *ctx))\
   IMPORT_FUNC(unsigned long, ERR_get_error, (void))\
+  IMPORT_FUNC(unsigned long, ERR_peek_error, (void))\
   IMPORT_FUNC(char *, ERR_error_string, (unsigned long e, char *buf))\
   IMPORT_FUNC(int, RAND_bytes, (unsigned char *buf, int num))\
-  IMPORT_FUNC(unsigned char *, SHA1, (const unsigned char *d, size_t n, unsigned char *md))
+  IMPORT_FUNC(unsigned char *, SHA1, (const unsigned char *d, size_t n, unsigned char *md))\
+  IMPORT_FUNC_WITH_ALT_NAMES(X509 *, SSL_get1_peer_certificate, (const SSL *ssl), { "SSL_get_peer_certificate" })\
+  IMPORT_FUNC(void, X509_free, (const X509 *cert))\
+  IMPORT_FUNC(int, i2d_X509_AUX, (X509 *cert, unsigned char **ppout))
 
 #define IMPORT_FUNC(ret, name, params) static ret (*name) params;
+#define IMPORT_FUNC_WITH_ALT_NAMES(ret, name, params, alt_names) IMPORT_FUNC(ret, name, params)
 IMPORTED_OPEN_SSL_FUNCTIONS
 #undef IMPORT_FUNC
+#undef IMPORT_FUNC_WITH_ALT_NAMES
 
 int moonbitlang_async_load_openssl(int *major, int *minor, int *fix) {
   void *handle = 0;
@@ -106,10 +114,20 @@ int moonbitlang_async_load_openssl(int *major, int *minor, int *fix) {
 #define IMPORT_FUNC(ret, func, params)\
   func = dlsym(handle, "" #func "");\
   if (!func) return 4;
+#define IMPORT_FUNC_WITH_ALT_NAMES(ret, func, params, alt_names)\
+  func = dlsym(handle, "" #func "");\
+  if (!func) {\
+    const char *names[] = alt_names;\
+    for (int i = 0; !func && i < sizeof(names) / sizeof(const char*); ++i) {\
+      func = dlsym(handle, names[i]);\
+    }\
+    if (!func) return 4;\
+  }
 
   IMPORTED_OPEN_SSL_FUNCTIONS
 
-#undef LOAD_FUNC
+#undef IMPORT_FUNC
+#undef IMPORT_FUNC_WITH_ALT_NAMES
 
   return 0;
 }
@@ -247,8 +265,30 @@ void moonbitlang_async_tls_ssl_free(SSL *ssl) {
   SSL_free(ssl);
 }
 
+moonbit_bytes_t moonbitlang_async_tls_ssl_get_peer_certificate(SSL *ssl) {
+  X509 *cert = SSL_get1_peer_certificate(ssl);
+  if (!cert) return 0;
+
+  int len = i2d_X509_AUX(cert, 0);
+  if (len < 0) goto handle_error;
+
+  moonbit_bytes_t result = moonbit_make_bytes_raw(len);
+  unsigned char *buf = result;
+  i2d_X509_AUX(cert, &buf);
+  X509_free(cert);
+  return result;
+
+handle_error:
+  X509_free(cert);
+  return 0;
+}
+
 int moonbitlang_async_tls_ssl_get_error(SSL *ssl, int ret) {
   return SSL_get_error(ssl, ret);
+}
+
+uint64_t moonbitlang_async_tls_peek_error_code() {
+  return ERR_peek_error();
 }
 
 int moonbitlang_async_tls_get_error(void *buf) {

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -79,6 +79,10 @@ extern "C" fn SSL::set_verify(self : SSL, verify : Bool) = "moonbitlang_async_tl
 extern "C" fn SSL::accept(self : SSL) -> Int = "moonbitlang_async_tls_ssl_accept"
 
 ///|
+#cfg(not(platform="windows"))
+extern "C" fn SSL::get_peer_certificate(self : SSL) -> Bytes? = "moonbitlang_async_tls_ssl_get_peer_certificate"
+
+///|
 pub(all) enum X509FileType {
   PEM = 1
   ANS1 = 2
@@ -153,6 +157,10 @@ const SSL_ERROR_SYSCALL = 5
 ///|
 #cfg(not(platform="windows"))
 const SSL_ERROR_ZERO_RETURN = 6
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn err_peek_error_code() -> UInt64 = "moonbitlang_async_tls_peek_error_code"
 
 ///|
 #cfg(not(platform="windows"))
@@ -514,6 +522,23 @@ pub async fn Tls::shutdown(self : Tls) -> Unit {
   } nobreak {
     self.transport.flush_write()
   }
+}
+
+///|
+/// Get the certificate of remote peer for a TLS connection in DER format.
+/// Note that even if nothing goes wrong, the certificate may not exist:
+///
+/// - although rare, some TLS algorithm choice does not have a certificate
+/// - for connection without client certificate, the server does not have any peer certificate
+///
+/// Therefore the return type is `Bytes?` instead of `Bytes`.
+#cfg(not(platform="windows"))
+pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
+  let result = self.ssl.get_peer_certificate()
+  if result is None && err_peek_error_code() != 0 {
+    raise TlsError(err_get_error())
+  }
+  result
 }
 
 ///|

--- a/src/tls/pkg.generated.mbti
+++ b/src/tls/pkg.generated.mbti
@@ -25,6 +25,7 @@ type Tls
 pub async fn[Inner : @io.Reader + @io.Writer] Tls::client(Inner, verify? : Bool, host? : String, sni? : Bool) -> Self
 pub async fn[R : @io.Reader, W : @io.Writer] Tls::client_from_pair(R, W, verify? : Bool, host? : String, sni? : Bool) -> Self
 pub fn Tls::close(Self) -> Unit
+pub fn Tls::get_peer_certificate(Self) -> Bytes? raise
 pub async fn[Inner : @io.Reader + @io.Writer] Tls::server(Inner, private_key_file~ : String, private_key_type~ : X509FileType, certificate_file~ : String, certificate_type~ : X509FileType) -> Self
 pub async fn[R : @io.Reader, W : @io.Writer] Tls::server_from_pair(R, W, private_key_file~ : String, private_key_type~ : X509FileType, certificate_file~ : String, certificate_type~ : X509FileType) -> Self
 pub async fn Tls::shutdown(Self) -> Unit

--- a/src/tls/schannel.c
+++ b/src/tls/schannel.c
@@ -489,6 +489,26 @@ int32_t moonbitlang_async_schannel_shutdown(struct Context *ctx) {
 }
 
 MOONBIT_FFI_EXPORT
+moonbit_bytes_t moonbitlang_async_schannel_get_peer_certificate(struct Context *ctx) {
+  CERT_CONTEXT *cert = 0;
+  int err = QueryContextAttributes(&ctx->context, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &cert);
+  if (err != SEC_E_OK && err != SEC_E_NO_CREDENTIALS) {
+    SetLastError(err);
+    return 0;
+  }
+
+  if (!cert) {
+    SetLastError(0);
+    return 0;
+  }
+
+  moonbit_bytes_t result = moonbit_make_bytes_raw(cert->cbCertEncoded);
+  memcpy(result, cert->pbCertEncoded, cert->cbCertEncoded);
+  CertFreeCertificateContext(cert);
+  return result;
+}
+
+MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_tls_rand_bytes(void *buf, int32_t num) {
   return BCryptGenRandom(NULL, buf, num, BCRYPT_USE_SYSTEM_PREFERRED_RNG) == STATUS_SUCCESS;
 }

--- a/src/tls/schannel.mbt
+++ b/src/tls/schannel.mbt
@@ -398,6 +398,24 @@ pub async fn Tls::shutdown(self : Tls) -> Unit {
 }
 
 ///|
+#cfg(platform="windows")
+#borrow(ch)
+extern "C" fn Schannel::get_peer_certificate(ch : Schannel) -> Bytes? = "moonbitlang_async_schannel_get_peer_certificate"
+
+///|
+#cfg(platform="windows")
+pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
+  let result = self.context.get_peer_certificate()
+  if result is None {
+    let errno = @os_error.get_errno()
+    if errno != 0 {
+      raise TlsError(@os_error.errno_to_string(errno))
+    }
+  }
+  result
+}
+
+///|
 // mute unused warning
 #cfg(platform="windows")
 let _unused : Unit = {


### PR DESCRIPTION
This PR adds a new method `get_peer_certificate` for `@tls.Tls`, which returns the certificate of the peer, in DER format. Note that not all TLS connection has/requires a peer certificate, so the return value may be `None` even if nothing goes wrong.

This method is useful for implementing server-endpoint style SASL channel binding.