### PR TITLE
add `@fs.rename`

### DIFF
--- a/src/fs/dir_test.mbt
+++ b/src/fs/dir_test.mbt
@@ -24,9 +24,9 @@ async test "read_all" {
     "stub.c", "dir.mbt", "file.mbt", "moon.pkg", "README.md", "utils.mbt", "tmpdir.mbt",
     "dir_test.mbt", "eof_test.mbt", "README.mbt.md", "constants.mbt", "lock_test.mbt",
     "stat_test.mbt", "walk_test.mbt", "deprecated.mbt", "mkdir_test.mbt", "access_test.mbt",
-    "create_test.mbt", "tmpdir_test.mbt", "read_all_test.mbt", "realpath_test.mbt",
-    "unimplemented.mbt", "pkg.generated.mbti", "text_file_test.mbt", "timestamp_test.mbt",
-    "named_pipe_test.mbt", "random_access_test.mbt", "unimplemented_test.mbt",
+    "create_test.mbt", "rename_test.mbt", "tmpdir_test.mbt", "read_all_test.mbt",
+    "realpath_test.mbt", "unimplemented.mbt", "pkg.generated.mbti", "text_file_test.mbt",
+    "timestamp_test.mbt", "named_pipe_test.mbt", "random_access_test.mbt", "unimplemented_test.mbt",
   ])
 }
 
@@ -59,10 +59,10 @@ async test "as_dir" {
     "eof_test.mbt: Regular", "README.mbt.md: Regular", "constants.mbt: Regular",
     "lock_test.mbt: Regular", "stat_test.mbt: Regular", "walk_test.mbt: Regular",
     "deprecated.mbt: Regular", "mkdir_test.mbt: Regular", "access_test.mbt: Regular",
-    "create_test.mbt: Regular", "tmpdir_test.mbt: Regular", "read_all_test.mbt: Regular",
-    "realpath_test.mbt: Regular", "unimplemented.mbt: Regular", "pkg.generated.mbti: Regular",
-    "text_file_test.mbt: Regular", "timestamp_test.mbt: Regular", "named_pipe_test.mbt: Regular",
-    "random_access_test.mbt: Regular", "unimplemented_test.mbt: Regular",
+    "create_test.mbt: Regular", "rename_test.mbt: Regular", "tmpdir_test.mbt: Regular",
+    "read_all_test.mbt: Regular", "realpath_test.mbt: Regular", "unimplemented.mbt: Regular",
+    "pkg.generated.mbti: Regular", "text_file_test.mbt: Regular", "timestamp_test.mbt: Regular",
+    "named_pipe_test.mbt: Regular", "random_access_test.mbt: Regular", "unimplemented_test.mbt: Regular",
   ])
 }
 
@@ -81,7 +81,7 @@ test "readdir clear errno" {
     inspect(
       list.length(),
       content=(
-        #|28
+        #|29
       ),
     )
   })

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -355,6 +355,12 @@ pub async fn remove(path : StringView) -> Unit {
 }
 
 ///|
+/// Rename (move) the file located at `old_path` to `new_path`.
+pub async fn rename(old_path : StringView, new_path : StringView) -> Unit {
+  @event_loop.rename(old_path, new_path, context="@fs.remove()")
+}
+
+///|
 /// Get the size of the file. This method will not change position in the file.
 /// Can only be applied to a regular file.
 pub async fn File::size(self : File) -> Int64 {

--- a/src/fs/moon.pkg
+++ b/src/fs/moon.pkg
@@ -37,6 +37,7 @@ options(
     "random_access_test.mbt": [ "native" ],
     "read_all_test.mbt": [ "native" ],
     "realpath_test.mbt": [ "native" ],
+    "rename_test.mbt": [ "native" ],
     "stat_test.mbt": [ "native" ],
     "text_file_test.mbt": [ "native" ],
     "timestamp_test.mbt": [ "native" ],

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -43,6 +43,8 @@ pub async fn realpath(StringView) -> String
 
 pub async fn remove(StringView) -> Unit
 
+pub async fn rename(StringView, StringView) -> Unit
+
 pub async fn rmdir(StringView, recursive? : Bool) -> Unit
 
 pub async fn symlink(target~ : StringView, StringView) -> Unit

--- a/src/fs/rename_test.mbt
+++ b/src/fs/rename_test.mbt
@@ -1,0 +1,34 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "rename basic" {
+  let old_path = "_build/rename_basic_test_old"
+  let new_path = "_build/rename_basic_test_new"
+  let file = @fs.open(
+    old_path,
+    mode=WriteOnly,
+    create_mode=CreateOrTruncate,
+    sync=Full,
+  )
+  defer file.close()
+  file.write("abcd")
+  inspect(@fs.read_file(old_path).text(), content="abcd")
+  @fs.rename(old_path, new_path)
+  inspect(@fs.read_file(new_path).text(), content="abcd")
+  file.write_at(b"ABCD", position=0)
+  inspect(@fs.read_file(new_path).text(), content="ABCD")
+  inspect(@fs.exists(old_path), content="false")
+  @fs.remove(new_path)
+}

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -200,6 +200,28 @@ pub async fn remove(path : StringView, context~ : String) -> Unit {
 }
 
 ///|
+pub async fn rename(
+  old_path : StringView,
+  new_path : StringView,
+  context~ : String,
+) -> Unit {
+  let old_path_bytes = @os_string.encode(old_path)
+  let new_path_bytes = @os_string.encode(new_path)
+  try
+    perform_job_in_worker(Job::rename(old_path_bytes, new_path_bytes), context~)
+  catch {
+    @os_error.OSError(errno, context~) =>
+      raise @os_error.OSError(
+        errno,
+        context="\{context}: \{old_path.escape()} => \{new_path.escape()}",
+      )
+    err => raise err
+  } noraise {
+    _ => ()
+  }
+}
+
+///|
 pub async fn symlink(
   target : StringView,
   path : StringView,

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -48,6 +48,8 @@ pub async fn realpath(StringView, context~ : String) -> String
 
 pub async fn remove(StringView, context~ : String) -> Unit
 
+pub async fn rename(StringView, StringView, context~ : String) -> Unit
+
 pub async fn rmdir(StringView, context~ : String) -> Unit
 
 pub fn set_global_cancellation_signals(ReadOnlyArray[Int]) -> Unit

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -1044,60 +1044,6 @@ struct file_time_by_path_job *moonbitlang_async_make_file_time_by_path_job(
   return job;
 }
 
-// ===== access job, test permission of file path =====
-
-struct access_job {
-  struct job job;
-  char *path;
-  int amode;
-};
-
-static
-void free_access_job(void *obj) {
-  struct access_job *job = (struct access_job*)obj;
-  moonbit_decref(job->path);
-}
-
-static
-void access_job_worker(struct job *job) {
-#ifdef _WIN32
-
-  static int access_modes[] = { 0, GENERIC_READ, GENERIC_WRITE, FILE_EXECUTE };
-  struct access_job *access_job = (struct access_job*)job;
-
-  HANDLE handle = CreateFileW(
-    (LPCWSTR)access_job->path,
-    access_modes[access_job->amode],
-    FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-    NULL,
-    OPEN_EXISTING,
-    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
-    NULL
-  );
-  if (handle == INVALID_HANDLE_VALUE) {
-    job->err = GetLastError();
-  } else {
-    CloseHandle(handle);
-  }
-
-#else
-
-  static int access_modes[] = { F_OK, R_OK, W_OK, X_OK };
-  struct access_job *access_job = (struct access_job*)job;
-  job->ret = access(access_job->path, access_modes[access_job->amode]);
-  if (job->ret < 0)
-    job->err = errno;
-
-#endif
-}
-
-struct access_job *moonbitlang_async_make_access_job(char *path, int amode) {
-  struct access_job *job = MAKE_JOB(access);
-  job->path = path;
-  job->amode = amode;
-  return job;
-}
-
 #ifndef _WIN32
 // ===== chmod job, change permission of file =====
 
@@ -1253,6 +1199,99 @@ void remove_job_worker(struct job *job) {
 struct remove_job *moonbitlang_async_make_remove_job(char *path) {
   struct remove_job *job = MAKE_JOB(remove);
   job->path = path;
+  return job;
+}
+
+// ===== access job, test permission of file path =====
+
+struct access_job {
+  struct job job;
+  char *path;
+  int amode;
+};
+
+static
+void free_access_job(void *obj) {
+  struct access_job *job = (struct access_job*)obj;
+  moonbit_decref(job->path);
+}
+
+static
+void access_job_worker(struct job *job) {
+#ifdef _WIN32
+
+  static int access_modes[] = { 0, GENERIC_READ, GENERIC_WRITE, FILE_EXECUTE };
+  struct access_job *access_job = (struct access_job*)job;
+
+  HANDLE handle = CreateFileW(
+    (LPCWSTR)access_job->path,
+    access_modes[access_job->amode],
+    FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+    NULL,
+    OPEN_EXISTING,
+    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
+    NULL
+  );
+  if (handle == INVALID_HANDLE_VALUE) {
+    job->err = GetLastError();
+  } else {
+    CloseHandle(handle);
+  }
+
+#else
+
+  static int access_modes[] = { F_OK, R_OK, W_OK, X_OK };
+  struct access_job *access_job = (struct access_job*)job;
+  job->ret = access(access_job->path, access_modes[access_job->amode]);
+  if (job->ret < 0)
+    job->err = errno;
+
+#endif
+}
+
+struct access_job *moonbitlang_async_make_access_job(char *path, int amode) {
+  struct access_job *job = MAKE_JOB(access);
+  job->path = path;
+  job->amode = amode;
+  return job;
+}
+
+// ===== rename job, rename file =====
+struct rename_job {
+  struct job job;
+  char *old_path;
+  char *new_path;
+};
+
+static
+void free_rename_job(void *obj) {
+  struct rename_job *job = (struct rename_job*)obj;
+  moonbit_decref(job->old_path);
+  moonbit_decref(job->new_path);
+}
+
+static
+void rename_job_worker(struct job *job) {
+  struct rename_job *rename_job = (struct rename_job*)job;
+
+#ifdef _WIN32
+
+  if (!MoveFileW((LPCWSTR)rename_job->old_path, (LPCWSTR)rename_job->new_path))
+    job->err = GetLastError();
+
+#else
+
+  job->ret = rename(rename_job->old_path, rename_job->new_path);
+  if (job->ret < 0)
+    job->err = errno;
+
+#endif
+}
+
+struct rename_job *moonbitlang_async_make_rename_job(char *old_path, char *new_path) {
+  struct rename_job *job = MAKE_JOB(rename);
+  job->old_path = old_path;
+  job->new_path = new_path;
   return job;
 }
 

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -174,6 +174,13 @@ extern "C" fn Job::flock(fd : @fd_util.Fd, exclusive : Bool) -> Job = "moonbitla
 extern "C" fn Job::remove(path : @os_string.OsString) -> Job = "moonbitlang_async_make_remove_job"
 
 ///|
+#owned(old_path, new_path)
+extern "C" fn Job::rename(
+  old_path : @os_string.OsString,
+  new_path : @os_string.OsString,
+) -> Job = "moonbitlang_async_make_rename_job"
+
+///|
 #owned(target, path)
 extern "C" fn Job::symlink(
   target : @os_string.OsString,


### PR DESCRIPTION
Add `@fs.rename` for moving/renaming a file asynchronously. Uses thread pool to make the operation async.