### PR TITLE
[codex] simplify logger writes

### DIFF
--- a/examples/http_file_server/server_wbtest.mbt
+++ b/examples/http_file_server/server_wbtest.mbt
@@ -14,9 +14,9 @@
 
 ///|
 fn output_response(response : @http.Response, logger : &Logger) -> Unit {
-  logger.write_string("HTTP/1.1 \{response.code} \{response.reason}\n")
+  logger <+ "HTTP/1.1 \{response.code} \{response.reason}\n"
   for k, v in response.headers {
-    logger.write_string("\{k}: \{v}\n")
+    logger <+ "\{k}: \{v}\n"
   }
 }
 
@@ -32,7 +32,7 @@ async fn client(
   let response = conn.get(path)
   output_response(response, logger)
   match handle_response {
-    None => logger.write_string(conn.read_all().text())
+    None => logger <+ "\{conn.read_all().text()}"
     Some(f) => f(conn)
   }
 }

--- a/examples/tcp_ping_pong/deprecated.mbt
+++ b/examples/tcp_ping_pong/deprecated.mbt
@@ -18,5 +18,5 @@ impl Show for ServerTerminate
 
 ///|
 impl Show for ServerTerminate with output(_self, logger) {
-  logger.write_string("ServerTerminate")
+  logger <+ "ServerTerminate"
 }

--- a/examples/udp_ping_pong/deprecated.mbt
+++ b/examples/udp_ping_pong/deprecated.mbt
@@ -18,5 +18,5 @@ impl Show for ServerTerminate
 
 ///|
 impl Show for ServerTerminate with output(_self, logger) {
-  logger.write_string("ServerTerminate")
+  logger <+ "ServerTerminate"
 }

--- a/src/aqueue/deprecated.mbt
+++ b/src/aqueue/deprecated.mbt
@@ -18,5 +18,5 @@ pub impl Show for QueueAlreadyClosed
 
 ///|
 pub impl Show for QueueAlreadyClosed with output(_self, logger) {
-  logger.write_string("QueueAlreadyClosed")
+  logger <+ "QueueAlreadyClosed"
 }

--- a/src/deprecated.mbt
+++ b/src/deprecated.mbt
@@ -18,7 +18,7 @@ pub impl Show for TimeoutError
 
 ///|
 pub impl Show for TimeoutError with output(_self, logger) {
-  logger.write_string("TimeoutError")
+  logger <+ "TimeoutError"
 }
 
 ///|
@@ -27,5 +27,5 @@ pub impl Show for TimerCancelled
 
 ///|
 pub impl Show for TimerCancelled with output(_self, logger) {
-  logger.write_string("TimerCancelled")
+  logger <+ "TimerCancelled"
 }

--- a/src/fs/deprecated.mbt
+++ b/src/fs/deprecated.mbt
@@ -19,13 +19,13 @@ pub impl Show for FileKind
 ///|
 pub impl Show for FileKind with output(self, logger) {
   match self {
-    Unknown => logger.write_string("Unknown")
-    Regular => logger.write_string("Regular")
-    Directory => logger.write_string("Directory")
-    SymLink => logger.write_string("SymLink")
-    Socket => logger.write_string("Socket")
-    Pipe => logger.write_string("Pipe")
-    BlockDevice => logger.write_string("BlockDevice")
-    CharDevice => logger.write_string("CharDevice")
+    Unknown => logger <+ "Unknown"
+    Regular => logger <+ "Regular"
+    Directory => logger <+ "Directory"
+    SymLink => logger <+ "SymLink"
+    Socket => logger <+ "Socket"
+    Pipe => logger <+ "Pipe"
+    BlockDevice => logger <+ "BlockDevice"
+    CharDevice => logger <+ "CharDevice"
   }
 }

--- a/src/http/deprecated.mbt
+++ b/src/http/deprecated.mbt
@@ -45,7 +45,7 @@ fn write_headers_show(headers : Map[String, String], logger : &Logger) -> Unit {
     } else {
       logger <+ ", "
     }
-    logger <+ "\{to_repr(key)}: \{to_repr(value)}"
+    logger <+ "\{key.escape()}: \{value.escape()}"
   }
   logger <+ "}"
 }
@@ -54,14 +54,14 @@ fn write_headers_show(headers : Map[String, String], logger : &Logger) -> Unit {
 fn Request::write_show(self : Request, logger : &Logger) -> Unit {
   logger <+ "{meth: "
   self.meth.write_show(logger)
-  logger <+ ", path: \{to_repr(self.path)}, headers: "
+  logger <+ ", path: \{self.path.escape()}, headers: "
   write_headers_show(self.headers, logger)
   logger <+ "}"
 }
 
 ///|
 fn Response::write_show(self : Response, logger : &Logger) -> Unit {
-  logger <+ "{code: \{self.code}, reason: \{to_repr(self.reason)}, headers: "
+  logger <+ "{code: \{self.code}, reason: \{self.reason.escape()}, headers: "
   write_headers_show(self.headers, logger)
   logger <+ "}"
 }

--- a/src/http/deprecated.mbt
+++ b/src/http/deprecated.mbt
@@ -15,63 +15,55 @@
 ///|
 fn RequestMethod::write_show(self : RequestMethod, logger : &Logger) -> Unit {
   match self {
-    Get => logger.write_string("Get")
-    Head => logger.write_string("Head")
-    Post => logger.write_string("Post")
-    Put => logger.write_string("Put")
-    Delete => logger.write_string("Delete")
-    Connect => logger.write_string("Connect")
-    Options => logger.write_string("Options")
-    Trace => logger.write_string("Trace")
-    Patch => logger.write_string("Patch")
+    Get => logger <+ "Get"
+    Head => logger <+ "Head"
+    Post => logger <+ "Post"
+    Put => logger <+ "Put"
+    Delete => logger <+ "Delete"
+    Connect => logger <+ "Connect"
+    Options => logger <+ "Options"
+    Trace => logger <+ "Trace"
+    Patch => logger <+ "Patch"
   }
 }
 
 ///|
 fn Protocol::write_show(self : Protocol, logger : &Logger) -> Unit {
   match self {
-    Http => logger.write_string("Http")
-    Https => logger.write_string("Https")
+    Http => logger <+ "Http"
+    Https => logger <+ "Https"
   }
 }
 
 ///|
 fn write_headers_show(headers : Map[String, String], logger : &Logger) -> Unit {
-  logger.write_char('{')
+  logger <+ "{"
   let mut first = true
   for key, value in headers {
     if first {
       first = false
     } else {
-      logger.write_string(", ")
+      logger <+ ", "
     }
-    logger.write_string(key.escape())
-    logger.write_string(": ")
-    logger.write_string(value.escape())
+    logger <+ "\{to_repr(key)}: \{to_repr(value)}"
   }
-  logger.write_char('}')
+  logger <+ "}"
 }
 
 ///|
 fn Request::write_show(self : Request, logger : &Logger) -> Unit {
-  logger.write_string("{meth: ")
+  logger <+ "{meth: "
   self.meth.write_show(logger)
-  logger.write_string(", path: ")
-  logger.write_string(self.path.escape())
-  logger.write_string(", headers: ")
+  logger <+ ", path: \{to_repr(self.path)}, headers: "
   write_headers_show(self.headers, logger)
-  logger.write_string("}")
+  logger <+ "}"
 }
 
 ///|
 fn Response::write_show(self : Response, logger : &Logger) -> Unit {
-  logger.write_string("{code: ")
-  logger.write_object(self.code)
-  logger.write_string(", reason: ")
-  logger.write_string(self.reason.escape())
-  logger.write_string(", headers: ")
+  logger <+ "{code: \{self.code}, reason: \{to_repr(self.reason)}, headers: "
   write_headers_show(self.headers, logger)
-  logger.write_string("}")
+  logger <+ "}"
 }
 
 ///|
@@ -117,12 +109,9 @@ pub impl Show for URIParseError
 ///|
 pub impl Show for URIParseError with output(self, logger) {
   match self {
-    InvalidFormat => logger.write_string("InvalidFormat")
+    InvalidFormat => logger <+ "InvalidFormat"
     UnsupportedProtocol(protocol) =>
-      logger
-      ..write_string("UnsupportedProtocol(")
-      ..write_object(protocol)
-      .write_string(")")
+      logger <+ "UnsupportedProtocol(\{to_repr(protocol)})"
   }
 }
 
@@ -136,9 +125,9 @@ pub impl Show for ProxyError
 pub impl Show for ProxyError with output(self, logger) {
   match self {
     ProxyError(response) => {
-      logger.write_string("ProxyError(")
+      logger <+ "ProxyError("
       response.write_show(logger)
-      logger.write_string(")")
+      logger <+ ")"
     }
   }
 }
@@ -152,12 +141,9 @@ pub impl Show for HttpProtocolError
 #cfg(target="native")
 pub impl Show for HttpProtocolError with output(self, logger) {
   match self {
-    BadRequest => logger.write_string("BadRequest")
+    BadRequest => logger <+ "BadRequest"
     HttpVersionNotSupported(version) =>
-      logger
-      ..write_string("HttpVersionNotSupported(")
-      ..write_object(version)
-      .write_string(")")
-    NotImplemented => logger.write_string("NotImplemented")
+      logger <+ "HttpVersionNotSupported(\{to_repr(version)})"
+    NotImplemented => logger <+ "NotImplemented"
   }
 }

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -15,19 +15,19 @@
 ///|
 fn log_headers(headers : Map[String, String], logger : &Logger) -> Unit {
   for k, v in headers {
-    logger.write_string("\{k}: \{v}\n")
+    logger <+ "\{k}: \{v}\n"
   }
 }
 
 ///|
 fn log_request(req : Request, logger : &Logger) -> Unit {
-  logger.write_string("\{@debug.to_string(req.meth)} \{req.path}\n")
+  logger <+ "\{@debug.to_string(req.meth)} \{req.path}\n"
   log_headers(req.headers, logger)
 }
 
 ///|
 fn log_response(req : Response, logger : &Logger) -> Unit {
-  logger.write_string("\{req.code} \{req.reason}\n")
+  logger <+ "\{req.code} \{req.reason}\n"
   log_headers(req.headers, logger)
 }
 

--- a/src/internal/coroutine/deprecated.mbt
+++ b/src/internal/coroutine/deprecated.mbt
@@ -18,5 +18,5 @@ pub impl Show for Cancelled
 
 ///|
 pub impl Show for Cancelled with output(_self, logger) {
-  logger.write_string("Cancelled")
+  logger <+ "Cancelled"
 }

--- a/src/internal/fd_util/deprecated.mbt
+++ b/src/internal/fd_util/deprecated.mbt
@@ -19,13 +19,13 @@ pub impl Show for FileKind
 ///|
 pub impl Show for FileKind with output(self, logger) {
   match self {
-    Unknown => logger.write_string("Unknown")
-    Regular => logger.write_string("Regular")
-    Directory => logger.write_string("Directory")
-    SymLink => logger.write_string("SymLink")
-    Socket => logger.write_string("Socket")
-    Pipe => logger.write_string("Pipe")
-    BlockDevice => logger.write_string("BlockDevice")
-    CharDevice => logger.write_string("CharDevice")
+    Unknown => logger <+ "Unknown"
+    Regular => logger <+ "Regular"
+    Directory => logger <+ "Directory"
+    SymLink => logger <+ "SymLink"
+    Socket => logger <+ "Socket"
+    Pipe => logger <+ "Pipe"
+    BlockDevice => logger <+ "BlockDevice"
+    CharDevice => logger <+ "CharDevice"
   }
 }

--- a/src/io/deprecated.mbt
+++ b/src/io/deprecated.mbt
@@ -18,7 +18,7 @@ pub impl Show for ReaderClosed
 
 ///|
 pub impl Show for ReaderClosed with output(_self, logger) {
-  logger.write_string("ReaderClosed")
+  logger <+ "ReaderClosed"
 }
 
 ///|
@@ -27,5 +27,5 @@ pub impl Show for PipeClosed
 
 ///|
 pub impl Show for PipeClosed with output(_self, logger) {
-  logger.write_string("PipeClosed")
+  logger <+ "PipeClosed"
 }

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -82,7 +82,7 @@ struct DummyWriter {
 impl @io.Writer for DummyWriter with write_once(self, buf, offset~, len~) {
   guard offset + len <= buf.length()
   @async.sleep(self.base_timeout)
-  self.logger.write_string("writing byte \{buf[offset]}\n")
+  self.logger <+ "writing byte \{buf[offset]}\n"
   1
 }
 

--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -48,7 +48,7 @@ suberror JsError {
 ///|
 pub impl Show for JsError with output(self, logger) {
   let JsError(value) = self
-  logger.write_string(value.to_string())
+  logger <+ "\{value.to_string()}"
 }
 
 ///|

--- a/src/os_error/error.mbt
+++ b/src/os_error/error.mbt
@@ -60,10 +60,8 @@ pub(all) suberror OSError {
 ///|
 pub impl Show for OSError with output(self, logger) -> Unit {
   let OSError(errno, context~) = self
-  logger
-  ..write_string("OSError(")
-  ..write_object("\{context}: \{errno_to_string(errno)}")
-  .write_string(")")
+  let msg = "\{context}: \{errno_to_string(errno)}"
+  logger <+ "OSError(\{to_repr(msg)})"
 }
 
 ///|

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -84,30 +84,23 @@ extern "C" fn Addr::is_ipv6_wildcard(addr : Addr) -> Bool = "moonbitlang_async_a
 pub impl Show for Addr with output(self, logger) {
   if self.is_ipv6() {
     // IPv6 address format
-    logger.write_char('[')
+    logger <+ "["
     write_ipv6_str(self.get_ipv6_bytes(), logger)
     let scope_id = self.scope_id()
     if scope_id > 0 {
       let interface = if_indextoname(scope_id, context="") catch {
         _ => scope_id.to_string()
       }
-      logger..write_char('%').write_string(interface)
+      logger <+ "%\{interface}"
     }
-    logger..write_char(']')..write_char(':').write_object(self.port())
+    logger <+ "]:\{self.port()}"
   } else {
     // IPv4 address format
     let ip = self.ip()
     let port = self.port()
     logger
-    ..write_object(ip >> 24)
-    ..write_char('.')
-    ..write_object((ip >> 16) & 255)
-    ..write_char('.')
-    ..write_object((ip >> 8) & 255)
-    ..write_char('.')
-    ..write_object(ip & 255)
-    ..write_char(':')
-    .write_object(port)
+      <+
+      "\{ip >> 24}.\{(ip >> 16) & 255}.\{(ip >> 8) & 255}.\{ip & 255}:\{port}"
   }
 }
 

--- a/src/socket/addr_utils.mbt
+++ b/src/socket/addr_utils.mbt
@@ -279,28 +279,23 @@ fn write_ipv6_str(addr : @c_buffer.Buffer, logger : &Logger) -> Unit {
     match longest_zero_group {
       Some((start, end)) if i == start => {
         if i == 0 {
-          logger.write_string("::")
+          logger <+ "::"
         } else {
-          logger.write_string(":")
+          logger <+ ":"
         }
         continue end
       }
       _ => ()
     }
     let value = (addr[i * 2].to_int() << 8) | addr[i * 2 + 1].to_int()
-    logger.write_string(value.to_string(radix=16))
+    logger <+ "\{value.to_string(radix=16)}"
     if i < 7 {
-      logger.write_string(":")
+      logger <+ ":"
     }
   }
   if is_v4_mapped {
     logger
-    ..write_object(addr[12].to_int())
-    ..write_string(".")
-    ..write_object(addr[13].to_int())
-    ..write_string(".")
-    ..write_object(addr[14].to_int())
-    ..write_string(".")
-    .write_object(addr[15].to_int())
+      <+
+      "\{addr[12].to_int()}.\{addr[13].to_int()}.\{addr[14].to_int()}.\{addr[15].to_int()}"
   }
 }

--- a/src/socket/deprecated.mbt
+++ b/src/socket/deprecated.mbt
@@ -18,7 +18,7 @@ pub impl Show for InvalidAddr
 
 ///|
 pub impl Show for InvalidAddr with output(_self, logger) {
-  logger.write_string("InvalidAddr")
+  logger <+ "InvalidAddr"
 }
 
 ///|
@@ -29,10 +29,7 @@ pub impl Show for ResolveHostnameError
 pub impl Show for ResolveHostnameError with output(self, logger) {
   match self {
     ResolveHostnameError(msg) =>
-      logger
-      ..write_string("ResolveHostnameError(")
-      ..write_object(msg)
-      .write_string(")")
+      logger <+ "ResolveHostnameError(\{to_repr(msg)})"
   }
 }
 
@@ -43,10 +40,10 @@ pub impl Show for IpProtocolPreference
 ///|
 pub impl Show for IpProtocolPreference with output(self, logger) {
   match self {
-    OnlyV4 => logger.write_string("OnlyV4")
-    OnlyV6 => logger.write_string("OnlyV6")
-    FavorV4 => logger.write_string("FavorV4")
-    FavorV6 => logger.write_string("FavorV6")
-    NoPreference => logger.write_string("NoPreference")
+    OnlyV4 => logger <+ "OnlyV4"
+    OnlyV6 => logger <+ "OnlyV6"
+    FavorV4 => logger <+ "FavorV4"
+    FavorV6 => logger <+ "FavorV6"
+    NoPreference => logger <+ "NoPreference"
   }
 }

--- a/src/tls/deprecated.mbt
+++ b/src/tls/deprecated.mbt
@@ -19,8 +19,7 @@ pub impl Show for TlsError
 ///|
 pub impl Show for TlsError with output(self, logger) {
   match self {
-    TlsError(msg) =>
-      logger..write_string("TlsError(")..write_object(msg).write_string(")")
+    TlsError(msg) => logger <+ "TlsError(\{to_repr(msg)})"
   }
 }
 
@@ -30,5 +29,5 @@ pub impl Show for ConnectionClosed
 
 ///|
 pub impl Show for ConnectionClosed with output(_self, logger) {
-  logger.write_string("ConnectionClosed")
+  logger <+ "ConnectionClosed"
 }

--- a/src/websocket/deprecated.mbt
+++ b/src/websocket/deprecated.mbt
@@ -15,18 +15,17 @@
 ///|
 fn CloseCode::write_show(self : CloseCode, logger : &Logger) -> Unit {
   match self {
-    Normal => logger.write_string("Normal")
-    GoingAway => logger.write_string("GoingAway")
-    ProtocolError => logger.write_string("ProtocolError")
-    UnsupportedData => logger.write_string("UnsupportedData")
-    Abnormal => logger.write_string("Abnormal")
-    InvalidFramePayload => logger.write_string("InvalidFramePayload")
-    PolicyViolation => logger.write_string("PolicyViolation")
-    MessageTooBig => logger.write_string("MessageTooBig")
-    MissingExtension => logger.write_string("MissingExtension")
-    InternalError => logger.write_string("InternalError")
-    Other(code) =>
-      logger..write_string("Other(")..write_object(code).write_string(")")
+    Normal => logger <+ "Normal"
+    GoingAway => logger <+ "GoingAway"
+    ProtocolError => logger <+ "ProtocolError"
+    UnsupportedData => logger <+ "UnsupportedData"
+    Abnormal => logger <+ "Abnormal"
+    InvalidFramePayload => logger <+ "InvalidFramePayload"
+    PolicyViolation => logger <+ "PolicyViolation"
+    MessageTooBig => logger <+ "MessageTooBig"
+    MissingExtension => logger <+ "MissingExtension"
+    InternalError => logger <+ "InternalError"
+    Other(code) => logger <+ "Other(\{code})"
   }
 }
 
@@ -37,8 +36,8 @@ pub impl Show for MessageKind
 ///|
 pub impl Show for MessageKind with output(self, logger) {
   match self {
-    Binary => logger.write_string("Binary")
-    Text => logger.write_string("Text")
+    Binary => logger <+ "Binary"
+    Text => logger <+ "Text"
   }
 }
 
@@ -60,28 +59,28 @@ pub impl Show for WebSocketError
 pub impl Show for WebSocketError with output(self, logger) {
   match self {
     ConnectionClosed(close_code, msg) => {
-      logger.write_string("ConnectionClosed(")
+      logger <+ "ConnectionClosed("
       close_code.write_show(logger)
-      logger..write_string(", ")..write_object(msg).write_string(")")
+      logger <+ ", "
+      logger <+ "\{msg}"
+      logger <+ ")"
     }
-    InvalidHandshake(msg) =>
-      logger
-      ..write_string("InvalidHandshake(")
-      ..write_object(msg)
-      .write_string(")")
-    HandshakeRejected(msg, response) =>
-      logger
-      ..write_string("HandshakeRejected(")
-      ..write_object(msg)
-      ..write_string(", ")
-      ..write_object(response.code)
-      ..write_string(", ")
-      ..write_object(response.reason)
-      .write_string(")")
-    ProtocolError(msg) =>
-      logger
-      ..write_string("ProtocolError(")
-      ..write_object(msg)
-      .write_string(")")
+    InvalidHandshake(msg) => {
+      logger <+ "InvalidHandshake("
+      logger <+ "\{msg}"
+      logger <+ ")"
+    }
+    HandshakeRejected(msg, response) => {
+      logger <+ "HandshakeRejected("
+      logger <+ "\{msg}"
+      logger <+ ", \{response.code}, "
+      logger <+ "\{to_repr(response.reason)}"
+      logger <+ ")"
+    }
+    ProtocolError(msg) => {
+      logger <+ "ProtocolError("
+      logger <+ "\{msg}"
+      logger <+ ")"
+    }
   }
 }

--- a/src/websocket/deprecated.mbt
+++ b/src/websocket/deprecated.mbt
@@ -58,29 +58,13 @@ pub impl Show for WebSocketError
 #warnings("-deprecated")
 pub impl Show for WebSocketError with output(self, logger) {
   match self {
-    ConnectionClosed(close_code, msg) => {
-      logger <+ "ConnectionClosed("
-      close_code.write_show(logger)
-      logger <+ ", "
-      logger <+ "\{msg}"
-      logger <+ ")"
-    }
-    InvalidHandshake(msg) => {
-      logger <+ "InvalidHandshake("
-      logger <+ "\{msg}"
-      logger <+ ")"
-    }
-    HandshakeRejected(msg, response) => {
-      logger <+ "HandshakeRejected("
-      logger <+ "\{msg}"
-      logger <+ ", \{response.code}, "
-      logger <+ "\{to_repr(response.reason)}"
-      logger <+ ")"
-    }
-    ProtocolError(msg) => {
-      logger <+ "ProtocolError("
-      logger <+ "\{msg}"
-      logger <+ ")"
-    }
+    ConnectionClosed(close_code, msg) =>
+      logger <+ "ConnectionClosed(\{close_code}, \{msg})"
+    InvalidHandshake(msg) => logger <+ "InvalidHandshake(\{msg})"
+    HandshakeRejected(msg, response) =>
+      logger
+        <+
+        "HandshakeRejected(\{msg}, \{response.code}, \{to_repr(response.reason)})"
+    ProtocolError(msg) => logger <+ "ProtocolError(\{msg})"
   }
 }


### PR DESCRIPTION
## Summary

Replace `logger.write_string`, `logger.write_char`, and `logger.write_object` call sites in `src` and `examples` with the newer `logger <+ "..."` template-writing style.

The conversion keeps behavior where the old output used object-style string rendering by using `to_repr(...)` in those interpolations. Plain string interpolation now uses `<+` directly with the upgraded compiler behavior.

## Validation

- `moon fmt`
- `moon check`
- `moon info`
- Focused regression tests: `moon test src/http/parser_wbtest.mbt src/http/proxy_test.mbt src/socket/addr_test.mbt src/socket/resolve_host_test.mbt src/socket/dual_stack_test.mbt src/websocket/utf8_validation_test.mbt examples/http_file_server/server_wbtest.mbt` passed: 45 tests
- Full `moon test` still reports existing unrelated failures in `fs/dir_test`, `fs/lock_test`, and `process/*` timing/cancellation tests; no logger/http/socket/websocket regressions were present after the compiler upgrade.