### PR TITLE
add zone suffix/scope id support for IPv6 address

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -88,7 +88,10 @@ priv struct EventLoopHook {
 let hooks : Array[EventLoopHook] = []
 
 ///|
-fn register_hook(init? : () -> Unit raise, exit? : () -> Unit raise) -> Unit {
+pub fn register_hook(
+  init? : () -> Unit raise,
+  exit? : () -> Unit raise,
+) -> Unit {
   hooks.push({ init, exit })
 }
 

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -45,6 +45,8 @@ pub async fn readdir(Int, FixedArray[Byte], Int, context~ : String) -> Int
 
 pub async fn realpath(StringView, context~ : String) -> String
 
+pub fn register_hook(init? : () -> Unit raise, exit? : () -> Unit raise) -> Unit
+
 pub async fn remove(StringView, context~ : String) -> Unit
 
 pub async fn rename(StringView, StringView, replace~ : Bool, context~ : String) -> Unit

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -31,7 +31,11 @@ extern "C" fn Addr::empty(family : AddrFamily) -> Addr = "moonbitlang_async_make
 
 ///|
 #borrow(ip)
-extern "C" fn Addr::new_ipv6(ip : FixedArray[Byte], port : Int) -> Addr = "moonbitlang_async_make_ipv6_addr"
+extern "C" fn Addr::new_ipv6(
+  ip : FixedArray[Byte],
+  port : Int,
+  scope_id~ : UInt,
+) -> Addr = "moonbitlang_async_make_ipv6_addr"
 
 ///|
 #borrow(addr)
@@ -60,6 +64,10 @@ extern "C" fn Addr::get_ipv6_bytes(addr : Addr) -> @c_buffer.Buffer = "moonbitla
 
 ///|
 #borrow(addr)
+extern "C" fn Addr::scope_id(addr : Addr) -> UInt = "moonbitlang_async_addr_get_ipv6_scope_id"
+
+///|
+#borrow(addr)
 extern "C" fn Addr::is_ipv6_wildcard(addr : Addr) -> Bool = "moonbitlang_async_addr_is_ipv6_wildcard"
 
 ///|
@@ -68,6 +76,13 @@ pub impl Show for Addr with output(self, logger) {
     // IPv6 address format
     logger.write_char('[')
     write_ipv6_str(self.get_ipv6_bytes(), logger)
+    let scope_id = self.scope_id()
+    if scope_id > 0 {
+      let interface = if_indextoname(scope_id, context="") catch {
+        _ => scope_id.to_string()
+      }
+      logger..write_char('%').write_string(interface)
+    }
     logger..write_char(']')..write_char(':').write_object(self.port())
   } else {
     // IPv4 address format
@@ -92,10 +107,19 @@ pub suberror InvalidAddr derive(Debug, ToJson)
 ///|
 /// Parse a string into IPv4 or IPv6 address, format should be `ip:port` for IPv4 or `[ip]:port` for IPv6
 // TODO: faster implementation
-pub fn Addr::parse(src : String) -> Addr raise InvalidAddr {
+pub fn Addr::parse(src : String) -> Addr raise {
   if src.has_prefix("[") {
-    let (ip_bytes, port, _, _) = try_parse_ipv6(src)
-    Addr::new_ipv6(ip_bytes, port)
+    let (ip_bytes, port, interface) = try_parse_ipv6(src)
+    let scope_id = if interface is Some(interface) {
+      try @string.parse_uint(interface) catch {
+        _ => if_nametoindex(interface, context="@socket.Addr::parse()")
+      } noraise {
+        index => index
+      }
+    } else {
+      0
+    }
+    Addr::new_ipv6(ip_bytes, port, scope_id~)
   } else {
     // IPv4 format: ip:port
     let (ip, port) = try_parse_ipv4(src) catch { _ => raise InvalidAddr }

--- a/src/socket/addr_test.mbt
+++ b/src/socket/addr_test.mbt
@@ -54,6 +54,14 @@ test "Parse IPv6 address" {
     "[::1]:8080",
   )
   assert_eq(@socket.Addr::parse("[::1]:8080").to_string(), "[::1]:8080")
+  assert_eq(
+    @socket.Addr::parse("[::1%\{localhost_interface}]:8080").to_string(),
+    "[::1%\{localhost_interface}]:8080",
+  )
+  assert_eq(
+    @socket.Addr::parse("[::1%\{localhost_index}]:8080").to_string(),
+    "[::1%\{localhost_interface}]:8080",
+  )
 }
 
 ///|

--- a/src/socket/addr_utils.mbt
+++ b/src/socket/addr_utils.mbt
@@ -15,7 +15,7 @@
 ///|
 fn try_parse_ipv6(
   input : String,
-) -> (FixedArray[Byte], Int, Int, Int) raise InvalidAddr {
+) -> (FixedArray[Byte], Int, String?) raise InvalidAddr {
   // Make sure the format is [addr]:port
   guard input.has_prefix("[") else {
     // IPv6 address must start with '['
@@ -39,10 +39,21 @@ fn try_parse_ipv6(
   let ip_str = input[1:bracket_end]
   let port_str = remaining[1:]
 
+  // Extract optional zone suffix
+  let (ip_str, interface) = if ip_str.find("%") is Some(ip_end) {
+    let interface = ip_str[ip_end + 1:]
+    guard interface.length() > 0 else { raise InvalidAddr }
+    (ip_str[:ip_end], Some(interface.to_owned()))
+  } else {
+    (ip_str, None)
+  }
+
   // Parse the IPv6 address into a byte array
   let ip_bytes = parse_ipv6_to_bytes(ip_str)
+
   let port = parse_port(port_str)
-  (ip_bytes, port, 0, 0)
+
+  (ip_bytes, port, interface)
 }
 
 ///|

--- a/src/socket/ifname.mbt
+++ b/src/socket/ifname.mbt
@@ -1,0 +1,85 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+let global_ifname_socket : Ref[@fd_util.Fd] = {
+  let context = "creating global socket object for interface name lookup"
+  let sock = Ref(
+    if @event_loop.platform is Linux {
+      make_udp_socket(IPv4, context~) catch {
+        err => abort(err.to_string())
+      }
+    } else {
+      @fd_util.invalid_fd
+    },
+  )
+  @event_loop.register_hook(
+    init=() => {
+      // In some tests there may be multiple event loops spawned in a single program run,
+      // ensure the global socket object is valid after the last event loop disposed it
+      if @event_loop.platform is Linux && !@fd_util.fd_is_valid(sock.val) {
+        sock.val = make_udp_socket(IPv4, context~)
+      }
+    },
+    exit=() => {
+      guard @fd_util.fd_is_valid(sock.val) else {  }
+      defer {
+        sock.val = @fd_util.invalid_fd
+      }
+      @fd_util.close(
+        sock.val,
+        kind=Socket,
+        context="closing global socket object for interface name lookup",
+      )
+    },
+  )
+  sock
+}
+
+///|
+#borrow(name)
+extern "C" fn if_nametoindex_ffi(
+  global_sock : @fd_util.Fd,
+  name : @os_string.OsString,
+) -> UInt = "moonbitlang_async_if_nametoindex"
+
+///|
+extern "C" fn if_indextoname_ffi(
+  global_sock : @fd_util.Fd,
+  index : UInt,
+) -> @os_string.OsString? = "moonbitlang_async_if_indextoname"
+
+///|
+#doc(hidden)
+#internal(internal, "for internal use only")
+pub fn if_nametoindex(name : StringView, context~ : String) -> UInt raise {
+  let os_name = @os_string.encode(name)
+  let index = if_nametoindex_ffi(global_ifname_socket.val, os_name)
+  if index is 0 {
+    @os_error.check_errno("\{context}: if_nametoindex(\{name.escape()})")
+  }
+  index
+}
+
+///|
+#doc(hidden)
+#internal(internal, "for internal use only")
+pub fn if_indextoname(index : UInt, context~ : String) -> String raise {
+  let name = if_indextoname_ffi(global_ifname_socket.val, index)
+  guard name is Some(os_name) else {
+    @os_error.check_errno("\{context}: if_indextoname(\{index})")
+    panic()
+  }
+  os_name.to_string()
+}

--- a/src/socket/interface_util_for_test.mbt
+++ b/src/socket/interface_util_for_test.mbt
@@ -13,15 +13,21 @@
 // limitations under the License.
 
 ///|
-/// This package currently does not support JavaScript backend
-#cfg(not(target="native"))
-#coverage.skip
-pub let unimplemented : Unit = {
-  ignore(@io.pipe)
-  ignore(@event_loop.Timer::new)
-  ignore(@async.sleep)
-  ignore(@os_error.unimplemented)
-  ignore(@fd_util.unimplemented)
-  ignore(@c_buffer.unimplemented)
-  ignore(@os_string.unimplemented)
+extern "C" fn find_ipv6_localhost() -> UInt = "moonbitlang_async_find_ipv6_localhost"
+
+///|
+let localhost_index : UInt = {
+  let index = find_ipv6_localhost()
+  if index is 0 {
+    abort("cannot find localhost adaptor, or localhost does not support IPv6")
+  }
+  index
+}
+
+///|
+let localhost_interface : String = @socket.if_indextoname(
+  localhost_index,
+  context="fetch name of localhost adaptor",
+) catch {
+  err => abort(err.to_string())
 }

--- a/src/socket/moon.pkg
+++ b/src/socket/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/async/internal/c_buffer",
   "moonbitlang/async/io",
   "moonbitlang/async",
+  "moonbitlang/async/internal/os_string",
 }
 
 import {
@@ -25,6 +26,8 @@ options(
     "ffi.mbt": [ "native" ],
     "getsockname_test.mbt": [ "native" ],
     "happy_eyeball.mbt": [ "native" ],
+    "ifname.mbt": [ "native" ],
+    "interface_util_for_test.mbt": [ "native" ],
     "read_exactly_test.mbt": [ "native" ],
     "resolve_host_test.mbt": [ "native" ],
     "reuse_addr_test.mbt": [ "native" ],

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -24,7 +24,7 @@ type Addr derive(Compare, Eq, Hash)
 pub fn Addr::ip(Self) -> UInt
 pub fn Addr::is_ipv6(Self) -> Bool
 pub fn Addr::new(UInt, Int) -> Self
-pub fn Addr::parse(String) -> Self raise InvalidAddr
+pub fn Addr::parse(String) -> Self raise
 pub fn Addr::port(Self) -> Int
 pub async fn Addr::resolve(String, port~ : Int, protocol? : IpProtocolPreference) -> Self
 pub impl Show for Addr

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -22,10 +22,13 @@
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <iphlpapi.h>
 #include <windows.h>
 
 #define setsockopt(sock, level, opt, optval, len)\
   setsockopt((SOCKET)sock, level, opt, (const char*)(optval), len)
+
+#pragma comment(lib, "Iphlpapi.lib")
 
 #else
 
@@ -36,6 +39,13 @@
 #include <netdb.h>
 #include <stdio.h>
 #include <fcntl.h>
+#include <net/if.h>
+#include <ifaddrs.h>
+#include <errno.h>
+
+#ifdef __linux__
+#include <sys/ioctl.h>
+#endif
 
 typedef int HANDLE;
 typedef int SOCKET;
@@ -265,7 +275,7 @@ void *moonbitlang_async_make_empty_addr(int family) {
 }
 
 MOONBIT_FFI_EXPORT
-void *moonbitlang_async_make_ipv6_addr(uint8_t *ip, int port) {
+void *moonbitlang_async_make_ipv6_addr(uint8_t *ip, int port, uint32_t scope_id) {
   // For IPv6, create sockaddr_in6 structure directly
   struct sockaddr_in6 *addr = (struct sockaddr_in6*)moonbit_make_bytes(
     sizeof(struct sockaddr_in6),
@@ -275,7 +285,7 @@ void *moonbitlang_async_make_ipv6_addr(uint8_t *ip, int port) {
   addr->sin6_flowinfo = 0;
   addr->sin6_port = htons(port);
   memcpy(&addr->sin6_addr, ip, 16);
-  addr->sin6_scope_id = 0;
+  addr->sin6_scope_id = scope_id;
   return addr;
 }
 
@@ -300,6 +310,10 @@ int32_t moonbitlang_async_addr_is_ipv6(void *addr_bytes) {
 MOONBIT_FFI_EXPORT
 uint8_t *moonbitlang_async_addr_get_ipv6_bytes(struct sockaddr_in6 *addr) {
   return addr->sin6_addr.s6_addr;
+}
+MOONBIT_FFI_EXPORT
+uint32_t moonbitlang_async_addr_get_ipv6_scope_id(struct sockaddr_in6 *addr) {
+  return addr->sin6_scope_id;
 }
 
 MOONBIT_FFI_EXPORT
@@ -372,4 +386,171 @@ MOONBIT_FFI_EXPORT
 int moonbitlang_async_getpeername(HANDLE sock, struct sockaddr *addr_out) {
   socklen_t len = Moonbit_array_length(addr_out);
   return getpeername((SOCKET)sock, addr_out, &len);
+}
+
+MOONBIT_FFI_EXPORT
+uint32_t moonbitlang_async_if_nametoindex(HANDLE sock, const char *name) {
+#ifdef _WIN32
+
+  NET_LUID luid;
+  int err = ConvertInterfaceAliasToLuid((const WCHAR*)name, &luid);
+  if (err) {
+    SetLastError(err);
+    return 0;
+  }
+
+  NET_IFINDEX index;
+  err = ConvertInterfaceLuidToIndex(&luid, &index);
+  if (err) {
+    SetLastError(err);
+    return 0;
+  }
+
+  return index;
+
+#elif defined(__linux__)
+
+  int name_len = Moonbit_array_length(name);
+  if (name_len >= IFNAMSIZ) {
+    errno = ENAMETOOLONG;
+    return 0;
+  }
+
+  struct ifreq ifreq;
+  // also copy the null terminator
+  memcpy(ifreq.ifr_name, name, name_len + 1);
+
+  if (ioctl(sock, SIOCGIFINDEX, &ifreq) < 0)
+    return 0;
+
+  return ifreq.ifr_ifindex;
+
+#else
+
+  return if_nametoindex(name);
+
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+void *moonbitlang_async_if_indextoname(HANDLE sock, uint32_t index) {
+#ifdef _WIN32
+
+  WCHAR buf[NDIS_IF_MAX_STRING_SIZE + 1];
+  NET_LUID luid;
+
+  int err = ConvertInterfaceIndexToLuid(index, &luid);
+  if (err) {
+    SetLastError(err);
+    return 0;
+  }
+
+  err = ConvertInterfaceLuidToAlias(&luid, buf, NDIS_IF_MAX_STRING_SIZE + 1);
+  if (err) {
+    SetLastError(err);
+    return 0;
+  }
+
+  int len = wcslen(buf);
+  moonbit_string_t str = moonbit_make_string_raw(len);
+  memcpy(str, buf, len * sizeof(WCHAR));
+
+  return str;
+
+#elif defined(__linux__)
+
+  struct ifreq ifreq;
+  ifreq.ifr_ifindex = index;
+
+  if (ioctl(sock, SIOCGIFNAME, &ifreq) < 0)
+    return 0;
+
+  int len = strlen(ifreq.ifr_name);
+  moonbit_bytes_t str = moonbit_make_bytes_raw(len);
+  memcpy(str, ifreq.ifr_name, len);
+
+  return str;
+
+#else
+
+  char buf[IF_NAMESIZE];
+  if (!if_indextoname(index, buf))
+    return 0;
+
+  int len = strlen(buf);
+  moonbit_bytes_t str = moonbit_make_bytes_raw(len);
+  memcpy(str, buf, len);
+
+  return str;
+
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_find_ipv6_localhost() {
+#ifdef _WIN32
+  ULONG flags =
+    GAA_FLAG_SKIP_ANYCAST |
+    GAA_FLAG_SKIP_MULTICAST |
+    GAA_FLAG_SKIP_DNS_SERVER;
+  ULONG buf_len = 16 * 1024;
+  IP_ADAPTER_ADDRESSES *addrs = 0;
+  ULONG err = ERROR_BUFFER_OVERFLOW;
+
+  for (int i = 0; i < 3 && err == ERROR_BUFFER_OVERFLOW; i++) {
+    if (addrs != 0) {
+      HeapFree(GetProcessHeap(), 0, addrs);
+      addrs = 0;
+    }
+    addrs = (IP_ADAPTER_ADDRESSES*)HeapAlloc(GetProcessHeap(), 0, buf_len);
+    if (addrs == 0) {
+      return 0;
+    }
+    err = GetAdaptersAddresses(AF_INET6, flags, NULL, addrs, &buf_len);
+  }
+
+  if (err != NO_ERROR) {
+    if (addrs != 0) {
+      HeapFree(GetProcessHeap(), 0, addrs);
+    }
+    return 0;
+  }
+
+  int32_t result = 0;
+  for (IP_ADAPTER_ADDRESSES *adapter = addrs; adapter; adapter = adapter->Next) {
+    if (adapter->OperStatus != IfOperStatusUp) continue;
+    if (adapter->IfType != IF_TYPE_SOFTWARE_LOOPBACK) continue;
+    if (adapter->Ipv6IfIndex == 0) continue;
+    if (adapter->Flags & IP_ADAPTER_NO_MULTICAST) continue;
+
+    result = adapter->Ipv6IfIndex;
+    break;
+  }
+
+  HeapFree(GetProcessHeap(), 0, addrs);
+  return result;
+
+#else
+
+  int32_t result = 0;
+  struct ifaddrs *ifs0 = 0;
+  if (getifaddrs(&ifs0) < 0)
+    return 0;
+
+  for (struct ifaddrs *ifs = ifs0; ifs; ifs = ifs->ifa_next) {
+    if (
+      ifs->ifa_addr
+      && ifs->ifa_addr->sa_family == AF_INET6
+      && (ifs->ifa_flags & IFF_LOOPBACK)
+      && (ifs->ifa_flags & IFF_UP)
+      && (ifs->ifa_flags & IFF_RUNNING)
+    ) {
+      result = if_nametoindex(ifs->ifa_name);
+      if (result) break;
+    }
+  }
+  freeifaddrs(ifs0);
+  return result;
+
+#endif
 }


### PR DESCRIPTION
This PR adds zone suffix/scope id support for IPv6 address:

- `@socket.Addr::parse` now accept IPv6 address with zone suffix such as `[::1%lo]:8080`. The zone suffix can either be a non-negative decimal integer, in this case it is passed as-is via `sin6_scope_id` to the OS without validation. Otherwise, the zone name will be treated as a network adapter name and get passed to `if_nametoindex` or alternative API to obtain the interface index of the NIC
    - if the name does not exist, `@socket.Addr::parse` will now fail with the specific OS error, so it may now raise arbitrary error instead of just `InvalidAddr`. This is kinda a breaking change?
- if the `scope_id` part of an IPv6 address is non-zero, `@socket.Addr::to_string` will first try to convert it to a human-readable name using `if_indextoname` or similar. If the conversion failed, the raw scope ID is displayed as-is (because `Show` implementations are not allowed to raise error, it is also possible that the NIC is already gone or something)