### PR TITLE
[codex] add ServerConnection write helpers

### DIFF
--- a/examples/http_file_server/main.mbt
+++ b/examples/http_file_server/main.mbt
@@ -20,21 +20,23 @@ async fn serve_directory(
 ) -> Unit {
   let files = dir.read_all()
   files.sort()
+  conn.send_response(200, "OK", extra_headers={ "Content-Type": "text/html" })
   conn
-  ..send_response(200, "OK", extra_headers={ "Content-Type": "text/html" })
-  ..write("<!DOCTYPE html><html><head></head><body>")
-  ..write("<h1>\{path}</h1>\n")
-  ..write("<div style=\"margin: 1em; font-size: 15pt\">")
-  .write("<a href=\"\{path}?download_zip\">download as zip</a><br/><br/>\n")
+    <+
+    $|<!DOCTYPE html><html><head></head><body>
+    $|<h1>\{path}</h1>
+    $|<div style="margin: 1em; font-size: 15pt">
+    $|<a href="\{path}?download_zip">download as zip</a><br/><br/>
   if path[:-1].rev_find("/") is Some(index) {
     let parent : StringView = if index == 0 { "/" } else { path[:index] }
-    conn.write("<a href=\"\{parent}\">..</a><br/><br/>\n")
+    conn <+ "<a href=\"\{parent}\">..</a><br/><br/>\n"
   }
   for file in files {
     let sep = if path is [.., '/'] { "" } else { "/" }
-    conn.write("<a href=\"\{path}\{sep}\{file}\">\{file}</a><br/>\n")
+    conn <+ "<a href=\"\{path}\{sep}\{file}\">\{file}</a><br/>\n"
   }
-  conn..write("</div></body></html>").end_response()
+  conn <+ "</div></body></html>"
+  conn.end_response()
 }
 
 ///|

--- a/examples/http_file_server/server_wbtest.mbt
+++ b/examples/http_file_server/server_wbtest.mbt
@@ -103,9 +103,10 @@ async test "basic" {
       #|HTTP/1.1 200 OK
       #|content-type: text/html
       #|transfer-encoding: chunked
-      #|<!DOCTYPE html><html><head></head><body><h1>/examples/http_file_server</h1>
-      #|<div style="margin: 1em; font-size: 15pt"><a href="/examples/http_file_server?download_zip">download as zip</a><br/><br/>
-      #|<a href="/examples">..</a><br/><br/>
+      #|<!DOCTYPE html><html><head></head><body>
+      #|<h1>/examples/http_file_server</h1>
+      #|<div style="margin: 1em; font-size: 15pt">
+      #|<a href="/examples/http_file_server?download_zip">download as zip</a><br/><br/><a href="/examples">..</a><br/><br/>
       #|<a href="/examples/http_file_server/main.mbt">main.mbt</a><br/>
       #|<a href="/examples/http_file_server/moon.pkg">moon.pkg</a><br/>
       #|<a href="/examples/http_file_server/server_wbtest.mbt">server_wbtest.mbt</a><br/>

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -139,6 +139,8 @@ pub fn ServerConnection::new(@socket.Tcp, headers? : Map[String, String]) -> Sel
 pub async fn ServerConnection::read_request(Self) -> Request
 pub async fn ServerConnection::send_response(Self, Int, String, extra_headers? : Map[String, String], cookies? : Array[Cookie]) -> Unit
 pub async fn ServerConnection::skip_request_body(Self) -> Unit
+pub async fn ServerConnection::write(Self, &@io.Data) -> Unit
+pub async fn ServerConnection::write_string(Self, String) -> Unit
 pub impl @io.Reader for ServerConnection
 pub impl @io.Writer for ServerConnection
 

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -117,6 +117,25 @@ pub impl @io.Writer for ServerConnection with write_once(
 }
 
 ///|
+/// Introduced so that the sugar `writer <+ "hello \{world}"` can work on `ServerConnection`.
+/// Performance will be improved in the future
+pub async fn ServerConnection::write_string(
+  self : ServerConnection,
+  s : String,
+) -> Unit {
+  @io.Writer::write(self, s)
+}
+
+///|
+/// TODO: using = @io.Writer::write in the future do more checking
+pub async fn ServerConnection::write(
+  self : ServerConnection,
+  data : &@io.Data,
+) -> Unit {
+  @io.Writer::write(self, data)
+}
+
+///|
 pub impl @io.Writer for ServerConnection with write_reader(self, reader) {
   guard !(self.sender.mode is SendingHeader)
   self.sender.write_reader(reader)


### PR DESCRIPTION
## Summary

- Add public `ServerConnection::write_string` and `ServerConnection::write` helpers that delegate to the `@io.Writer` implementation.
- Update the HTTP file server example to use the `<+` writing sugar for response body construction.
- Regenerate the HTTP package interface for the new public helpers.

## Validation

- `moon check src/http examples/http_file_server`
