### PR TITLE
fix `reuse_addr` handling on Windows

### DIFF
--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -55,6 +55,21 @@ HANDLE moonbitlang_async_make_tcp_socket(int family) {
   );
   if (sock == INVALID_SOCKET)
     return INVALID_HANDLE_VALUE;
+
+  int exclusive_addruse = 0;
+  if (
+    setsockopt(
+      sock,
+      SOL_SOCKET,
+      SO_EXCLUSIVEADDRUSE,
+      (char*)&exclusive_addruse,
+      sizeof(int)
+    ) < 0
+  ) {
+    closesocket(sock);
+    return INVALID_HANDLE_VALUE;
+  }
+
   return (HANDLE)sock;
 #else
   return socket(family == 4 ? AF_INET : AF_INET6, SOCK_STREAM, 0);
@@ -67,6 +82,7 @@ int moonbitlang_async_disable_nagle(HANDLE sock) {
   return setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
 }
 
+MOONBIT_FFI_EXPORT
 int moonbitlang_async_allow_reuse_addr(HANDLE sock) {
   int reuse_addr = 1;
   return setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse_addr, sizeof(int));
@@ -85,6 +101,21 @@ HANDLE moonbitlang_async_make_udp_socket(int family) {
   );
   if (sock == INVALID_SOCKET)
     return INVALID_HANDLE_VALUE;
+
+  int exclusive_addruse = 0;
+  if (
+    setsockopt(
+      sock,
+      SOL_SOCKET,
+      SO_EXCLUSIVEADDRUSE,
+      (char*)&exclusive_addruse,
+      sizeof(int)
+    ) < 0
+  ) {
+    closesocket(sock);
+    return INVALID_HANDLE_VALUE;
+  }
+
   return (HANDLE)sock;
 #else
   return socket(family == 4 ? AF_INET : AF_INET6, SOCK_DGRAM, 0);

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -77,7 +77,7 @@ pub async fn TcpServer::TcpServer(
         @os_error.check_errno(context)
       }
     }
-    if reuse_addr {
+    if !@event_loop.IS_WINDOWS && reuse_addr {
       guard allow_reuse_addr(sock) >= 0 else { @os_error.check_errno(context) }
     }
     io.bind(addr.0, context~)

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -56,11 +56,18 @@ pub struct TcpServer {
 ///
 /// If `reuse_addr` is `true` (`false` by default),
 /// the `SO_REUSEADDR` option will be enabled on the server,
-/// allowing in currently-in-use socket address
-/// (as long as there is no one else currently listening on the same address).
-/// This is useful for avoiding "address already in use" error while testing.
-/// WARNING: enabling `reuse_addr` on production is unsafe,
-/// packets from the previous listener of the address may be accidentally received.
+/// allowing binding to `addr` even if there are still
+/// dead-ish `TIME_WAIT` sockets on that address.
+///
+/// On Windows, `TIME_WAIT` sockets are always ignored,
+/// so the behavior is always `reuse_addr=true` and `reuse_addr` will be ignored.
+///
+/// On MacOS (BSD), `reuse_addr` has the extra side effect that
+/// a server binding to a specific address may "steal" the specific interface
+/// from a previous wildcard bind (`0.0.0.0`),
+/// and similarly a server binding to a wildcard address can bind to
+/// the remaining interfaces if a bind to a specific interface already exists.
+/// This side effect cannot be isolated, so `reuse_addr` should be used with this in mind.
 #alias(new, deprecated)
 pub async fn TcpServer::TcpServer(
   addr : Addr,


### PR DESCRIPTION
The `reuse_addr` option for `@socket.TcpServer` is intended for enabling fast restart of server, ignoring `TIME_WAIT` connections from the last run of the server. This is currently implemented via `SO_REUSEADDR` on all platforms. However, on Windows, `TIME_WAIT` sockets are ignored by default and this behavior is not configurable, so in effect `reuse_addr` is always `true` on Windows no matter what we do. Meanwhile, `SO_REUSEADDR` has completely different meaning on Windows. It  is more like `SO_REUSEPORT` on other systems, and has bad security implications.

This PR no longer emits `SO_REUSEADDR` on Windows, and document the platform-dependent behavior of `reuse_addr` more clearly (it has some side effects on MacOS/BSD that cannot be isolated).