### PR TITLE
uniform replace semantic for `@fs.rename`

### DIFF
--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -356,8 +356,17 @@ pub async fn remove(path : StringView) -> Unit {
 
 ///|
 /// Rename (move) the file located at `old_path` to `new_path`.
-pub async fn rename(old_path : StringView, new_path : StringView) -> Unit {
-  @event_loop.rename(old_path, new_path, context="@fs.rename()")
+///
+/// If `replace` is `true` (`true` by default),
+/// and a file already exist on `new_path`, that file will be replaced.
+/// In this case, open handles to the existing file remain valid,
+/// and still point to the old file.
+pub async fn rename(
+  old_path : StringView,
+  new_path : StringView,
+  replace? : Bool = true,
+) -> Unit {
+  @event_loop.rename(old_path, new_path, replace~, context="@fs.rename()")
 }
 
 ///|

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -43,7 +43,7 @@ pub async fn realpath(StringView) -> String
 
 pub async fn remove(StringView) -> Unit
 
-pub async fn rename(StringView, StringView) -> Unit
+pub async fn rename(StringView, StringView, replace? : Bool) -> Unit
 
 pub async fn rmdir(StringView, recursive? : Bool) -> Unit
 

--- a/src/fs/rename_test.mbt
+++ b/src/fs/rename_test.mbt
@@ -32,3 +32,30 @@ async test "rename basic" {
   inspect(@fs.exists(old_path), content="false")
   @fs.remove(new_path)
 }
+
+///|
+async test "rename replace" {
+  let old_path = "_build/rename_replace_test_old"
+  let new_path = "_build/rename_replace_test_new"
+  @fs.write_file(new_path, "xyzw", create_mode=CreateOrTruncate)
+  let old_file = @fs.open(
+    old_path,
+    mode=WriteOnly,
+    create_mode=CreateOrTruncate,
+    sync=Full,
+  )
+  defer old_file.close()
+  let new_file = @fs.open(new_path, mode=ReadOnly, create_mode=OpenExisting)
+  defer new_file.close()
+  old_file.write("abcd")
+  inspect(@fs.read_file(old_path).text(), content="abcd")
+  inspect(@fs.read_file(new_path).text(), content="xyzw")
+  assert_true((try? @fs.rename(old_path, new_path, replace=false)) is Err(_))
+  @fs.rename(old_path, new_path, replace=true)
+  inspect(@fs.read_file(new_path).text(), content="abcd")
+  inspect(new_file.read_all().text(), content="xyzw")
+  old_file.write_at(b"ABCD", position=0)
+  inspect(@fs.read_file(new_path).text(), content="ABCD")
+  inspect(@fs.exists(old_path), content="false")
+  @fs.remove(new_path)
+}

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -206,12 +206,16 @@ pub async fn remove(path : StringView, context~ : String) -> Unit {
 pub async fn rename(
   old_path : StringView,
   new_path : StringView,
+  replace~ : Bool,
   context~ : String,
 ) -> Unit {
   let old_path_bytes = @os_string.encode(old_path)
   let new_path_bytes = @os_string.encode(new_path)
   try
-    perform_job_in_worker(Job::rename(old_path_bytes, new_path_bytes), context~)
+    perform_job_in_worker(
+      Job::rename(old_path_bytes, new_path_bytes, replace~),
+      context~,
+    )
   catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -47,7 +47,7 @@ pub async fn realpath(StringView, context~ : String) -> String
 
 pub async fn remove(StringView, context~ : String) -> Unit
 
-pub async fn rename(StringView, StringView, context~ : String) -> Unit
+pub async fn rename(StringView, StringView, replace~ : Bool, context~ : String) -> Unit
 
 pub async fn rmdir(StringView, context~ : String) -> Unit
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -51,6 +51,7 @@
 
 #ifdef __linux__
 #include <sys/syscall.h>
+#include <linux/fs.h>
 #endif
 
 #ifdef __MACH__
@@ -1292,6 +1293,7 @@ struct rename_job {
   struct job job;
   char *old_path;
   char *new_path;
+  int32_t replace;
 };
 
 static
@@ -1307,22 +1309,92 @@ void rename_job_worker(struct job *job) {
 
 #ifdef _WIN32
 
-  if (!MoveFileW((LPCWSTR)rename_job->old_path, (LPCWSTR)rename_job->new_path))
+  HANDLE handle = CreateFileW(
+    (LPCWSTR)rename_job->old_path,
+    DELETE,
+    FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+    NULL,
+    OPEN_EXISTING,
+    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
+    NULL
+  );
+
+  if (handle == INVALID_HANDLE_VALUE) {
     job->err = GetLastError();
+    return;
+  }
+
+  int new_path_len = Moonbit_array_length(rename_job->new_path);
+  int buffer_size = sizeof(FILE_RENAME_INFO) + new_path_len * 2 + 2;
+  FILE_RENAME_INFO *info = (FILE_RENAME_INFO*)malloc(buffer_size);
+
+  // 3 = FILE_RENAME_REPLACE_IF_EXISTS | FILE_RENAME_POSIX_SEMANTICS 
+  info->Flags = rename_job->replace ? 3 : 0;
+  info->RootDirectory = NULL;
+  info->FileNameLength = new_path_len * 2;
+  memcpy(info->FileName, rename_job->new_path, new_path_len * 2);
+  info->FileName[new_path_len] = 0;
+
+  BOOL ret = SetFileInformationByHandle(handle, FileRenameInfoEx, info, buffer_size);
+
+  CloseHandle(handle);
+  free(info);
+
+  if (ret)
+    return;
+
+  if (GetLastError() != ERROR_INVALID_PARAMETER) {
+    job->err = GetLastError();
+    return;
+  }
+
+  // fallback on older systems
+
+  ret = MoveFileExW(
+    (LPCWSTR)rename_job->old_path,
+    (LPCWSTR)rename_job->new_path,
+    MOVEFILE_COPY_ALLOWED | (rename_job->replace ? MOVEFILE_REPLACE_EXISTING : 0)
+  );
+  if (!ret)
+    job->err = GetLastError();
+
+#elif defined(__MACH__)
+
+  job->ret = renameatx_np(
+    AT_FDCWD, rename_job->old_path,
+    AT_FDCWD, rename_job->new_path,
+    rename_job->replace ? 0 : RENAME_EXCL
+  );
+  if (job->ret < 0)
+    job->err = errno;
+
+#elif defined(__linux__)
+
+  job->ret = syscall(
+    SYS_renameat2,
+    AT_FDCWD, rename_job->old_path,
+    AT_FDCWD, rename_job->new_path,
+    rename_job->replace ? 0 : RENAME_NOREPLACE
+  );
+  if (job->ret < 0)
+    job->err = errno;
 
 #else
 
-  job->ret = rename(rename_job->old_path, rename_job->new_path);
-  if (job->ret < 0)
-    job->err = errno;
+  job->err = ENOSYS;
 
 #endif
 }
 
-struct rename_job *moonbitlang_async_make_rename_job(char *old_path, char *new_path) {
+struct rename_job *moonbitlang_async_make_rename_job(
+  char *old_path,
+  char *new_path,
+  int32_t replace
+) {
   struct rename_job *job = MAKE_JOB(rename);
   job->old_path = old_path;
   job->new_path = new_path;
+  job->replace = replace;
   return job;
 }
 

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -182,6 +182,7 @@ extern "C" fn Job::remove(path : @os_string.OsString) -> Job = "moonbitlang_asyn
 extern "C" fn Job::rename(
   old_path : @os_string.OsString,
   new_path : @os_string.OsString,
+  replace~ : Bool,
 ) -> Job = "moonbitlang_async_make_rename_job"
 
 ///|


### PR DESCRIPTION
Previously, `@fs.rename` uses `MoveFile` on Windows, which will fail with error when a file already exists on the new path, in contrast to the default silently-replace-existing-file behavior on Linux/MacOS.

This PR makes the behavior of file replacement uniform on all platforms. A new optional argument, `replace? : Bool = true`, is added to `@fs.rename`, controlling whether new file replacement is allowed. Implementation wise:

- on Linux, the `renameat2` syscall with the `RENAME_NOREPLACE` flag is used to implement no-replace semantic
- on MacOS, the `renameatx_np` syscall with the `RENAME_EXCL` flag is used to implement no-replace semantic
- on Windows, the Windows 10 specific `FILE_RENAME_POSIX_SEMANTICS` flag with `SetFileInformationByHandle(.., FileRenameInfoEx, ..)` is used to implement replacing rename with POSIX semantic (i.e. open handles to the old file remain valid after the old file being replaced by the rename operation). On older systems, `MoveFileEx` is used as a fallback, but that would require no open handles to the old file exist on replacement.