### PR TITLE
add UDP multicast support

### DIFF
--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -66,7 +66,7 @@ fn Addr::family(self : Addr) -> AddrFamily {
 let ipv4_any : Addr = Addr::new(0, 0)
 
 ///|
-let ipv6_any : Addr = Addr::new_ipv6(FixedArray::make(16, 0), 0)
+let ipv6_any : Addr = Addr::new_ipv6(FixedArray::make(16, 0), 0, scope_id=0)
 
 ///|
 #borrow(addr)

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+/// Copyright 2025 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,10 @@ pub extern "C" fn Addr::port(addr : Addr) -> Int = "moonbitlang_async_ip_addr_ge
 pub extern "C" fn Addr::is_ipv6(addr : Addr) -> Bool = "moonbitlang_async_addr_is_ipv6"
 
 ///|
+#borrow(addr)
+pub extern "C" fn Addr::is_multicast(addr : Addr) -> Bool = "moonbitlang_async_addr_is_multicast"
+
+///|
 fn Addr::family(self : Addr) -> AddrFamily {
   if self.is_ipv6() {
     IPv6
@@ -57,6 +61,12 @@ fn Addr::family(self : Addr) -> AddrFamily {
     IPv4
   }
 }
+
+///|
+let ipv4_any : Addr = Addr::new(0, 0)
+
+///|
+let ipv6_any : Addr = Addr::new_ipv6(FixedArray::make(16, 0), 0)
 
 ///|
 #borrow(addr)

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -121,11 +121,7 @@ pub fn Addr::parse(src : String) -> Addr raise {
   if src.has_prefix("[") {
     let (ip_bytes, port, interface) = try_parse_ipv6(src)
     let scope_id = if interface is Some(interface) {
-      try @string.parse_uint(interface) catch {
-        _ => if_nametoindex(interface, context="@socket.Addr::parse()")
-      } noraise {
-        index => index
-      }
+      parse_ipv6_zone_suffix(interface, context="socket.Addr::parse()")
     } else {
       0
     }

--- a/src/socket/addr_test.mbt
+++ b/src/socket/addr_test.mbt
@@ -55,12 +55,12 @@ test "Parse IPv6 address" {
   )
   assert_eq(@socket.Addr::parse("[::1]:8080").to_string(), "[::1]:8080")
   assert_eq(
-    @socket.Addr::parse("[::1%\{localhost_interface}]:8080").to_string(),
-    "[::1%\{localhost_interface}]:8080",
+    @socket.Addr::parse("[::1%\{test_interface}]:8080").to_string(),
+    "[::1%\{test_interface}]:8080",
   )
   assert_eq(
-    @socket.Addr::parse("[::1%\{localhost_index}]:8080").to_string(),
-    "[::1%\{localhost_interface}]:8080",
+    @socket.Addr::parse("[::1%\{test_interface_index}]:8080").to_string(),
+    "[::1%\{test_interface}]:8080",
   )
 }
 

--- a/src/socket/addr_utils.mbt
+++ b/src/socket/addr_utils.mbt
@@ -198,6 +198,15 @@ fn parse_ipv6_group(group : StringView) -> UInt raise InvalidAddr {
 }
 
 ///|
+fn parse_ipv6_zone_suffix(zone : StringView, context~ : String) -> UInt raise {
+  try @string.parse_uint(zone) catch {
+    _ => if_nametoindex(zone, context~)
+  } noraise {
+    index => index
+  }
+}
+
+///|
 fn parse_ipv4_to_bytes(
   ip_str : StringView,
 ) -> (UInt, UInt, UInt, UInt) raise InvalidAddr {

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -96,14 +96,14 @@ fn join_multicast_group(
 extern "C" fn join_multicast_group_v6_ffi(
   sock : @fd_util.Fd,
   multi_addr : Addr,
-  interface_index : Int,
+  interface_index : UInt,
 ) -> Int = "moonbitlang_async_join_multicast_group_v6"
 
 ///|
 fn join_multicast_group_v6(
   sock : @fd_util.Fd,
   multi_addr : Addr,
-  interface_index : Int,
+  interface_index : UInt,
   context~ : String,
 ) -> Unit raise {
   if join_multicast_group_v6_ffi(sock, multi_addr, interface_index) < 0 {
@@ -132,13 +132,13 @@ fn set_multicast_interface(
 ///|
 extern "C" fn set_multicast_interface_v6_ffi(
   sock : @fd_util.Fd,
-  interface_index : Int,
+  interface_index : UInt,
 ) -> Int = "moonbitlang_async_set_multicast_interface_v6"
 
 ///|
 fn set_multicast_interface_v6(
   sock : @fd_util.Fd,
-  interface_index : Int,
+  interface_index : UInt,
   context~ : String,
 ) -> Unit raise {
   if set_multicast_interface_v6_ffi(sock, interface_index) < 0 {

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -37,12 +37,19 @@ fn make_tcp_socket(family : AddrFamily, context~ : String) -> @fd_util.Fd raise 
 }
 
 ///|
-extern "C" fn make_udp_socket_ffi(family : AddrFamily) -> @fd_util.Fd = "moonbitlang_async_make_udp_socket"
+extern "C" fn make_udp_socket_ffi(
+  family : AddrFamily,
+  multicast~ : Bool,
+) -> @fd_util.Fd = "moonbitlang_async_make_udp_socket"
 
 ///|
 #cfg(not(platform="windows"))
-fn make_udp_socket(family : AddrFamily, context~ : String) -> @fd_util.Fd raise {
-  let sock = make_udp_socket_ffi(family)
+fn make_udp_socket(
+  family : AddrFamily,
+  multicast~ : Bool,
+  context~ : String,
+) -> @fd_util.Fd raise {
+  let sock = make_udp_socket_ffi(family, multicast~)
   if sock < 0 {
     @os_error.check_errno(context)
   }
@@ -52,12 +59,129 @@ fn make_udp_socket(family : AddrFamily, context~ : String) -> @fd_util.Fd raise 
 
 ///|
 #cfg(platform="windows")
-fn make_udp_socket(family : AddrFamily, context~ : String) -> @fd_util.Fd raise {
-  let sock = make_udp_socket_ffi(family)
+fn make_udp_socket(
+  family : AddrFamily,
+  multicast~ : Bool,
+  context~ : String,
+) -> @fd_util.Fd raise {
+  let sock = make_udp_socket_ffi(family, multicast~)
   if !@fd_util.fd_is_valid(sock) {
     @os_error.check_errno(context)
   }
   sock
+}
+
+///|
+#borrow(multi_addr, local_addr)
+extern "C" fn join_multicast_group_ffi(
+  sock : @fd_util.Fd,
+  multi_addr : Addr,
+  local_addr : Addr,
+) -> Int = "moonbitlang_async_join_multicast_group"
+
+///|
+fn join_multicast_group(
+  sock : @fd_util.Fd,
+  multi_addr : Addr,
+  local_addr : Addr,
+  context~ : String,
+) -> Unit raise {
+  if join_multicast_group_ffi(sock, multi_addr, local_addr) < 0 {
+    @os_error.check_errno(context)
+  }
+}
+
+///|
+#borrow(multi_addr)
+extern "C" fn join_multicast_group_v6_ffi(
+  sock : @fd_util.Fd,
+  multi_addr : Addr,
+  interface_index : Int,
+) -> Int = "moonbitlang_async_join_multicast_group_v6"
+
+///|
+fn join_multicast_group_v6(
+  sock : @fd_util.Fd,
+  multi_addr : Addr,
+  interface_index : Int,
+  context~ : String,
+) -> Unit raise {
+  if join_multicast_group_v6_ffi(sock, multi_addr, interface_index) < 0 {
+    @os_error.check_errno(context)
+  }
+}
+
+///|
+#borrow(local_addr)
+extern "C" fn set_multicast_interface_ffi(
+  sock : @fd_util.Fd,
+  local_addr : Addr,
+) -> Int = "moonbitlang_async_set_multicast_interface"
+
+///|
+fn set_multicast_interface(
+  sock : @fd_util.Fd,
+  local_addr : Addr,
+  context~ : String,
+) -> Unit raise {
+  if set_multicast_interface_ffi(sock, local_addr) < 0 {
+    @os_error.check_errno(context)
+  }
+}
+
+///|
+extern "C" fn set_multicast_interface_v6_ffi(
+  sock : @fd_util.Fd,
+  interface_index : Int,
+) -> Int = "moonbitlang_async_set_multicast_interface_v6"
+
+///|
+fn set_multicast_interface_v6(
+  sock : @fd_util.Fd,
+  interface_index : Int,
+  context~ : String,
+) -> Unit raise {
+  if set_multicast_interface_v6_ffi(sock, interface_index) < 0 {
+    @os_error.check_errno(context)
+  }
+}
+
+///|
+extern "C" fn set_multicast_ttl_ffi(
+  sock : @fd_util.Fd,
+  ttl : Int,
+  family~ : AddrFamily,
+) -> Int = "moonbitlang_async_set_multicast_ttl"
+
+///|
+fn set_multicast_ttl(
+  sock : @fd_util.Fd,
+  ttl : Int,
+  family~ : AddrFamily,
+  context~ : String,
+) -> Unit raise {
+  if set_multicast_ttl_ffi(sock, ttl, family~) < 0 {
+    @os_error.check_errno(context)
+  }
+}
+
+///|
+extern "C" fn set_multicast_loopback_ffi(
+  sock : @fd_util.Fd,
+  loopback : Bool,
+  family~ : AddrFamily,
+) -> Int = "moonbitlang_async_set_multicast_loopback"
+
+///|
+fn set_multicast_loopback(
+  sock : @fd_util.Fd,
+  loopback : Bool,
+  family~ : AddrFamily,
+  context~ : String,
+) -> Unit raise {
+  if set_multicast_loopback_ffi(sock, loopback, family~) < 0 {
+    @os_error.check_errno(context)
+  }
 }
 
 ///|

--- a/src/socket/ifname.mbt
+++ b/src/socket/ifname.mbt
@@ -17,7 +17,7 @@ let global_ifname_socket : Ref[@fd_util.Fd] = {
   let context = "creating global socket object for interface name lookup"
   let sock = Ref(
     if @event_loop.platform is Linux {
-      make_udp_socket(IPv4, context~) catch {
+      make_udp_socket(IPv4, multicast=false, context~) catch {
         err => abort(err.to_string())
       }
     } else {
@@ -29,7 +29,7 @@ let global_ifname_socket : Ref[@fd_util.Fd] = {
       // In some tests there may be multiple event loops spawned in a single program run,
       // ensure the global socket object is valid after the last event loop disposed it
       if @event_loop.platform is Linux && !@fd_util.fd_is_valid(sock.val) {
-        sock.val = make_udp_socket(IPv4, context~)
+        sock.val = make_udp_socket(IPv4, multicast=false, context~)
       }
     },
     exit=() => {

--- a/src/socket/interface_util_for_test.mbt
+++ b/src/socket/interface_util_for_test.mbt
@@ -19,7 +19,7 @@ extern "C" fn find_ipv6_test_interface() -> UInt = "moonbitlang_async_find_ipv6_
 let test_interface_index : UInt = {
   let index = find_ipv6_test_interface()
   if index is 0 {
-    abort("cannot find localhost adaptor, or localhost does not support IPv6")
+    abort("cannot find suitable network interface for testing")
   }
   index
 }
@@ -27,7 +27,7 @@ let test_interface_index : UInt = {
 ///|
 let test_interface : String = @socket.if_indextoname(
   test_interface_index,
-  context="fetch name of localhost adaptor",
+  context="fetch name of test network interface",
 ) catch {
   err => abort(err.to_string())
 }

--- a/src/socket/interface_util_for_test.mbt
+++ b/src/socket/interface_util_for_test.mbt
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 ///|
-extern "C" fn find_ipv6_localhost() -> UInt = "moonbitlang_async_find_ipv6_localhost"
+extern "C" fn find_ipv6_test_interface() -> UInt = "moonbitlang_async_find_ipv6_test_interface"
 
 ///|
-let localhost_index : UInt = {
-  let index = find_ipv6_localhost()
+let test_interface_index : UInt = {
+  let index = find_ipv6_test_interface()
   if index is 0 {
     abort("cannot find localhost adaptor, or localhost does not support IPv6")
   }
@@ -25,8 +25,8 @@ let localhost_index : UInt = {
 }
 
 ///|
-let localhost_interface : String = @socket.if_indextoname(
-  localhost_index,
+let test_interface : String = @socket.if_indextoname(
+  test_interface_index,
   context="fetch name of localhost adaptor",
 ) catch {
   err => abort(err.to_string())

--- a/src/socket/moon.pkg
+++ b/src/socket/moon.pkg
@@ -28,6 +28,7 @@ options(
     "happy_eyeball.mbt": [ "native" ],
     "ifname.mbt": [ "native" ],
     "interface_util_for_test.mbt": [ "native" ],
+    "multicast_test.mbt": [ "native" ],
     "read_exactly_test.mbt": [ "native" ],
     "resolve_host_test.mbt": [ "native" ],
     "reuse_addr_test.mbt": [ "native" ],

--- a/src/socket/multicast_test.mbt
+++ b/src/socket/multicast_test.mbt
@@ -99,6 +99,10 @@ async test "multicast discovery then unicast" {
 
 ///|
 async test "multicast no loopback" {
+  if @event_loop.platform is MacOS {
+    // MacOS requires the user clicking a GUI alertbox for UDP multicast since MacOS 15
+    return
+  }
   let log = []
   @async.with_task_group() <| group => {
     let server = @socket.UdpServer::multicast(
@@ -142,6 +146,10 @@ async test "multicast no loopback" {
 
 ///|
 async test "multicast discovery then unicast v6" {
+  if @event_loop.platform is MacOS {
+    // MacOS requires the user clicking a GUI alertbox for UDP multicast since MacOS 15
+    return
+  }
   let log = []
   @async.with_task_group <| group => {
     let server = @socket.UdpServer(@socket.Addr::parse("[::]:0"))
@@ -191,8 +199,11 @@ async test "multicast discovery then unicast v6" {
 
 ///|
 async test "multicast no loopback v6" {
+  if @event_loop.platform is MacOS {
+    // MacOS requires the user clicking a GUI alertbox for UDP multicast since MacOS 15
+    return
+  }
   let log = []
-  println(test_interface)
   @async.with_task_group() <| group => {
     let server = @socket.UdpServer(@socket.Addr::parse("[::]:0"))
     let port = server.addr.port()

--- a/src/socket/multicast_test.mbt
+++ b/src/socket/multicast_test.mbt
@@ -35,6 +35,7 @@ async test "multicast basic" {
       for ;; {
         let (n, _) = server2.recvfrom(buf)
         let data = buf.unsafe_reinterpret_as_bytes()[:n]
+        @async.sleep(50) // make the result stable
         log.push("server 2 received: \{@utf8.decode(data)}")
       }
     }
@@ -48,37 +49,6 @@ async test "multicast basic" {
   }
   json_inspect(log, content=[
     "client sending: abcd", "server 1 received: abcd", "server 2 received: abcd",
-  ])
-}
-
-///|
-async test "multicast server send reply" {
-  let log = []
-  @async.with_task_group <| group => {
-    let addr = @socket.Addr::parse("239.0.0.1:4201")
-    let interface_addr = @socket.Addr::parse("127.0.0.1:0")
-    group.spawn_bg() <| () => {
-      let server1 = @socket.UdpServer::multicast(addr, interface_addr~)
-      defer server1.close()
-      let buf = FixedArray::make(1024, b'\x00')
-      let (n, peer_addr) = server1.recvfrom(buf)
-      let data = buf.unsafe_reinterpret_as_bytes()[:n]
-      log.push("server received: \{@utf8.decode(data)}, sending it back...")
-      ignore <| server1.sendto(data.to_owned(), peer_addr)
-    }
-    let client = @socket.UdpClient(addr)
-    defer client.close()
-    client.set_multicast_interface(interface_addr)
-    @async.sleep(200)
-    log.push("client sending: abcd")
-    let _ = client.send(b"abcd")
-    let buf = FixedArray::make(1024, b'\x00')
-    let (n, server_addr) = client.recvfrom(buf)
-    let data = buf.unsafe_reinterpret_as_bytes()[:n]
-    log.push("client received: \{@utf8.decode(data)} from \{server_addr}")
-  }
-  json_inspect(log, content=[
-    "client sending: abcd", "server received: abcd, sending it back...", "client received: abcd from 127.0.0.1:4201",
   ])
 }
 
@@ -128,52 +98,6 @@ async test "multicast discovery then unicast" {
 }
 
 ///|
-async test "multicast peer group" {
-  let log = []
-  @async.with_task_group <| group => {
-    let interface_addr = @socket.Addr::parse("127.0.0.1:0")
-    let mut port = 0
-    for server_index in 0..<3 {
-      let server = @socket.UdpServer::multicast(
-        @socket.Addr::parse("239.0.0.1:\{port}"),
-        interface_addr~,
-      )
-      port = server.addr.port()
-      group.add_defer(() => server.close())
-      server.set_multicast_interface(interface_addr)
-      server.set_multicast_ttl(0)
-      group.spawn_bg() <| () => {
-        let buf = FixedArray::make(1024, b'\x00')
-        for i in 0..<3 {
-          if i == server_index {
-            @async.sleep(100)
-            let msg = "message from server \{server_index}"
-            log.push("server \{server_index} sending: \{msg}")
-            ignore <| server.sendto(
-              @utf8.encode(msg),
-              @socket.Addr::parse("239.0.0.1:\{port}"),
-            )
-          }
-          let (n, _) = server.recvfrom(buf)
-          let data = buf.unsafe_reinterpret_as_bytes()[:n]
-          // to make the output stable
-          @async.sleep(server_index * 20)
-          log.push("server \{server_index} received: \{@utf8.decode(data)}")
-        }
-      }
-    }
-  }
-  json_inspect(log, content=[
-    "server 0 sending: message from server 0", "server 0 received: message from server 0",
-    "server 1 received: message from server 0", "server 2 received: message from server 0",
-    "server 1 sending: message from server 1", "server 0 received: message from server 1",
-    "server 1 received: message from server 1", "server 2 received: message from server 1",
-    "server 2 sending: message from server 2", "server 0 received: message from server 2",
-    "server 1 received: message from server 2", "server 2 received: message from server 2",
-  ])
-}
-
-///|
 async test "multicast no loopback" {
   let log = []
   @async.with_task_group() <| group => {
@@ -217,25 +141,20 @@ async test "multicast no loopback" {
 }
 
 ///|
-extern "C" fn find_first_public_ipv6_interface() -> Int = "moonbitlang_async_find_first_public_ipv6_interface"
-
-///|
-let interface_index : Int = find_first_public_ipv6_interface()
-
-///|
 async test "multicast discovery then unicast v6" {
   let log = []
   @async.with_task_group <| group => {
     let server = @socket.UdpServer(@socket.Addr::parse("[::]:0"))
     defer server.close()
-    let multicast_addr = @socket.Addr::parse("[ff0e::1]:\{server.addr.port()}")
-    server.join_multicast_group_v6(multicast_addr, interface_index~)
+    let port = server.addr.port()
+    let multicast_addr = @socket.Addr::parse("[ff02::1]:\{server.addr.port()}")
+    server.join_multicast_group_v6(multicast_addr, interface_index=localhost_index)
     server.set_multicast_ttl(0)
     group.spawn_bg(() => {
-      let client = @socket.UdpClient(multicast_addr)
+      let client = @socket.UdpClient(@socket.Addr::parse("[ff02::1%\{localhost_interface}]:\{port}"))
       defer client.close()
       client.set_multicast_ttl(0)
-      client.set_multicast_interface_v6(interface_index)
+      client.set_multicast_interface_v6(localhost_index)
       @async.sleep(150)
       log.push("client sending discovery packet")
       let _ = client.send(b"anybody here?")
@@ -274,10 +193,10 @@ async test "multicast no loopback v6" {
   @async.with_task_group() <| group => {
     let server = @socket.UdpServer(@socket.Addr::parse("[::]:0"))
     let port = server.addr.port()
-    let multicast_addr = @socket.Addr::parse("[ff0e::1]:\{port}")
+    let multicast_addr = @socket.Addr::parse("[ff02::1]:\{port}")
     group.spawn_bg(no_wait=true, () => {
       defer server.close()
-      server.join_multicast_group_v6(multicast_addr, interface_index~)
+      server.join_multicast_group_v6(multicast_addr, interface_index=localhost_index)
       let buf = FixedArray::make(1024, b'\x00')
       for ;; {
         let (n, _) = server.recvfrom(buf)
@@ -285,10 +204,10 @@ async test "multicast no loopback v6" {
         log.push("server received: \{@utf8.decode(data)}")
       }
     })
-    let client = @socket.UdpClient(multicast_addr)
+    let client = @socket.UdpClient(@socket.Addr::parse("[ff02::1%\{localhost_interface}]:\{port}"))
     defer client.close()
     @async.sleep(200)
-    client.set_multicast_interface_v6(interface_index)
+    client.set_multicast_interface_v6(localhost_index)
     client.set_multicast_ttl(0)
     if @event_loop.IS_WINDOWS {
       server.set_multicast_loopback(false)

--- a/src/socket/multicast_test.mbt
+++ b/src/socket/multicast_test.mbt
@@ -192,6 +192,7 @@ async test "multicast discovery then unicast v6" {
 ///|
 async test "multicast no loopback v6" {
   let log = []
+  println(test_interface)
   @async.with_task_group() <| group => {
     let server = @socket.UdpServer(@socket.Addr::parse("[::]:0"))
     let port = server.addr.port()

--- a/src/socket/multicast_test.mbt
+++ b/src/socket/multicast_test.mbt
@@ -148,13 +148,18 @@ async test "multicast discovery then unicast v6" {
     defer server.close()
     let port = server.addr.port()
     let multicast_addr = @socket.Addr::parse("[ff02::1]:\{server.addr.port()}")
-    server.join_multicast_group_v6(multicast_addr, interface_index=localhost_index)
+    server.join_multicast_group_v6(
+      multicast_addr,
+      interface_index=test_interface_index,
+    )
     server.set_multicast_ttl(0)
     group.spawn_bg(() => {
-      let client = @socket.UdpClient(@socket.Addr::parse("[ff02::1%\{localhost_interface}]:\{port}"))
+      let client = @socket.UdpClient(
+        @socket.Addr::parse("[ff02::1%\{test_interface}]:\{port}"),
+      )
       defer client.close()
       client.set_multicast_ttl(0)
-      client.set_multicast_interface_v6(localhost_index)
+      client.set_multicast_interface_v6(test_interface_index)
       @async.sleep(150)
       log.push("client sending discovery packet")
       let _ = client.send(b"anybody here?")
@@ -196,7 +201,10 @@ async test "multicast no loopback v6" {
     let multicast_addr = @socket.Addr::parse("[ff02::1]:\{port}")
     group.spawn_bg(no_wait=true, () => {
       defer server.close()
-      server.join_multicast_group_v6(multicast_addr, interface_index=localhost_index)
+      server.join_multicast_group_v6(
+        multicast_addr,
+        interface_index=test_interface_index,
+      )
       let buf = FixedArray::make(1024, b'\x00')
       for ;; {
         let (n, _) = server.recvfrom(buf)
@@ -204,10 +212,12 @@ async test "multicast no loopback v6" {
         log.push("server received: \{@utf8.decode(data)}")
       }
     })
-    let client = @socket.UdpClient(@socket.Addr::parse("[ff02::1%\{localhost_interface}]:\{port}"))
+    let client = @socket.UdpClient(
+      @socket.Addr::parse("[ff02::1%\{test_interface}]:\{port}"),
+    )
     defer client.close()
     @async.sleep(200)
-    client.set_multicast_interface_v6(localhost_index)
+    client.set_multicast_interface_v6(test_interface_index)
     client.set_multicast_ttl(0)
     if @event_loop.IS_WINDOWS {
       server.set_multicast_loopback(false)

--- a/src/socket/multicast_test.mbt
+++ b/src/socket/multicast_test.mbt
@@ -1,0 +1,312 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "multicast basic" {
+  let log = []
+  @async.with_task_group <| group => {
+    let addr = @socket.Addr::parse("239.0.0.1:4200")
+    let interface_addr = @socket.Addr::parse("127.0.0.1:0")
+    group.spawn_bg(no_wait=true) <| () => {
+      let server1 = @socket.UdpServer::multicast(addr, interface_addr~)
+      defer server1.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      for ;; {
+        let (n, _) = server1.recvfrom(buf)
+        let data = buf.unsafe_reinterpret_as_bytes()[:n]
+        log.push("server 1 received: \{@utf8.decode(data)}")
+      }
+    }
+    group.spawn_bg(no_wait=true) <| () => {
+      let server2 = @socket.UdpServer::multicast(addr, interface_addr~)
+      defer server2.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      for ;; {
+        let (n, _) = server2.recvfrom(buf)
+        let data = buf.unsafe_reinterpret_as_bytes()[:n]
+        log.push("server 2 received: \{@utf8.decode(data)}")
+      }
+    }
+    let client = @socket.UdpClient(addr)
+    defer client.close()
+    client.set_multicast_interface(interface_addr)
+    @async.sleep(200)
+    log.push("client sending: abcd")
+    let _ = client.send(b"abcd")
+    @async.sleep(200)
+  }
+  json_inspect(log, content=[
+    "client sending: abcd", "server 1 received: abcd", "server 2 received: abcd",
+  ])
+}
+
+///|
+async test "multicast server send reply" {
+  let log = []
+  @async.with_task_group <| group => {
+    let addr = @socket.Addr::parse("239.0.0.1:4201")
+    let interface_addr = @socket.Addr::parse("127.0.0.1:0")
+    group.spawn_bg() <| () => {
+      let server1 = @socket.UdpServer::multicast(addr, interface_addr~)
+      defer server1.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      let (n, peer_addr) = server1.recvfrom(buf)
+      let data = buf.unsafe_reinterpret_as_bytes()[:n]
+      log.push("server received: \{@utf8.decode(data)}, sending it back...")
+      ignore <| server1.sendto(data.to_owned(), peer_addr)
+    }
+    let client = @socket.UdpClient(addr)
+    defer client.close()
+    client.set_multicast_interface(interface_addr)
+    @async.sleep(200)
+    log.push("client sending: abcd")
+    let _ = client.send(b"abcd")
+    let buf = FixedArray::make(1024, b'\x00')
+    let (n, server_addr) = client.recvfrom(buf)
+    let data = buf.unsafe_reinterpret_as_bytes()[:n]
+    log.push("client received: \{@utf8.decode(data)} from \{server_addr}")
+  }
+  json_inspect(log, content=[
+    "client sending: abcd", "server received: abcd, sending it back...", "client received: abcd from 127.0.0.1:4201",
+  ])
+}
+
+///|
+async test "multicast discovery then unicast" {
+  let log = []
+  @async.with_task_group <| group => {
+    let interface_addr = @socket.Addr::parse("127.0.0.1:0")
+    let server = @socket.UdpServer(@socket.Addr::parse("0.0.0.0:0"))
+    defer server.close()
+    let multicast_addr = @socket.Addr::parse("239.0.0.1:\{server.addr.port()}")
+    server.join_multicast_group(multicast_addr, interface_addr~)
+    group.spawn_bg(() => {
+      let client = @socket.UdpClient(multicast_addr)
+      defer client.close()
+      client.set_multicast_interface(interface_addr)
+      @async.sleep(150)
+      log.push("client sending discovery packet")
+      let _ = client.send(b"anybody here?")
+      let buf = FixedArray::make(1024, b'\x00')
+      let (n, server_addr) = client.recvfrom(buf)
+      let data = buf.unsafe_reinterpret_as_bytes()[:n]
+      log.push("client found server via message: \{@utf8.decode(data)}")
+      client.connect(server_addr)
+      log.push("client sending directly to discovered server: hello")
+      client.send(b"hello")
+      let n = client.recv(buf)
+      let data = buf.unsafe_reinterpret_as_bytes()[:n]
+      log.push("client received \{@utf8.decode(data)} from server")
+    })
+    let buf = FixedArray::make(1024, b'\x00')
+    let (n, peer_addr) = server.recvfrom(buf)
+    let data = buf.unsafe_reinterpret_as_bytes()[:n]
+    log.push("server received: \{@utf8.decode(data)}. Sending reply...")
+    ignore <| server.sendto(b"I am here", peer_addr)
+    let (n, peer_addr2) = server.recvfrom(buf)
+    assert_eq(peer_addr, peer_addr2)
+    let data = buf.unsafe_reinterpret_as_bytes()[:n]
+    log.push("server received: \{@utf8.decode(data)}. Sending reply...")
+    ignore <| server.sendto(b"Hello", peer_addr2)
+  }
+  json_inspect(log, content=[
+    "client sending discovery packet", "server received: anybody here?. Sending reply...",
+    "client found server via message: I am here", "client sending directly to discovered server: hello",
+    "server received: hello. Sending reply...", "client received Hello from server",
+  ])
+}
+
+///|
+async test "multicast peer group" {
+  let log = []
+  @async.with_task_group <| group => {
+    let interface_addr = @socket.Addr::parse("127.0.0.1:0")
+    let mut port = 0
+    for server_index in 0..<3 {
+      let server = @socket.UdpServer::multicast(
+        @socket.Addr::parse("239.0.0.1:\{port}"),
+        interface_addr~,
+      )
+      port = server.addr.port()
+      group.add_defer(() => server.close())
+      server.set_multicast_interface(interface_addr)
+      server.set_multicast_ttl(0)
+      group.spawn_bg() <| () => {
+        let buf = FixedArray::make(1024, b'\x00')
+        for i in 0..<3 {
+          if i == server_index {
+            @async.sleep(100)
+            let msg = "message from server \{server_index}"
+            log.push("server \{server_index} sending: \{msg}")
+            ignore <| server.sendto(
+              @utf8.encode(msg),
+              @socket.Addr::parse("239.0.0.1:\{port}"),
+            )
+          }
+          let (n, _) = server.recvfrom(buf)
+          let data = buf.unsafe_reinterpret_as_bytes()[:n]
+          // to make the output stable
+          @async.sleep(server_index * 20)
+          log.push("server \{server_index} received: \{@utf8.decode(data)}")
+        }
+      }
+    }
+  }
+  json_inspect(log, content=[
+    "server 0 sending: message from server 0", "server 0 received: message from server 0",
+    "server 1 received: message from server 0", "server 2 received: message from server 0",
+    "server 1 sending: message from server 1", "server 0 received: message from server 1",
+    "server 1 received: message from server 1", "server 2 received: message from server 1",
+    "server 2 sending: message from server 2", "server 0 received: message from server 2",
+    "server 1 received: message from server 2", "server 2 received: message from server 2",
+  ])
+}
+
+///|
+async test "multicast no loopback" {
+  let log = []
+  @async.with_task_group() <| group => {
+    let server = @socket.UdpServer::multicast(
+      @socket.Addr::parse("239.0.0.1:0"),
+    )
+    group.spawn_bg(no_wait=true, () => {
+      defer server.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      for ;; {
+        let (n, _) = server.recvfrom(buf)
+        let data = buf.unsafe_reinterpret_as_bytes()[:n]
+        log.push("server received: \{@utf8.decode(data)}")
+      }
+    })
+    let client = @socket.UdpClient(
+      @socket.Addr::parse("239.0.0.1:\{server.addr.port()}"),
+    )
+    defer client.close()
+    @async.sleep(200)
+    if @event_loop.IS_WINDOWS {
+      server.set_multicast_loopback(false)
+    } else {
+      client.set_multicast_loopback(false)
+    }
+    client.set_multicast_ttl(0)
+    log.push("client sending: abcd")
+    let _ = client.send(b"abcd")
+    if @event_loop.IS_WINDOWS {
+      server.set_multicast_loopback(true)
+    } else {
+      client.set_multicast_loopback(true)
+    }
+    log.push("client sending: xyzw")
+    let _ = client.send(b"xyzw")
+    @async.sleep(200)
+  }
+  json_inspect(log, content=[
+    "client sending: abcd", "client sending: xyzw", "server received: xyzw",
+  ])
+}
+
+///|
+extern "C" fn find_first_public_ipv6_interface() -> Int = "moonbitlang_async_find_first_public_ipv6_interface"
+
+///|
+let interface_index : Int = find_first_public_ipv6_interface()
+
+///|
+async test "multicast discovery then unicast v6" {
+  let log = []
+  @async.with_task_group <| group => {
+    let server = @socket.UdpServer(@socket.Addr::parse("[::]:0"))
+    defer server.close()
+    let multicast_addr = @socket.Addr::parse("[ff0e::1]:\{server.addr.port()}")
+    server.join_multicast_group_v6(multicast_addr, interface_index~)
+    server.set_multicast_ttl(0)
+    group.spawn_bg(() => {
+      let client = @socket.UdpClient(multicast_addr)
+      defer client.close()
+      client.set_multicast_ttl(0)
+      client.set_multicast_interface_v6(interface_index)
+      @async.sleep(150)
+      log.push("client sending discovery packet")
+      let _ = client.send(b"anybody here?")
+      let buf = FixedArray::make(1024, b'\x00')
+      let (n, server_addr) = client.recvfrom(buf)
+      let data = buf.unsafe_reinterpret_as_bytes()[:n]
+      log.push("client found server via message: \{@utf8.decode(data)}")
+      client.connect(server_addr)
+      log.push("client sending directly to discovered server: hello")
+      client.send(b"hello")
+      let n = client.recv(buf)
+      let data = buf.unsafe_reinterpret_as_bytes()[:n]
+      log.push("client received \{@utf8.decode(data)} from server")
+    })
+    let buf = FixedArray::make(1024, b'\x00')
+    let (n, peer_addr) = server.recvfrom(buf)
+    let data = buf.unsafe_reinterpret_as_bytes()[:n]
+    log.push("server received: \{@utf8.decode(data)}. Sending reply...")
+    ignore <| server.sendto(b"I am here", peer_addr)
+    let (n, peer_addr2) = server.recvfrom(buf)
+    assert_eq(peer_addr, peer_addr2)
+    let data = buf.unsafe_reinterpret_as_bytes()[:n]
+    log.push("server received: \{@utf8.decode(data)}. Sending reply...")
+    ignore <| server.sendto(b"Hello", peer_addr2)
+  }
+  json_inspect(log, content=[
+    "client sending discovery packet", "server received: anybody here?. Sending reply...",
+    "client found server via message: I am here", "client sending directly to discovered server: hello",
+    "server received: hello. Sending reply...", "client received Hello from server",
+  ])
+}
+
+///|
+async test "multicast no loopback v6" {
+  let log = []
+  @async.with_task_group() <| group => {
+    let server = @socket.UdpServer(@socket.Addr::parse("[::]:0"))
+    let port = server.addr.port()
+    let multicast_addr = @socket.Addr::parse("[ff0e::1]:\{port}")
+    group.spawn_bg(no_wait=true, () => {
+      defer server.close()
+      server.join_multicast_group_v6(multicast_addr, interface_index~)
+      let buf = FixedArray::make(1024, b'\x00')
+      for ;; {
+        let (n, _) = server.recvfrom(buf)
+        let data = buf.unsafe_reinterpret_as_bytes()[:n]
+        log.push("server received: \{@utf8.decode(data)}")
+      }
+    })
+    let client = @socket.UdpClient(multicast_addr)
+    defer client.close()
+    @async.sleep(200)
+    client.set_multicast_interface_v6(interface_index)
+    client.set_multicast_ttl(0)
+    if @event_loop.IS_WINDOWS {
+      server.set_multicast_loopback(false)
+    } else {
+      client.set_multicast_loopback(false)
+    }
+    log.push("client sending: abcd")
+    let _ = client.send(b"abcd")
+    if @event_loop.IS_WINDOWS {
+      server.set_multicast_loopback(true)
+    } else {
+      client.set_multicast_loopback(true)
+    }
+    log.push("client sending: xyzw")
+    let _ = client.send(b"xyzw")
+    @async.sleep(200)
+  }
+  json_inspect(log, content=[
+    "client sending: abcd", "client sending: xyzw", "server received: xyzw",
+  ])
+}

--- a/src/socket/multicast_test.mbt
+++ b/src/socket/multicast_test.mbt
@@ -148,10 +148,7 @@ async test "multicast discovery then unicast v6" {
     defer server.close()
     let port = server.addr.port()
     let multicast_addr = @socket.Addr::parse("[ff02::1]:\{server.addr.port()}")
-    server.join_multicast_group_v6(
-      multicast_addr,
-      interface_index=test_interface_index,
-    )
+    server.join_multicast_group_v6(multicast_addr, interface=test_interface)
     server.set_multicast_ttl(0)
     group.spawn_bg(() => {
       let client = @socket.UdpClient(
@@ -159,7 +156,7 @@ async test "multicast discovery then unicast v6" {
       )
       defer client.close()
       client.set_multicast_ttl(0)
-      client.set_multicast_interface_v6(test_interface_index)
+      client.set_multicast_interface_v6(test_interface)
       @async.sleep(150)
       log.push("client sending discovery packet")
       let _ = client.send(b"anybody here?")
@@ -201,10 +198,7 @@ async test "multicast no loopback v6" {
     let multicast_addr = @socket.Addr::parse("[ff02::1]:\{port}")
     group.spawn_bg(no_wait=true, () => {
       defer server.close()
-      server.join_multicast_group_v6(
-        multicast_addr,
-        interface_index=test_interface_index,
-      )
+      server.join_multicast_group_v6(multicast_addr, interface=test_interface)
       let buf = FixedArray::make(1024, b'\x00')
       for ;; {
         let (n, _) = server.recvfrom(buf)
@@ -217,7 +211,7 @@ async test "multicast no loopback v6" {
     )
     defer client.close()
     @async.sleep(200)
-    client.set_multicast_interface_v6(test_interface_index)
+    client.set_multicast_interface_v6(test_interface)
     client.set_multicast_ttl(0)
     if @event_loop.IS_WINDOWS {
       server.set_multicast_loopback(false)

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -81,7 +81,7 @@ pub async fn UdpClient::recv(Self, FixedArray[Byte], offset? : Int, max_len? : I
 pub async fn UdpClient::recvfrom(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> (Int, Addr)
 pub async fn UdpClient::send(Self, Bytes, offset? : Int, len? : Int) -> Unit
 pub fn UdpClient::set_multicast_interface(Self, Addr) -> Unit raise
-pub fn UdpClient::set_multicast_interface_v6(Self, Int) -> Unit raise
+pub fn UdpClient::set_multicast_interface_v6(Self, String) -> Unit raise
 pub fn UdpClient::set_multicast_loopback(Self, Bool) -> Unit raise
 pub fn UdpClient::set_multicast_ttl(Self, Int) -> Unit raise
 
@@ -96,12 +96,12 @@ pub fn UdpServer::addr(Self) -> Addr
 pub fn UdpServer::close(Self) -> Unit
 pub fn UdpServer::fd(Self) -> Int
 pub fn UdpServer::join_multicast_group(Self, Addr, interface_addr? : Addr) -> Unit raise
-pub fn UdpServer::join_multicast_group_v6(Self, Addr, interface_index? : Int) -> Unit raise
+pub fn UdpServer::join_multicast_group_v6(Self, Addr, interface? : String) -> Unit raise
 pub async fn UdpServer::multicast(Addr, interface_addr? : Addr) -> Self
 pub async fn UdpServer::recvfrom(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> (Int, Addr)
 pub async fn UdpServer::sendto(Self, Bytes, Addr, offset? : Int, len? : Int) -> Unit
 pub fn UdpServer::set_multicast_interface(Self, Addr) -> Unit raise
-pub fn UdpServer::set_multicast_interface_v6(Self, Int) -> Unit raise
+pub fn UdpServer::set_multicast_interface_v6(Self, String) -> Unit raise
 pub fn UdpServer::set_multicast_loopback(Self, Bool) -> Unit raise
 pub fn UdpServer::set_multicast_ttl(Self, Int) -> Unit raise
 

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -23,6 +23,7 @@ pub impl Show for ResolveHostnameError
 type Addr derive(Compare, Eq, Hash)
 pub fn Addr::ip(Self) -> UInt
 pub fn Addr::is_ipv6(Self) -> Bool
+pub fn Addr::is_multicast(Self) -> Bool
 pub fn Addr::new(UInt, Int) -> Self
 pub fn Addr::parse(String) -> Self raise
 pub fn Addr::port(Self) -> Int
@@ -70,13 +71,19 @@ pub struct UdpClient {
   // private fields
 }
 #alias(new, deprecated)
-pub fn UdpClient::UdpClient(Addr) -> Self raise
+pub async fn UdpClient::UdpClient(Addr) -> Self
 #deprecated
 pub fn UdpClient::addr(Self) -> Addr
 pub fn UdpClient::close(Self) -> Unit
+pub fn UdpClient::connect(Self, Addr) -> Unit raise
 pub fn UdpClient::fd(Self) -> Int
 pub async fn UdpClient::recv(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int
+pub async fn UdpClient::recvfrom(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> (Int, Addr)
 pub async fn UdpClient::send(Self, Bytes, offset? : Int, len? : Int) -> Unit
+pub fn UdpClient::set_multicast_interface(Self, Addr) -> Unit raise
+pub fn UdpClient::set_multicast_interface_v6(Self, Int) -> Unit raise
+pub fn UdpClient::set_multicast_loopback(Self, Bool) -> Unit raise
+pub fn UdpClient::set_multicast_ttl(Self, Int) -> Unit raise
 
 pub struct UdpServer {
   addr : Addr
@@ -88,8 +95,15 @@ pub async fn UdpServer::UdpServer(Addr, dual_stack? : Bool) -> Self
 pub fn UdpServer::addr(Self) -> Addr
 pub fn UdpServer::close(Self) -> Unit
 pub fn UdpServer::fd(Self) -> Int
+pub fn UdpServer::join_multicast_group(Self, Addr, interface_addr? : Addr) -> Unit raise
+pub fn UdpServer::join_multicast_group_v6(Self, Addr, interface_index? : Int) -> Unit raise
+pub async fn UdpServer::multicast(Addr, interface_addr? : Addr) -> Self
 pub async fn UdpServer::recvfrom(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> (Int, Addr)
 pub async fn UdpServer::sendto(Self, Bytes, Addr, offset? : Int, len? : Int) -> Unit
+pub fn UdpServer::set_multicast_interface(Self, Addr) -> Unit raise
+pub fn UdpServer::set_multicast_interface_v6(Self, Int) -> Unit raise
+pub fn UdpServer::set_multicast_loopback(Self, Bool) -> Unit raise
+pub fn UdpServer::set_multicast_ttl(Self, Int) -> Unit raise
 
 // Type aliases
 

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -646,7 +646,6 @@ int32_t moonbitlang_async_find_ipv6_test_interface() {
   int32_t result = 0;
   for (IP_ADAPTER_ADDRESSES *adapter = addrs; adapter; adapter = adapter->Next) {
     if (adapter->OperStatus != IfOperStatusUp) continue;
-    if (adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK) continue;
     if (adapter->Ipv6IfIndex == 0) continue;
     if (adapter->Flags & IP_ADAPTER_NO_MULTICAST) continue;
 

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -681,8 +681,12 @@ int32_t moonbitlang_async_find_ipv6_test_interface() {
     if (
       ifs->ifa_addr
       && ifs->ifa_addr->sa_family == AF_INET6
+    // on Linux: loopback cannot do multicast
+    // on MacOS: a lot of non-localhost non-routable interface
 #   ifdef __linux__
       && !(ifs->ifa_flags & IFF_LOOPBACK)
+#else
+      && (ifs->ifa_flags & IFF_LOOPBACK)
 #   endif
       && (ifs->ifa_flags & IFF_UP)
       && (ifs->ifa_flags & IFF_RUNNING)

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -186,7 +186,7 @@ MOONBIT_FFI_EXPORT
 int moonbitlang_async_join_multicast_group_v6(
   HANDLE sock,
   struct sockaddr_in6 *multi_addr,
-  int32_t if_index
+  uint32_t if_index
 ) {
   struct ipv6_mreq mreq;
   mreq.ipv6mr_multiaddr = multi_addr->sin6_addr;
@@ -211,7 +211,7 @@ int moonbitlang_async_set_multicast_interface(
 MOONBIT_FFI_EXPORT
 int moonbitlang_async_set_multicast_interface_v6(
   HANDLE sock,
-  int32_t interface_index
+  uint32_t interface_index
 ) {
   return setsockopt(
     sock,

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -614,7 +614,7 @@ void *moonbitlang_async_if_indextoname(HANDLE sock, uint32_t index) {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_find_ipv6_localhost() {
+int32_t moonbitlang_async_find_ipv6_test_interface() {
 #ifdef _WIN32
   ULONG flags =
     GAA_FLAG_SKIP_ANYCAST |
@@ -646,12 +646,26 @@ int32_t moonbitlang_async_find_ipv6_localhost() {
   int32_t result = 0;
   for (IP_ADAPTER_ADDRESSES *adapter = addrs; adapter; adapter = adapter->Next) {
     if (adapter->OperStatus != IfOperStatusUp) continue;
-    if (adapter->IfType != IF_TYPE_SOFTWARE_LOOPBACK) continue;
+    if (adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK) continue;
     if (adapter->Ipv6IfIndex == 0) continue;
     if (adapter->Flags & IP_ADAPTER_NO_MULTICAST) continue;
 
-    result = adapter->Ipv6IfIndex;
-    break;
+    for (
+      IP_ADAPTER_UNICAST_ADDRESS *unicast = adapter->FirstUnicastAddress;
+      unicast;
+      unicast = unicast->Next
+    ) {
+      struct sockaddr *sa = unicast->Address.lpSockaddr;
+      if (sa == NULL || sa->sa_family != AF_INET6) continue;
+
+      struct sockaddr_in6 *sa6 = (struct sockaddr_in6*)sa;
+      if (!IN6_IS_ADDR_LINKLOCAL(&sa6->sin6_addr)) continue;
+
+      result = adapter->Ipv6IfIndex;
+      break;
+    }
+
+    if (result != 0) break;
   }
 
   HeapFree(GetProcessHeap(), 0, addrs);
@@ -668,9 +682,13 @@ int32_t moonbitlang_async_find_ipv6_localhost() {
     if (
       ifs->ifa_addr
       && ifs->ifa_addr->sa_family == AF_INET6
-      && (ifs->ifa_flags & IFF_LOOPBACK)
+#   ifdef __linux__
+      && !(ifs->ifa_flags & IFF_LOOPBACK)
+#   endif
       && (ifs->ifa_flags & IFF_UP)
       && (ifs->ifa_flags & IFF_RUNNING)
+      && (ifs->ifa_flags & IFF_MULTICAST)
+      && IN6_IS_ADDR_LINKLOCAL(&(((struct sockaddr_in6*)ifs->ifa_addr)->sin6_addr))
     ) {
       result = if_nametoindex(ifs->ifa_name);
       if (result) break;

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -39,6 +39,7 @@
 #include <netdb.h>
 #include <stdio.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <net/if.h>
 #include <ifaddrs.h>
 #include <errno.h>
@@ -49,6 +50,10 @@
 
 typedef int HANDLE;
 typedef int SOCKET;
+
+#ifdef __MACH__
+#define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
+#endif
 
 #endif
 
@@ -99,7 +104,7 @@ int moonbitlang_async_allow_reuse_addr(HANDLE sock) {
 }
 
 MOONBIT_FFI_EXPORT
-HANDLE moonbitlang_async_make_udp_socket(int family) {
+HANDLE moonbitlang_async_make_udp_socket(int family, int32_t multicast) {
 #ifdef _WIN32
   SOCKET sock = WSASocket(
     family == 4 ? AF_INET : AF_INET6,
@@ -112,24 +117,131 @@ HANDLE moonbitlang_async_make_udp_socket(int family) {
   if (sock == INVALID_SOCKET)
     return INVALID_HANDLE_VALUE;
 
-  int exclusive_addruse = 0;
-  if (
-    setsockopt(
-      sock,
-      SOL_SOCKET,
-      SO_EXCLUSIVEADDRUSE,
-      (char*)&exclusive_addruse,
-      sizeof(int)
-    ) < 0
-  ) {
-    closesocket(sock);
-    return INVALID_HANDLE_VALUE;
+  if (multicast) {
+    int reuse_multicastport = 1;
+    if (
+      setsockopt(
+        sock,
+        SOL_SOCKET,
+        SO_REUSE_MULTICASTPORT,
+        &reuse_multicastport,
+        sizeof(int)
+      ) < 0
+    ) {
+      closesocket(sock);
+      return INVALID_HANDLE_VALUE;
+    }
+  } else {
+    int exclusive_addruse = 0;
+    if (
+      setsockopt(
+        sock,
+        SOL_SOCKET,
+        SO_EXCLUSIVEADDRUSE,
+        &exclusive_addruse,
+        sizeof(int)
+      ) < 0
+    ) {
+      closesocket(sock);
+      return INVALID_HANDLE_VALUE;
+    }
   }
 
   return (HANDLE)sock;
 #else
-  return socket(family == 4 ? AF_INET : AF_INET6, SOCK_DGRAM, 0);
+  int sock = socket(family == 4 ? AF_INET : AF_INET6, SOCK_DGRAM, 0);
+  if (multicast) {
+    int enable = 1;
+# ifdef __linux__
+    if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
+      close(sock);
+      return -1;
+    }
+# elif defined(__MACH__)
+    if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(int)) < 0) {
+      close(sock);
+      return -1;
+    }
+# else
+    moonbit_panic();
+# endif
+  }
+  return sock;
 #endif
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_join_multicast_group(
+  HANDLE sock,
+  struct sockaddr_in *multi_addr,
+  struct sockaddr_in *local_addr
+) {
+  struct ip_mreq mreq;
+  mreq.imr_multiaddr = multi_addr->sin_addr;
+  mreq.imr_interface = local_addr->sin_addr;
+  return setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(struct ip_mreq));
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_join_multicast_group_v6(
+  HANDLE sock,
+  struct sockaddr_in6 *multi_addr,
+  int32_t if_index
+) {
+  struct ipv6_mreq mreq;
+  mreq.ipv6mr_multiaddr = multi_addr->sin6_addr;
+  mreq.ipv6mr_interface = if_index;
+  return setsockopt(sock, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, &mreq, sizeof(struct ipv6_mreq));
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_set_multicast_interface(
+  HANDLE sock,
+  struct sockaddr_in *local_addr
+) {
+  return setsockopt(
+    sock,
+    IPPROTO_IP,
+    IP_MULTICAST_IF,
+    &local_addr->sin_addr,
+    sizeof(struct in_addr)
+  );
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_set_multicast_interface_v6(
+  HANDLE sock,
+  int32_t interface_index
+) {
+  return setsockopt(
+    sock,
+    IPPROTO_IPV6,
+    IPV6_MULTICAST_IF,
+    &interface_index,
+    sizeof(interface_index)
+  );
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_set_multicast_ttl(HANDLE sock, int32_t ttl, int32_t family) {
+  return setsockopt(
+    sock,
+    family == 4 ? IPPROTO_IP : IPPROTO_IPV6,
+    family == 4 ? IP_MULTICAST_TTL : IPV6_MULTICAST_HOPS,
+    (char*)&ttl,
+    sizeof(ttl)
+  );
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_set_multicast_loopback(HANDLE sock, int32_t enable, int32_t family) {
+  return setsockopt(
+    sock,
+    family == 4 ? IPPROTO_IP : IPPROTO_IPV6,
+    family == 4 ? IP_MULTICAST_LOOP : IPV6_MULTICAST_LOOP,
+    (char*)&enable,
+    sizeof(enable)
+  );
 }
 
 MOONBIT_FFI_EXPORT
@@ -305,6 +417,21 @@ int32_t moonbitlang_async_addr_is_ipv6(void *addr_bytes) {
   // use sa_family to be compatible with more platforms(BSD, Linux)
   struct sockaddr *sa = (struct sockaddr *)addr_bytes;
   return sa->sa_family == AF_INET6;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_addr_is_multicast(void *addr_bytes) {
+  struct sockaddr *sa = (struct sockaddr *)addr_bytes;
+  switch (sa->sa_family) {
+    case AF_INET: {
+      int first_octet = ntohl(((struct sockaddr_in*)sa)->sin_addr.s_addr) >> 24;
+      return 224 <= first_octet && first_octet < 240;
+    }
+    case AF_INET6: {
+      return ((struct sockaddr_in6*)sa)->sin6_addr.s6_addr[0] == 0xff;
+    };
+    default: return 0;
+  };
 }
 
 MOONBIT_FFI_EXPORT

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -45,8 +45,8 @@ pub async fn UdpClient::UdpClient(addr : Addr) -> UdpClient {
   let context = "@socket.UdpClient::new()"
   let family = addr.family()
   let sock = make_udp_socket(family, multicast=false, context~)
+  let io = @event_loop.IoHandle::from_fd(sock, kind=Socket)
   try {
-    let io = @event_loop.IoHandle::from_fd(sock, kind=Socket)
     if addr.is_multicast() {
       if @event_loop.IS_WINDOWS {
         let local_addr = match family {
@@ -62,7 +62,7 @@ pub async fn UdpClient::UdpClient(addr : Addr) -> UdpClient {
     { io, addr: local_addr, dst_addr: addr }
   } catch {
     err => {
-      @fd_util.close(sock, kind=Socket, context~)
+      io.close()
       raise err
     }
   }
@@ -231,7 +231,7 @@ pub async fn UdpServer::UdpServer(
     { io, addr }
   } catch {
     err => {
-      @fd_util.close(sock, kind=Socket, context~)
+      io.close()
       raise err
     }
   }
@@ -286,7 +286,7 @@ pub async fn UdpServer::multicast(
     { io, addr }
   } catch {
     err => {
-      @fd_util.close(sock, kind=Socket, context~)
+      io.close()
       raise err
     }
   }

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -18,33 +18,54 @@
 /// UDP is a connectionless protocol, here "connected" means
 /// the client always send packet to and receive packet from
 /// the specified remote server.
+///
+/// UDP does not really have a clear client/server distinction,
+/// especially when multicast is involved.
+/// The essence of `UdpClient` is a UDP socket without a fixed/well-known port.
 pub struct UdpClient {
   /// Local address of the client
   addr : Addr
   priv io : @event_loop.IoHandle
+  priv mut dst_addr : Addr
 }
 
 ///|
 /// Create a new UDP client connected to server at `addr`.
 /// The client always send packet to and receive packet from
 /// the specified remote server.
+///
+/// If `addr` is a multicast address,
+/// `connect` will not be called under the hood,
+/// and the client may receive packets from arbitrary peer.
+/// However, since the port of the client is random,
+/// the client effectively can only receive packets
+/// from multicast servers that have received packets from this client.
 #alias(new, deprecated)
-pub fn UdpClient::UdpClient(server : Addr) -> UdpClient raise {
+pub async fn UdpClient::UdpClient(addr : Addr) -> UdpClient {
   let context = "@socket.UdpClient::new()"
-  let family = server.family()
-  let sock = make_udp_socket(family, context~)
+  let family = addr.family()
+  let sock = make_udp_socket(family, multicast=false, context~)
   try {
-    if 0 != connect_ffi(sock, server) {
+    let io = @event_loop.IoHandle::from_fd(sock, kind=Socket)
+    if addr.is_multicast() {
+      if @event_loop.IS_WINDOWS {
+        let local_addr = match family {
+          IPv4 => ipv4_any
+          IPv6 => ipv6_any
+        }
+        io.bind(local_addr.0, context~)
+      }
+    } else if 0 != connect_ffi(sock, addr) {
       @os_error.check_errno(context)
     }
+    let local_addr = getsockname(sock, family, context~)
+    { io, addr: local_addr, dst_addr: addr }
   } catch {
     err => {
       @fd_util.close(sock, kind=Socket, context~)
       raise err
     }
   }
-  let addr = getsockname(sock, family, context~)
-  { io: @event_loop.IoHandle::from_fd(sock, kind=Socket), addr }
 }
 
 ///|
@@ -65,7 +86,93 @@ pub fn UdpClient::addr(self : UdpClient) -> Addr {
 }
 
 ///|
+/// Set the outgoing interface used for sending multicast packets with this client.
+///
+/// This function is IPv4-only. For IPv6, use `set_multicast_interface_v6` instead.
+pub fn UdpClient::set_multicast_interface(
+  self : UdpClient,
+  addr : Addr,
+) -> Unit raise {
+  let context = "@socket.UdpClient::set_multicast_interface()"
+  guard self.addr.family() is IPv4
+  guard addr.family() is IPv4 else {
+    raise Failure::Failure("\{context}: expected IPv4 address")
+  }
+  set_multicast_interface(self.io.fd(), addr, context~)
+}
+
+///|
+/// Set the outgoing interface used for sending multicast packets with this client.
+///
+/// This function is IPv6-only. For IPv4, use `set_multicast_interface` instead.
+pub fn UdpClient::set_multicast_interface_v6(
+  self : UdpClient,
+  interface_index : Int,
+) -> Unit raise {
+  guard self.addr.family() is IPv6
+  set_multicast_interface_v6(
+    self.io.fd(),
+    interface_index,
+    context="@socket.UdpClient::set_multicast_interface_v6()",
+  )
+}
+
+///|
+/// Set the multicast TTL (or hop limit for IPv6) for this client.
+/// `ttl=0` means packet never goes out of local machine.
+/// `ttl=1` means packet never goes out of local subnet.
+pub fn UdpClient::set_multicast_ttl(self : UdpClient, ttl : Int) -> Unit raise {
+  set_multicast_ttl(
+    self.io.fd(),
+    ttl,
+    family=self.addr.family(),
+    context="@socket.UdpClient::set_multicast_ttl()",
+  )
+}
+
+///|
+/// Set the multicast loopback option for this client.
+/// On Windows: make sure multicast packets sent from local machine is not received by this client.
+/// On other systems: make sure multicast packets sent by this client are not routed back to local machine
+///
+/// Note that the loopback setting does not apply for localhost traffic.
+pub fn UdpClient::set_multicast_loopback(
+  self : UdpClient,
+  loopback : Bool,
+) -> Unit raise {
+  set_multicast_loopback(
+    self.io.fd(),
+    loopback,
+    family=self.addr.family(),
+    context="@socket.UdpClient::set_multicast_loopback()",
+  )
+}
+
+///|
+/// Connect the client to a remote address,
+/// subsequently the client will send packets to this address,
+/// and only receive packets from this address.
+///
+/// Unicast UDP clients are connected automatically,
+/// so `connect` is mainly useful for turning a multicast client into a unicast one.
+/// The typical workflow is to create the client as a multicast client,
+/// send multicast packets, and wait for response from servers listening on the multicast address.
+/// Once a responding server is found, use `connect` to turn the client into a unicast one,
+/// and start point-to-point communication with the discovered server.
+pub fn UdpClient::connect(self : UdpClient, addr : Addr) -> Unit raise {
+  let context = "@socket.UdpClient::connect()"
+  if 0 != connect_ffi(self.io.fd(), addr) {
+    @os_error.check_errno(context)
+  }
+  self.dst_addr = addr
+}
+
+///|
 /// A UDP server bound to a listen address and receive packets from clients.
+///
+/// UDP does not really have a clear client/server distinction,
+/// especially when multicast is involved.
+/// The essence of `UdpServer` is a UDP socket with a fixed/well-known port.
 pub struct UdpServer {
   addr : Addr
   priv io : @event_loop.IoHandle
@@ -95,6 +202,12 @@ pub fn UdpServer::fd(self : UdpServer) -> @fd_util.Fd {
 /// If the port of `addr` is zero, the server will be bound to a random port,
 /// assigned by the operating system.
 /// The actual listen address can be retrieved via `.addr()`.
+///
+/// The server will only receive packets whose destination address matches `addr`.
+/// So if you want to receive multicast traffic,
+/// the server should be bound to `0.0.0.0` or `[::]`.
+/// DO NOT bind the server to a multicast address: this is not supported on Windows.
+/// For multicast-only servers, use `UdpServer::multicast()` instead.
 #alias(new, deprecated)
 pub async fn UdpServer::UdpServer(
   addr : Addr,
@@ -102,7 +215,7 @@ pub async fn UdpServer::UdpServer(
 ) -> UdpServer {
   let context = "@socket.UdpServer::new()"
   let family = addr.family()
-  let sock = make_udp_socket(family, context~)
+  let sock = make_udp_socket(family, multicast=false, context~)
   let io = @event_loop.IoHandle::from_fd(sock, kind=Socket)
   try {
     if addr.is_ipv6() && addr.is_ipv6_wildcard() {
@@ -125,10 +238,191 @@ pub async fn UdpServer::UdpServer(
 }
 
 ///|
+/// Create a multicast-only UDP server listening for multicast packets towards `multi_addr`. 
+/// The server will only receive packets towards `multi_addr`,
+/// no unicast traffic will be received.
+///
+/// Multicast only servers created via `UdpServer::multicast` are shared.
+/// There can be multiple such server listening on the same address at the same time.
+///
+/// The server will automatically join the IP multicast group at `multi_addr`,
+/// using interface `interface_addr` (defaults to a random interface chosen by the OS).
+/// Only the IP part of `interface_addr` matters, the port is irrelevant.
+///
+/// Due to OS limitation, currently every multicast-only server
+/// can listen for only one multicast IP.
+/// Calling `join_multicast_group` on server created by `UdpServer::multicast`
+/// with different address simply does not work.
+/// Users can join the same IP with a different interface using `join_multicast_group`, though.
+///
+/// Currently this function is IPv4 only.
+/// There is no simple way to implement multicast-only IPv6 socket on Linux/MacOS.
+pub async fn UdpServer::multicast(
+  multi_addr : Addr,
+  interface_addr? : Addr = Addr::new(0, 0),
+) -> UdpServer {
+  let context = "@socket.UdpServer::multicast()"
+  let family = multi_addr.family()
+  guard family is IPv4 else {
+    abort("@socket.UdpServer::multicast() is IPv4 only")
+  }
+  let sock = make_udp_socket(family, multicast=true, context~)
+  let io = @event_loop.IoHandle::from_fd(sock, kind=Socket)
+  try {
+    if @event_loop.IS_WINDOWS {
+      let local_addr = match family {
+        IPv4 => Addr::new(0, multi_addr.port())
+        IPv6 => Addr::new_ipv6(FixedArray::make(16, 0), multi_addr.port())
+      }
+      io.bind(local_addr.0, context~)
+    } else {
+      io.bind(multi_addr.0, context~)
+    }
+    join_multicast_group(sock, multi_addr, interface_addr, context~)
+    // If `addr` specifies zero as the listen port,
+    // the OS will assign a random port for us,
+    // in this case, we need to retrieve the actual port via `getsockname`.
+    let addr = getsockname(sock, family, context~)
+    { io, addr }
+  } catch {
+    err => {
+      @fd_util.close(sock, kind=Socket, context~)
+      raise err
+    }
+  }
+}
+
+///|
 /// Get the listen address of a UDP server.
 #deprecated("use `.addr` instead")
 pub fn UdpServer::addr(self : UdpServer) -> Addr {
   self.addr
+}
+
+///|
+/// Set the outgoing interface used for sending multicast packets with this server.
+///
+/// This function is IPv4-only. For IPv6, use `set_multicast_interface_v6` instead.
+pub fn UdpServer::set_multicast_interface(
+  self : UdpServer,
+  addr : Addr,
+) -> Unit raise {
+  guard self.addr.family() is IPv4
+  set_multicast_interface(
+    self.io.fd(),
+    addr,
+    context="@socket.UdpServer::set_multicast_interface()",
+  )
+}
+
+///|
+/// Set the outgoing interface used for sending multicast packets with this client.
+///
+/// This function is IPv6-only. For IPv4, use `set_multicast_interface` instead.
+pub fn UdpServer::set_multicast_interface_v6(
+  self : UdpServer,
+  interface_index : Int,
+) -> Unit raise {
+  guard self.addr.family() is IPv6
+  set_multicast_interface_v6(
+    self.io.fd(),
+    interface_index,
+    context="@socket.UdpServer::set_multicast_interface_v6()",
+  )
+}
+
+///|
+/// Set the multicast TTL (or hop limit for IPv6) for this client.
+/// `ttl=0` means packet never goes out of local machine.
+/// `ttl=1` means packet never goes out of local subnet.
+pub fn UdpServer::set_multicast_ttl(self : UdpServer, ttl : Int) -> Unit raise {
+  set_multicast_ttl(
+    self.io.fd(),
+    ttl,
+    family=self.addr.family(),
+    context="@socket.UdpServer::set_multicast_ttl()",
+  )
+}
+
+///|
+/// Set the multicast loopback option for this server.
+/// On Windows: make sure multicast packets sent from local machine is not received by this server.
+/// On other systems: make sure multicast packets sent by this server are not routed back to local machine
+///
+/// Note that the loopback setting does not apply for localhost traffic.
+pub fn UdpServer::set_multicast_loopback(
+  self : UdpServer,
+  loopback : Bool,
+) -> Unit raise {
+  set_multicast_loopback(
+    self.io.fd(),
+    loopback,
+    family=self.addr.family(),
+    context="@socket.UdpServer::set_multicast_loopback()",
+  )
+}
+
+///|
+/// Let the server join multicast group at address `multi_addr`, via interface `interface_addr`.
+/// `interface_addr` defaults to a random interface chosen by the OS.
+/// Only the IP part of `multi_addr` and `interface_addr` matters, the port is irrelevant.
+///
+/// Note that `join_multicast_group` is mainly about IGMP related stuff,
+/// it does not serve as a packet filter.
+/// A UDP server can receive all packets whose destination match the server's address.
+/// Some consquence of this:
+///
+/// - The port to receive multicast traffic is determined on server creation
+///
+/// - if the server is bound to a specific interface, it will not receive any multicast traffic,
+///   because multicast traffic has special destination IP
+///
+/// - multicast-only server created by `UdpServer::multicast` cannot join
+///   multiple multicast groups with different IP address.
+///
+/// This function is IPv4 only. For IPv6 multicast, use `join_multicast_group_v6` instead.
+pub fn UdpServer::join_multicast_group(
+  self : UdpServer,
+  multi_addr : Addr,
+  interface_addr? : Addr = Addr::new(0, 0),
+) -> Unit raise {
+  let context = "@socket.UdpServer::join_multicast_group()"
+  guard self.addr.family() is IPv4 else { abort("\{context} is IPv4 only") }
+  guard multi_addr.family() is IPv4 && interface_addr.family() is IPv4 else {
+    raise Failure::Failure("\{context}: expected IPv4 address")
+  }
+  join_multicast_group(self.io.fd(), multi_addr, interface_addr, context~)
+}
+
+///|
+/// Let the server join multicast group at address `multi_addr`, via interface `interface_index`.
+/// `interface_index` defaults to a 0, which assigns a default output interface
+/// for site-local/global multicast packets.
+/// For link-local multicast packets, an interface index must be explicitly specified.
+/// Only the IP part of `multi_addr` matters, the port is irrelevant.
+///
+/// Note that `join_multicast_group` is mainly about IGMP related stuff,
+/// it does not serve as a packet filter.
+/// A UDP server can receive all packets whose destination match the server's address.
+/// Some consquence of this:
+///
+/// - The port to receive multicast traffic is determined on server creation
+///
+/// - if the server is bound to a specific interface, it will not receive any multicast traffic,
+///   because multicast traffic has special destination IP
+///
+/// This function is IPv6 only. For IPv4 multicast, use `join_multicast_group` instead.
+pub fn UdpServer::join_multicast_group_v6(
+  self : UdpServer,
+  multi_addr : Addr,
+  interface_index? : Int = 0,
+) -> Unit raise {
+  let context = "@socket.UdpServer::join_multicast_group_v6()"
+  guard self.addr.family() is IPv6 else { abort("\{context} is IPv6 only") }
+  guard multi_addr.family() is IPv6 else {
+    raise Failure::Failure("\{context}: expected IPv6 address")
+  }
+  join_multicast_group_v6(self.io.fd(), multi_addr, interface_index, context~)
 }
 
 ///|
@@ -152,6 +446,28 @@ pub async fn UdpClient::recv(
   max_len? : Int = buf.length() - offset,
 ) -> Int {
   self.io.read(buf, offset~, len=max_len, context="@socket.UdpClient::recv")
+}
+
+///|
+/// Similar to `recv`, but additionally return the address of the packet's sender.
+/// Unicast `UdpClient` can only receive traffic from the target server,
+/// so this is mainly useful for multicast clients.
+pub async fn UdpClient::recvfrom(
+  self : UdpClient,
+  buf : FixedArray[Byte],
+  offset? : Int = 0,
+  max_len? : Int = buf.length() - offset,
+) -> (Int, Addr) {
+  // Create a big enough Addr to hold both IPv4 and IPv6 address
+  let addr = Addr::empty(self.addr.family())
+  let n_read = self.io.recvfrom(
+    buf,
+    offset~,
+    len=max_len,
+    addr=addr.0,
+    context="@socket.UdpClient::recvfrom",
+  )
+  (n_read, addr)
 }
 
 ///|
@@ -200,7 +516,14 @@ pub async fn UdpClient::send(
   offset? : Int = 0,
   len? : Int = buf.length() - offset,
 ) -> Unit {
-  self.io.write(buf, offset~, len~, context="@socket.UdpClient::send") |> ignore
+  self.io.sendto(
+    buf,
+    offset~,
+    len~,
+    addr=self.dst_addr.0,
+    context="@socket.UdpClient::send",
+  )
+  |> ignore
 }
 
 ///|

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -107,17 +107,21 @@ pub fn UdpClient::set_multicast_interface(
 
 ///|
 /// Set the outgoing interface used for sending multicast packets with this client.
+/// The interface is provided via IPv6 zone suffix index.
+/// It can either be a decimal string for a raw interface index,
+/// or a network interface name.
 ///
 /// This function is IPv6-only. For IPv4, use `set_multicast_interface` instead.
 pub fn UdpClient::set_multicast_interface_v6(
   self : UdpClient,
-  interface_index : UInt,
+  interface : String,
 ) -> Unit raise {
   guard self.addr.family() is IPv6
+  let context = "@socket.UdpClient::set_multicast_interface_v6()"
   set_multicast_interface_v6(
     self.io.fd(),
-    interface_index,
-    context="@socket.UdpClient::set_multicast_interface_v6()",
+    parse_ipv6_zone_suffix(interface, context~),
+    context~,
   )
 }
 
@@ -319,17 +323,21 @@ pub fn UdpServer::set_multicast_interface(
 
 ///|
 /// Set the outgoing interface used for sending multicast packets with this client.
+/// The interface is provided via IPv6 zone suffix index.
+/// It can either be a decimal string for a raw interface index,
+/// or a network interface name.
 ///
 /// This function is IPv6-only. For IPv4, use `set_multicast_interface` instead.
 pub fn UdpServer::set_multicast_interface_v6(
   self : UdpServer,
-  interface_index : UInt,
+  interface : String,
 ) -> Unit raise {
   guard self.addr.family() is IPv6
+  let context = "@socket.UdpServer::set_multicast_interface_v6()"
   set_multicast_interface_v6(
     self.io.fd(),
-    interface_index,
-    context="@socket.UdpServer::set_multicast_interface_v6()",
+    parse_ipv6_zone_suffix(interface, context~),
+    context~,
   )
 }
 
@@ -397,10 +405,11 @@ pub fn UdpServer::join_multicast_group(
 }
 
 ///|
-/// Let the server join multicast group at address `multi_addr`, via interface `interface_index`.
-/// `interface_index` defaults to a 0, which assigns a default output interface
-/// for site-local/global multicast packets.
-/// For link-local multicast packets, an interface index must be explicitly specified.
+/// Let the server join multicast group at address `multi_addr`, via interface `interface`.
+/// `interface`, if provided, should use IPv6 zone suffix syntax,
+/// meaning it can either be a decimal string for raw interface index, or a network interface name.
+/// `interface` defaults to "0", meaning a default output interface chosen by the OS.
+/// For interface-local/link-local multicast packets, the interface must be explicitly specified.
 /// Only the IP part of `multi_addr` matters, the port is irrelevant.
 ///
 /// Note that `join_multicast_group` is mainly about IGMP related stuff,
@@ -417,14 +426,19 @@ pub fn UdpServer::join_multicast_group(
 pub fn UdpServer::join_multicast_group_v6(
   self : UdpServer,
   multi_addr : Addr,
-  interface_index? : UInt = 0,
+  interface? : String = "0",
 ) -> Unit raise {
   let context = "@socket.UdpServer::join_multicast_group_v6()"
   guard self.addr.family() is IPv6 else { abort("\{context} is IPv6 only") }
   guard multi_addr.family() is IPv6 else {
     raise Failure::Failure("\{context}: expected IPv6 address")
   }
-  join_multicast_group_v6(self.io.fd(), multi_addr, interface_index, context~)
+  join_multicast_group_v6(
+    self.io.fd(),
+    multi_addr,
+    parse_ipv6_zone_suffix(interface, context~),
+    context~,
+  )
 }
 
 ///|

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -26,7 +26,7 @@ pub struct UdpClient {
   /// Local address of the client
   addr : Addr
   priv io : @event_loop.IoHandle
-  priv mut dst_addr : Addr
+  priv mut dst_addr : Addr?
 }
 
 ///|
@@ -47,7 +47,7 @@ pub async fn UdpClient::UdpClient(addr : Addr) -> UdpClient {
   let sock = make_udp_socket(family, multicast=false, context~)
   let io = @event_loop.IoHandle::from_fd(sock, kind=Socket)
   try {
-    if addr.is_multicast() {
+    let dst_addr = if addr.is_multicast() {
       if @event_loop.IS_WINDOWS {
         let local_addr = match family {
           IPv4 => ipv4_any
@@ -55,11 +55,15 @@ pub async fn UdpClient::UdpClient(addr : Addr) -> UdpClient {
         }
         io.bind(local_addr.0, context~)
       }
+      Some(addr)
     } else if 0 != connect_ffi(sock, addr) {
       @os_error.check_errno(context)
+      None
+    } else {
+      None
     }
     let local_addr = getsockname(sock, family, context~)
-    { io, addr: local_addr, dst_addr: addr }
+    { io, addr: local_addr, dst_addr }
   } catch {
     err => {
       io.close()
@@ -107,7 +111,7 @@ pub fn UdpClient::set_multicast_interface(
 /// This function is IPv6-only. For IPv4, use `set_multicast_interface` instead.
 pub fn UdpClient::set_multicast_interface_v6(
   self : UdpClient,
-  interface_index : Int,
+  interface_index : UInt,
 ) -> Unit raise {
   guard self.addr.family() is IPv6
   set_multicast_interface_v6(
@@ -164,7 +168,7 @@ pub fn UdpClient::connect(self : UdpClient, addr : Addr) -> Unit raise {
   if 0 != connect_ffi(self.io.fd(), addr) {
     @os_error.check_errno(context)
   }
-  self.dst_addr = addr
+  self.dst_addr = None
 }
 
 ///|
@@ -176,6 +180,7 @@ pub fn UdpClient::connect(self : UdpClient, addr : Addr) -> Unit raise {
 pub struct UdpServer {
   addr : Addr
   priv io : @event_loop.IoHandle
+  priv is_multicast_only : Bool
 }
 
 ///|
@@ -228,7 +233,7 @@ pub async fn UdpServer::UdpServer(
     // the OS will assign a random port for us,
     // in this case, we need to retrieve the actual port via `getsockname`.
     let addr = getsockname(sock, family, context~)
-    { io, addr }
+    { io, addr, is_multicast_only: false }
   } catch {
     err => {
       io.close()
@@ -270,10 +275,7 @@ pub async fn UdpServer::multicast(
   let io = @event_loop.IoHandle::from_fd(sock, kind=Socket)
   try {
     if @event_loop.IS_WINDOWS {
-      let local_addr = match family {
-        IPv4 => Addr::new(0, multi_addr.port())
-        IPv6 => Addr::new_ipv6(FixedArray::make(16, 0), multi_addr.port())
-      }
+      let local_addr = Addr::new(0, multi_addr.port())
       io.bind(local_addr.0, context~)
     } else {
       io.bind(multi_addr.0, context~)
@@ -283,7 +285,7 @@ pub async fn UdpServer::multicast(
     // the OS will assign a random port for us,
     // in this case, we need to retrieve the actual port via `getsockname`.
     let addr = getsockname(sock, family, context~)
-    { io, addr }
+    { io, addr, is_multicast_only: true }
   } catch {
     err => {
       io.close()
@@ -321,7 +323,7 @@ pub fn UdpServer::set_multicast_interface(
 /// This function is IPv6-only. For IPv4, use `set_multicast_interface` instead.
 pub fn UdpServer::set_multicast_interface_v6(
   self : UdpServer,
-  interface_index : Int,
+  interface_index : UInt,
 ) -> Unit raise {
   guard self.addr.family() is IPv6
   set_multicast_interface_v6(
@@ -415,7 +417,7 @@ pub fn UdpServer::join_multicast_group(
 pub fn UdpServer::join_multicast_group_v6(
   self : UdpServer,
   multi_addr : Addr,
-  interface_index? : Int = 0,
+  interface_index? : UInt = 0,
 ) -> Unit raise {
   let context = "@socket.UdpServer::join_multicast_group_v6()"
   guard self.addr.family() is IPv6 else { abort("\{context} is IPv6 only") }
@@ -516,14 +518,11 @@ pub async fn UdpClient::send(
   offset? : Int = 0,
   len? : Int = buf.length() - offset,
 ) -> Unit {
-  self.io.sendto(
-    buf,
-    offset~,
-    len~,
-    addr=self.dst_addr.0,
-    context="@socket.UdpClient::send",
-  )
-  |> ignore
+  let context = "@socket.UdpClient::send()"
+  let _ = match self.dst_addr {
+    Some(Addr(addr)) => self.io.sendto(buf, offset~, len~, addr~, context~)
+    None => self.io.write(buf, offset~, len~, context~)
+  }
 }
 
 ///|
@@ -541,6 +540,11 @@ pub async fn UdpServer::sendto(
   offset? : Int = 0,
   len? : Int = buf.length() - offset,
 ) -> Unit {
+  guard !self.is_multicast_only else {
+    raise Failure::Failure(
+      "multicast-only sockets created with `@socket.UdpServer::multicast()` cannot be used for sending",
+    )
+  }
   self.io.sendto(
     buf,
     offset~,


### PR DESCRIPTION
#348

This PR adds multicast support for `moonbitlang/async/socket`. It contains the following API change:

- introduce a new method `@socket.UdpServer::multicast(..)` for creating shared (i.e. multiple process on the same machine can share the same address + port with this method), multicast-only (i.e. will not receive unicast traffic), receive-only (due to OS restriction) UDP server
- introduce a new method `@socket.UdpServer::join_multicast_group{,_v6}(..)` for joining IP multicast group from an existing UDP server
- [breaking] `@socket.UdpClient::UdpClient(..)` is now `async` because it may invoke `bind` on Windows when the destination address is a multicast address
- introduce a new method `@socket.UdpClient::connect(..)`, for connecting a UDP client to a destination address. Unicast UDP clients are connected automatically on creation, so this is mainly useful for multicast clients. The typical workflow is initiating the client with a multicast destination, send some discovery packet, and wait for server reply. Upon receiving reply from servers, choose a responding server and `connect` to it, turning the socket into unicast mode with a specific server
- introduce a new method `@socket.UdpClient::recvfrom` for the multicast case
- introduce the methods `set_multicast_ttl`, `set_multicast_loopback`, `set_multicast_interface` and `set_multicast_interface_v6` for `@socket.UdpServer` and `@socket.UdpClient` for setting various properties concerning multicast

Here are some semantic/implementation details:

- There is really no such thing as "client" and "server" in the UDP world, especially for the multicast case. The real distinction of `@socket.UdpServer` and `@socket.UdpClient` is actually:
    - `@socket.UdpServer` usually has a fixed/well-known port
    - `@socket.UdpClient` has a OS-assigned ephemeral port
    
    For the simple unicast case, the client/server intuition still works. But for the multicast case, "whether the port is well-known" is the correct intuition behind the client/server distinction
- one of the goals of this PR is to avoid **port sharing for unicast**, because it is tricky and not portable. Hence there are two ways to create a UDP multicast server in this PR:
    - create a normal unicast UDP server, bound to `0.0.0.0` or `[::]`, and call `join_multicast_group` later. This way, the server:
        - own the port exclusively
        - can receive both unicast and multicast traffic
        - can join multiple multicast groups with different IPs
    - use `@socket.UdpServer::multicast(..)` to create a multicast-only server. This way, the server:
        - only receives multicast traffic **towards the address specified to `@socket.UdpServer::multicast`**
        - can only join multicast group with that IP (but users can still call `join_multicast_group` again to join the same IP with different interfaces)
        - cannot send packets, only receive
        
        On Windows, multicast-only behavior is implemented with the `SO_REUSE_MULTICASTPORT` socket option. On Linux/MacOS, such convenient flag is not available, and this PR relies on the trick of binding the socket to the multicast address. For UDP sockets, the bound address merely serve as a destination address filter for incoming packets, that's why the trick can exclude unicast traffic. The use of this trick has some undesirable consequences though:
        - the "only one multicast IP" restriction
        - IPv6 does not allow binding to a multicast address. So `@socket.UdpServer::multicast` is IPv4 only and has no IPv6 alternative. This is doable on Windows, but currently I am not aware of a way to do this on Linux/MacOS