### PR TITLE
enhance `readdir` handling, allow extra information in directory entry

### DIFF
--- a/src/fs/README.mbt.md
+++ b/src/fs/README.mbt.md
@@ -315,9 +315,7 @@ async test "readdir with sorting" {
   @fs.remove("\{dir_path}/b.txt")
   @fs.remove("\{dir_path}/c.txt")
   @fs.rmdir(dir_path)
-  guard entries.length() >= 3 else {
-    println(entries)
-  }
+  guard entries.length() >= 3 else { println(entries) }
   inspect(entries[0], content="a.txt")
   inspect(entries[1], content="b.txt")
   inspect(entries[2], content="c.txt")

--- a/src/fs/README.mbt.md
+++ b/src/fs/README.mbt.md
@@ -315,6 +315,9 @@ async test "readdir with sorting" {
   @fs.remove("\{dir_path}/b.txt")
   @fs.remove("\{dir_path}/c.txt")
   @fs.rmdir(dir_path)
+  guard entries.length() >= 3 else {
+    println(entries)
+  }
   inspect(entries[0], content="a.txt")
   inspect(entries[1], content="b.txt")
   inspect(entries[2], content="c.txt")

--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -82,7 +82,7 @@ int32_t moonbitlang_async_dir_entry_length(char *buf, int32_t offset, int32_t le
 
 #else
 
-  return offset < len ? ent->d_reclen : 0;
+  return ent->d_reclen;
 
 #endif
 }
@@ -93,7 +93,7 @@ char *moonbitlang_async_dir_entry_get_name(char *buf, int32_t offset) {
 
 #ifdef _WIN32
 
-  return ent->FileName;
+  return (char*)ent->FileName;
 
 #else
 

--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+typedef FILE_ID_BOTH_DIR_INFO sys_dirent;
+
+#elif defined(__MACH__)
+
+#include <sys/types.h>
+#include <sys/dirent.h>
+
+// https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getdirentries.2.html
+typedef struct {
+   u_int32_t d_fileno; /* file number of entry */
+   u_int16_t d_reclen; /* length of this record */
+   u_int8_t  d_type;   /* file type, see below */
+   u_int8_t  d_namlen; /* length of string in d_name */
+   char      d_name[];
+} sys_dirent;
+
+#elif defined(__linux__)
+
+#include <unistd.h>
+#include <stdint.h>
+#include <dirent.h>
+
+// glibc wrapper for this does not exist until 2.30,
+// so manually define for compatibility sake.
+// Definition come from https://man7.org/linux/man-pages/man2/getdents.2.html
+typedef struct {
+  uint64_t       d_ino;    /* 64-bit inode number */
+  int64_t        d_off;    /* Not an offset; see getdents() */
+  unsigned short d_reclen; /* Size of this dirent */
+  unsigned char  d_type;   /* File type */
+  char           d_name[]; /* Filename (null-terminated) */
+} sys_dirent;
+
+#else
+
+#error "unsupported platform"
+
+#endif
+
+#include "moonbit.h"
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_dir_entry_length(char *buf, int32_t offset, int32_t len) {
+  sys_dirent *ent = (sys_dirent *)(buf + offset);
+
+#ifdef _WIN32
+
+  return ent->NextEntryOffset;
+
+#else
+
+  return offset < len ? ent->d_reclen : 0;
+
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+char *moonbitlang_async_dir_entry_get_name(char *buf, int32_t offset) {
+  sys_dirent *ent = (sys_dirent *)(buf + offset);
+
+#ifdef _WIN32
+
+  return ent->FileName;
+
+#else
+
+  return ent->d_name;
+
+#endif
+}
+
+// 1 => is directory
+// 0 => not directory
+// -1 => unknown
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_dir_entry_is_dir(char *buf, int32_t offset) {
+  sys_dirent *ent = (sys_dirent *)(buf + offset);
+
+#ifdef _WIN32
+
+  return (ent->FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == 0
+      && (ent->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+
+#else
+
+  switch (ent->d_type) {
+    case DT_UNKNOWN: return -1;
+    case DT_DIR:     return 1;
+    default:         return 0;
+  }
+
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_dir_entry_is_hidden(char *buf, int32_t offset) {
+  sys_dirent *ent = (sys_dirent *)(buf + offset);
+
+#ifdef _WIN32
+
+  return (ent->FileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+
+#else
+
+  return ent->d_name[0] == '.';
+
+#endif
+}

--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -38,6 +38,7 @@ typedef struct {
 
 #include <unistd.h>
 #include <stdint.h>
+#include <string.h>
 #include <dirent.h>
 
 // glibc wrapper for this does not exist until 2.30,

--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -23,7 +23,6 @@ typedef FILE_ID_BOTH_DIR_INFO sys_dirent;
 #elif defined(__MACH__)
 
 #include <stdio.h>
-#include <sys/types.h>
 #include <sys/attr.h>
 #include <sys/vnode.h>
 
@@ -148,6 +147,9 @@ int32_t moonbitlang_async_dir_entry_is_dir(char *buf, int32_t offset) {
       && (ent->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
 
 #elif defined(__MACH__)
+
+  if ((ent->d_attrs.commonattr & ATTR_CMN_OBJTYPE) == 0)
+    return -1;
 
   switch (ent->d_type) {
     case VNON: return -1;

--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -22,16 +22,17 @@ typedef FILE_ID_BOTH_DIR_INFO sys_dirent;
 
 #elif defined(__MACH__)
 
+#include <stdio.h>
 #include <sys/types.h>
-#include <sys/dirent.h>
+#include <sys/attr.h>
+#include <sys/vnode.h>
 
-// https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getdirentries.2.html
+// https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getattrlist.2.html
 typedef struct {
-   u_int32_t d_fileno; /* file number of entry */
-   u_int16_t d_reclen; /* length of this record */
-   u_int8_t  d_type;   /* file type, see below */
-   u_int8_t  d_namlen; /* length of string in d_name */
-   char      d_name[];
+   u_int32_t       d_reclen; /* length of the whole record */
+   attribute_set_t d_attrs;  /* list of supported attributes */
+   attrreference_t d_name;   /* the name of the file */
+   fsobj_type_t    d_type;   /* the type of the file */
 } sys_dirent;
 
 #elif defined(__linux__)
@@ -98,7 +99,7 @@ int32_t moonbitlang_async_dir_entry_get_name_len(char *buf, int32_t offset) {
 
 #elif defined(__MACH__)
 
-  return ent->d_namelen;
+  return ent->d_name.attr_length - 1;
 
 #elif defined(__linux__)
 
@@ -119,9 +120,17 @@ char *moonbitlang_async_dir_entry_get_name(char *buf, int32_t offset) {
 
   return (char*)ent->FileName;
 
-#else
+#elif defined(__MACH__)
+
+  return ((char*)&ent->d_name) + ent->d_name.attr_dataoffset;
+
+#elif defined(__linux__)
 
   return ent->d_name;
+
+#else
+
+  moonbit_panic();
 
 #endif
 }
@@ -138,13 +147,25 @@ int32_t moonbitlang_async_dir_entry_is_dir(char *buf, int32_t offset) {
   return (ent->FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == 0
       && (ent->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
 
-#else
+#elif defined(__MACH__)
+
+  switch (ent->d_type) {
+    case VNON: return -1;
+    case VDIR: return 1;
+    default:   return 0;
+  }
+
+#elif defined(__linux__)
 
   switch (ent->d_type) {
     case DT_UNKNOWN: return -1;
     case DT_DIR:     return 1;
     default:         return 0;
   }
+
+#else
+
+  moonbit_panic();
 
 #endif
 }
@@ -157,9 +178,14 @@ int32_t moonbitlang_async_dir_entry_is_hidden(char *buf, int32_t offset) {
 
   return (ent->FileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
 
-#else
+#elif defined(__MACH__)
+
+  return ((char*)&ent->d_name)[ent->d_name.attr_dataoffset] == '.';
+
+#elif defined(__linux__)
 
   return ent->d_name[0] == '.';
+
 
 #endif
 }

--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -60,6 +60,19 @@ typedef struct {
 #include "moonbit.h"
 
 MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_dir_buffer_min_size() {
+#ifdef _WIN32
+
+  return sizeof(sys_dirent) + MAX_PATH;
+
+#else
+
+  return sizeof(sys_dirent) + NAME_MAX;
+
+#endif
+}
+
+MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_dir_entry_length(char *buf, int32_t offset, int32_t len) {
   sys_dirent *ent = (sys_dirent *)(buf + offset);
 

--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -75,7 +75,7 @@ int32_t moonbitlang_async_dir_buffer_min_size() {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_dir_entry_length(char *buf, int32_t offset, int32_t len) {
+int32_t moonbitlang_async_dir_entry_length(char *buf, int32_t offset) {
   sys_dirent *ent = (sys_dirent *)(buf + offset);
 
 #ifdef _WIN32

--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -88,6 +88,29 @@ int32_t moonbitlang_async_dir_entry_length(char *buf, int32_t offset, int32_t le
 }
 
 MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_dir_entry_get_name_len(char *buf, int32_t offset) {
+  sys_dirent *ent = (sys_dirent *)(buf + offset);
+
+#ifdef _WIN32
+
+  return ent->FileNameLength;
+
+#elif defined(__MACH__)
+
+  return ent->d_namelen;
+
+#elif defined(__linux__)
+
+  return strlen(ent->d_name);
+
+#else
+
+  moonbit_panic();
+
+#endif
+}
+
+MOONBIT_FFI_EXPORT
 char *moonbitlang_async_dir_entry_get_name(char *buf, int32_t offset) {
   sys_dirent *ent = (sys_dirent *)(buf + offset);
 

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -144,7 +144,7 @@ extern "C" fn Directory::entry_name(
 extern "C" fn Directory::entry_is_dir(
   buf : FixedArray[Byte],
   offset : Int,
-) -> Bool = "moonbitlang_async_dir_entry_is_dir"
+) -> Int = "moonbitlang_async_dir_entry_is_dir"
 
 ///|
 #borrow(buf)
@@ -207,7 +207,19 @@ async fn Directory::next_aux(
   if !include_special && name is ("." | "..") {
     return dir.next_aux(include_special~, include_hidden~, context~)
   }
-  let is_dir = Directory::entry_is_dir(dir.buf, offset)
+  let is_dir = match Directory::entry_is_dir(dir.buf, offset) {
+    0 => false
+    1..<_ => true
+    _..<0 => {
+      let kind = @event_loop.file_kind_by_path(
+        name,
+        parent=dir.fd,
+        follow_symlink=false,
+        context~,
+      )
+      kind is Directory
+    }
+  }
   Some({ name, is_dir })
 }
 

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -58,14 +58,12 @@ pub async fn rmdir(path : StringView, recursive? : Bool = false) -> Unit {
   let context = "@fs.rmdir()"
   if recursive {
     let base = path.to_string()
-    for file in readdir(base) {
-      let child_path = base + "/" + file
-      let kind = @event_loop.file_kind_by_path(
-        child_path,
-        follow_symlink=false,
-        context~,
-      )
-      if kind is Directory {
+    let dir = opendir_aux(path, context~)
+    defer dir.close()
+    while dir.next_aux(include_special=false, include_hidden=true, context~)
+          is Some(ent) {
+      let child_path = base + "/" + ent.name
+      if ent.is_dir {
         rmdir(child_path, recursive=true)
       } else {
         @event_loop.remove(child_path, context~)
@@ -77,28 +75,140 @@ pub async fn rmdir(path : StringView, recursive? : Bool = false) -> Unit {
 
 ///|
 /// A directory in file system
-struct Directory(@event_loop.Directory)
+struct Directory {
+  fd : @fd_util.Fd
+  buf : FixedArray[Byte]
+  mut offset : Int
+  mut buf_len : Int
+  mut completed : Bool
+}
 
 ///|
 pub fn Directory::close(self : Directory) -> Unit {
-  guard self.0.close() == 0
+  @fd_util.close(self.fd, kind=Directory, context="") catch {
+    _ => ()
+  }
 }
 
 ///|
 /// Open the directory at `path`. `path` is encoded UTF8.
 /// If `path` is not a directory, an error will be raised
 pub async fn opendir(path : StringView) -> Directory {
-  @event_loop.opendir(path, context="@fs.opendir()")
+  opendir_aux(path, context="@fs.opendir()")
 }
 
 ///|
-async fn Directory::read_next(dir : Directory) -> String? {
-  let name = @event_loop.readdir(dir.0, context="@fs.readdir()")
-  if name.is_null() {
-    None
-  } else {
-    Some(@os_string.decode(name))
+async fn opendir_aux(path : StringView, context~ : String) -> Directory {
+  let (fd, kind) = @event_loop.open_detached(
+    path,
+    0,
+    create=0,
+    append=false,
+    sync=0,
+    mode=0,
+    context~,
+  )
+  if !(kind is Directory) {
+    @fd_util.close(fd, kind~, context~)
+    raise @os_error.OSError(
+      @os_error.errno_ENOTDIR,
+      context="\{context}: \{path.escape()}",
+    )
   }
+  {
+    fd,
+    buf: FixedArray::make(1024, b'\x00'),
+    offset: 0,
+    buf_len: 0,
+    completed: false,
+  }
+}
+
+///|
+#borrow(buf)
+extern "C" fn Directory::entry_length(
+  buf : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+) -> Int = "moonbitlang_async_dir_entry_length"
+
+///|
+#borrow(buf)
+extern "C" fn Directory::entry_name(
+  buf : FixedArray[Byte],
+  offset : Int,
+) -> @c_buffer.Buffer = "moonbitlang_async_dir_entry_get_name"
+
+///|
+#borrow(buf)
+extern "C" fn Directory::entry_is_dir(
+  buf : FixedArray[Byte],
+  offset : Int,
+) -> Bool = "moonbitlang_async_dir_entry_is_dir"
+
+///|
+#borrow(buf)
+extern "C" fn Directory::entry_is_hidden(
+  buf : FixedArray[Byte],
+  offset : Int,
+) -> Bool = "moonbitlang_async_dir_entry_is_hidden"
+
+///|
+#valtype
+pub struct DirectoryEntry {
+  name : String
+  is_dir : Bool
+}
+
+///|
+pub async fn Directory::next(
+  dir : Directory,
+  include_hidden? : Bool = true,
+  include_special? : Bool = false,
+) -> DirectoryEntry? {
+  dir.next_aux(
+    include_special~,
+    include_hidden~,
+    context="@fs.Directory::next()",
+  )
+}
+
+///|
+async fn Directory::next_aux(
+  dir : Directory,
+  include_hidden~ : Bool,
+  include_special~ : Bool,
+  context~ : String,
+) -> DirectoryEntry? {
+  guard !dir.completed else { None }
+  let entry_len = Directory::entry_length(dir.buf, dir.offset, dir.buf_len)
+  let entry_len = if entry_len is 0 {
+    dir.offset = 0
+    dir.buf_len = @event_loop.readdir(
+      dir.fd,
+      dir.buf,
+      dir.buf.length(),
+      context~,
+    )
+    Directory::entry_length(dir.buf, dir.offset, dir.buf_len)
+  } else {
+    entry_len
+  }
+  guard entry_len > 0 else {
+    dir.completed = true
+    None
+  }
+  let offset = dir.offset
+  dir.offset += entry_len
+  if !include_hidden && Directory::entry_is_hidden(dir.buf, offset) {
+    return dir.next_aux(include_special~, include_hidden~, context~)
+  }
+  let name = @os_string.decode(Directory::entry_name(dir.buf, offset))
+  if !include_special && name is ("." | "..") {
+    return dir.next_aux(include_special~, include_hidden~, context~)
+  }
+  let is_dir = Directory::entry_is_dir(dir.buf, offset)
+  Some({ name, is_dir })
 }
 
 ///|
@@ -114,14 +224,9 @@ pub async fn Directory::read_all(
   include_special? : Bool = false,
 ) -> Array[String] {
   let result = []
-  while dir.read_next() is Some(entry) {
-    if !include_special && entry is ("." | "..") {
-      continue
-    }
-    if !include_hidden && entry is ['.', ..] {
-      continue
-    }
-    result.push(entry)
+  let context = "@fs.Directory::read_all()"
+  while dir.next_aux(include_hidden~, include_special~, context~) is Some(entry) {
+    result.push(entry.name)
   }
   result
 }
@@ -140,9 +245,13 @@ pub async fn readdir(
   include_special? : Bool = false,
   sort? : Bool = false,
 ) -> Array[String] {
-  let dir : Directory = @event_loop.opendir(path, context="@fs.readdir()")
+  let context = "@fs.readdir()"
+  let dir : Directory = opendir_aux(path, context~)
   defer dir.close()
-  let list = dir.read_all(include_hidden~, include_special~)
+  let list = []
+  while dir.next_aux(include_hidden~, include_special~, context~) is Some(entry) {
+    list.push(entry.name)
+  }
   if sort {
     list.sort()
   }
@@ -176,6 +285,7 @@ pub async fn walk(
   max_concurrency? : Int = 1000,
   allow_failure? : Bool = false,
 ) -> Unit {
+  let context = "@fs.walk()"
   guard max_concurrency > 0
   let sem = @async.Semaphore::new(max_concurrency)
   @async.with_task_group(fn(group) {
@@ -184,16 +294,19 @@ pub async fn walk(
       group.spawn_bg(allow_failure~, () => {
         sem.acquire()
         defer sem.release()
-        let files = readdir(path)
-        for file in files {
+        let dir = opendir_aux(path, context~)
+        let files = []
+        while dir.next_aux(include_hidden=true, include_special=false, context~)
+              is Some(ent) {
           let file_path = if path is [.., '/'] {
-            path + file
+            path + ent.name
           } else {
-            "\{path}/\{file}"
+            "\{path}/\{ent.name}"
           }
-          if kind(file_path) is Directory {
+          if ent.is_dir {
             handle_path(file_path)
           }
+          files.push(ent.name)
         }
         f(path, files)
       })

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -74,13 +74,27 @@ pub async fn rmdir(path : StringView, recursive? : Bool = false) -> Unit {
 }
 
 ///|
+priv enum DirectoryState {
+  NoMoreEntry
+  NeedMoreEntry
+  HasBufferedEntry
+}
+
+///|
 /// A directory in file system
 struct Directory {
   fd : @fd_util.Fd
   buf : FixedArray[Byte]
+  // The offset of the next entry in the buffer
   mut offset : Int
-  mut buf_len : Int
-  mut completed : Bool
+  // The number of entries already consumed
+  mut count : Int
+  // the return value of the corresponding job has different semantic of different platforms.
+  // - Linux: number of bytes read
+  // - MacOS: number on entries
+  // - Windows: nonzero unless EOF
+  mut job_ret : Int
+  mut state : DirectoryState
 }
 
 ///|
@@ -120,18 +134,21 @@ async fn opendir_aux(path : StringView, context~ : String) -> Directory {
       context="\{context}: \{path.escape()}",
     )
   }
-  // According to https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getdirentries.2.html,
-  // some file systems does not support buffer smaller than block size.
-  let buffer_size = @cmp.maximum(
-    Directory::min_buffer_size(),
-    open_result.block_size(),
-  )
+  Directory::from_fd(fd)
+}
+
+///|
+fn Directory::from_fd(fd : @fd_util.Fd) -> Directory {
   {
     fd,
-    buf: FixedArray::make(@cmp.maximum(buffer_size, 1024), b'\x00'),
+    buf: FixedArray::make(
+      @cmp.maximum(Directory::min_buffer_size(), 1024),
+      b'\x00',
+    ),
     offset: 0,
-    buf_len: 0,
-    completed: false,
+    count: 0,
+    job_ret: 0,
+    state: NeedMoreEntry,
   }
 }
 
@@ -140,7 +157,6 @@ async fn opendir_aux(path : StringView, context~ : String) -> Directory {
 extern "C" fn Directory::entry_length(
   buf : FixedArray[Byte],
   offset : Int,
-  len : Int,
 ) -> Int = "moonbitlang_async_dir_entry_length"
 
 ///|
@@ -212,25 +228,36 @@ async fn Directory::next_aux(
   include_special~ : Bool,
   context~ : String,
 ) -> DirectoryEntry? {
-  guard !dir.completed else { None }
-  if dir.offset >= dir.buf_len {
-    dir.offset = 0
-    dir.buf_len = @event_loop.readdir(
-      dir.fd,
-      dir.buf,
-      dir.buf.length(),
-      context~,
-    )
-    if dir.buf_len is 0 {
-      dir.completed = true
-      return None
+  match dir.state {
+    NoMoreEntry => return None
+    HasBufferedEntry => ()
+    NeedMoreEntry => {
+      dir.offset = 0
+      dir.job_ret = @event_loop.readdir(
+        dir.fd,
+        dir.buf,
+        dir.buf.length(),
+        context~,
+      )
+      if dir.job_ret is 0 {
+        dir.state = NoMoreEntry
+        return None
+      } else {
+        dir.state = HasBufferedEntry
+      }
     }
   }
-  let entry_len = Directory::entry_length(dir.buf, dir.offset, dir.buf_len)
+  let entry_len = Directory::entry_length(dir.buf, dir.offset)
   let offset = dir.offset
   dir.offset += entry_len
-  if @event_loop.IS_WINDOWS && entry_len is 0 {
-    dir.offset = dir.buf_len
+  dir.count += 1
+  let need_more_entry = match @event_loop.platform {
+    Linux => dir.offset >= dir.job_ret
+    MacOS => dir.count >= dir.job_ret
+    Windows => entry_len is 0
+  }
+  if need_more_entry {
+    dir.state = NeedMoreEntry
   }
   if !include_hidden && Directory::entry_is_hidden(dir.buf, offset) {
     return dir.next_aux(include_special~, include_hidden~, context~)

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -91,6 +91,9 @@ pub fn Directory::close(self : Directory) -> Unit {
 }
 
 ///|
+extern "C" fn Directory::min_buffer_size() -> Int = "moonbitlang_async_dir_buffer_min_size"
+
+///|
 /// Open the directory at `path`. `path` is encoded UTF8.
 /// If `path` is not a directory, an error will be raised
 pub async fn opendir(path : StringView) -> Directory {
@@ -99,7 +102,7 @@ pub async fn opendir(path : StringView) -> Directory {
 
 ///|
 async fn opendir_aux(path : StringView, context~ : String) -> Directory {
-  let (fd, kind) = @event_loop.open_detached(
+  let open_result = @event_loop.open_detached(
     path,
     0,
     create=0,
@@ -108,6 +111,8 @@ async fn opendir_aux(path : StringView, context~ : String) -> Directory {
     mode=0,
     context~,
   )
+  let fd = open_result.fd()
+  let kind = open_result.kind()
   if !(kind is Directory) {
     @fd_util.close(fd, kind~, context~)
     raise @os_error.OSError(
@@ -115,9 +120,15 @@ async fn opendir_aux(path : StringView, context~ : String) -> Directory {
       context="\{context}: \{path.escape()}",
     )
   }
+  // According to https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getdirentries.2.html,
+  // some file systems does not support buffer smaller than block size.
+  let buffer_size = @cmp.maximum(
+    Directory::min_buffer_size(),
+    open_result.block_size(),
+  )
   {
     fd,
-    buf: FixedArray::make(1024, b'\x00'),
+    buf: FixedArray::make(@cmp.maximum(buffer_size, 1024), b'\x00'),
     offset: 0,
     buf_len: 0,
     completed: false,

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -145,6 +145,13 @@ extern "C" fn Directory::entry_length(
 
 ///|
 #borrow(buf)
+extern "C" fn Directory::entry_name_len(
+  buf : FixedArray[Byte],
+  offset : Int,
+) -> Int = "moonbitlang_async_dir_entry_get_name_len"
+
+///|
+#borrow(buf)
 extern "C" fn Directory::entry_name(
   buf : FixedArray[Byte],
   offset : Int,
@@ -222,17 +229,16 @@ async fn Directory::next_aux(
   let entry_len = Directory::entry_length(dir.buf, dir.offset, dir.buf_len)
   let offset = dir.offset
   dir.offset += entry_len
-  if @event_loop.IS_WINDOWS {
-    if entry_len > 0 {
-      dir.buf_len = dir.offset + 1
-    } else {
-      dir.buf_len = dir.offset
-    }
+  if @event_loop.IS_WINDOWS && entry_len is 0 {
+    dir.offset = dir.buf_len
   }
   if !include_hidden && Directory::entry_is_hidden(dir.buf, offset) {
     return dir.next_aux(include_special~, include_hidden~, context~)
   }
-  let name = @os_string.decode(Directory::entry_name(dir.buf, offset))
+  let name = @os_string.decode(
+    Directory::entry_name(dir.buf, offset),
+    len=Directory::entry_name_len(dir.buf, offset),
+  )
   if !include_special && name is ("." | "..") {
     return dir.next_aux(include_special~, include_hidden~, context~)
   }

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -233,6 +233,7 @@ async fn Directory::next_aux(
     HasBufferedEntry => ()
     NeedMoreEntry => {
       dir.offset = 0
+      dir.count = 0
       dir.job_ret = @event_loop.readdir(
         dir.fd,
         dir.buf,

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -168,10 +168,24 @@ extern "C" fn Directory::entry_is_hidden(
 #valtype
 pub struct DirectoryEntry {
   name : String
+  /// Indicate whether the directory entry is another directory.
+  /// Symbolic links are not treated as directories here.
   is_dir : Bool
 }
 
 ///|
+/// Fetch the next entry in the directory,
+/// including its name and some extra information, see `DirectoryEntry`.
+/// `None` indicates that the directory has no more files.
+///
+/// - If `include_special` is `true` (`false` by default),
+///   `.` (current directory) and `..` (parent directory) will be included too
+///
+/// - If `include_hidden` is `true` (`true` by default),
+///   hidden files (on Unix: file name starts with `.`, on Windows: has the hidden attribute)
+///   will be included
+///
+/// The file name in the returned directory entry is interpreted as UTF8-encoded on Unix-like systems.
 pub async fn Directory::next(
   dir : Directory,
   include_hidden? : Bool = true,
@@ -236,11 +250,15 @@ async fn Directory::next_aux(
 
 ///|
 /// Read all entries in a directory.
+///
 /// - If `include_special` is `true` (`false` by default),
 ///   `.` (current directory) and `..` (parent directory) will be included too
+///
 /// - If `include_hidden` is `true` (`true` by default),
-///   directory entries starting with `.` (except `.` and `..`) will be included
-/// All returned directory entries are encoded using UTF8.
+///   hidden files (on Unix: file name starts with `.`, on Windows: has the hidden attribute)
+///   will be included
+///
+/// The returned file names are interpreted as UTF8-encoded on Unix-like systems.
 pub async fn Directory::read_all(
   dir : Directory,
   include_hidden? : Bool = true,
@@ -256,12 +274,18 @@ pub async fn Directory::read_all(
 
 ///|
 /// Read all entries in the directory located at `path`.
+///
 /// - If `include_special` is `true` (`false` by default),
 ///   `.` (current directory) and `..` (parent directory) will be included too
+///
 /// - If `include_hidden` is `true` (`true` by default),
-///   directory entries starting with `.` (except `.` and `..`) will be included
+///   hidden files (on Unix: file name starts with `.`, on Windows: has the hidden attribute)
+///   will be included
+///
 /// - If `sort` is `true` (`false` by default),
 ///   the result will be sorted using `Array::sort`.
+///
+/// The returned file names are interpreted as UTF8-encoded on Unix-like systems.
 pub async fn readdir(
   path : StringView,
   include_hidden? : Bool = true,

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -206,8 +206,7 @@ async fn Directory::next_aux(
   context~ : String,
 ) -> DirectoryEntry? {
   guard !dir.completed else { None }
-  let entry_len = Directory::entry_length(dir.buf, dir.offset, dir.buf_len)
-  let entry_len = if entry_len is 0 {
+  if dir.offset >= dir.buf_len {
     dir.offset = 0
     dir.buf_len = @event_loop.readdir(
       dir.fd,
@@ -215,16 +214,21 @@ async fn Directory::next_aux(
       dir.buf.length(),
       context~,
     )
-    Directory::entry_length(dir.buf, dir.offset, dir.buf_len)
-  } else {
-    entry_len
+    if dir.buf_len is 0 {
+      dir.completed = true
+      return None
+    }
   }
-  guard entry_len > 0 else {
-    dir.completed = true
-    None
-  }
+  let entry_len = Directory::entry_length(dir.buf, dir.offset, dir.buf_len)
   let offset = dir.offset
   dir.offset += entry_len
+  if @event_loop.IS_WINDOWS {
+    if entry_len > 0 {
+      dir.buf_len = dir.offset + 1
+    } else {
+      dir.buf_len = dir.offset
+    }
+  }
   if !include_hidden && Directory::entry_is_hidden(dir.buf, offset) {
     return dir.next_aux(include_special~, include_hidden~, context~)
   }

--- a/src/fs/dir_test.mbt
+++ b/src/fs/dir_test.mbt
@@ -21,48 +21,29 @@ async test "read_all" {
     .filter_map(x => if x is "target" { None } else { Some(x) })
   list.sort()
   json_inspect(list, content=[
-    "stub.c", "dir.mbt", "file.mbt", "moon.pkg", "README.md", "utils.mbt", "tmpdir.mbt",
-    "dir_test.mbt", "eof_test.mbt", "README.mbt.md", "constants.mbt", "lock_test.mbt",
-    "stat_test.mbt", "walk_test.mbt", "deprecated.mbt", "mkdir_test.mbt", "access_test.mbt",
-    "create_test.mbt", "rename_test.mbt", "tmpdir_test.mbt", "read_all_test.mbt",
+    "dir.c", "stub.c", "dir.mbt", "file.mbt", "moon.pkg", "README.md", "utils.mbt",
+    "tmpdir.mbt", "dir_test.mbt", "eof_test.mbt", "README.mbt.md", "constants.mbt",
+    "lock_test.mbt", "stat_test.mbt", "walk_test.mbt", "deprecated.mbt", "mkdir_test.mbt",
+    "access_test.mbt", "create_test.mbt", "rename_test.mbt", "tmpdir_test.mbt", "read_all_test.mbt",
     "realpath_test.mbt", "unimplemented.mbt", "pkg.generated.mbti", "text_file_test.mbt",
     "timestamp_test.mbt", "named_pipe_test.mbt", "random_access_test.mbt", "unimplemented_test.mbt",
   ])
 }
 
 ///|
-#cfg(not(platform="windows"))
-#warnings("-deprecated")
 async test "as_dir" {
   let dir_file = @fs.open("src/fs", mode=ReadOnly)
   guard dir_file.kind() is Directory
   let dir = dir_file.as_dir()
   defer dir.close()
-  let list = dir
-    .read_all()
-    .filter_map(x => if x is "target" { None } else { Some(x) })
-  list.sort()
-  let kinds = []
-  for file in list {
-    let path = "src/fs/" + file
-    let kind = {
-      let file = @fs.open(path, mode=ReadOnly)
-      defer file.close()
-      file.kind()
-    }
-    assert_eq(kind, @fs.kind(path))
-    kinds.push("\{file}: \{kind}")
-  }
-  json_inspect(kinds, content=[
-    "stub.c: Regular", "dir.mbt: Regular", "file.mbt: Regular", "moon.pkg: Regular",
-    "README.md: Regular", "utils.mbt: Regular", "tmpdir.mbt: Regular", "dir_test.mbt: Regular",
-    "eof_test.mbt: Regular", "README.mbt.md: Regular", "constants.mbt: Regular",
-    "lock_test.mbt: Regular", "stat_test.mbt: Regular", "walk_test.mbt: Regular",
-    "deprecated.mbt: Regular", "mkdir_test.mbt: Regular", "access_test.mbt: Regular",
-    "create_test.mbt: Regular", "rename_test.mbt: Regular", "tmpdir_test.mbt: Regular",
-    "read_all_test.mbt: Regular", "realpath_test.mbt: Regular", "unimplemented.mbt: Regular",
-    "pkg.generated.mbti: Regular", "text_file_test.mbt: Regular", "timestamp_test.mbt: Regular",
-    "named_pipe_test.mbt: Regular", "random_access_test.mbt: Regular", "unimplemented_test.mbt: Regular",
+  let list = dir.read_all()..sort()
+  json_inspect(list, content=[
+    "dir.c", "stub.c", "dir.mbt", "file.mbt", "moon.pkg", "README.md", "utils.mbt",
+    "tmpdir.mbt", "dir_test.mbt", "eof_test.mbt", "README.mbt.md", "constants.mbt",
+    "lock_test.mbt", "stat_test.mbt", "walk_test.mbt", "deprecated.mbt", "mkdir_test.mbt",
+    "access_test.mbt", "create_test.mbt", "rename_test.mbt", "tmpdir_test.mbt", "read_all_test.mbt",
+    "realpath_test.mbt", "unimplemented.mbt", "pkg.generated.mbti", "text_file_test.mbt",
+    "timestamp_test.mbt", "named_pipe_test.mbt", "random_access_test.mbt", "unimplemented_test.mbt",
   ])
 }
 
@@ -81,7 +62,7 @@ test "readdir clear errno" {
     inspect(
       list.length(),
       content=(
-        #|29
+        #|30
       ),
     )
   })

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -383,14 +383,7 @@ pub fn File::as_dir(self : File) -> Directory raise {
       context="@fs.File::as_dir()",
     )
   }
-  let fd = self.io.detach_from_event_loop()
-  {
-    fd,
-    buf: FixedArray::make(1024, b'\x00'),
-    offset: 0,
-    buf_len: 0,
-    completed: false,
-  }
+  Directory::from_fd(self.io.detach_from_event_loop())
 }
 
 ///|

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -368,14 +368,6 @@ pub async fn File::size(self : File) -> Int64 {
 }
 
 ///|
-#cfg(not(platform="windows"))
-extern "C" fn as_dir_ffi(fd : @fd_util.Fd) -> Directory = "fdopendir"
-
-///|
-#cfg(not(platform="windows"))
-extern "C" fn Directory::is_null(dir : Directory) -> Bool = "moonbitlang_async_dir_is_null"
-
-///|
 /// Convert a file to directory.
 /// If the file is not a directory, an error will be raised.
 ///
@@ -383,17 +375,22 @@ extern "C" fn Directory::is_null(dir : Directory) -> Bool = "moonbitlang_async_d
 /// The input file will be automatically closed when the
 /// result directory object is closed.
 /// If `as_dir` fails, the input file will be closed automatically.
-#cfg(not(platform="windows"))
-#deprecated("`as_dir` is deprecated because it is not portable, use `opendir` instead.")
 pub fn File::as_dir(self : File) -> Directory raise {
-  let fd = self.io.detach_from_event_loop()
-  let dir = as_dir_ffi(fd)
-  if dir.is_null() {
-    let context = "@fs.File::as_dir()"
-    @fd_util.close(fd, kind=self.io.kind(), context~)
-    @os_error.check_errno(context)
+  guard self.io.kind() is Directory else {
+    self.close()
+    raise @os_error.OSError(
+      @os_error.errno_ENOTDIR,
+      context="@fs.File::as_dir()",
+    )
   }
-  dir
+  let fd = self.io.detach_from_event_loop()
+  {
+    fd,
+    buf: FixedArray::make(1024, b'\x00'),
+    offset: 0,
+    buf_len: 0,
+    completed: false,
+  }
 }
 
 ///|

--- a/src/fs/moon.pkg
+++ b/src/fs/moon.pkg
@@ -8,6 +8,7 @@ import {
   "moonbitlang/async/internal/fd_util",
   "moonbitlang/async/internal/os_string",
   "moonbitlang/async/internal/env_util",
+  "moonbitlang/async/internal/c_buffer",
   "moonbitlang/async",
 }
 
@@ -19,7 +20,7 @@ import {
 
 options(
   "max-concurrent-tests": 5,
-  "native-stub": [ "stub.c" ],
+  "native-stub": [ "stub.c", "dir.c" ],
   targets: {
     "README.mbt.md": [ "native" ],
     "access_test.mbt": [ "native" ],

--- a/src/fs/moon.pkg
+++ b/src/fs/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbitlang/core/random",
   "moonbitlang/core/buffer",
   "moonbitlang/core/int",
+  "moonbitlang/core/cmp",
   "moonbitlang/async/os_error",
   "moonbitlang/async/io",
   "moonbitlang/async/internal/event_loop",

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -70,10 +70,15 @@ pub(all) enum CreateMode {
 
 type Directory
 pub fn Directory::close(Self) -> Unit
+pub async fn Directory::next(Self, include_hidden? : Bool, include_special? : Bool) -> DirectoryEntry?
 pub async fn Directory::read_all(Self, include_hidden? : Bool, include_special? : Bool) -> Array[String]
 
+pub struct DirectoryEntry {
+  name : String
+  is_dir : Bool
+}
+
 type File
-#deprecated
 pub fn File::as_dir(Self) -> Directory raise
 pub async fn File::atime(Self) -> (Int64, Int)
 pub fn File::close(Self) -> Unit

--- a/src/fs/unimplemented.mbt
+++ b/src/fs/unimplemented.mbt
@@ -24,4 +24,5 @@ pub let unimplemented : Unit = {
   ignore(@fd_util.unimplemented)
   ignore(@os_string.unimplemented)
   ignore(@env_util.unimplemented)
+  ignore(@c_buffer.unimplemented)
 }

--- a/src/fs/utils.mbt
+++ b/src/fs/utils.mbt
@@ -17,7 +17,12 @@
 /// If `path` is a symbolic link and `follow_symlink` is `true` (`true` by default),
 /// the kind of the target of the link will be returned.
 pub async fn kind(path : StringView, follow_symlink? : Bool = true) -> FileKind {
-  @event_loop.file_kind_by_path(path, follow_symlink~, context="@fs.kind()")
+  @event_loop.file_kind_by_path(
+    path,
+    parent=@fd_util.invalid_fd,
+    follow_symlink~,
+    context="@fs.kind()",
+  )
   |> FileKind::from_fd_util_file_kind
 }
 

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -21,6 +21,19 @@ pub const IS_WINDOWS : Bool = false
 pub const IS_WINDOWS : Bool = true
 
 ///|
+pub(all) enum Platform {
+  Linux = 0
+  MacOS = 1
+  Windows = 2
+}
+
+///|
+extern "C" fn get_platform() -> Platform = "moonbitlang_async_get_platform"
+
+///|
+pub let platform : Platform = get_platform()
+
+///|
 #cfg(not(platform="windows"))
 priv struct EventLoop {
   poll : Instance

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -13,10 +13,6 @@
 // limitations under the License.
 
 ///|
-#external
-pub type Directory
-
-///|
 pub async fn open_detached(
   path : StringView,
   // 0 => read only, 1 => write only, 2 => read write
@@ -268,46 +264,14 @@ pub async fn rmdir(path : StringView, context~ : String) -> Unit {
 }
 
 ///|
-#cfg(platform="windows")
-fn prepare_opendir_path(path : StringView) -> StringView {
-  if path is [.., '/' | '\\'] {
-    path + "*"
-  } else {
-    path + "\\*"
-  }
-}
-
-///|
-#cfg(not(platform="windows"))
-fn prepare_opendir_path(path : StringView) -> StringView {
-  path
-}
-
-///|
-pub async fn opendir(path : StringView, context~ : String) -> Directory {
-  let path_bytes = @os_string.encode(prepare_opendir_path(path))
-  let job = Job::opendir(path_bytes)
-  let _ = perform_job_in_worker(job, context~) catch {
-    @os_error.OSError(errno, context~) =>
-      raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
-    err => raise err
-  }
-  job.get_opendir_result()
-}
-
-///|
-#cfg(not(platform="windows"))
-pub extern "C" fn Directory::close(self : Directory) -> Int = "closedir"
-
-///|
-#cfg(platform="windows")
-pub extern "C" fn Directory::close(self : Directory) -> Int = "moonbitlang_async_closedir"
-
-///|
-pub async fn readdir(dir : Directory, context~ : String) -> @c_buffer.Buffer {
-  let job = Job::readdir(dir)
-  let _ = perform_job_in_worker(job, context~)
-  job.get_readdir_result()
+pub async fn readdir(
+  dir : @fd_util.Fd,
+  buf : FixedArray[Byte],
+  len : Int,
+  context~ : String,
+) -> Int {
+  let job = Job::readdir(dir, buf, len)
+  perform_job_in_worker(job, context~)
 }
 
 ///|

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -25,20 +25,20 @@ pub async fn open_detached(
   // permission for file when new file is created
   mode~ : Int,
   context~ : String,
-) -> (@fd_util.Fd, @fd_util.FileKind) {
+) -> OpenResult {
   let path_bytes = @os_string.encode(path)
-  let job = Job::open(path_bytes, access, create~, append~, sync~, mode~)
+  let result = Job::open(path_bytes, access, create~, append~, sync~, mode~)
   fn cancel(job_id) raise {
     guard curr_loop.val is Some(evloop)
     evloop.cancel_job_in_worker(job_id, context~)
   }
 
-  try perform_job_in_worker(job, context~, cancel~) catch {
+  try perform_job_in_worker(result.0, context~, cancel~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
     err => raise err
   } noraise {
-    _ => (job.get_open_job_result(), job.get_open_job_kind())
+    _ => result
   }
 }
 
@@ -56,7 +56,7 @@ pub async fn open(
   mode~ : Int,
   context~ : String,
 ) -> IoHandle {
-  let (fd, kind) = open_detached(
+  let result = open_detached(
     path,
     access,
     create~,
@@ -65,6 +65,8 @@ pub async fn open(
     mode~,
     context~,
   )
+  let fd = result.fd()
+  let kind = result.kind()
   // On Windows, due to a lot of complexity,
   // we use synchronous IO + thread pool unconditionally for regular files.
   // However, on Windows, overlapped IO must be enabled on file creation time,

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -84,13 +84,18 @@ pub async fn kind_of_fd(
 }
 
 ///|
+/// If `parent` is a valid fd and `path` is relative,
+/// `path` will be interpreted relative to the directory pointed by `parent`,
+/// see `fstatat` for more details.
+/// `parent` is not supported on Windows.
 pub async fn file_kind_by_path(
   path : StringView,
+  parent~ : @fd_util.Fd,
   follow_symlink~ : Bool,
   context~ : String,
 ) -> @fd_util.FileKind {
   let path_bytes = @os_string.encode(path)
-  let job = Job::file_kind_by_path(path_bytes, follow_symlink~)
+  let job = Job::file_kind_by_path(parent, path_bytes, follow_symlink~)
   try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -21,7 +21,7 @@ pub async fn access(StringView, Access, context~ : String) -> Int
 
 pub async fn chmod(StringView, Int, context~ : String) -> Unit
 
-pub async fn file_kind_by_path(StringView, follow_symlink~ : Bool, context~ : String) -> @fd_util.FileKind
+pub async fn file_kind_by_path(StringView, parent~ : Int, follow_symlink~ : Bool, context~ : String) -> @fd_util.FileKind
 
 pub async fn file_size(Int, context~ : String) -> Int64
 

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -37,7 +37,7 @@ pub async fn mkdir(StringView, mode~ : Int, context~ : String) -> Unit
 
 pub async fn open(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> IoHandle
 
-pub async fn open_detached(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> (Int, @fd_util.FileKind)
+pub async fn open_detached(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> OpenResult
 
 pub async fn readdir(Int, FixedArray[Byte], Int, context~ : String) -> Int
 
@@ -96,6 +96,11 @@ pub async fn IoHandle::recvfrom(Self, FixedArray[Byte], offset~ : Int, len~ : In
 pub async fn IoHandle::sendto(Self, Bytes, offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 pub async fn IoHandle::write(Self, Bytes, offset~ : Int, len~ : Int, context~ : String) -> Int
 pub async fn IoHandle::write_at(Self, Bytes, offset~ : Int, len~ : Int, position~ : Int64, context~ : String) -> Unit
+
+type OpenResult
+pub fn OpenResult::block_size(Self) -> Int
+pub fn OpenResult::fd(Self) -> Int
+pub fn OpenResult::kind(Self) -> @fd_util.FileKind
 
 type Process
 pub fn Process::close(Self) -> Unit

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -100,7 +100,6 @@ pub async fn IoHandle::write(Self, Bytes, offset~ : Int, len~ : Int, context~ : 
 pub async fn IoHandle::write_at(Self, Bytes, offset~ : Int, len~ : Int, position~ : Int64, context~ : String) -> Unit
 
 type OpenResult
-pub fn OpenResult::block_size(Self) -> Int
 pub fn OpenResult::fd(Self) -> Int
 pub fn OpenResult::kind(Self) -> @fd_util.FileKind
 

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -39,6 +39,8 @@ pub async fn open(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, m
 
 pub async fn open_detached(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> OpenResult
 
+pub let platform : Platform
+
 pub async fn readdir(Int, FixedArray[Byte], Int, context~ : String) -> Int
 
 pub async fn realpath(StringView, context~ : String) -> String
@@ -101,6 +103,12 @@ type OpenResult
 pub fn OpenResult::block_size(Self) -> Int
 pub fn OpenResult::fd(Self) -> Int
 pub fn OpenResult::kind(Self) -> @fd_util.FileKind
+
+pub(all) enum Platform {
+  Linux
+  MacOS
+  Windows
+}
 
 type Process
 pub fn Process::close(Self) -> Unit

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -2,7 +2,6 @@
 package "moonbitlang/async/internal/event_loop"
 
 import {
-  "moonbitlang/async/internal/c_buffer",
   "moonbitlang/async/internal/fd_util",
   "moonbitlang/async/internal/os_string",
 }
@@ -40,9 +39,7 @@ pub async fn open(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, m
 
 pub async fn open_detached(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> (Int, @fd_util.FileKind)
 
-pub async fn opendir(StringView, context~ : String) -> Directory
-
-pub async fn readdir(Directory, context~ : String) -> @c_buffer.Buffer
+pub async fn readdir(Int, FixedArray[Byte], Int, context~ : String) -> Int
 
 pub async fn realpath(StringView, context~ : String) -> String
 
@@ -81,10 +78,6 @@ pub(all) enum Access {
 
 #external
 pub type AddrInfo
-
-#external
-pub type Directory
-pub fn Directory::close(Self) -> Int
 
 type IoHandle
 pub async fn IoHandle::accept(Self, Bytes, context~ : String) -> Self

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -667,7 +667,11 @@ struct open_job {
   int sync;
   int mode;
   HANDLE result;
+#ifdef _WIN32
   int32_t kind;
+#else
+  struct stat stat;
+#endif
 };
 
 static
@@ -755,6 +759,11 @@ void open_job_worker(struct job *job) {
     return;
   }
 
+  if (fstat(open_job->result, &open_job->stat) < 0) {
+    job->err = errno;
+    return;
+  }
+
   open_job->kind = moonbitlang_async_kind_of_fd(open_job->result);
   if (open_job->kind < 0) {
     job->err = errno;
@@ -785,13 +794,22 @@ struct open_job *moonbitlang_async_make_open_job(
 }
 
 MOONBIT_FFI_EXPORT
-HANDLE moonbitlang_async_get_open_job_result(struct open_job *job) {
+HANDLE moonbitlang_async_open_job_get_fd(struct open_job *job) {
   return job->result;
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_get_open_job_kind(struct open_job *job) {
-  return job->kind;
+int32_t moonbitlang_async_open_job_get_kind(struct open_job *job) {
+  return moonbitlang_async_file_kind_from_stat(&job->stat);
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_open_job_get_block_size(struct open_job *job) {
+#ifdef _WIN32
+  moonbit_panic();
+#else
+  return job->stat.st_blksize;
+#endif
 }
 
 // ===== file kind of fd job, get kind of an existing fd =====

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -53,6 +53,10 @@
 #include <sys/syscall.h>
 #endif
 
+#ifdef __MACH__
+#include <sys/attr.h>
+#endif
+
 typedef int HANDLE;
 typedef int SOCKET;
 #define GetLastError() errno;
@@ -1495,7 +1499,16 @@ void readdir_job_worker(struct job *job) {
 
 #elif defined(__MACH__)
 
-  job->ret = getdirentries(readdir_job->dir, readdir_job->out, readdir_job->len, 0);
+  struct attrlist attr_spec = {
+    ATTR_BIT_MAP_COUNT,
+    0, // reserved
+    ATTR_CMN_NAME | ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_OBJTYPE, // commonattr
+    0, // volattr
+    0, // dirattr
+    0, // fileattr
+    0 // forkattr
+  };
+  job->ret = getattrlistbulk(readdir_job->dir, &attr_spec, readdir_job->out, readdir_job->len, 0);
   if (job->ret < 0)
     job->err = errno;
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -821,6 +821,7 @@ struct kind_of_fd_job *moonbitlang_async_make_kind_of_fd_job(HANDLE fd) {
 
 struct file_kind_by_path_job {
   struct job job;
+  HANDLE parent;
   char *path;
   int follow_symlink;
 };
@@ -863,12 +864,12 @@ void file_kind_by_path_job_worker(struct job *job) {
 #else
 
   struct stat stat_obj;
-  int ret;
-  if (file_kind_by_path_job->follow_symlink) {
-    ret = stat(file_kind_by_path_job->path, &stat_obj);
-  } else {
-    ret = lstat(file_kind_by_path_job->path, &stat_obj);
-  }
+  int ret = fstatat(
+    file_kind_by_path_job->parent < 0 ? AT_FDCWD : file_kind_by_path_job->parent,
+    file_kind_by_path_job->path,
+    &stat_obj,
+    file_kind_by_path_job->follow_symlink ? 0 : AT_SYMLINK_NOFOLLOW
+  );
   if (ret < 0) {
     job->err = errno;
   } else {
@@ -879,10 +880,12 @@ void file_kind_by_path_job_worker(struct job *job) {
 }
 
 struct file_kind_by_path_job *moonbitlang_async_make_file_kind_by_path_job(
+  HANDLE parent,
   char *path,
   int follow_symlink
 ) {
   struct file_kind_by_path_job *job = MAKE_JOB(file_kind_by_path);
+  job->parent = parent;
   job->path = path;
   job->follow_symlink = follow_symlink;
   return job;

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -98,6 +98,18 @@ int32_t moonbitlang_async_kind_of_fd(HANDLE fd);
 int32_t moonbitlang_async_file_kind_from_stat(struct stat *stat);
 #endif
 
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_get_platform() {
+#ifdef __linux__
+  return 0;
+#elif defined(__MACH__)
+  return 1;
+#elif defined(_WIN32)
+  return 2;
+#else
+  abort();
+#endif
+}
 
 struct job {
   // the return value of the job.

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -761,13 +761,8 @@ void open_job_worker(struct job *job) {
 
   if (fstat(open_job->result, &open_job->stat) < 0) {
     job->err = errno;
-    return;
-  }
-
-  open_job->kind = moonbitlang_async_kind_of_fd(open_job->result);
-  if (open_job->kind < 0) {
-    job->err = errno;
     close(open_job->result);
+    return;
   }
 
 #endif

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -49,6 +49,10 @@
 #include <sys/file.h>
 #include <sys/wait.h>
 
+#ifdef __linux__
+#include <sys/syscall.h>
+#endif
+
 typedef int HANDLE;
 typedef int SOCKET;
 #define GetLastError() errno;
@@ -1425,108 +1429,20 @@ struct rmdir_job *moonbitlang_async_make_rmdir_job(char *path) {
   return job;
 }
 
-// ===== opendir job, open directory =====
-
-#ifdef _WIN32
-
-typedef struct {
-  HANDLE handle;
-
-  // In Windows, the directory search handle is obtained via `FindFirstFile`,
-  // which, in addition to creating the search handle,
-  // also read the first entry from the directory.
-  // So on the next `readdir` request, we should just return this initial entry.
-  int32_t has_cached_entry;
-  WIN32_FIND_DATAW curr_entry;
-} DIR;
-
-int32_t moonbitlang_async_closedir(DIR *dir) {
-  int32_t ret = FindClose(dir->handle) ? 0 : -1;
-  free(dir);
-  return ret;
-}
-
-#endif
-
-struct opendir_job {
-  struct job job;
-  char *path;
-  DIR *result;
-
-  // if the waiter is cancelled before `opendir` succeed,
-  // we need to call `closedir` to free resource on the result.
-  // however, if the waiter is not cancelled,
-  // the ownership of the result should be transferred to the waiter.
-  // here we use a flag `result_fetched` to determine which case it is.
-  int result_fetched;
-};
-
-static
-void free_opendir_job(void *obj) {
-  struct opendir_job *job = (struct opendir_job*)obj;
-  moonbit_decref(job->path);
-
-  if (job->result && !(job->result_fetched)) {
-#ifdef _WIN32
-    moonbitlang_async_closedir(job->result);
-#else
-    closedir(job->result);
-#endif
-  }
-}
-
-static
-void opendir_job_worker(struct job *job) {
-  struct opendir_job *opendir_job = (struct opendir_job*)job;
-
-#ifdef _WIN32
-
-  DIR *dir = (DIR*)malloc(sizeof(DIR));
-  opendir_job->result = dir;
-
-  dir->handle = FindFirstFileW(
-    (LPCWSTR)opendir_job->path,
-    &(dir->curr_entry)
-  );
-  if (dir->handle == INVALID_HANDLE_VALUE) {
-    job->err = GetLastError();
-    return;
-  }
-  dir->has_cached_entry = 1;
-
-#else
-
-  opendir_job->result = opendir(opendir_job->path);
-  if (!(opendir_job->result)) {
-    job->err = errno;
-  }
-
-#endif
-}
-
-struct opendir_job *moonbitlang_async_make_opendir_job(char *path) {
-  struct opendir_job *job = MAKE_JOB(opendir);
-  job->path = path;
-  job->result = 0;
-  job->result_fetched = 0;
-  return job;
-}
-
-DIR *moonbitlang_async_get_opendir_result(struct opendir_job *job) {
-  job->result_fetched = 1;
-  return job->result;
-}
-
 // ===== readdir job, read directory entry =====
 
 struct readdir_job {
   struct job job;
-  DIR *dir;
-  char *result;
+  HANDLE dir;
+  void *out;
+  int32_t len;
 };
 
 static
-void free_readdir_job(void *obj) {}
+void free_readdir_job(void *obj) {
+  struct readdir_job *job = (struct readdir_job*)obj;
+  moonbit_decref(job->out);
+}
 
 static
 void readdir_job_worker(struct job *job) {
@@ -1534,45 +1450,43 @@ void readdir_job_worker(struct job *job) {
 
 #ifdef _WIN32
 
-  if (readdir_job->dir->has_cached_entry) {
-    readdir_job->result = (char*)readdir_job->dir->curr_entry.cFileName;
-    readdir_job->dir->has_cached_entry = 0;
-  } else if (FindNextFileW(readdir_job->dir->handle, &(readdir_job->dir->curr_entry))) {
-    readdir_job->result = (char*)readdir_job->dir->curr_entry.cFileName;
-  } else {
-    int err = GetLastError();
-    if (err == ERROR_NO_MORE_FILES) {
-      readdir_job->result = 0;
-    } else {
-      job->ret = -1;
-      job->err = err;
-    }
+  if (
+    !GetFileInformationByHandleEx(
+      readdir_job->dir,
+      FileIdBothDirectoryInfo,
+      readdir_job->out,
+      readdir_job->len
+    )
+  ) {
+    job->err = GetLastError();
+    return;
   }
+
+#elif defined(__linux__)
+
+  job->ret = syscall(SYS_getdents64, readdir_job->dir, readdir_job->out, readdir_job->len);
+  if (job->ret < 0)
+    job->err = errno;
+
+#elif defined(__MACH__)
+
+  job->ret = getdirentries(readdir_job->dir, readdir_job->out, readdir_job->len, 0);
+  if (job->ret < 0)
+    job->err = errno;
 
 #else
 
-  errno = 0;
-  struct dirent *dirent = readdir(readdir_job->dir);
-  if (dirent) {
-    readdir_job->result = dirent->d_name;
-  } else if (errno) {
-    job->ret = -1;
-    job->err = errno;
-  } else {
-    readdir_job->result = 0;
-  }
+  errno = ENOSYS;
 
 #endif
 }
 
-struct readdir_job *moonbitlang_async_make_readdir_job(DIR *dir) {
+struct readdir_job *moonbitlang_async_make_readdir_job(HANDLE dir, void *out, int32_t len) {
   struct readdir_job *job = MAKE_JOB(readdir);
   job->dir = dir;
+  job->out = out;
+  job->len = len;
   return job;
-}
-
-char *moonbitlang_async_get_readdir_result(struct readdir_job *job) {
-  return job->result;
 }
 
 // ===== realpath job, get canonical representation of a path =====

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -1490,7 +1490,7 @@ void readdir_job_worker(struct job *job) {
   }
 
   // `GetFileInformationByHandleEx` does not support a total length
-  job->ret = 1;
+  job->ret = readdir_job->len;
 
 #elif defined(__linux__)
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -800,13 +800,17 @@ HANDLE moonbitlang_async_open_job_get_fd(struct open_job *job) {
 
 MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_open_job_get_kind(struct open_job *job) {
+#ifdef _WIN32
+  return job->kind;
+#else
   return moonbitlang_async_file_kind_from_stat(&job->stat);
+#endif
 }
 
 MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_open_job_get_block_size(struct open_job *job) {
 #ifdef _WIN32
-  moonbit_panic();
+  return -1;
 #else
   return job->stat.st_blksize;
 #endif
@@ -1470,7 +1474,6 @@ void readdir_job_worker(struct job *job) {
   struct readdir_job *readdir_job = (struct readdir_job*)job;
 
 #ifdef _WIN32
-
   if (
     !GetFileInformationByHandleEx(
       readdir_job->dir,
@@ -1479,9 +1482,15 @@ void readdir_job_worker(struct job *job) {
       readdir_job->len
     )
   ) {
-    job->err = GetLastError();
+    if (GetLastError() == ERROR_NO_MORE_FILES)
+      job->ret = 0;
+    else
+      job->err = GetLastError();
     return;
   }
+
+  // `GetFileInformationByHandleEx` does not support a total length
+  job->ret = 1;
 
 #elif defined(__linux__)
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -818,15 +818,6 @@ int32_t moonbitlang_async_open_job_get_kind(struct open_job *job) {
 #endif
 }
 
-MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_open_job_get_block_size(struct open_job *job) {
-#ifdef _WIN32
-  return -1;
-#else
-  return job->stat.st_blksize;
-#endif
-}
-
 // ===== file kind of fd job, get kind of an existing fd =====
 struct kind_of_fd_job {
   struct job job;

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -108,15 +108,23 @@ extern "C" fn Job::open(
   sync~ : Int,
   // permission for file when new file is created
   mode~ : Int,
-) -> Job = "moonbitlang_async_make_open_job"
+) -> OpenResult = "moonbitlang_async_make_open_job"
+
+///|
+struct OpenResult(Job)
 
 ///|
 #borrow(job)
-extern "C" fn Job::get_open_job_result(job : Job) -> @fd_util.Fd = "moonbitlang_async_get_open_job_result"
+pub extern "C" fn OpenResult::fd(job : OpenResult) -> @fd_util.Fd = "moonbitlang_async_open_job_get_fd"
 
 ///|
 #borrow(job)
-extern "C" fn Job::get_open_job_kind(job : Job) -> @fd_util.FileKind = "moonbitlang_async_get_open_job_kind"
+pub extern "C" fn OpenResult::kind(job : OpenResult) -> @fd_util.FileKind = "moonbitlang_async_open_job_get_kind"
+
+///|
+/// not supported on Windows, will return `-1`
+#borrow(job)
+pub extern "C" fn OpenResult::block_size(job : OpenResult) -> Int = "moonbitlang_async_open_job_get_block_size"
 
 ///|
 extern "C" fn Job::kind_of_fd(fd : @fd_util.Fd) -> Job = "moonbitlang_async_make_kind_of_fd_job"

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -286,3 +286,7 @@ extern "C" fn Job::get_getaddrinfo_result(job : Job) -> AddrInfo = "moonbitlang_
 #cfg(not(platform="windows"))
 #borrow(signals)
 extern "C" fn Job::sigwait(signals : ReadOnlyArray[Int]) -> Job = "moonbitlang_async_make_sigwait_job"
+
+///|
+#cfg(platform="windows")
+let _mute_unused_warning : Unit = ignore(@c_buffer.Buffer::get)

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -196,19 +196,12 @@ extern "C" fn Job::mkdir(path : @os_string.OsString, mode : Int) -> Job = "moonb
 extern "C" fn Job::rmdir(path : @os_string.OsString) -> Job = "moonbitlang_async_make_rmdir_job"
 
 ///|
-#owned(path)
-extern "C" fn Job::opendir(path : @os_string.OsString) -> Job = "moonbitlang_async_make_opendir_job"
-
-///|
-#borrow(job)
-extern "C" fn Job::get_opendir_result(job : Job) -> Directory = "moonbitlang_async_get_opendir_result"
-
-///|
-extern "C" fn Job::readdir(dir : Directory) -> Job = "moonbitlang_async_make_readdir_job"
-
-///|
-#borrow(job)
-extern "C" fn Job::get_readdir_result(job : Job) -> @c_buffer.Buffer = "moonbitlang_async_get_readdir_result"
+#owned(buf)
+extern "C" fn Job::readdir(
+  dir : @fd_util.Fd,
+  buf : FixedArray[Byte],
+  len : Int,
+) -> Job = "moonbitlang_async_make_readdir_job"
 
 ///|
 #owned(path)

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -122,11 +122,6 @@ pub extern "C" fn OpenResult::fd(job : OpenResult) -> @fd_util.Fd = "moonbitlang
 pub extern "C" fn OpenResult::kind(job : OpenResult) -> @fd_util.FileKind = "moonbitlang_async_open_job_get_kind"
 
 ///|
-/// not supported on Windows, will return `-1`
-#borrow(job)
-pub extern "C" fn OpenResult::block_size(job : OpenResult) -> Int = "moonbitlang_async_open_job_get_block_size"
-
-///|
 extern "C" fn Job::kind_of_fd(fd : @fd_util.Fd) -> Job = "moonbitlang_async_make_kind_of_fd_job"
 
 ///|

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -124,6 +124,7 @@ extern "C" fn Job::kind_of_fd(fd : @fd_util.Fd) -> Job = "moonbitlang_async_make
 ///|
 #owned(path)
 extern "C" fn Job::file_kind_by_path(
+  parent : @fd_util.Fd,
   path : @os_string.OsString,
   follow_symlink~ : Bool,
 ) -> Job = "moonbitlang_async_make_file_kind_by_path_job"

--- a/src/internal/os_string/os_string.mbt
+++ b/src/internal/os_string/os_string.mbt
@@ -51,9 +51,13 @@ pub impl Show for OsString with to_string(self) {
 }
 
 ///|
+/// `len`, if present, is the number of bytes to decode in `os_str`.
+/// The default value is determined using `strlen` or `wcslen`.
 #cfg(not(platform="windows"))
-pub fn decode(os_str : @c_buffer.Buffer) -> String {
-  let len = os_str.strlen()
+pub fn decode(
+  os_str : @c_buffer.Buffer,
+  len? : Int = os_str.strlen(),
+) -> String {
   let data = FixedArray::make(len, b'\x00')
   os_str.blit_to_bytes(dst=data, offset=0, len~)
   @utf8.decode_lossy(data.unsafe_reinterpret_as_bytes())
@@ -61,7 +65,7 @@ pub fn decode(os_str : @c_buffer.Buffer) -> String {
 
 ///|
 #cfg(platform="windows")
-pub extern "C" fn decode(os_str : @c_buffer.Buffer) -> String = "moonbitlang_async_c_buffer_as_string"
+pub extern "C" fn decode(os_str : @c_buffer.Buffer, len? : Int = -1) -> String = "moonbitlang_async_c_buffer_as_string"
 
 ///|
 #cfg(platform="windows")

--- a/src/internal/os_string/pkg.generated.mbti
+++ b/src/internal/os_string/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn decode(@c_buffer.Buffer) -> String
+pub fn decode(@c_buffer.Buffer, len? : Int) -> String
 
 pub fn encode(StringView) -> OsString
 

--- a/src/internal/os_string/stub.c
+++ b/src/internal/os_string/stub.c
@@ -19,8 +19,8 @@
 #include <moonbit.h>
 
 MOONBIT_FFI_EXPORT
-moonbit_string_t moonbitlang_async_c_buffer_as_string(wchar_t *str) {
-  size_t bytes = wcslen(str) * sizeof(wchar_t);
+moonbit_string_t moonbitlang_async_c_buffer_as_string(wchar_t *str, int32_t len) {
+  size_t bytes = len == -1 ? wcslen(str) * sizeof(wchar_t) : len;
   moonbit_string_t result = moonbit_make_string(bytes / 2, 0);
   memcpy(result, str, bytes);
   return result;

--- a/src/os_error/error.mbt
+++ b/src/os_error/error.mbt
@@ -113,3 +113,9 @@ pub fn check_errno(context : String) -> Unit raise OSError {
     raise OSError(err_code, context~)
   }
 }
+
+///|
+extern "C" fn get_ENOTDIR() -> Int = "moonbitlang_async_get_ENOTDIR"
+
+///|
+pub let errno_ENOTDIR : Int = get_ENOTDIR()

--- a/src/os_error/pkg.generated.mbti
+++ b/src/os_error/pkg.generated.mbti
@@ -4,6 +4,8 @@ package "moonbitlang/async/os_error"
 // Values
 pub fn check_errno(String) -> Unit raise OSError
 
+pub let errno_ENOTDIR : Int
+
 pub fn errno_to_string(Int) -> String
 
 pub fn get_errno() -> Int

--- a/src/os_error/stub.c
+++ b/src/os_error/stub.c
@@ -125,7 +125,7 @@ int32_t moonbitlang_async_get_ENOTDIR() {
 
   return ERROR_DIRECTORY;
 
-#ese
+#else
 
   return ENOTDIR;
 

--- a/src/os_error/stub.c
+++ b/src/os_error/stub.c
@@ -118,3 +118,16 @@ void moonbitlang_async_free_errno_str(void *ptr) {
   LocalFree(ptr);
 #endif
 }
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_get_ENOTDIR() {
+#ifdef _WIN32
+
+  return ERROR_DIRECTORY;
+
+#ese
+
+  return ENOTDIR;
+
+#endif
+}

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -146,7 +146,7 @@ pub async fn redirect_to_file(
     None if create is Some(perm) => perm
     None => 0o644
   }
-  let (fd, kind) = @event_loop.open_detached(
+  let file = @event_loop.open_detached(
     path,
     1, // write only
     create=create_mode.to_int(),
@@ -155,13 +155,13 @@ pub async fn redirect_to_file(
     mode=permission,
     context="@process.redirect_to_file()",
   )
-  RedirectToFile(fd, kind)
+  RedirectToFile(file.fd(), file.kind())
 }
 
 ///|
 /// Redirect the content of a file at `path` to the stdin of a process.
 pub async fn redirect_from_file(path : String) -> &ProcessInput {
-  let (fd, kind) = @event_loop.open_detached(
+  let file = @event_loop.open_detached(
     path,
     0, // read only
     create=0, // `OpenExisting`
@@ -170,7 +170,7 @@ pub async fn redirect_from_file(path : String) -> &ProcessInput {
     mode=0,
     context="@process.redirect_to_file()",
   )
-  RedirectToFile(fd, kind)
+  RedirectToFile(file.fd(), file.kind())
 }
 
 ///|

--- a/src/raw_fd/raw_fd_test.mbt
+++ b/src/raw_fd/raw_fd_test.mbt
@@ -57,7 +57,7 @@ async test "pipe as raw fd" {
 ///|
 async test "file as raw fd" {
   let truth = @fs.read_file("LICENSE").binary()
-  let (fd, _) = @event_loop.open_detached(
+  let fd = @event_loop.open_detached(
     "LICENSE",
     0,
     create=0,
@@ -65,7 +65,7 @@ async test "file as raw fd" {
     sync=0,
     mode=0,
     context="file as raw fd test",
-  )
+  ).fd()
   let file = @raw_fd.RawFd(fd)
   assert_true(@event_loop.kind_of_fd(fd, context="kind_of_fd") is Regular)
   let buf = FixedArray::make(truth.length() + 1, b'\x00')


### PR DESCRIPTION
This PR enhances directory traversal handling. Previously, directory handling uses `readdir` on Unix/`FindFirstFileW` + `FindNextFilew` on Windows. Both API retrieve only one directory entry per syscall, which is slow. This PR utilizes batch directory reading APIs on various platforms: `getdents64` on Linux, `getattrlistbulk` on MacOS, and `GetFileInformationByHandleEx` with `FileIdBothDirectoryInfo` on Windows.

In addition to internal performance enhancement, the API for `@fs.Directory` also become richer. A new API, `@fs.Directory::next()`, retries the next directory entry from a directory object, with addition information. Currently the only available information is `is_dir : Bool`, indicating whether the directory entry is a sub directory. More may be added in the future, for both internal and external use.

Another side benefit: previously, `@fs.File::as_dir` cannot be implemented on Windows because we cannot perform directory searching with a regular file handle. But now that the implementation strategy has changed, no special handle or libc directory object are needed anymore, so `as_dir` is trivial to implement. Its deprecation is withdrawn.