### PR TITLE
adapt latest release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,7 +54,7 @@ jobs:
         run: moon check --deny-warn
 
       - name: moon check (test programs)
-        run: moon check --manifest-path src/process/test_programs/moon.mod.json --deny-warn
+        run: moon -C src/process/test_programs check --deny-warn
 
       - name: moon test
         run: moon test
@@ -112,7 +112,7 @@ jobs:
         run: moon check
 
       - name: moon check (test programs)
-        run: moon check --manifest-path src/process/test_programs/moon.mod.json
+        run: moon -C src/process/test_programs check
 
       - name: moon test
         run: moon test
@@ -247,7 +247,7 @@ jobs:
 
       - name: setup sanitizer check
         run: |
-          moon run --debug --manifest-path src/process/test_programs/moon.mod.json src/process/test_programs/setup_sanitizer_check
+          moon run --debug src/process/test_programs/setup_sanitizer_check
 
       - name: run test with address sanitizer
         run: |
@@ -289,7 +289,7 @@ jobs:
 
       - name: setup sanitizer check
         run: |
-          moon run --debug --manifest-path src/process/test_programs/moon.mod.json src/process/test_programs/setup_sanitizer_check
+          moon run --debug src/process/test_programs/setup_sanitizer_check
 
       - name: run test with address sanitizer
         run: |

--- a/examples/http_file_server/main.mbt
+++ b/examples/http_file_server/main.mbt
@@ -79,7 +79,7 @@ async fn serve_zip(conn : @http.ServerConnection, path : String) -> Unit {
   let full_path = @fs.realpath(path)
   let path_sep = if is_windows { "\\" } else { "/" }
   let base_name = if full_path.rev_find(path_sep) is Some(i) {
-    full_path[i + 1:].to_string()
+    full_path[i + 1:]
   } else {
     path
   }
@@ -133,7 +133,7 @@ pub async fn server_main(
   let base_path = path
   server.run_forever((request, _body, conn) => {
     let (path, download_zip) = match request.path {
-      [.. path, .. "?download_zip"] => (path.to_string(), true)
+      [.. path, .. "?download_zip"] => (path.to_owned(), true)
       path => (path, false)
     }
     log("serving \{path}")

--- a/examples/http_file_server/server_wbtest.mbt
+++ b/examples/http_file_server/server_wbtest.mbt
@@ -75,7 +75,7 @@ async test "basic" {
       if is_windows {
         guard from_unzip.read_until("\r\n") is Some(line) else { break }
         let name = if line is [.. "./", .. name] {
-          name.to_string()
+          name.to_owned()
         } else {
           line
         }
@@ -87,7 +87,7 @@ async test "basic" {
         }
         let last_word = line[i + 1:]
         if last_word.has_prefix("examples/http_file_server") {
-          zip_content.push(last_word.to_string())
+          zip_content.push(last_word.to_owned())
         }
       }
     }

--- a/examples/idle_timeout/main.mbt
+++ b/examples/idle_timeout/main.mbt
@@ -15,7 +15,7 @@
 ///|
 async fn main {
   @async.with_task_group(group => {
-    let idle_timer = @async.Timer::new(5000)
+    let idle_timer = @async.Timer(5000)
     group.spawn_bg(no_wait=true, () => {
       idle_timer.wait()
       println("You have not type anything for 5 seconds, exit now...")

--- a/examples/udp_echo_server/main.mbt
+++ b/examples/udp_echo_server/main.mbt
@@ -22,7 +22,7 @@ async fn main {
       let (n, addr) = server.recvfrom(buf)
       root.spawn_bg(() => {
         let buf = buf.unsafe_reinterpret_as_bytes()
-        server.sendto(buf[0:n].to_bytes(), addr)
+        server.sendto(buf[0:n].to_owned(), addr)
       })
     }
   })

--- a/examples/websocket_echo_server/main.mbt
+++ b/examples/websocket_echo_server/main.mbt
@@ -64,7 +64,7 @@ async fn start_echo_server(port? : Int = 9001) -> Unit {
     } catch {
       @websocket.ConnectionClosed(e, reason) =>
         println(
-          "Client \{client_addr} disconnected with \{@debug.to_string(e)}, reason: \{reason}",
+          "Client \{client_addr} disconnected with \{@debug.to_string(e)}, reason: \{@debug.to_string(reason)}",
         )
       e => println("Error with client \{client_addr}: \{e}")
     }

--- a/examples/xargs/main.mbt
+++ b/examples/xargs/main.mbt
@@ -37,7 +37,7 @@ async fn main {
         }
         let count = @string.parse_int(count)
         // Use a semaphore to limit the max number of parallel jobs
-        max_jobs = Some(@async.Semaphore::new(count))
+        max_jobs = Some(@async.Semaphore(count))
         continue rest
       }
       ["-h" | "--help", ..] => {

--- a/src/all_any_test.mbt
+++ b/src/all_any_test.mbt
@@ -145,7 +145,7 @@ async test "all cancelled" {
   let result = @async.with_timeout_opt(300, () => {
     @async.all([() => task(1, 450), () => task(2, 150)])
   })
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
   json_inspect(log, content=[
     "task #2 completed", "task #1 cancelled with Cancelled",
   ])
@@ -303,7 +303,7 @@ async test "any cancelled" {
   let result = @async.with_timeout_opt(200, () => {
     @async.any([() => task(1, 400), () => task(2, 400)])
   })
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
   json_inspect(log, content=[
     "task #1 cancelled with Cancelled", "task #2 cancelled with Cancelled",
   ])

--- a/src/aqueue/aqueue.mbt
+++ b/src/aqueue/aqueue.mbt
@@ -62,16 +62,15 @@ pub struct Queue[X] {
   priv buffer : @deque.Deque[X]
   /// `Some(err)` if the queue is already closed
   priv mut closed : Error?
-
-  fn[X] new(kind~ : Kind) -> Queue[X]
 }
 
 ///|
 /// Create an empty queue.
 /// The behavior of `put` is determined by the `kind` argument,
 /// see the type `@aqueue.Kind` for more details.
-#as_free_fn
-pub fn[X] Queue::new(kind~ : Kind) -> Queue[X] {
+#as_free_fn(new, deprecated)
+#alias(new, deprecated)
+pub fn[X] Queue::Queue(kind~ : Kind) -> Queue[X] {
   match kind {
     Unbounded => ()
     Blocking(n) | DiscardOldest(n) | DiscardLatest(n) =>

--- a/src/aqueue/aqueue_test.mbt
+++ b/src/aqueue/aqueue_test.mbt
@@ -114,7 +114,7 @@ async test "aqueue cancellation no_swallow" {
     q.put(42)
     get_task.cancel()
     @async.sleep(100)
-    inspect(q.try_get(), content="None")
+    debug_inspect(q.try_get(), content="None")
   })
   inspect(
     log.to_string(),
@@ -200,13 +200,13 @@ async test "aqueue fairness2" {
 ///|
 test "try_get" {
   let q = @aqueue.Queue(kind=Unbounded)
-  inspect(q.try_get(), content="None")
+  debug_inspect(q.try_get(), content="None")
   assert_true(q.try_put(42))
-  inspect(q.try_get(), content="Some(42)")
-  inspect(q.try_get(), content="None")
+  debug_inspect(q.try_get(), content="Some(42)")
+  debug_inspect(q.try_get(), content="None")
   assert_true(q.try_put(1))
   assert_true(q.try_put(2))
-  inspect(q.try_get(), content="Some(1)")
-  inspect(q.try_get(), content="Some(2)")
-  inspect(q.try_get(), content="None")
+  debug_inspect(q.try_get(), content="Some(1)")
+  debug_inspect(q.try_get(), content="Some(2)")
+  debug_inspect(q.try_get(), content="None")
 }

--- a/src/aqueue/blocking_test.mbt
+++ b/src/aqueue/blocking_test.mbt
@@ -16,7 +16,7 @@
 async test "blocking unbuffered" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=Blocking(1))
+    let q = @async.Queue(kind=Blocking(1))
     group.spawn_bg(() => {
       for i in 0..<3 {
         q.put(i)
@@ -40,7 +40,7 @@ async test "blocking unbuffered" {
 async test "blocking buffered" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=Blocking(2))
+    let q = @async.Queue(kind=Blocking(2))
     group.spawn_bg(() => {
       for i in 0..<4 {
         q.put(i)
@@ -65,7 +65,7 @@ async test "blocking buffered" {
 async test "blocking fairness" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=Blocking(1))
+    let q = @async.Queue(kind=Blocking(1))
     q.put(0)
     group.spawn_bg(() => {
       for i in 0..<3 {
@@ -96,7 +96,7 @@ async test "blocking fairness" {
 async test "blocking cancellation" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=Blocking(1))
+    let q = @async.Queue(kind=Blocking(1))
     q.put(0)
     group.spawn_bg(no_wait=true, () => {
       @async.sleep(250)
@@ -124,7 +124,7 @@ async test "blocking cancellation" {
 async test "blocking fairness2" {
   let log = []
   @async.with_task_group(root => {
-    let queue = @aqueue.Queue::new(kind=Blocking(1))
+    let queue = @async.Queue(kind=Blocking(1))
     queue.put(0)
     root.spawn_bg(() => {
       for i in 0..<2 {
@@ -158,7 +158,7 @@ async test "blocking fairness2" {
 async test "blocking immediate cancellation" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=Blocking(1))
+    let q = @async.Queue(kind=Blocking(1))
     q.put(0)
     let put_task = group.spawn(() => {
       q.put(1) catch {
@@ -173,7 +173,7 @@ async test "blocking immediate cancellation" {
     let _ = q.get()
     put_task.cancel()
     @async.sleep(100)
-    inspect(q.try_get(), content="Some(1)")
+    debug_inspect(q.try_get(), content="Some(1)")
   })
   json_inspect(log, content=["put() completed"])
 }
@@ -182,7 +182,7 @@ async test "blocking immediate cancellation" {
 async test "blocking zero buffered" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=Blocking(0))
+    let q = @async.Queue(kind=Blocking(0))
     group.spawn_bg(() => {
       for i in 0..<4 {
         q.put(i)
@@ -205,39 +205,39 @@ async test "blocking zero buffered" {
 
 ///|
 async test "zero buffered try_put" {
-  let q = @aqueue.Queue::new(kind=Blocking(0))
-  inspect(q.try_put(0), content="false")
-  inspect(q.try_get(), content="None")
+  let q = @async.Queue(kind=Blocking(0))
+  debug_inspect(q.try_put(0), content="false")
+  debug_inspect(q.try_get(), content="None")
 }
 
 ///|
 test "blocking try_put" {
-  let q = @aqueue.Queue::new(kind=Blocking(3))
-  inspect(q.try_put(0), content="true")
-  inspect(q.try_put(1), content="true")
-  inspect(q.try_put(2), content="true")
-  inspect(q.try_put(3), content="false")
+  let q = @async.Queue(kind=Blocking(3))
+  debug_inspect(q.try_put(0), content="true")
+  debug_inspect(q.try_put(1), content="true")
+  debug_inspect(q.try_put(2), content="true")
+  debug_inspect(q.try_put(3), content="false")
   // the last `put` should have no effect
   for i in 0..<3 {
-    assert_eq(q.try_get(), Some(i))
+    @debug.assert_eq(q.try_get(), Some(i))
   }
-  inspect(q.try_get(), content="None")
+  debug_inspect(q.try_get(), content="None")
   // `put` again
-  inspect(q.try_put(0), content="true")
-  inspect(q.try_put(1), content="true")
-  inspect(q.try_put(2), content="true")
-  inspect(q.try_put(3), content="false")
-  inspect(q.try_get(), content="Some(0)")
-  inspect(q.try_put(3), content="true")
-  inspect(q.try_put(4), content="false")
+  debug_inspect(q.try_put(0), content="true")
+  debug_inspect(q.try_put(1), content="true")
+  debug_inspect(q.try_put(2), content="true")
+  debug_inspect(q.try_put(3), content="false")
+  debug_inspect(q.try_get(), content="Some(0)")
+  debug_inspect(q.try_put(3), content="true")
+  debug_inspect(q.try_put(4), content="false")
 }
 
 ///|
 async test "blocked zero buffered try_get" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=Blocking(0))
-    assert_eq(None, q.try_get())
+    let q = @async.Queue(kind=Blocking(0))
+    @debug.assert_eq(None, q.try_get())
     for i in 0..<3 {
       group.spawn_bg(() => {
         q.put(i)
@@ -249,7 +249,7 @@ async test "blocked zero buffered try_get" {
         log.push("try_get() => \{x}")
       }
     })
-    assert_eq(None, q.try_get())
+    @debug.assert_eq(None, q.try_get())
   })
   json_inspect(log, content=[
     "try_get() => 0", "try_get() => 1", "try_get() => 2", "put(0)", "put(1)", "put(2)",
@@ -260,7 +260,7 @@ async test "blocked zero buffered try_get" {
 async test "blocked zero buffered try_put" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=Blocking(0))
+    let q = @async.Queue(kind=Blocking(0))
     assert_eq(false, q.try_put(-1))
     for _ in 0..<3 {
       group.spawn_bg(() => {
@@ -288,8 +288,8 @@ async test "blocked zero buffered try_put" {
 async test "blocked zero buffered discard oldest try_get" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=DiscardOldest(0))
-    assert_eq(None, q.try_get())
+    let q = @async.Queue(kind=DiscardOldest(0))
+    @debug.assert_eq(None, q.try_get())
     for i in 0..<3 {
       group.spawn_bg(() => {
         q.put(i) // will be discarded since the buffer size is 0 and no waiting readers
@@ -301,7 +301,7 @@ async test "blocked zero buffered discard oldest try_get" {
         log.push("try_get() => \{x}")
       }
     })
-    assert_eq(None, q.try_get())
+    @debug.assert_eq(None, q.try_get())
   })
   json_inspect(log, content=["put(0)", "put(1)", "put(2)"])
 }
@@ -310,8 +310,8 @@ async test "blocked zero buffered discard oldest try_get" {
 async test "blocked zero buffered discard oldest try_put" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=DiscardOldest(0))
-    assert_eq(false, q.try_put(-1))
+    let q = @async.Queue(kind=DiscardOldest(0))
+    @debug.assert_eq(false, q.try_put(-1))
     for _ in 0..<3 {
       group.spawn_bg(() => {
         let x = q.get()
@@ -327,7 +327,7 @@ async test "blocked zero buffered discard oldest try_put" {
         }
       }
     })
-    assert_eq(false, q.try_put(-1))
+    @debug.assert_eq(false, q.try_put(-1))
   })
   json_inspect(log, content=[
     "try_put(0)", "try_put(1)", "try_put(2)", "get() => 0", "get() => 1", "get() => 2",
@@ -338,8 +338,8 @@ async test "blocked zero buffered discard oldest try_put" {
 async test "blocked zero buffered discard latest try_put" {
   let log = []
   @async.with_task_group(group => {
-    let q = @async.Queue::new(kind=DiscardLatest(0))
-    assert_eq(false, q.try_put(-1))
+    let q = @async.Queue(kind=DiscardLatest(0))
+    @debug.assert_eq(false, q.try_put(-1))
     for _ in 0..<3 {
       group.spawn_bg(() => {
         let x = q.get()
@@ -355,7 +355,7 @@ async test "blocked zero buffered discard latest try_put" {
         }
       }
     })
-    assert_eq(false, q.try_put(-1))
+    @debug.assert_eq(false, q.try_put(-1))
   })
   json_inspect(log, content=[
     "try_put(0)", "try_put(1)", "try_put(2)", "get() => 0", "get() => 1", "get() => 2",

--- a/src/aqueue/close_test.mbt
+++ b/src/aqueue/close_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 async test "put after closed" {
-  let q = @aqueue.new(kind=Unbounded)
+  let q = @async.Queue(kind=Unbounded)
   q.close()
   inspect(try? q.put(42), content="Err(QueueAlreadyClosed)")
   inspect(try? q.try_put(42), content="Err(QueueAlreadyClosed)")
@@ -22,7 +22,7 @@ async test "put after closed" {
 
 ///|
 async test "get after closed" {
-  let q = @aqueue.new(kind=Unbounded)
+  let q = @async.Queue(kind=Unbounded)
   q.put(42)
   q.close()
   inspect(try? q.get(), content="Ok(42)")
@@ -31,32 +31,32 @@ async test "get after closed" {
 
 ///|
 async test "try_get after closed" {
-  let q = @aqueue.new(kind=Unbounded)
+  let q = @async.Queue(kind=Unbounded)
   q.put(42)
   q.close()
-  inspect(try? q.try_get(), content="Ok(Some(42))")
-  inspect(try? q.try_get(), content="Err(QueueAlreadyClosed)")
+  debug_inspect(try? q.try_get(), content="Ok(Some(42))")
+  debug_inspect(try? q.try_get(), content="Err(QueueAlreadyClosed)")
 }
 
 ///|
 async test "get after hard close" {
-  let q = @aqueue.new(kind=Unbounded)
+  let q = @async.Queue(kind=Unbounded)
   q.put(42)
   q.close(clear=true)
-  inspect(try? q.get(), content="Err(QueueAlreadyClosed)")
+  debug_inspect(try? q.get(), content="Err(QueueAlreadyClosed)")
 }
 
 ///|
 async test "try_get after hard close" {
-  let q = @aqueue.new(kind=Unbounded)
+  let q = @async.Queue(kind=Unbounded)
   q.put(42)
   q.close(clear=true)
-  inspect(try? q.try_get(), content="Err(QueueAlreadyClosed)")
+  debug_inspect(try? q.try_get(), content="Err(QueueAlreadyClosed)")
 }
 
 ///|
 async test "close with blocking put" {
-  let q = @aqueue.new(kind=Blocking(1))
+  let q = @async.Queue(kind=Blocking(1))
   q.put(1)
   @async.with_task_group(group => {
     let start = @async.now()
@@ -73,7 +73,7 @@ async test "close with blocking put" {
 
 ///|
 async test "close zero buffered with blocking put" {
-  let q = @aqueue.new(kind=Blocking(0))
+  let q = @async.Queue(kind=Blocking(0))
   @async.with_task_group(group => {
     let start = @async.now()
     group.spawn_bg(() => {
@@ -89,7 +89,7 @@ async test "close zero buffered with blocking put" {
 
 ///|
 async test "close with blocking get" {
-  let q : @aqueue.Queue[Int] = @aqueue.new(kind=Unbounded)
+  let q : @aqueue.Queue[Int] = @async.Queue(kind=Unbounded)
   @async.with_task_group(group => {
     let start = @async.now()
     group.spawn_bg(() => {

--- a/src/aqueue/moon.pkg
+++ b/src/aqueue/moon.pkg
@@ -4,5 +4,6 @@ import {
 }
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/async",
 } for "test"

--- a/src/aqueue/overwrite_test.mbt
+++ b/src/aqueue/overwrite_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 async test "discard oldest basic" {
-  let q = @async.Queue::new(kind=DiscardOldest(2))
+  let q = @async.Queue(kind=DiscardOldest(2))
   for i in 1..<=3 {
     q.put(i)
   }
@@ -27,7 +27,7 @@ async test "discard oldest basic" {
 
 ///|
 async test "discard oldest try_put" {
-  let q = @async.Queue::new(kind=DiscardOldest(2))
+  let q = @async.Queue(kind=DiscardOldest(2))
   inspect(q.try_put(1), content="true")
   inspect(q.try_put(2), content="true")
   inspect(q.try_put(3), content="false")
@@ -41,7 +41,7 @@ async test "discard oldest try_put" {
 
 ///|
 async test "discard latest basic" {
-  let q = @async.Queue::new(kind=DiscardLatest(2))
+  let q = @async.Queue(kind=DiscardLatest(2))
   for i in 1..<=3 {
     q.put(i)
   }
@@ -54,7 +54,7 @@ async test "discard latest basic" {
 
 ///|
 async test "discard latest try_put" {
-  let q = @async.Queue::new(kind=DiscardLatest(2))
+  let q = @async.Queue(kind=DiscardLatest(2))
   inspect(q.try_put(1), content="true")
   inspect(q.try_put(2), content="true")
   inspect(q.try_put(3), content="false")
@@ -68,7 +68,7 @@ async test "discard latest try_put" {
 
 ///|
 async test "discard oldest zero buffered" {
-  let q = @async.Queue::new(kind=DiscardOldest(0))
+  let q = @async.Queue(kind=DiscardOldest(0))
   // all `put` should have no effect
   inspect(q.try_put(1), content="false")
   inspect(q.try_put(2), content="false")
@@ -81,7 +81,7 @@ async test "discard oldest zero buffered" {
 
 ///|
 async test "discard latest zero buffered" {
-  let q = @async.Queue::new(kind=DiscardLatest(0))
+  let q = @async.Queue(kind=DiscardLatest(0))
   // all `put` should have no effect
   inspect(q.try_put(1), content="false")
   inspect(q.try_put(2), content="false")

--- a/src/aqueue/pkg.generated.mbti
+++ b/src/aqueue/pkg.generated.mbti
@@ -23,13 +23,12 @@ pub(all) enum Kind {
 pub struct Queue[X] {
   kind : Kind
   // private fields
-
-  fn[X] new(kind~ : Kind) -> Queue[X]
 }
+#alias(new, deprecated)
+#as_free_fn(new, deprecated)
+pub fn[X] Queue::Queue(kind~ : Kind) -> Self[X]
 pub fn[X] Queue::close(Self[X], error? : Error, clear? : Bool) -> Unit
 pub async fn[X] Queue::get(Self[X]) -> X
-#as_free_fn
-pub fn[X] Queue::new(kind~ : Kind) -> Self[X]
 pub async fn[X] Queue::put(Self[X], X) -> Unit
 pub fn[X] Queue::try_get(Self[X]) -> X? raise
 pub fn[X] Queue::try_put(Self[X], X) -> Bool raise

--- a/src/async.mbt
+++ b/src/async.mbt
@@ -224,7 +224,7 @@ pub async fn[X] all(
   max_concurrent? : Int,
 ) -> Array[X] {
   let semaphore = if max_concurrent is Some(p) {
-    Some(@semaphore.Semaphore::new(p))
+    Some(Semaphore(p))
   } else {
     None
   }
@@ -268,7 +268,7 @@ pub async fn[X] any(
   loc~ : SourceLoc,
 ) -> X {
   let semaphore = if max_concurrent is Some(p) {
-    Some(@semaphore.Semaphore::new(p))
+    Some(Semaphore(p))
   } else {
     None
   }

--- a/src/cond_var/cond_var.mbt
+++ b/src/cond_var/cond_var.mbt
@@ -30,15 +30,14 @@ priv struct Waiter {
 
 ///|
 /// A condition variable that can be used for synchronization between tasks.
-pub struct Cond {
-  priv waiters : @deque.Deque[Waiter]
-
-  fn new() -> Cond
+struct Cond {
+  waiters : @deque.Deque[Waiter]
 }
 
 ///|
 /// Create a new condition variable.
-pub fn Cond::new() -> Cond {
+#alias(new, deprecated)
+pub fn Cond::Cond() -> Cond {
   { waiters: @deque.new() }
 }
 

--- a/src/cond_var/pkg.generated.mbti
+++ b/src/cond_var/pkg.generated.mbti
@@ -8,11 +8,10 @@ package "moonbitlang/async/cond_var"
 // Types and methods
 pub struct Cond {
   // private fields
-
-  fn new() -> Cond
 }
+#alias(new, deprecated)
+pub fn Cond::Cond() -> Self
 pub fn Cond::broadcast(Self) -> Unit
-pub fn Cond::new() -> Self
 pub fn Cond::signal(Self) -> Unit
 pub async fn Cond::wait(Self) -> Unit
 

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -57,12 +57,16 @@ pub async fn mkdir(
 pub async fn rmdir(path : StringView, recursive? : Bool = false) -> Unit {
   let context = "@fs.rmdir()"
   if recursive {
-    let base = path.to_string()
+    let base = if @event_loop.IS_WINDOWS {
+      path.trim_end(chars="/\\")
+    } else {
+      path.trim_end(chars="/")
+    }
     let dir = opendir_aux(path, context~)
     defer dir.close()
     while dir.next_aux(include_special=false, include_hidden=true, context~)
           is Some(ent) {
-      let child_path = base + "/" + ent.name
+      let child_path = "\{base}/\{ent.name}"
       if ent.is_dir {
         rmdir(child_path, recursive=true)
       } else {
@@ -372,7 +376,7 @@ pub async fn walk(
 ) -> Unit {
   let context = "@fs.walk()"
   guard max_concurrency > 0
-  let sem = @async.Semaphore::new(max_concurrency)
+  let sem = @async.Semaphore(max_concurrency)
   @async.with_task_group(fn(group) {
     fn handle_path(path : String) {
       guard !exclude(path) else {  }
@@ -397,6 +401,6 @@ pub async fn walk(
       })
     }
 
-    handle_path(path.to_string())
+    handle_path(path.to_owned())
   })
 }

--- a/src/fs/lock_test.mbt
+++ b/src/fs/lock_test.mbt
@@ -15,8 +15,7 @@
 ///|
 let lock_file_prog : @async.Lazy[String] = @async.Lazy(() => {
   let code = @process.run("moon", [
-    "build", "--manifest-path", "src/process/test_programs/moon.mod.json", "src/process/test_programs/lock_file",
-    "--debug",
+    "-C", "src/process/test_programs", "build", "lock_file", "--debug",
   ])
   if code != 0 {
     fail("failed to build test program `lock_file`: \{code}")
@@ -272,7 +271,7 @@ async test "flock cancelled" {
     @async.sleep(250)
     log.push("attempting to acquire lock")
     let result = @async.with_timeout_opt(100, () => file.lock(Exclusive))
-    log.push("lock() with timeout: \{result}")
+    log.push("lock() with timeout: \{@debug.to_string(result)}")
     if result is Some(_) {
       file.unlock()
     }

--- a/src/fs/mkdir_test.mbt
+++ b/src/fs/mkdir_test.mbt
@@ -54,7 +54,7 @@ async test "mkdir recursive" {
 #cfg(platform="windows")
 async test "mkdir recursive windows" {
   @async.with_task_group(group => {
-    let base_path = "target\\recursive_mkdir_windows"
+    let base_path = "_build\\recursive_mkdir_windows"
     let path = "\{base_path}\\test\\\\directory"
     @fs.mkdir(path, recursive=true)
     group.add_defer(() => @fs.rmdir(base_path, recursive=true))

--- a/src/fs/moon.pkg
+++ b/src/fs/moon.pkg
@@ -16,6 +16,7 @@ import {
 import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
+  "moonbitlang/core/debug",
   "moonbitlang/async/process",
 } for "test"
 

--- a/src/fs/named_pipe_test.mbt
+++ b/src/fs/named_pipe_test.mbt
@@ -29,7 +29,7 @@ async test "cancel named fifo open" {
     let result = @async.with_timeout_opt(500, () => {
       @fs.open(path, mode=ReadOnly).close()
     })
-    inspect(result, content="None")
+    debug_inspect(result, content="None")
   })
 }
 
@@ -51,7 +51,7 @@ async test "cancel named pipe open" {
   let result = @async.with_timeout_opt(500, () => {
     @fs.open(path, mode=ReadOnly).close()
   })
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }
 
 ///|
@@ -67,7 +67,7 @@ async test "named fifo" {
       let r = @fs.open(path, mode=ReadOnly)
       defer r.close()
       inspect(r.read_until("\n").unwrap_or(""), content="abcd")
-      inspect(
+      debug_inspect(
         @async.with_timeout_opt(250, () => r.read_all().text()),
         content="None",
       )
@@ -100,7 +100,7 @@ async test "named pipe" {
       let r = @fs.open(path, mode=ReadOnly)
       defer r.close()
       inspect(r.read_until("\n").unwrap_or(""), content="abcd")
-      inspect(
+      debug_inspect(
         @async.with_timeout_opt(250, () => r.read_all().text()),
         content="None",
       )

--- a/src/gzip/decoder.mbt
+++ b/src/gzip/decoder.mbt
@@ -19,19 +19,18 @@ let decoder_buffer_size = 4096
 fn @io.ReaderBuffer::repr(buf : Self) -> @io_buffer.Buffer = "%identity"
 
 ///|
-pub struct Decoder[R] {
-  priv inner : R
-  priv core : @gzip_internal.Decoder
-  priv read_buf : @io.ReaderBuffer
-
-  fn[R : @io.Reader] new(inner : R) -> Decoder[R]
+struct Decoder[R] {
+  inner : R
+  core : @gzip_internal.Decoder
+  read_buf : @io.ReaderBuffer
 }
 
 ///|
-pub fn[R : @io.Reader] Decoder::new(inner : R) -> Decoder[R] {
+#alias(new, deprecated)
+pub fn[R : @io.Reader] Decoder::Decoder(inner : R) -> Decoder[R] {
   let decoder = {
     inner,
-    core: @gzip_internal.Decoder::new(),
+    core: @gzip_internal.Decoder(),
     read_buf: @io.ReaderBuffer::new(),
   }
   decoder.inner._get_internal_buffer().repr().enlarge_to(decoder_buffer_size)

--- a/src/gzip/encoder.mbt
+++ b/src/gzip/encoder.mbt
@@ -16,22 +16,16 @@
 let encoder_buffer_size = 4096
 
 ///|
-pub struct Encoder[W] {
-  priv inner : W
-  priv buf : FixedArray[Byte]
-  priv mut buf_len : Int
-  priv core : @gzip_internal.Encoder
-
-  fn[W] new(
-    inner : W,
-    mtime? : UInt,
-    extra_flags? : Byte,
-    operating_system? : Byte,
-  ) -> Encoder[W]
+struct Encoder[W] {
+  inner : W
+  buf : FixedArray[Byte]
+  mut buf_len : Int
+  core : @gzip_internal.Encoder
 }
 
 ///|
-pub fn[W] Encoder::new(
+#alias(new, deprecated)
+pub fn[W] Encoder::Encoder(
   inner : W,
   mtime? : UInt = 0U,
   extra_flags? : Byte = b'\x00',
@@ -42,7 +36,7 @@ pub fn[W] Encoder::new(
     inner,
     buf,
     buf_len: 0,
-    core: @gzip_internal.Encoder::new(mtime~, extra_flags~, operating_system~),
+    core: @gzip_internal.Encoder(mtime~, extra_flags~, operating_system~),
   }
 }
 

--- a/src/gzip/gzip_test.mbt
+++ b/src/gzip/gzip_test.mbt
@@ -38,7 +38,7 @@ async fn encode_with_moonbit(input : Bytes) -> Bytes {
   @async.with_task_group(group => {
     group.spawn_bg(() => {
       defer w.close()
-      Encoder::new(w)..write(input).end()
+      @gzip.Encoder(w)..write(input).end()
     })
     defer r.close()
     r.read_all().binary()
@@ -55,7 +55,7 @@ async fn decode_with_moonbit(input : Bytes) -> Bytes {
       w.write(input)
     })
     defer r.close()
-    Decoder::new(r).read_all().binary()
+    @gzip.Decoder(r).read_all().binary()
   })
 }
 
@@ -76,7 +76,7 @@ async test "encode decode roundtrip" {
     let (compressed_r, compressed_w) = @io.pipe()
     root.spawn_bg(() => {
       defer compressed_w.close()
-      let encoder = Encoder::new(
+      let encoder = @gzip.Encoder(
         compressed_w,
         mtime=123456789U,
         operating_system=b'\x03',
@@ -88,7 +88,7 @@ async test "encode decode roundtrip" {
       encoder.end()
     })
 
-    let decoder = Decoder::new(compressed_r)
+    let decoder = @gzip.Decoder(compressed_r)
     inspect(decoder.read_all().text(), content="hello gzip world")
     compressed_r.close()
   })
@@ -101,12 +101,12 @@ async test "encoder uses valid blocks across large writes" {
     let (compressed_r, compressed_w) = @io.pipe()
     root.spawn_bg(() => {
       defer compressed_w.close()
-      let encoder = Encoder::new(compressed_w)
+      let encoder = @gzip.Encoder(compressed_w)
       encoder.write(payload)
       encoder.end()
     })
 
-    let decoder = Decoder::new(compressed_r)
+    let decoder = @gzip.Decoder(compressed_r)
     inspect(decoder.read_all().binary() == payload, content="true")
     compressed_r.close()
   })
@@ -120,7 +120,7 @@ async test "encoder emits output when flushed" {
     root.spawn_bg(() => {
       defer w.close()
       log.push("start init")
-      let encoder = Encoder::new(w)
+      let encoder = @gzip.Encoder(w)
       log.push("encoder ready")
       log.push("write plain ab")
       encoder.write("ab")
@@ -168,7 +168,7 @@ async test "decoder yields plain chunks lazily across delayed chunks" {
       compressed_w.write(b"\x01\x00\x00\xff\xff")
       compressed_w.write(b"\xef\x39\x8e\x4b\x06\x00\x00\x00")
     })
-    let decoder = Decoder::new(compressed_r)
+    let decoder = @gzip.Decoder(compressed_r)
     match decoder.read_some(max_len=2) {
       Some(chunk) => log.push("read plain \{@utf8.decode(chunk)}")
       None => assert_true(false)
@@ -181,7 +181,7 @@ async test "decoder yields plain chunks lazily across delayed chunks" {
       Some(chunk) => log.push("read plain \{@utf8.decode(chunk)}")
       None => assert_true(false)
     }
-    inspect(decoder.read_some(max_len=2), content="None")
+    debug_inspect(decoder.read_some(max_len=2), content="None")
   })
   json_inspect(log, content=[
     "write plain ab", "read plain ab", "write plain cd", "read plain cd", "write plain ef",
@@ -202,12 +202,32 @@ async test "decoder supports reads smaller than writer chunks" {
       compressed_w.write(b"\x01\x00\x00\xff\xff")
       compressed_w.write(b"\x50\x2a\xef\xae\x08\x00\x00\x00")
     })
-    let decoder = Decoder::new(compressed_r)
-    inspect(decoder.read_some(max_len=2), content="Some(b\"ab\")")
-    inspect(decoder.read_some(max_len=2), content="Some(b\"cd\")")
-    inspect(decoder.read_some(max_len=2), content="Some(b\"ef\")")
-    inspect(decoder.read_some(max_len=2), content="Some(b\"gh\")")
-    inspect(decoder.read_some(max_len=2), content="None")
+    let decoder = @gzip.Decoder(compressed_r)
+    debug_inspect(
+      decoder.read_some(max_len=2),
+      content=(
+        #|Some(<Bytes: [0x61, 0x62]>)
+      ),
+    )
+    debug_inspect(
+      decoder.read_some(max_len=2),
+      content=(
+        #|Some(<Bytes: [0x63, 0x64]>)
+      ),
+    )
+    debug_inspect(
+      decoder.read_some(max_len=2),
+      content=(
+        #|Some(<Bytes: [0x65, 0x66]>)
+      ),
+    )
+    debug_inspect(
+      decoder.read_some(max_len=2),
+      content=(
+        #|Some(<Bytes: [0x67, 0x68]>)
+      ),
+    )
+    debug_inspect(decoder.read_some(max_len=2), content="None")
   })
 }
 

--- a/src/gzip/pkg.generated.mbti
+++ b/src/gzip/pkg.generated.mbti
@@ -12,20 +12,18 @@ import {
 // Types and methods
 pub struct Decoder[R] {
   // private fields
-
-  fn[R : @io.Reader] new(R) -> Decoder[R]
 }
-pub fn[R : @io.Reader] Decoder::new(R) -> Self[R]
+#alias(new, deprecated)
+pub fn[R : @io.Reader] Decoder::Decoder(R) -> Self[R]
 pub impl[R : @io.Reader] @io.Reader for Decoder[R]
 
 pub struct Encoder[W] {
   // private fields
-
-  fn[W] new(W, mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Encoder[W]
 }
+#alias(new, deprecated)
+pub fn[W] Encoder::Encoder(W, mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Self[W]
 pub async fn[W : @io.Writer] Encoder::end(Self[W]) -> Unit
 pub async fn[W : @io.Writer] Encoder::flush(Self[W]) -> Unit
-pub fn[W] Encoder::new(W, mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Self[W]
 pub impl[W : @io.Writer] @io.Writer for Encoder[W]
 
 // Type aliases

--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -62,20 +62,13 @@ priv struct OngoingRequest {
 }
 
 ///|
-pub struct Client {
-  priv host : String
-  priv port : Int
-  priv protocol : Protocol
-  priv headers : Map[String, String]
-  priv mut request : OngoingRequest?
-  priv mut response_body : @js_async.ReadableStream?
-
-  async fn new(
-    uri : String,
-    headers? : Map[String, String],
-    proxy? : Client,
-    verify? : Bool,
-  ) -> Client
+struct Client {
+  host : String
+  port : Int
+  protocol : Protocol
+  headers : Map[String, String]
+  mut request : OngoingRequest?
+  mut response_body : @js_async.ReadableStream?
 }
 
 ///|
@@ -120,7 +113,8 @@ fn Client::connect(
 ///
 /// `verify` is ignored on JS backend
 #warnings("-unused_async")
-pub async fn Client::new(
+#alias(new, deprecated)
+pub async fn Client::Client(
   uri : String,
   headers? : Map[String, String] = {},
   proxy? : Client,

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -20,21 +20,14 @@ priv enum ClientTransport {
 
 ///|
 /// Simple HTTP client which connect to a remote host via TCP
-pub struct Client {
-  priv reader : Reader
-  priv transport : ClientTransport
-  priv tls : @tls.Tls?
-  priv sender : Sender
-  priv mut request_method : RequestMethod?
+struct Client {
+  reader : Reader
+  transport : ClientTransport
+  tls : @tls.Tls?
+  sender : Sender
+  mut request_method : RequestMethod?
   /// whether automatic decompression should be enabled for current request
-  priv mut auto_decompress : Bool
-
-  async fn new(
-    uri : String,
-    headers? : Map[String, String],
-    proxy? : Client,
-    verify? : Bool,
-  ) -> Client
+  mut auto_decompress : Bool
 }
 
 ///|
@@ -131,7 +124,8 @@ async fn Client::connect(
 /// so it must not be used nor closed anymore by the caller.
 /// Using another HTTP client as proxy allows advanced features such as
 /// proxy authentication and https `CONNECT` proxy.
-pub async fn Client::new(
+#alias(new, deprecated)
+pub async fn Client::Client(
   uri : String,
   headers? : Map[String, String] = {},
   proxy? : Client,
@@ -244,7 +238,7 @@ pub async fn Client::end_request(self : Client) -> Response {
 pub async fn Client::request(
   self : Client,
   meth : RequestMethod,
-  path : String,
+  path : StringView,
   extra_headers? : Map[String, String] = {},
 ) -> Unit {
   self.auto_decompress = self.sender.send_request(meth, path, extra_headers~)

--- a/src/http/cookie.mbt
+++ b/src/http/cookie.mbt
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 ///|
-pub fn Cookie::new(
+#alias(new, deprecated)
+pub fn Cookie::Cookie(
   name : String,
   value : String,
   path? : String,
@@ -41,12 +42,12 @@ pub fn Cookie::new(
 #cfg(target="native")
 fn Cookie::parse(line : StringView) -> Cookie raise {
   guard line.find("=") is Some(name_end) else { raise BadRequest }
-  let name = line[:name_end].to_string()
+  let name = line[:name_end].to_owned()
   guard line[name_end + 1:].find(";") is Some(value_end) else {
-    Cookie(name, line[name_end + 1:].to_string())
+    Cookie(name, line[name_end + 1:].to_owned())
   }
   let value_end = name_end + 1 + value_end
-  let value = line[name_end + 1:value_end].to_string()
+  let value = line[name_end + 1:value_end].to_owned()
 
   let mut path = None
   let mut expires_raw = None
@@ -67,20 +68,20 @@ fn Cookie::parse(line : StringView) -> Cookie raise {
       let name = attr[:attr_name_end]
       let value = attr[attr_name_end + 1:]
       match name.to_lower() {
-        "path" => path = Some(value.to_string())
-        "expires" => expires_raw = Some(value.to_string())
+        "path" => path = Some(value.to_owned())
+        "expires" => expires_raw = Some(value.to_owned())
         "max-age" => {
           let value = @string.parse_int64(value) catch { _ => raise BadRequest }
           max_age = Some(value)
         }
-        "domain" => domain = Some(value.to_string())
-        _ => extensions.push(attr.to_string())
+        "domain" => domain = Some(value.to_owned())
+        _ => extensions.push(attr.to_owned())
       }
     } else {
       match attr.to_lower() {
         "secure" => secure = true
         "httponly" => http_only = true
-        _ => extensions.push(attr.to_string())
+        _ => extensions.push(attr.to_owned())
       }
     }
 

--- a/src/http/parser.mbt
+++ b/src/http/parser.mbt
@@ -237,14 +237,14 @@ async fn Reader::read_headers(
       break
     }
     guard header_line.find(":") is Some(colon_index) else { raise BadRequest }
-    let key = header_line[:colon_index].to_lower().to_string()
+    let key = header_line[:colon_index].to_lower().to_owned()
     guard colon_index + 1 < header_line.length() else { raise BadRequest }
     let value_start = if header_line.code_unit_at(colon_index + 1) == ' ' {
       colon_index + 2
     } else {
       colon_index + 1
     }
-    let value = header_line[value_start:].to_string()
+    let value = header_line[value_start:].to_owned()
     match key {
       "content-length" => {
         guard !(self.body is Fixed(_)) else { raise BadRequest }
@@ -315,10 +315,10 @@ async fn Reader::read_request(self : Reader) -> Request {
   }
   let request_line = request_line[meth_len + 1:]
   guard request_line.find(" ") is Some(path_len) else { raise BadRequest }
-  let path = request_line[:path_len].to_string()
+  let path = request_line[:path_len].to_owned()
   match request_line[path_len + 1:] {
     "HTTP/1.1" | "HTTP/1.0" => ()
-    protocol => raise HttpVersionNotSupported(protocol.to_string())
+    protocol => raise HttpVersionNotSupported(protocol.to_owned())
   }
   let (headers, cookies) = self.read_headers()
   guard cookies.length() is 0 else { raise BadRequest }
@@ -381,14 +381,14 @@ async fn Reader::read_response(
   guard response_line.find(" ") is Some(protocol_len) else { raise BadRequest }
   match response_line[:protocol_len] {
     "HTTP/1.1" | "HTTP/1.0" => ()
-    protocol => raise HttpVersionNotSupported(protocol.to_string())
+    protocol => raise HttpVersionNotSupported(protocol.to_owned())
   }
   let response_line = response_line[protocol_len + 1:]
   guard response_line.find(" ") is Some(code_len) else { raise BadRequest }
   let code = @string.parse_int(response_line[:code_len], base=10) catch {
     _ => raise BadRequest
   }
-  let reason = response_line[code_len + 1:].to_string()
+  let reason = response_line[code_len + 1:].to_owned()
   let (headers, cookies) = self.read_headers()
 
   // HTTP/1.1 Spec (RFC 7230 Section 3.3.3): Message Body Length Determination

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -47,18 +47,17 @@ pub impl Show for URIParseError
 // Types and methods
 pub struct Client {
   // private fields
-
-  async fn new(String, headers? : Map[String, String], proxy? : Client, verify? : Bool) -> Client
 }
+#alias(new, deprecated)
+pub async fn Client::Client(String, headers? : Map[String, String], proxy? : Self, verify? : Bool) -> Self
 pub fn Client::close(Self) -> Unit
 pub async fn Client::end_request(Self) -> Response
 pub async fn Client::enter_passthrough_mode(Self) -> Unit
 pub async fn Client::flush(Self) -> Unit
 pub async fn Client::get(Self, String, extra_headers? : Map[String, String], body? : &@io.Data) -> Response
-pub async fn Client::new(String, headers? : Map[String, String], proxy? : Self, verify? : Bool) -> Self
 pub async fn Client::post(Self, String, &@io.Data, extra_headers? : Map[String, String]) -> Response
 pub async fn Client::put(Self, String, &@io.Data, extra_headers? : Map[String, String]) -> Response
-pub async fn Client::request(Self, RequestMethod, String, extra_headers? : Map[String, String]) -> Unit
+pub async fn Client::request(Self, RequestMethod, StringView, extra_headers? : Map[String, String]) -> Unit
 pub async fn Client::skip_response_body(Self) -> Unit
 pub impl @io.Reader for Client
 pub impl @io.Writer for Client
@@ -73,10 +72,9 @@ pub struct Cookie {
   secure : Bool
   http_only : Bool
   extensions : Array[String]
-
-  fn new(String, String, path? : String, expires_raw? : String, max_age? : Int64, domain? : String, secure? : Bool, http_only? : Bool, extensions? : Array[String]) -> Cookie
 } derive(ToJson, @debug.Debug)
-pub fn Cookie::new(String, String, path? : String, expires_raw? : String, max_age? : Int64, domain? : String, secure? : Bool, http_only? : Bool, extensions? : Array[String]) -> Self
+#alias(new, deprecated)
+pub fn Cookie::Cookie(String, String, path? : String, expires_raw? : String, max_age? : Int64, domain? : String, secure? : Bool, http_only? : Bool, extensions? : Array[String]) -> Self
 
 pub(all) enum Protocol {
   Http
@@ -120,14 +118,13 @@ pub impl Show for Response
 pub struct Server {
   addr : @socket.Addr
   // private fields
-
-  async fn new(@socket.Addr, dual_stack? : Bool, reuse_addr? : Bool, headers? : Map[String, String]) -> Server
 }
+#alias(new, deprecated)
+pub async fn Server::Server(@socket.Addr, dual_stack? : Bool, reuse_addr? : Bool, headers? : Map[String, String]) -> Self
 pub async fn Server::accept(Self) -> (ServerConnection, @socket.Addr)
 #deprecated
 pub fn Server::addr(Self) -> @socket.Addr
 pub fn Server::close(Self) -> Unit
-pub async fn Server::new(@socket.Addr, dual_stack? : Bool, reuse_addr? : Bool, headers? : Map[String, String]) -> Self
 pub async fn Server::run_forever(Self, async (Request, &@io.Reader, ServerConnection) -> Unit, allow_failure? : Bool, max_connections? : Int) -> Unit
 
 type ServerConnection

--- a/src/http/proxy_test.mbt
+++ b/src/http/proxy_test.mbt
@@ -90,7 +90,7 @@ async fn handle_connect(
     return
   }
   let client = try {
-    let host = request.path[:index].to_string()
+    let host = request.path[:index]
     let port = @string.parse_int(request.path[index + 1:])
     @socket.Tcp::connect_to_host(host, port~)
   } catch {

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -38,23 +38,29 @@ fn resolve_url(uri : String) -> (Protocol, Int, String, String) raise {
   let protocol = match uri[:protocol_len] {
     "http" => Http
     "https" => Https
-    protocol => raise UnsupportedProtocol(protocol.to_string())
+    protocol => raise UnsupportedProtocol(protocol.to_owned())
   }
   let uri = uri[protocol_len + 3:]
   let (host, path) = if uri.find("/") is Some(i) {
-    (uri[:i].to_string(), uri[i:].to_string())
+    (uri[:i], uri[i:])
   } else {
-    (uri.to_string(), "/")
+    (uri, "/")
   }
-  let (host, port) = if host lexmatch? (host, ":" ("[0-9]+" as port_str)) {
+  let (host, port) = if host =~ (
+      re"^" +
+      (re".*" as host) +
+      re":" +
+      (re"[0-9]+" as port_str) +
+      re"$"
+    ) {
     let port = @string.parse_int(port_str) catch { _ => raise InvalidFormat }
     guard port is (1..<65536) else { raise InvalidFormat }
-    (host.to_string(), port)
+    (host, port)
   } else {
     (host, protocol.default_port())
   }
-  let path = if path == "" { "/" } else { path }
-  (protocol, port, host, path)
+  let path = if path == "" { "/" } else { path.to_owned() }
+  (protocol, port, host.to_owned(), path)
 }
 
 ///|

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -283,7 +283,7 @@ async fn Sender::send_headers(
 async fn Sender::send_request(
   self : Sender,
   meth : RequestMethod,
-  path : String,
+  path : StringView,
   extra_headers~ : Map[String, String],
 ) -> Bool {
   guard self.mode is SendingHeader

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -175,13 +175,6 @@ pub struct Server {
   addr : @socket.Addr
   priv server : @socket.TcpServer
   priv headers : Map[String, String]
-
-  async fn new(
-    addr : @socket.Addr,
-    dual_stack? : Bool,
-    reuse_addr? : Bool,
-    headers? : Map[String, String],
-  ) -> Server
 }
 
 ///|
@@ -192,13 +185,14 @@ pub struct Server {
 ///
 /// `headers` can be used to specify common headers
 /// shared by all responses sent by this server.
-pub async fn Server::new(
+#alias(new, deprecated)
+pub async fn Server::Server(
   addr : @socket.Addr,
   dual_stack? : Bool,
   reuse_addr? : Bool,
   headers? : Map[String, String] = {},
 ) -> Server {
-  let server = @socket.TcpServer::new(addr, dual_stack?, reuse_addr?)
+  let server = @socket.TcpServer(addr, dual_stack?, reuse_addr?)
   { addr: server.addr, server, headers }
 }
 

--- a/src/http/types.mbt
+++ b/src/http/types.mbt
@@ -55,16 +55,4 @@ pub struct Cookie {
   secure : Bool
   http_only : Bool
   extensions : Array[String]
-
-  fn new(
-    name : String,
-    value : String,
-    path? : String,
-    expires_raw? : String,
-    max_age? : Int64,
-    domain? : String,
-    secure? : Bool,
-    http_only? : Bool,
-    extensions? : Array[String],
-  ) -> Cookie
 } derive(Debug, ToJson)

--- a/src/http/unimplemented.mbt
+++ b/src/http/unimplemented.mbt
@@ -21,7 +21,7 @@ pub let unimplemented : Unit = {
   ignore(@socket.unimplemented)
   ignore(@tls.unimplemented)
   ignore(@io_buffer.new)
-  ignore(@gzip.Decoder::new)
+  ignore(@gzip.Decoder::is_finished)
 }
 
 ///|

--- a/src/http/unimplemented_wbtest.mbt
+++ b/src/http/unimplemented_wbtest.mbt
@@ -15,7 +15,7 @@
 ///|
 #cfg(not(target="native"))
 fn _ignore_unused_import() -> Unit {
-  let _ : (&@io.Reader) -> _ = @gzip_stream.Decoder::new
+  let _ : (@gzip_stream.Decoder[&@io.Reader]) -> Unit = ignore
   ignore(@async.sleep)
   ignore(@fs.unimplemented)
   ignore(@bytes_util.ascii_to_string)

--- a/src/internal/event_loop/cancel_before_submit_test.mbt
+++ b/src/internal/event_loop/cancel_before_submit_test.mbt
@@ -22,5 +22,5 @@ async test "cancel before submit" {
 
     }
   })
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
 }

--- a/src/internal/gzip_internal/decoder.mbt
+++ b/src/internal/gzip_internal/decoder.mbt
@@ -46,26 +46,25 @@ priv enum DecodeMode {
 }
 
 ///|
-pub struct Decoder {
-  priv trailer_state : TrailerState
-  priv mut mode : DecodeMode
-  priv mut bit_buffer : UInt
-  priv mut bit_count : Int
-  priv mut copy_remaining : Int
-  priv mut copy_distance : Int
-  priv mut pending_buf : FixedArray[Byte]
-  priv mut pending_len : Int
-  priv history : FixedArray[Byte]
-  priv mut history_pos : Int
-  priv mut history_len : Int
-
-  fn new() -> Decoder
+struct Decoder {
+  trailer_state : TrailerState
+  mut mode : DecodeMode
+  mut bit_buffer : UInt
+  mut bit_count : Int
+  mut copy_remaining : Int
+  mut copy_distance : Int
+  mut pending_buf : FixedArray[Byte]
+  mut pending_len : Int
+  history : FixedArray[Byte]
+  mut history_pos : Int
+  mut history_len : Int
 }
 
 ///|
 /// Create a decoder state machine.
 /// The gzip header is consumed by the first successful `write` call.
-pub fn Decoder::new() -> Decoder {
+#alias(new, deprecated)
+pub fn Decoder::Decoder() -> Decoder {
   {
     trailer_state: TrailerState::new(),
     mode: Header,

--- a/src/internal/gzip_internal/encoder.mbt
+++ b/src/internal/gzip_internal/encoder.mbt
@@ -25,28 +25,23 @@ let encoder_max_match_len = 64
 let encoder_min_match_len = 3
 
 ///|
-pub struct Encoder {
-  priv header : Header
-  priv trailer_state : TrailerState
-  priv mut bit_buffer : UInt
-  priv mut bit_count : Int
-  priv mut finished : Bool
-  priv mut started : Bool
-  priv history : FixedArray[Byte]
-  priv mut history_pos : Int
-  priv mut history_len : Int
-
-  fn new(
-    mtime? : UInt,
-    extra_flags? : Byte,
-    operating_system? : Byte,
-  ) -> Encoder
+struct Encoder {
+  header : Header
+  trailer_state : TrailerState
+  mut bit_buffer : UInt
+  mut bit_count : Int
+  mut finished : Bool
+  mut started : Bool
+  history : FixedArray[Byte]
+  mut history_pos : Int
+  mut history_len : Int
 }
 
 ///|
 /// Create an encoder state machine.
 /// The gzip header is written by the first successful `write` or `end` call.
-pub fn Encoder::new(
+#alias(new, deprecated)
+pub fn Encoder::Encoder(
   mtime? : UInt = 0U,
   extra_flags? : Byte = b'\x00',
   operating_system? : Byte = b'\xff',

--- a/src/internal/gzip_internal/gzip_internal_test.mbt
+++ b/src/internal/gzip_internal/gzip_internal_test.mbt
@@ -25,7 +25,7 @@ fn encode(
   output_step? : Step = Max,
 ) -> Bytes raise {
   let output = FixedArray::make(data.length() * 4 + 256, b'\x00')
-  let encoder = Encoder::new()
+  let encoder = @gzip_internal.Encoder()
   let mut input_offset = 0
   let mut output_offset = 0
   let mut step = 0
@@ -61,7 +61,7 @@ fn encode(
     output_offset~,
     output_len=output.length() - output_offset,
   )
-  output.unsafe_reinterpret_as_bytes()[:output_offset].to_bytes()
+  output.unsafe_reinterpret_as_bytes()[:output_offset].to_owned()
 }
 
 ///|
@@ -79,7 +79,7 @@ fn decode(
     },
     b'\x00',
   )
-  let decoder = Decoder::new()
+  let decoder = @gzip_internal.Decoder()
   let mut input_offset = 0
   let mut output_offset = 0
   let mut step = 0
@@ -112,7 +112,7 @@ fn decode(
     }
   }
   guard input_offset == compressed.length()
-  output.unsafe_reinterpret_as_bytes()[:output_offset].to_bytes()
+  output.unsafe_reinterpret_as_bytes()[:output_offset].to_owned()
 }
 
 ///|
@@ -120,7 +120,7 @@ test "gzip decode one byte partial chunks" {
   let data = b"A simple message to compress"
   let compressed = encode(data)
   let output = FixedArray::make(data.length() * 2, b'\x00')
-  let decoder = Decoder::new()
+  let decoder = @gzip_internal.Decoder()
   let mut input_offset = 0
   let mut output_offset = 0
   while !decoder.is_finished() {

--- a/src/internal/gzip_internal/invalid_test.mbt
+++ b/src/internal/gzip_internal/invalid_test.mbt
@@ -24,7 +24,7 @@ test "decoder rejects invalid gzip header" {
 ///|
 test "decoder verifies trailer automatically" {
   let encoded = encode(b"\x00")
-  let corrupted = encoded[:encoded.length() - 8].to_bytes() +
+  let corrupted = encoded[:encoded.length() - 8].to_owned() +
     b"\x00\x00\x00\x00\x01\x00\x00\x00"
   let result = try? decode(corrupted, expected_len=1)
   assert_true(result is Err(_))

--- a/src/internal/gzip_internal/pkg.generated.mbti
+++ b/src/internal/gzip_internal/pkg.generated.mbti
@@ -9,23 +9,21 @@ pub const HEADER_SIZE : Int = 10
 // Types and methods
 pub struct Decoder {
   // private fields
-
-  fn new() -> Decoder
 }
+#alias(new, deprecated)
+pub fn Decoder::Decoder() -> Self
 pub fn Decoder::is_finished(Self) -> Bool
 pub fn Decoder::minimum_input_size(Self) -> Int
-pub fn Decoder::new() -> Self
 pub fn Decoder::write(Self, Bytes, FixedArray[Byte], input_offset? : Int, input_len? : Int, output_offset? : Int, output_len? : Int) -> (Int, Int) raise
 pub fn Decoder::write_partial_data(Self, Bytes, input_offset? : Int, input_len? : Int) -> Unit
 
 pub struct Encoder {
   // private fields
-
-  fn new(mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Encoder
 }
+#alias(new, deprecated)
+pub fn Encoder::Encoder(mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Self
 pub fn Encoder::end(Self, FixedArray[Byte], output_offset? : Int, output_len? : Int) -> Int
 pub fn Encoder::minimum_output_space(Self, end~ : Bool) -> Int
-pub fn Encoder::new(mtime? : UInt, extra_flags? : Byte, operating_system? : Byte) -> Self
 pub fn Encoder::write(Self, Bytes, FixedArray[Byte], input_offset? : Int, input_len? : Int, output_offset? : Int, output_len? : Int) -> (Int, Int)
 
 // Type aliases

--- a/src/internal/os_string/os_string.mbt
+++ b/src/internal/os_string/os_string.mbt
@@ -30,7 +30,7 @@ pub fn encode(str : StringView) -> OsString {
 ///|
 #cfg(platform="windows")
 pub fn encode(str : StringView) -> OsString {
-  str.to_string()
+  str.to_owned()
 }
 
 ///|

--- a/src/io/README.mbt.md
+++ b/src/io/README.mbt.md
@@ -180,34 +180,34 @@ async test "read_some - read next chunk of data" {
       @async.sleep(200)
       w.write("ijkl")
     })
-    inspect(
+    debug_inspect(
       r.read_some(),
       content=(
-        #|Some(b"abcd")
+        #|Some(<Bytes: [0x61, 0x62, 0x63, 0x64]>)
       ),
     )
     // `read_some` can optionally accept a length limit
-    inspect(
+    debug_inspect(
       r.read_some(max_len=2),
       content=(
-        #|Some(b"ef")
+        #|Some(<Bytes: [0x65, 0x66]>)
       ),
     )
     // the amount of data returned may be smaller than `max_len`
-    inspect(
+    debug_inspect(
       r.read_some(max_len=4),
       content=(
-        #|Some(b"gh")
+        #|Some(<Bytes: [0x67, 0x68]>)
       ),
     )
-    inspect(
+    debug_inspect(
       r.read_some(),
       content=(
-        #|Some(b"ijkl")
+        #|Some(<Bytes: [0x69, 0x6a, 0x6b, 0x6c]>)
       ),
     )
     // on EOF, `None` is returned
-    inspect(r.read_some(), content="None")
+    debug_inspect(r.read_some(), content="None")
   })
 }
 
@@ -269,21 +269,21 @@ async test "read_until - read text from stream until a separator is found" {
       w.write("defg")
     })
     // read until the separator "|" is met. The separator will be consumed as well
-    inspect(
+    debug_inspect(
       r.read_until("|"),
       content=(
         #|Some("abcd")
       ),
     )
     // .. or read until EOF is reached
-    inspect(
+    debug_inspect(
       r.read_until("|"),
       content=(
         #|Some("defg")
       ),
     )
     // `None` will be returned when no more data is available
-    inspect(r.read_until("|"), content="None")
+    debug_inspect(r.read_until("|"), content="None")
   })
 }
 

--- a/src/io/data.mbt
+++ b/src/io/data.mbt
@@ -37,7 +37,7 @@ pub impl Data for Bytes with to_bytes(self) {
 
 ///|
 pub impl Data for BytesView with to_bytes(self) {
-  self.to_bytes()
+  self.to_owned()
 }
 
 ///|

--- a/src/io/reader.mbt
+++ b/src/io/reader.mbt
@@ -107,12 +107,12 @@ impl Reader with read_some(self, max_len?) {
   if buf.len > 0 {
     let buf_bytes = buf.buf.unsafe_reinterpret_as_bytes()
     if max_len is Some(max_len) && max_len < buf.len {
-      let data = buf_bytes[buf.start:buf.start + max_len].to_bytes()
+      let data = buf_bytes[buf.start:buf.start + max_len].to_owned()
       buf.start += max_len
       buf.len -= max_len
       return Some(data)
     } else {
-      let data = buf_bytes[buf.start:buf.start + buf.len].to_bytes()
+      let data = buf_bytes[buf.start:buf.start + buf.len].to_owned()
       buf.start = 0
       buf.len = 0
       return Some(data)
@@ -126,11 +126,11 @@ impl Reader with read_some(self, max_len?) {
   if max_len is Some(max_len) && max_len < n {
     buf.start = max_len
     buf.len = n - max_len
-    Some(buf.buf.unsafe_reinterpret_as_bytes()[:max_len].to_bytes())
+    Some(buf.buf.unsafe_reinterpret_as_bytes()[:max_len].to_owned())
   } else {
     buf.start = 0
     buf.len = 0
-    Some(buf.buf.unsafe_reinterpret_as_bytes()[:n].to_bytes())
+    Some(buf.buf.unsafe_reinterpret_as_bytes()[:n].to_owned())
   }
 }
 

--- a/src/lazy_init.mbt
+++ b/src/lazy_init.mbt
@@ -26,12 +26,10 @@ priv enum LazyValueState[X] {
 /// the result will be cached, so the initialization process will run only once.
 /// If no one is waiting for the result anymore before initialization completes,
 /// the initialization process will be cancelled automatically.
-pub struct Lazy[X] {
-  priv worker : async () -> X
-  priv waiters : Set[@coroutine.Coroutine]
-  priv mut state : LazyValueState[X]
-
-  fn[X] new(f : async () -> X) -> Lazy[X]
+struct Lazy[X] {
+  worker : async () -> X
+  waiters : Set[@coroutine.Coroutine]
+  mut state : LazyValueState[X]
 }
 
 ///|
@@ -98,6 +96,7 @@ pub async fn[X] Lazy::wait(self : Lazy[X]) -> X {
 /// the result will be cached, and subsequent `.wait()` on the lazy value
 /// always complete immediately.
 #as_free_fn(lazy_init, deprecated="use `@async.Lazy(..)` instead")
-pub fn[X] Lazy::new(f : async () -> X) -> Lazy[X] {
+#alias(new, deprecated)
+pub fn[X] Lazy::Lazy(f : async () -> X) -> Lazy[X] {
   { worker: f, waiters: @set.new(), state: Uninitialized }
 }

--- a/src/lazy_init_test.mbt
+++ b/src/lazy_init_test.mbt
@@ -83,7 +83,7 @@ async test "lazy init cancelled" {
     }
     log.push("lazy init completed at tick \{current_tick()}")
   })
-  inspect(@async.with_timeout_opt(200, () => x.wait()), content="None")
+  debug_inspect(@async.with_timeout_opt(200, () => x.wait()), content="None")
   @async.sleep(100)
   // the previous attempt is already cancelled,
   // this `wait` will trigger a new attempt
@@ -119,7 +119,7 @@ async test "lazy init multiple waiters 1" {
     })
     @async.with_timeout_opt(200, () => x.wait())
   })
-  inspect(result, content="None")
+  debug_inspect(result, content="None")
   json_inspect(log, content=[
     "lazy init started at tick 0", "lazy init completed at tick 2", "got lazy init value at tick 2",
   ])
@@ -145,10 +145,16 @@ async test "lazy init multiple waiters 2" {
   })
   @async.with_task_group(group => {
     group.spawn_bg(() => {
-      inspect(@async.with_timeout_opt(200, () => x.wait()), content="None")
+      debug_inspect(
+        @async.with_timeout_opt(200, () => x.wait()),
+        content="None",
+      )
     })
     group.spawn_bg(() => {
-      inspect(@async.with_timeout_opt(400, () => x.wait()), content="None")
+      debug_inspect(
+        @async.with_timeout_opt(400, () => x.wait()),
+        content="None",
+      )
     })
   })
   json_inspect(log, content=[

--- a/src/os_error/error.mbt
+++ b/src/os_error/error.mbt
@@ -49,7 +49,7 @@ extern "C" fn free_errno_str(str : @c_buffer.Buffer) = "moonbitlang_async_free_e
 pub fn errno_to_string(errno : Int) -> String {
   let c_str = strerror(errno)
   defer free_errno_str(c_str)
-  @os_string.decode(c_str).trim_end(chars="\r\n").to_string()
+  @os_string.decode(c_str).trim_end(chars="\r\n").to_owned()
 }
 
 ///|

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -48,11 +48,10 @@ pub impl Show for TimerCancelled
 // Types and methods
 pub struct Lazy[X] {
   // private fields
-
-  fn[X] new(async () -> X) -> Lazy[X]
 }
+#alias(new, deprecated)
 #as_free_fn(lazy_init, deprecated)
-pub fn[X] Lazy::new(async () -> X) -> Self[X]
+pub fn[X] Lazy::Lazy(async () -> X) -> Self[X]
 pub async fn[X] Lazy::wait(Self[X]) -> X
 
 pub(all) enum RetryMethod {
@@ -76,11 +75,10 @@ pub fn[X] TaskGroup::spawn_loop(Self[X], async () -> Unit, no_wait? : Bool, allo
 pub struct Timer {
   duration : Int
   // private fields
-
-  fn new(Int) -> Timer
 }
+#alias(new, deprecated)
+pub fn Timer::Timer(Int) -> Self
 pub fn Timer::cancel(Self, err? : Error) -> Unit
-pub fn Timer::new(Int) -> Self
 pub fn Timer::refresh(Self) -> Unit
 pub async fn Timer::wait(Self) -> Unit
 

--- a/src/process/commands_for_test.mbt
+++ b/src/process/commands_for_test.mbt
@@ -40,10 +40,10 @@ let ls : String = if is_windows { "Get-ChildItem -Name" } else { "ls" }
 fn make_test_prog(name : String) -> @async.Lazy[String] {
   @async.Lazy(() => {
     let code = @process.run("moon", [
+      "-C",
+      "src/process/test_programs",
       "build",
-      "--manifest-path",
-      "src/process/test_programs/moon.mod.json",
-      "src/process/test_programs/\{name}",
+      "\{name}",
       "--debug",
     ])
     if code != 0 {

--- a/src/process/spawn_in_group_test.mbt
+++ b/src/process/spawn_in_group_test.mbt
@@ -68,9 +68,9 @@ async test "Process::try_wait" {
   @async.with_task_group(group => {
     let child = @process.spawn(group, sleep, ["450", "-exit-code", "42"])
     @async.sleep(300)
-    inspect(child.try_wait(), content="None")
+    debug_inspect(child.try_wait(), content="None")
     @async.sleep(300)
-    inspect(child.try_wait(), content="Some(42)")
+    debug_inspect(child.try_wait(), content="Some(42)")
   })
 }
 

--- a/src/raw_fd/pkg.generated.mbti
+++ b/src/raw_fd/pkg.generated.mbti
@@ -9,11 +9,10 @@ package "moonbitlang/async/raw_fd"
 pub struct RawFd {
   fd : Int
   // private fields
-
-  async fn new(Int) -> RawFd
 }
+#alias(new, deprecated)
+pub async fn RawFd::RawFd(Int) -> Self
 pub fn RawFd::close(Self) -> Unit
-pub async fn RawFd::new(Int) -> Self
 pub async fn RawFd::read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int
 pub async fn RawFd::write(Self, Bytes, offset? : Int, len? : Int) -> Int
 

--- a/src/raw_fd/raw_fd.mbt
+++ b/src/raw_fd/raw_fd.mbt
@@ -20,14 +20,6 @@
 pub struct RawFd {
   fd : @fd_util.Fd
   priv io : @event_loop.IoHandle
-
-  /// Create a new `RawFd` object from the underlying file descriptor.
-  /// The ownership of the file descriptor will be transferred to this function,
-  /// so the file descriptor must not be used or closed directly later,
-  /// even if creation of `RawFd` object failed.
-  ///
-  /// Windows note: the file descriptor (`HANDLE`) MUST NOT be overlapped.
-  async fn new(@fd_util.Fd) -> RawFd
 }
 
 ///|
@@ -36,7 +28,8 @@ pub struct RawFd {
 /// so the file descriptor must not be used or closed directly later,
 /// even if creation of `RawFd` object failed.
 #cfg(not(platform="windows"))
-pub async fn RawFd::new(fd : @fd_util.Fd) -> RawFd {
+#alias(new, deprecated)
+pub async fn RawFd::RawFd(fd : @fd_util.Fd) -> RawFd {
   let context = "@raw_fd.RawFd::new()"
   let kind = @event_loop.kind_of_fd(fd, context~)
   try {
@@ -58,7 +51,8 @@ pub async fn RawFd::new(fd : @fd_util.Fd) -> RawFd {
 ///
 /// The file descriptor (`HANDLE`) MUST NOT be overlapped.
 #cfg(platform="windows")
-pub async fn RawFd::new(fd : @fd_util.Fd) -> RawFd {
+#alias(new, deprecated)
+pub async fn RawFd::RawFd(fd : @fd_util.Fd) -> RawFd {
   let context = "@raw_fd.RawFd::new()"
   let kind = @event_loop.kind_of_fd(fd, context~)
   { fd, io: @event_loop.IoHandle::from_fd(fd, kind~, is_async=false) } catch {

--- a/src/semaphore/pkg.generated.mbti
+++ b/src/semaphore/pkg.generated.mbti
@@ -9,11 +9,10 @@ package "moonbitlang/async/semaphore"
 pub struct Semaphore {
   size : Int
   // private fields
-
-  fn new(Int, initial_value? : Int) -> Semaphore
 }
+#alias(new, deprecated)
+pub fn Semaphore::Semaphore(Int, initial_value? : Int) -> Self
 pub async fn Semaphore::acquire(Self) -> Unit
-pub fn Semaphore::new(Int, initial_value? : Int) -> Self
 pub fn Semaphore::release(Self) -> Unit
 pub fn Semaphore::try_acquire(Self) -> Bool
 

--- a/src/semaphore/semaphore.mbt
+++ b/src/semaphore/semaphore.mbt
@@ -34,15 +34,17 @@ pub struct Semaphore {
   size : Int
   priv mut value : Int
   priv waiters : @deque.Deque[Waiter]
-
-  fn new(size : Int, initial_value? : Int) -> Semaphore
 }
 
 ///|
 /// Create a semaphore of size `size`,
 /// the initial value of the semaphore
 /// will be set to `initial_value` (`size` by default)
-pub fn Semaphore::new(size : Int, initial_value? : Int = size) -> Semaphore {
+#alias(new, deprecated)
+pub fn Semaphore::Semaphore(
+  size : Int,
+  initial_value? : Int = size,
+) -> Semaphore {
   guard initial_value >= 0 && initial_value <= size
   { value: initial_value, size, waiters: @deque.new() }
 }

--- a/src/signal/signal_test.mbt
+++ b/src/signal/signal_test.mbt
@@ -16,10 +16,10 @@
 fn make_test_prog(name : String) -> @async.Lazy[String] {
   @async.Lazy(() => {
     let code = @process.run("moon", [
+      "-C",
+      "src/process/test_programs",
       "build",
-      "--manifest-path",
-      "src/process/test_programs/moon.mod.json",
-      "src/process/test_programs/\{name}",
+      "\{name}",
       "--debug",
     ])
     if code != 0 {

--- a/src/socket/addr_utils.mbt
+++ b/src/socket/addr_utils.mbt
@@ -193,9 +193,7 @@ fn parse_ipv4_to_bytes(
   let parts = ip_str.split(".").collect()
   guard parts.length() == 4 else { raise InvalidAddr }
   fn parse_octal(x : StringView) raise InvalidAddr {
-    let value = @string.parse_uint(x.to_string()) catch {
-      _ => raise InvalidAddr
-    }
+    let value = @string.parse_uint(x) catch { _ => raise InvalidAddr }
     guard value < 256 else { raise InvalidAddr }
     value
   }

--- a/src/socket/getsockname_test.mbt
+++ b/src/socket/getsockname_test.mbt
@@ -54,7 +54,7 @@ async test "getsockname UDP" {
       peer_addr
     })
     let client_addr = group.spawn(() => {
-      let client = @socket.UdpClient::new(server_addr)
+      let client = @socket.UdpClient(server_addr)
       defer client.close()
       client.send(b"abcd")
       client.addr

--- a/src/socket/happy_eyeball.mbt
+++ b/src/socket/happy_eyeball.mbt
@@ -27,7 +27,7 @@
 /// - if `protocol` is `OnlyV6`,
 ///   `connect_to_host` will fail if no IPv4 address is available
 pub async fn Tcp::connect_to_host(
-  host : String,
+  host : StringView,
   port~ : Int,
   protocol? : IpProtocolPreference = NoPreference,
 ) -> Tcp {

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -46,7 +46,7 @@ pub struct Tcp {
 pub fn Tcp::addr(Self) -> Addr
 pub fn Tcp::close(Self) -> Unit
 pub async fn Tcp::connect(Addr) -> Self
-pub async fn Tcp::connect_to_host(String, port~ : Int, protocol? : IpProtocolPreference) -> Self
+pub async fn Tcp::connect_to_host(StringView, port~ : Int, protocol? : IpProtocolPreference) -> Self
 pub fn Tcp::enable_keepalive(Self, idle_before_keep_alive? : Int, keep_alive_count? : Int, keep_alive_interval? : Int) -> Unit raise
 pub fn Tcp::fd(Self) -> Int
 pub impl @io.Reader for Tcp
@@ -55,42 +55,39 @@ pub impl @io.Writer for Tcp
 pub struct TcpServer {
   addr : Addr
   // private fields
-
-  async fn new(Addr, dual_stack? : Bool, reuse_addr? : Bool) -> TcpServer
 }
+#alias(new, deprecated)
+pub async fn TcpServer::TcpServer(Addr, dual_stack? : Bool, reuse_addr? : Bool) -> Self
 pub async fn TcpServer::accept(Self) -> (Tcp, Addr)
 #deprecated
 pub fn TcpServer::addr(Self) -> Addr
 pub fn TcpServer::close(Self) -> Unit
 pub fn TcpServer::fd(Self) -> Int
-pub async fn TcpServer::new(Addr, dual_stack? : Bool, reuse_addr? : Bool) -> Self
 pub async fn TcpServer::run_forever(Self, async (Tcp, Addr) -> Unit, allow_failure? : Bool, max_connections? : Int) -> Unit
 
 pub struct UdpClient {
   addr : Addr
   // private fields
-
-  fn new(Addr) -> UdpClient raise
 }
+#alias(new, deprecated)
+pub fn UdpClient::UdpClient(Addr) -> Self raise
 #deprecated
 pub fn UdpClient::addr(Self) -> Addr
 pub fn UdpClient::close(Self) -> Unit
 pub fn UdpClient::fd(Self) -> Int
-pub fn UdpClient::new(Addr) -> Self raise
 pub async fn UdpClient::recv(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int
 pub async fn UdpClient::send(Self, Bytes, offset? : Int, len? : Int) -> Unit
 
 pub struct UdpServer {
   addr : Addr
   // private fields
-
-  async fn new(Addr, dual_stack? : Bool) -> UdpServer
 }
+#alias(new, deprecated)
+pub async fn UdpServer::UdpServer(Addr, dual_stack? : Bool) -> Self
 #deprecated
 pub fn UdpServer::addr(Self) -> Addr
 pub fn UdpServer::close(Self) -> Unit
 pub fn UdpServer::fd(UdpClient) -> Int
-pub async fn UdpServer::new(Addr, dual_stack? : Bool) -> Self
 pub async fn UdpServer::recvfrom(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> (Int, Addr)
 pub async fn UdpServer::sendto(Self, Bytes, Addr, offset? : Int, len? : Int) -> Unit
 

--- a/src/socket/resolve_host_test.mbt
+++ b/src/socket/resolve_host_test.mbt
@@ -24,7 +24,7 @@ async test "resolve mooncakes.io" {
 async test "resolve cancel" {
   let log = StringBuilder::new()
   @async.with_task_group(root => {
-    let lock = @async.Semaphore::new(1, initial_value=1)
+    let lock = @async.Semaphore(1, initial_value=1)
     let task = root.spawn(() => {
       lock.release()
       log.write_object(@socket.Addr::resolve("does.not.exist", port=443))

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -36,8 +36,6 @@ pub struct TcpServer {
   /// The actual listen address of the server
   addr : Addr
   priv io : @event_loop.IoHandle
-
-  async fn new(addr : Addr, dual_stack? : Bool, reuse_addr? : Bool) -> TcpServer
 }
 
 ///|
@@ -63,7 +61,8 @@ pub struct TcpServer {
 /// This is useful for avoiding "address already in use" error while testing.
 /// WARNING: enabling `reuse_addr` on production is unsafe,
 /// packets from the previous listener of the address may be accidentally received.
-pub async fn TcpServer::new(
+#alias(new, deprecated)
+pub async fn TcpServer::TcpServer(
   addr : Addr,
   dual_stack? : Bool = true,
   reuse_addr? : Bool = false,
@@ -130,7 +129,7 @@ pub async fn TcpServer::run_forever(
   defer self.close()
   let conn_limit = match max_connections {
     None => None
-    Some(n) => Some(@async.Semaphore::new(n))
+    Some(n) => Some(@async.Semaphore(n))
   }
   @async.with_task_group(group => {
     for ;; {

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -22,15 +22,14 @@ pub struct UdpClient {
   /// Local address of the client
   addr : Addr
   priv io : @event_loop.IoHandle
-
-  fn new(server : Addr) -> UdpClient raise
 }
 
 ///|
 /// Create a new UDP client connected to server at `addr`.
 /// The client always send packet to and receive packet from
 /// the specified remote server.
-pub fn UdpClient::new(server : Addr) -> UdpClient raise {
+#alias(new, deprecated)
+pub fn UdpClient::UdpClient(server : Addr) -> UdpClient raise {
   let context = "@socket.UdpClient::new()"
   let family = server.family()
   let sock = make_udp_socket(family, context~)
@@ -70,8 +69,6 @@ pub fn UdpClient::addr(self : UdpClient) -> Addr {
 pub struct UdpServer {
   addr : Addr
   priv io : @event_loop.IoHandle
-
-  async fn new(addr : Addr, dual_stack? : Bool) -> UdpServer
 }
 
 ///|
@@ -98,7 +95,8 @@ pub fn UdpServer::fd(self : UdpClient) -> @fd_util.Fd {
 /// If the port of `addr` is zero, the server will be bound to a random port,
 /// assigned by the operating system.
 /// The actual listen address can be retrieved via `.addr()`.
-pub async fn UdpServer::new(
+#alias(new, deprecated)
+pub async fn UdpServer::UdpServer(
   addr : Addr,
   dual_stack? : Bool = true,
 ) -> UdpServer {

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -18,8 +18,7 @@ let cat : @async.Lazy[String] = @async.Lazy(() => {
   // Currently, dependencies of a module is built locally in that module,
   // so there will be no build lock conflict between this test and the `cat` program.
   let exit_code = @process.run("moon", [
-    "build", "--manifest-path", "src/process/test_programs/moon.mod.json", "--debug",
-    "src/process/test_programs/cat",
+    "-C", "src/process/test_programs", "build", "--debug", "cat",
   ])
   guard exit_code is 0 else {
     fail("failed to build `cat` program: \{exit_code}")
@@ -90,10 +89,10 @@ async test "stdio cancel" {
     defer we_write.close()
     defer we_read.close()
     we_write.write("abcd")
-    inspect(
+    debug_inspect(
       we_read.read_some(),
       content=(
-        #|Some(b"abcd")
+        #|Some(<Bytes: [0x61, 0x62, 0x63, 0x64]>)
       ),
     )
     @async.sleep(750)

--- a/src/timer.mbt
+++ b/src/timer.mbt
@@ -51,14 +51,13 @@ pub struct Timer {
   priv mut expire_time : Int64
   // invariant: `waiters` is non-empty iff `state` is `Running`
   priv waiters : Set[@coroutine.Coroutine]
-
-  fn new(duration : Int) -> Timer
 }
 
 ///|
 /// Create a new timer that expires after `duration` milliseconds.
 /// The timer will start immediately, and expire after the duration elapsed.
-pub fn Timer::new(duration : Int) -> Timer {
+#alias(new, deprecated)
+pub fn Timer::Timer(duration : Int) -> Timer {
   let expire_time = @time.ms_since_epoch() + duration.to_int64()
   { state: Detached, duration, expire_time, waiters: Set::new() }
 }

--- a/src/timer_test.mbt
+++ b/src/timer_test.mbt
@@ -71,7 +71,8 @@ async test "Timer basic" {
         })
       }
     })
-    log.push("wait again: \{@async.with_timeout_opt(0, () => timer.wait())}")
+    let result = @async.with_timeout_opt(0, () => timer.wait())
+    log.push("wait again: \{@debug.to_string(result)}")
   })
   json_inspect(log, content=[
     "sleep: tick #1", "creating timer", "sleep: tick #2", "timer completed", "timer completed",
@@ -83,7 +84,7 @@ async test "Timer basic" {
 async test "Timer no waiter" {
   let timer = @async.Timer(200)
   @async.sleep(400)
-  inspect(
+  debug_inspect(
     @async.with_timeout_opt(0, () => timer.wait()),
     content=(
       #|Some(())
@@ -213,7 +214,7 @@ async test "Timer::refresh already cancelled" {
   let timer = @async.Timer(300)
   timer.cancel()
   timer.refresh()
-  inspect(
+  debug_inspect(
     @async.with_timeout_opt(0, () => try? timer.wait()),
     content=(
       #|Some(Err(TimerCancelled))

--- a/src/tls/shutdown_test.mbt
+++ b/src/tls/shutdown_test.mbt
@@ -16,7 +16,7 @@
 async test "peer close connection" {
   @async.with_task_group(root => {
     // server
-    let server = @socket.TcpServer::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
     root.spawn_bg(() => {
       defer server.close()

--- a/src/tls/tls_test.mbt
+++ b/src/tls/tls_test.mbt
@@ -199,7 +199,7 @@ async test "`read` already closed" {
         verify=false,
       )
       defer client.close()
-      inspect(try? client.read_some(), content="Ok(None)")
+      debug_inspect(try? client.read_some(), content="Ok(None)")
     })
   })
 }

--- a/src/tls/transport.mbt
+++ b/src/tls/transport.mbt
@@ -41,10 +41,10 @@ fn Transport::new(reader : &@io.Reader, writer : &@io.Writer) -> Transport {
   {
     state: Normal,
     reader,
-    read_lock: @semaphore.Semaphore::new(1),
+    read_lock: @semaphore.Semaphore(1),
     write_buf: @io_buffer.new(BUFFER_SIZE),
     writer,
-    write_lock: @semaphore.Semaphore::new(1),
+    write_lock: @semaphore.Semaphore(1),
   }
 }
 

--- a/src/wait_test.mbt
+++ b/src/wait_test.mbt
@@ -83,9 +83,9 @@ async test "try_wait" {
     })
     root.spawn_bg(() => {
       @async.sleep(300)
-      log.write_string("300ms: \{task.try_wait()}\n")
+      log.write_string("300ms: \{@debug.to_string(task.try_wait())}\n")
       @async.sleep(300)
-      log.write_string("600ms: \{task.try_wait()}\n")
+      log.write_string("600ms: \{@debug.to_string(task.try_wait())}\n")
     })
     log.write_string("task finished with \{task.wait()}\n")
   })

--- a/src/websocket/README.mbt.md
+++ b/src/websocket/README.mbt.md
@@ -17,7 +17,7 @@ This module provides RFC 6455 compilant WebSocket client & server support for `m
 ///|
 #cfg(target="native")
 async fn websocket_echo_server(addr : @socket.Addr) -> Unit {
-  let server = @http.Server::new(addr)
+  let server = @http.Server(addr)
   // WebSocket server are built on top of a HTTP server.
   // This allows mixing WebSocket and HTTP in a single server.
   server.run_forever((request, _, conn) => {

--- a/src/websocket/bad_client_test.mbt
+++ b/src/websocket/bad_client_test.mbt
@@ -15,9 +15,9 @@
 ///|
 async test "bad client" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    let server_result_queue = @async.Queue::new(kind=Unbounded)
+    let server_result_queue = @async.Queue(kind=Unbounded)
     group.spawn_bg(no_wait=true, () => {
       server.run_forever((req, _, conn) => {
         let ws = @websocket.from_http_server(req, conn)
@@ -34,7 +34,7 @@ async test "bad client" {
       })
     })
     async fn test_bad_frames(frames : Array[Bytes]) {
-      let http_client = @http.Client::new("http://localhost:\{port}")
+      let http_client = @http.Client("http://localhost:\{port}")
       defer http_client.close()
       let ws_client = @websocket.from_http_client(http_client, "/")
       defer ws_client.close()

--- a/src/websocket/client.mbt
+++ b/src/websocket/client.mbt
@@ -31,7 +31,7 @@
 #as_free_fn
 pub async fn Conn::from_http_client(
   conn : @http.Client,
-  path : String,
+  path : StringView,
   extra_headers? : Map[String, String] = {},
 ) -> Conn {
   // Ref : https://datatracker.ietf.org/doc/html/rfc6455#section-4.1
@@ -124,11 +124,11 @@ pub async fn Conn::connect(
   }
   let url = url[protocol_len + 3:]
   let (host, path) = if url.find("/") is Some(i) {
-    (url[:i].to_string(), url[i:].to_string())
+    (url[:i], url[i:])
   } else {
-    (url.to_string(), "/")
+    (url, "/")
   }
-  let path = if path == "" { "/" } else { path }
-  let conn = @http.Client::new("\{http_protocol}://\{host}", proxy?)
+  let path : StringView = if path == "" { "/" } else { path }
+  let conn = @http.Client("\{http_protocol}://\{host}", proxy?)
   Conn::from_http_client(conn, path, extra_headers=headers)
 }

--- a/src/websocket/conn.mbt
+++ b/src/websocket/conn.mbt
@@ -161,7 +161,7 @@ fn Conn::new(
     read_mask: None,
     mask_offset: 0,
     utf8_remaining: -1,
-    write_lock: @semaphore.Semaphore::new(1),
+    write_lock: @semaphore.Semaphore(1),
     write_mask: mask,
     payload_start: if mask is Some(_) {
       MAX_HEADER_SIZE + MASK_SIZE
@@ -736,7 +736,7 @@ pub async fn Conn::ping(self : Conn, msg? : BytesView) -> Unit {
     defer self.write_lock.release()
     self.transport.write(frame.unsafe_reinterpret_as_bytes())
   }
-  let msg = msg.to_bytes()
+  let msg = msg.to_owned()
   guard !self.pings.contains(msg) else {
     raise Failure::Failure(
       "A PING request with the same payload is already pending",

--- a/src/websocket/control_test.mbt
+++ b/src/websocket/control_test.mbt
@@ -15,7 +15,7 @@
 ///|
 async test "ping auto-reply" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(() => {
       defer server.close()
@@ -26,7 +26,7 @@ async test "ping auto-reply" {
       defer ws.close()
       inspect(ws.recv().read_all().text(), content="1234")
     })
-    let http_client = @http.Client::new("http://localhost:\{port}")
+    let http_client = @http.Client("http://localhost:\{port}")
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
     let ping_frame : Bytes = [0x89, 0x04, ..b"abcd"]
@@ -40,7 +40,7 @@ async test "ping auto-reply" {
 ///|
 async test "pong ignored" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(() => {
       defer server.close()
@@ -52,7 +52,7 @@ async test "pong ignored" {
       inspect(ws.recv().read_all().text(), content="1234")
       ws.send_text("1234")
     })
-    let http_client = @http.Client::new("http://localhost:\{port}")
+    let http_client = @http.Client("http://localhost:\{port}")
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
     let ping_frame : Bytes = [0x89, 0x04, ..b"abcd"]
@@ -65,7 +65,7 @@ async test "pong ignored" {
 ///|
 async test "ping auto-reply race-with-write" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(() => {
       defer server.close()
@@ -83,7 +83,7 @@ async test "ping auto-reply race-with-write" {
         ws.end_message()
       })
     })
-    let http_client = @http.Client::new("http://localhost:\{port}")
+    let http_client = @http.Client("http://localhost:\{port}")
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
     @async.sleep(200)
@@ -102,7 +102,7 @@ async test "ping auto-reply race-with-write" {
 ///|
 async test "close test" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(() => {
       defer server.close()
@@ -127,7 +127,7 @@ async test "close test" {
         ws.end_message()
       })
     })
-    let http_client = @http.Client::new("http://localhost:\{port}")
+    let http_client = @http.Client("http://localhost:\{port}")
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
     @async.sleep(200)
@@ -145,7 +145,7 @@ async test "close test" {
 ///|
 async test "send ping" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(() => {
       defer server.close()
@@ -172,7 +172,7 @@ async test "send ping" {
 ///|
 async test "ping inside message" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(() => {
       defer server.close()
@@ -198,7 +198,7 @@ async test "ping inside message" {
 ///|
 async test "multiple ping" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(() => {
       defer server.close()
@@ -229,7 +229,7 @@ async test "multiple ping" {
 ///|
 async test "ping cancelled" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(() => {
       defer server.close()
@@ -246,7 +246,7 @@ async test "ping cancelled" {
     defer ws.close()
     @async.with_task_group(group => {
       group.spawn_bg(() => inspect(ws.recv().read_all().text(), content="abcd"))
-      inspect(
+      debug_inspect(
         @async.with_timeout_opt(100, () => ws.ping(msg=b"1")),
         content="None",
       )
@@ -259,7 +259,7 @@ async test "ping cancelled" {
 ///|
 async test "duplicated ping" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(() => {
       defer server.close()

--- a/src/websocket/deprecated.mbt
+++ b/src/websocket/deprecated.mbt
@@ -56,6 +56,7 @@ pub impl Show for CloseCode with output(self, logger) {
 pub impl Show for WebSocketError
 
 ///|
+#warnings("-deprecated")
 pub impl Show for WebSocketError with output(self, logger) {
   match self {
     ConnectionClosed(close_code, msg) => {

--- a/src/websocket/external_client_test.mbt
+++ b/src/websocket/external_client_test.mbt
@@ -16,7 +16,7 @@
 async test "external client" {
   let log = []
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(no_wait=true, () => {
       server.run_forever((request, _, conn) => {

--- a/src/websocket/pkg.generated.mbti
+++ b/src/websocket/pkg.generated.mbti
@@ -42,7 +42,7 @@ pub fn Conn::close(Self) -> Unit
 pub async fn Conn::connect(String, headers? : Map[String, String], proxy? : @http.Client) -> Self
 pub async fn Conn::end_message(Self) -> Unit
 #as_free_fn
-pub async fn Conn::from_http_client(@http.Client, String, extra_headers? : Map[String, String]) -> Self
+pub async fn Conn::from_http_client(@http.Client, StringView, extra_headers? : Map[String, String]) -> Self
 #as_free_fn
 pub async fn Conn::from_http_server(@http.Request, @http.ServerConnection) -> Self
 pub async fn Conn::ping(Self, msg? : BytesView) -> Unit

--- a/src/websocket/utf8_validation_test.mbt
+++ b/src/websocket/utf8_validation_test.mbt
@@ -16,7 +16,7 @@
 async test "UTF8 validation" {
   let log = []
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
     group.spawn_bg(no_wait=true, () => {
       defer server.close()
@@ -88,7 +88,7 @@ async test "UTF8 validation" {
 ///|
 async test "UTF8 validation large message" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     group.spawn_bg(no_wait=true, () => {
       server.run_forever((req, _, conn) => {
@@ -118,7 +118,7 @@ async test "UTF8 validation large message" {
         let reply_chunk = reply.read_exactly(chunk_bin.length())
         assert_eq(@utf8.decode(reply_chunk), chunk_text)
       }
-      inspect(reply.read_some(), content="None")
+      debug_inspect(reply.read_some(), content="None")
     })
   })
 }

--- a/src/websocket/websocket_test.mbt
+++ b/src/websocket/websocket_test.mbt
@@ -15,7 +15,7 @@
 ///|
 async test "websocket basic" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
     group.spawn_bg(() => {
       defer server.close()
@@ -57,7 +57,7 @@ async test "websocket basic" {
 ///|
 async test "single frame multiple read" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
     group.spawn_bg(() => {
       defer server.close()
@@ -86,7 +86,7 @@ async test "single frame multiple read" {
 ///|
 async test "ignored message" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
     group.spawn_bg(() => {
       defer server.close()
@@ -116,7 +116,7 @@ async test "ignored message" {
 async test "write buffering" {
   let log = []
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
     group.spawn_bg(() => {
       defer server.close()
@@ -155,7 +155,7 @@ async test "write buffering" {
 ///|
 async test "large message" {
   @async.with_task_group(group => {
-    let server = @http.Server::new(@socket.Addr::parse("127.0.0.1:0"))
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
     let server_checksum = group.spawn(() => {
       defer server.close()

--- a/src/with_timeout_test.mbt
+++ b/src/with_timeout_test.mbt
@@ -14,29 +14,21 @@
 
 ///|
 async test "with_timeout normal exit" {
-  let log = StringBuilder::new()
-  log.write_object(
-    try? @async.with_task_group(root => {
-      root.spawn_bg(() => {
-        @async.sleep(300)
-        log.write_string("300ms tick\n")
-      })
-      @async.with_timeout(400, () => {
-        @async.sleep(200)
-        log.write_string("task finished after 200ms\n")
-      })
-      log.write_string("main task finished\n")
-    }),
-  )
-  inspect(
-    log.to_string(),
-    content=(
-      #|task finished after 200ms
-      #|main task finished
-      #|300ms tick
-      #|Ok(())
-    ),
-  )
+  let log = []
+  @async.with_task_group(root => {
+    root.spawn_bg(() => {
+      @async.sleep(300)
+      log.push("300ms tick")
+    })
+    @async.with_timeout(400, () => {
+      @async.sleep(200)
+      log.push("task finished after 200ms")
+    })
+    log.push("main task finished")
+  })
+  json_inspect(log, content=[
+    "task finished after 200ms", "main task finished", "300ms tick",
+  ])
 }
 
 ///|
@@ -255,32 +247,22 @@ async test "with_timeout error-on-timeout" {
 
 ///|
 async test "with_timeout_opt normal exit" {
-  let log = StringBuilder::new()
-  log.write_object(
-    try? @async.with_task_group(root => {
-      root.spawn_bg(() => {
-        @async.sleep(200)
-        log.write_string("200ms tick\n")
-      })
-      log.write_object(
-        @async.with_timeout_opt(1000, () => {
-          @async.sleep(100)
-          log.write_string("task finished after 100ms\n")
-          42
-        }),
-      )
-      log.write_char('\n')
-    }),
-  )
-  inspect(
-    log.to_string(),
-    content=(
-      #|task finished after 100ms
-      #|Some(42)
-      #|200ms tick
-      #|Ok(())
-    ),
-  )
+  let log = []
+  @async.with_task_group(root => {
+    root.spawn_bg(() => {
+      @async.sleep(200)
+      log.push("200ms tick")
+    })
+    let result = @async.with_timeout_opt(1000, () => {
+      @async.sleep(100)
+      log.push("task finished after 100ms")
+      42
+    })
+    log.push(@debug.to_string(result))
+  })
+  json_inspect(log, content=[
+    "task finished after 100ms", "Some(42)", "200ms tick",
+  ])
 }
 
 ///|
@@ -314,38 +296,26 @@ async test "with_timeout_opt failure" {
 
 ///|
 async test "with_timeout_opt timeout" {
-  let log = StringBuilder::new()
-  log.write_object(
-    try? @async.with_task_group(root => {
-      root.spawn_bg(() => {
-        @async.sleep(200)
-        log.write_string("200ms tick\n")
-      })
-      log.write_object(
-        @async.with_timeout_opt(100, () => {
-          try @async.sleep(2000) catch {
-            err => {
-              log.write_string("task cancelled\n")
-              raise err
-            }
-          } noraise {
-            _ => {
-              log.write_string("task finished after 2s\n")
-              42
-            }
-          }
-        }),
-      )
-      log.write_char('\n')
-    }),
-  )
-  inspect(
-    log.to_string(),
-    content=(
-      #|task cancelled
-      #|None
-      #|200ms tick
-      #|Ok(())
-    ),
-  )
+  let log = []
+  @async.with_task_group(root => {
+    root.spawn_bg(() => {
+      @async.sleep(200)
+      log.push("200ms tick")
+    })
+    let result = @async.with_timeout_opt(100, () => {
+      try @async.sleep(2000) catch {
+        err => {
+          log.push("task cancelled")
+          raise err
+        }
+      } noraise {
+        _ => {
+          log.push("task finished after 2s")
+          42
+        }
+      }
+    })
+    log.push(@debug.to_string(result))
+  })
+  json_inspect(log, content=["task cancelled", "None", "200ms tick"])
 }


### PR DESCRIPTION
Adapt latest compiler release (v0.9.1). Mainly warning fixes, with several other adaption:

1. some API now accept `StringView` instead of `String`
2. `::new` method is deprecated for all types with struct constructor