### PR TITLE
add TLS channel binding support

### DIFF
--- a/src/tls/channel_binding_test.mbt
+++ b/src/tls/channel_binding_test.mbt
@@ -1,0 +1,59 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "channel binding" {
+  @async.with_task_group(group => {
+    let (client_read_from_server, server_write_to_client) = @pipe.pipe()
+    let (server_read_from_client, client_write_to_server) = @pipe.pipe()
+    // server
+    let server_task = group.spawn(() => {
+      defer {
+        server_read_from_client.close()
+        server_write_to_client.close()
+      }
+      let server = test_server(server_read_from_client, server_write_to_client)
+      defer server.close()
+      (
+        server.unique_channel_binding(),
+        server.server_endpoint_channel_binding(),
+      )
+    })
+    // client
+    let client_task = group.spawn(() => {
+      defer {
+        client_read_from_server.close()
+        client_write_to_server.close()
+      }
+      let client = @tls.Tls::client_from_pair(
+        client_read_from_server,
+        client_write_to_server,
+        trust=NoVerification,
+      )
+      defer client.close()
+      let binding = (
+        client.unique_channel_binding(),
+        client.server_endpoint_channel_binding(),
+      )
+      client.shutdown()
+      binding
+    })
+    let (unique_binding_for_server, endpoint_binding_for_server) = server_task.wait()
+    let (unique_binding_for_client, endpoint_binding_for_client) = client_task.wait()
+    assert_eq(unique_binding_for_client, unique_binding_for_server)
+    assert_true(unique_binding_for_client.length() > 0)
+    assert_eq(endpoint_binding_for_client, endpoint_binding_for_server)
+    assert_true(endpoint_binding_for_client.length() > 0)
+  })
+}

--- a/src/tls/moon.pkg
+++ b/src/tls/moon.pkg
@@ -22,6 +22,7 @@ options(
   "native-stub": [ "openssl.c", "schannel.c" ],
   targets: {
     "certificate_test.mbt": [ "native" ],
+    "channel_binding_test.mbt": [ "native" ],
     "crypto_util.mbt": [ "native" ],
     "deprecated.mbt": [ "native" ],
     "openssl.mbt": [ "native" ],

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -30,12 +30,14 @@
 #define SSL_MODE_ENABLE_PARTIAL_WRITE 0x00000001U
 #define SSL_CTRL_SET_TLSEXT_HOSTNAME 55
 #define TLSEXT_NAMETYPE_host_name 0
+#define MAX_DIGEST_LEN 64
 
 typedef struct BIO_METHOD BIO_METHOD;
 typedef struct BIO BIO;
 typedef struct SSL SSL;
 typedef struct SSL_CTX SSL_CTX;
 typedef struct SSL_METHOD SSL_METHOD;
+typedef struct EVP_MD EVP_MD;
 typedef struct X509 X509;
 typedef struct X509_STORE X509_STORE;
 
@@ -63,8 +65,11 @@ typedef struct X509_STORE X509_STORE;
   IMPORT_FUNC(int, SSL_read, (SSL *ssl, void *buf, int num))\
   IMPORT_FUNC(int, SSL_write, (SSL *ssl, void *buf, int num))\
   IMPORT_FUNC(int, SSL_get_error, (SSL *ssl, int ret))\
+  IMPORT_FUNC(size_t, SSL_get_finished, (const SSL *ssl, void *buf, size_t count))\
+  IMPORT_FUNC(size_t, SSL_get_peer_finished, (const SSL *ssl, void *buf, size_t count))\
   IMPORT_FUNC(int, SSL_shutdown, (SSL *ssl))\
   IMPORT_FUNC(void, SSL_free, (SSL *ssl))\
+  IMPORT_FUNC(X509 *, SSL_get_certificate, (const SSL *ssl))\
   IMPORT_FUNC(SSL_CTX *, SSL_CTX_new, (const SSL_METHOD*))\
   IMPORT_FUNC(void, SSL_CTX_free, (SSL_CTX *))\
   IMPORT_FUNC(X509_STORE *, SSL_CTX_get_cert_store, (const SSL_CTX *ctx))\
@@ -76,12 +81,18 @@ typedef struct X509_STORE X509_STORE;
   IMPORT_FUNC(unsigned long, ERR_get_error, (void))\
   IMPORT_FUNC(unsigned long, ERR_peek_error, (void))\
   IMPORT_FUNC(char *, ERR_error_string, (unsigned long e, char *buf))\
+  IMPORT_FUNC(const char *, OBJ_nid2sn, (int n))\
+  IMPORT_FUNC(int, OBJ_find_sigid_algs, (int signid, int *pdig_nid, int *ppkey_nid))\
+  IMPORT_FUNC(const EVP_MD *, EVP_get_digestbyname, (const char *name))\
+  IMPORT_FUNC(const EVP_MD *, EVP_sha256, (void))\
   IMPORT_FUNC(int, RAND_bytes, (unsigned char *buf, int num))\
   IMPORT_FUNC(unsigned char *, SHA1, (const unsigned char *d, size_t n, unsigned char *md))\
   IMPORT_FUNC_WITH_ALT_NAMES(X509 *, SSL_get1_peer_certificate, (const SSL *ssl), { "SSL_get_peer_certificate" })\
   IMPORT_FUNC(X509 *, d2i_X509, (X509 **px, const unsigned char **in, long len))\
+  IMPORT_FUNC(int, X509_get_signature_nid, (const X509 *x))\
   IMPORT_FUNC(void, X509_free, (const X509 *cert))\
   IMPORT_FUNC(int, X509_STORE_add_cert, (X509_STORE *xs, X509 *x))\
+  IMPORT_FUNC(int, X509_digest, (const X509 *data, const EVP_MD *type, unsigned char *md, unsigned int *len))\
   IMPORT_FUNC(int, i2d_X509_AUX, (X509 *cert, unsigned char **ppout))
 
 #define IMPORT_FUNC(ret, name, params) static ret (*name) params;
@@ -309,6 +320,72 @@ moonbit_bytes_t moonbitlang_async_tls_ssl_get_peer_certificate(SSL *ssl) {
 handle_error:
   X509_free(cert);
   return 0;
+}
+
+static
+moonbit_bytes_t hash_server_endpoint_certificate(X509 *cert) {
+  int signature_nid = X509_get_signature_nid(cert);
+  int digest_nid = 0;
+  int public_key_nid = 0;
+  const EVP_MD *digest = 0;
+  const char *digest_name = 0;
+  unsigned int digest_len = 0;
+  unsigned char digest_buf[MAX_DIGEST_LEN];
+
+  if (!OBJ_find_sigid_algs(signature_nid, &digest_nid, &public_key_nid))
+    return 0;
+
+  digest_name = OBJ_nid2sn(digest_nid);
+  if (!digest_name)
+    return 0;
+
+  if (strcmp(digest_name, "MD5") == 0 || strcmp(digest_name, "SHA1") == 0) {
+    digest = EVP_sha256();
+  } else {
+    digest = EVP_get_digestbyname(digest_name);
+  }
+
+  if (!digest)
+    return 0;
+
+  if (!X509_digest(cert, digest, digest_buf, &digest_len))
+    return 0;
+
+  moonbit_bytes_t result = moonbit_make_bytes_raw(digest_len);
+  memcpy(result, digest_buf, digest_len);
+  return result;
+}
+
+moonbit_bytes_t moonbitlang_async_tls_ssl_unique_channel_binding(SSL *ssl, int32_t is_client) {
+  size_t len = is_client ?
+    SSL_get_finished(ssl, 0, 0) :
+    SSL_get_peer_finished(ssl, 0, 0);
+  if (len == 0)
+    return 0;
+
+  moonbit_bytes_t result = moonbit_make_bytes_raw(len);
+  size_t copied = is_client ?
+    SSL_get_finished(ssl, result, len) :
+    SSL_get_peer_finished(ssl, result, len);
+  if (copied != len)
+    return 0;
+  return result;
+}
+
+moonbit_bytes_t moonbitlang_async_tls_ssl_server_endpoint_channel_binding(SSL *ssl, int32_t is_client) {
+  if (is_client) {
+    X509 *cert = SSL_get1_peer_certificate(ssl);
+    if (!cert)
+      return 0;
+    moonbit_bytes_t result = hash_server_endpoint_certificate(cert);
+    X509_free(cert);
+    return result;
+  } else {
+    X509 *cert = SSL_get_certificate(ssl);
+    if (!cert)
+      return 0;
+    return hash_server_endpoint_certificate(cert);
+  }
 }
 
 int moonbitlang_async_tls_ssl_get_error(SSL *ssl, int ret) {

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -612,6 +612,8 @@ pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
 }
 
 ///|
+/// Return `tls-unique` type of channel binding data for this TLS connection,
+/// according to RFC 5929
 #cfg(not(platform="windows"))
 pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
   match self.ssl.unique_channel_binding(is_client=self.is_client) {
@@ -626,6 +628,10 @@ pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
 }
 
 ///|
+/// Return `tls-server-endpoint` type of channel binding data for this TLS connection,
+/// according to RFC 5929.
+/// Not all TLS connection has such thing as a server certificate,
+/// so `tls-unique` is the more recommended approach when available.
 #cfg(not(platform="windows"))
 pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
   match self.ssl.server_endpoint_channel_binding(is_client=self.is_client) {

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -101,6 +101,20 @@ extern "C" fn SSL::accept(self : SSL) -> Int = "moonbitlang_async_tls_ssl_accept
 extern "C" fn SSL::get_peer_certificate(self : SSL) -> Bytes? = "moonbitlang_async_tls_ssl_get_peer_certificate"
 
 ///|
+#cfg(not(platform="windows"))
+extern "C" fn SSL::unique_channel_binding(
+  self : SSL,
+  is_client~ : Bool,
+) -> Bytes? = "moonbitlang_async_tls_ssl_unique_channel_binding"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn SSL::server_endpoint_channel_binding(
+  self : SSL,
+  is_client~ : Bool,
+) -> Bytes? = "moonbitlang_async_tls_ssl_server_endpoint_channel_binding"
+
+///|
 pub(all) enum X509FileType {
   PEM = 1
   ANS1 = 2
@@ -271,6 +285,7 @@ struct Tls {
   ssl : SSL
   ctx : SSL_CTX
   host : String?
+  is_client : Bool
   transport : Transport
   read_buf : @io.ReaderBuffer
   mut shutdown : Bool
@@ -283,6 +298,7 @@ fn[R : @io.Reader, W : @io.Writer] Tls::from_pair(
   ctx : SSL_CTX,
   r : R,
   w : W,
+  is_client~ : Bool,
   host~ : String?,
 ) -> Tls {
   let transport = Transport::new(r, w)
@@ -293,6 +309,7 @@ fn[R : @io.Reader, W : @io.Writer] Tls::from_pair(
     ssl,
     ctx,
     host,
+    is_client,
     transport,
     read_buf: @io.ReaderBuffer::new(),
     shutdown: false,
@@ -370,7 +387,7 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::client_from_pair(
     NoVerification | SystemRoot => client_ctx
     CustomPemFile(root_cert) => SSL_CTX::client_with_custom_root(root_cert)
   }
-  let self = Tls::from_pair(ctx, r, w, host~)
+  let self = Tls::from_pair(ctx, r, w, is_client=true, host~)
   try {
     if trust is NoVerification {
       self.ssl.set_verify(false)
@@ -420,7 +437,7 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::server_from_pair(
 ) -> Tls {
   let private_key_file = @utf8.encode(private_key_file)
   let certificate_file = @utf8.encode(certificate_file)
-  let self = Tls::from_pair(server_ctx, r, w, host=None)
+  let self = Tls::from_pair(server_ctx, r, w, is_client=false, host=None)
   try {
     if self.ssl.use_certificate_file(certificate_file, certificate_type) != 1 {
       raise TlsError(err_get_error())
@@ -592,6 +609,34 @@ pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
     raise TlsError(err_get_error())
   }
   result
+}
+
+///|
+#cfg(not(platform="windows"))
+pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
+  match self.ssl.unique_channel_binding(is_client=self.is_client) {
+    Some(binding) => binding
+    None =>
+      if err_peek_error_code() != 0 {
+        raise TlsError(err_get_error())
+      } else {
+        raise TlsError("tls-unique channel binding unavailable")
+      }
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
+  match self.ssl.server_endpoint_channel_binding(is_client=self.is_client) {
+    Some(binding) => binding
+    None =>
+      if err_peek_error_code() != 0 {
+        raise TlsError(err_get_error())
+      } else {
+        raise TlsError("tls-server-endpoint channel binding unavailable")
+      }
+  }
 }
 
 ///|

--- a/src/tls/pkg.generated.mbti
+++ b/src/tls/pkg.generated.mbti
@@ -31,8 +31,10 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::client_from_pair(R, W, verify?
 pub fn Tls::close(Self) -> Unit
 pub fn Tls::get_peer_certificate(Self) -> Bytes? raise
 pub async fn[Inner : @io.Reader + @io.Writer] Tls::server(Inner, private_key_file~ : String, private_key_type~ : X509FileType, certificate_file~ : String, certificate_type~ : X509FileType) -> Self
+pub fn Tls::server_endpoint_channel_binding(Self) -> Bytes raise
 pub async fn[R : @io.Reader, W : @io.Writer] Tls::server_from_pair(R, W, private_key_file~ : String, private_key_type~ : X509FileType, certificate_file~ : String, certificate_type~ : X509FileType) -> Self
 pub async fn Tls::shutdown(Self) -> Unit
+pub fn Tls::unique_channel_binding(Self) -> Bytes raise
 pub impl @io.Reader for Tls
 pub impl @io.Writer for Tls
 

--- a/src/tls/schannel.c
+++ b/src/tls/schannel.c
@@ -569,6 +569,41 @@ int32_t moonbitlang_async_schannel_shutdown(struct Context *ctx) {
   return ApplyControlToken(&ctx->context, &buf_desc);
 }
 
+static
+moonbit_bytes_t get_channel_binding(struct Context *ctx, int attribute) {
+  SecPkgContext_Bindings bindings;
+  int32_t err = QueryContextAttributes(&ctx->context, attribute, &bindings);
+  if (err != SEC_E_OK) {
+    SetLastError(err);
+    return 0;
+  }
+
+  if (!bindings.Bindings) {
+    FreeContextBuffer(bindings.Bindings);
+    return 0;
+  }
+
+  unsigned long data_offset = bindings.Bindings->dwApplicationDataOffset;
+  unsigned long data_len = bindings.Bindings->cbApplicationDataLength;
+  if (
+    data_offset > bindings.BindingsLength ||
+    data_len > bindings.BindingsLength - data_offset
+  ) {
+    SetLastError(ERROR_INVALID_DATA);
+    FreeContextBuffer(bindings.Bindings);
+    return 0;
+  }
+
+  moonbit_bytes_t result = moonbit_make_bytes_raw(data_len);
+  memcpy(
+    result,
+    ((unsigned char *)bindings.Bindings) + data_offset,
+    data_len
+  );
+  FreeContextBuffer(bindings.Bindings);
+  return result;
+}
+
 MOONBIT_FFI_EXPORT
 moonbit_bytes_t moonbitlang_async_schannel_get_peer_certificate(struct Context *ctx) {
   CERT_CONTEXT *cert = 0;
@@ -587,6 +622,16 @@ moonbit_bytes_t moonbitlang_async_schannel_get_peer_certificate(struct Context *
   memcpy(result, cert->pbCertEncoded, cert->cbCertEncoded);
   CertFreeCertificateContext(cert);
   return result;
+}
+
+MOONBIT_FFI_EXPORT
+moonbit_bytes_t moonbitlang_async_schannel_unique_channel_binding(struct Context *ctx) {
+  return get_channel_binding(ctx, SECPKG_ATTR_UNIQUE_BINDINGS);
+}
+
+MOONBIT_FFI_EXPORT
+moonbit_bytes_t moonbitlang_async_schannel_server_endpoint_channel_binding(struct Context *ctx) {
+  return get_channel_binding(ctx, SECPKG_ATTR_ENDPOINT_BINDINGS);
 }
 
 MOONBIT_FFI_EXPORT

--- a/src/tls/schannel.mbt
+++ b/src/tls/schannel.mbt
@@ -486,6 +486,8 @@ pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
 }
 
 ///|
+/// Return `tls-unique` type of channel binding data for this TLS connection,
+/// according to RFC 5929
 #cfg(platform="windows")
 pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
   match self.context.unique_channel_binding() {
@@ -502,6 +504,10 @@ pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
 }
 
 ///|
+/// Return `tls-server-endpoint` type of channel binding data for this TLS connection,
+/// according to RFC 5929.
+/// Not all TLS connection has such thing as a server certificate,
+/// so `tls-unique` is the more recommended approach when available.
 #cfg(platform="windows")
 pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
   match self.context.server_endpoint_channel_binding() {

--- a/src/tls/schannel.mbt
+++ b/src/tls/schannel.mbt
@@ -462,6 +462,18 @@ extern "C" fn Schannel::get_peer_certificate(ch : Schannel) -> Bytes? = "moonbit
 
 ///|
 #cfg(platform="windows")
+#borrow(ch)
+extern "C" fn Schannel::unique_channel_binding(ch : Schannel) -> Bytes? = "moonbitlang_async_schannel_unique_channel_binding"
+
+///|
+#cfg(platform="windows")
+#borrow(ch)
+extern "C" fn Schannel::server_endpoint_channel_binding(
+  ch : Schannel,
+) -> Bytes? = "moonbitlang_async_schannel_server_endpoint_channel_binding"
+
+///|
+#cfg(platform="windows")
 pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
   let result = self.context.get_peer_certificate()
   if result is None {
@@ -471,6 +483,38 @@ pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
     }
   }
   result
+}
+
+///|
+#cfg(platform="windows")
+pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
+  match self.context.unique_channel_binding() {
+    Some(binding) => binding
+    None => {
+      let errno = @os_error.get_errno()
+      if errno != 0 {
+        raise TlsError(@os_error.errno_to_string(errno))
+      } else {
+        raise TlsError("tls-unique channel binding unavailable")
+      }
+    }
+  }
+}
+
+///|
+#cfg(platform="windows")
+pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
+  match self.context.server_endpoint_channel_binding() {
+    Some(binding) => binding
+    None => {
+      let errno = @os_error.get_errno()
+      if errno != 0 {
+        raise TlsError(@os_error.errno_to_string(errno))
+      } else {
+        raise TlsError("tls-server-endpoint channel binding unavailable")
+      }
+    }
+  }
 }
 
 ///|


### PR DESCRIPTION
This PR add native TLS channel binding support to `moonbitlang/async/tls`. The two most common channel binding type, `tls-unique` and `tls-server-endpoint`, are supported.

- For OpenSSL, `tls-unique` is implemented via `SSL_get_finished`/`SSL_get_peer_finished`. There is no native API for `tls-server-endpoint`, so manual hashing is performed according to RFC 5929
- For schannel, both kinds of channel binding are natively supported via `QueryContextAttributes`