### PR TITLE
[codex] simplify literal logger writes

### DIFF
--- a/examples/http_file_server/server_wbtest.mbt
+++ b/examples/http_file_server/server_wbtest.mbt
@@ -49,12 +49,12 @@ async test "basic" {
     let addr = server.addr
     root.spawn_bg(no_wait=true, () => server_main(server, path=".", log~))
     @async.sleep(50)
-    client_log.write_string("client: GET /examples/http_file_server\n")
+    client_log <+ "client: GET /examples/http_file_server\n"
     client(addr, "/examples/http_file_server", client_log)
-    client_log.write_string("\n\n")
-    client_log.write_string("client: GET /examples/moon.mod.json\n")
+    client_log <+ "\n\n"
+    client_log <+ "client: GET /examples/moon.mod.json\n"
     client(addr, "/examples/moon.mod.json", client_log)
-    client_log.write_string("\n\n")
+    client_log <+ "\n\n"
     let tmp_file_name = "examples/test.zip"
     let tmp_file = @fs.create(tmp_file_name, permission=0o644)
     root.add_defer(() => @fs.remove(tmp_file_name))

--- a/src/allow_failure_test.mbt
+++ b/src/allow_failure_test.mbt
@@ -18,7 +18,7 @@ async test "allow_failure ignored" {
   @async.with_task_group(root => {
     root.spawn_bg(allow_failure=true, () => raise Err)
     @async.sleep(100)
-    buf.write_string("main task terminate\n")
+    buf <+ "main task terminate\n"
   })
   inspect(
     buf.to_string(),
@@ -38,7 +38,7 @@ async test "allow_failure waited" {
         let task = root.spawn(allow_failure=true, () => raise Err)
         @async.sleep(100)
         task.wait()
-        buf.write_string("main task terminate\n")
+        buf <+ "main task terminate\n"
       }),
     ),
   )
@@ -53,10 +53,10 @@ async test "allow_failure no error" {
       try? @async.with_task_group(root => {
         root.spawn_bg(allow_failure=true, () => {
           @async.sleep(1000)
-          buf.write_string("`allow_failure` task terminate\n")
+          buf <+ "`allow_failure` task terminate\n"
         })
         @async.sleep(100)
-        buf.write_string("main task terminate\n")
+        buf <+ "main task terminate\n"
       }),
     ),
   )

--- a/src/cancellation_test.mbt
+++ b/src/cancellation_test.mbt
@@ -19,7 +19,7 @@ async test "manual cancel" {
     let task = root.spawn(() => {
       try {
         @async.sleep(300)
-        buf.write_string("task finished\n")
+        buf <+ "task finished\n"
       } catch {
         err => {
           buf.write_string("cancelled by error \{err}\n")
@@ -30,7 +30,7 @@ async test "manual cancel" {
     @async.sleep(100)
     task.cancel()
     @async.sleep(200)
-    buf.write_string("main task exit\n")
+    buf <+ "main task exit\n"
   })
   buf.write_string(@debug.to_string(result))
   inspect(
@@ -59,16 +59,16 @@ async test "error propagation" {
         root.spawn_bg(() => {
           try {
             @async.sleep(200)
-            buf.write_string("task 2, tick 1\n")
+            buf <+ "task 2, tick 1\n"
             @async.sleep(200)
-            buf.write_string("task 2, tick 2\n")
+            buf <+ "task 2, tick 2\n"
           } catch {
             err => {
               buf.write_string("task 2 cancelled with error \{err}\n")
               raise err
             }
           } noraise {
-            _ => buf.write_string("task 2 normal exit\n")
+            _ => buf <+ "task 2 normal exit\n"
           }
         })
       }),
@@ -102,18 +102,18 @@ async test "multiple scope" {
                 raise err
               }
             } noraise {
-              _ => buf.write_string("ctx 1 task 2 finished\n")
+              _ => buf <+ "ctx 1 task 2 finished\n"
             }
           })
         })
       catch {
         err => {
-          buf.write_string("ctx 1 received error ")
+          buf <+ "ctx 1 received error "
           buf.write_string(@debug.to_string(err))
           buf.write_char('\n')
         }
       } noraise {
-        _ => buf.write_string("ctx 1 finished normally\n")
+        _ => buf <+ "ctx 1 finished normally\n"
       }
     })
     root.spawn_bg(() => {
@@ -130,18 +130,18 @@ async test "multiple scope" {
                 raise err
               }
             } noraise {
-              _ => buf.write_string("ctx 2 task 2 finished\n")
+              _ => buf <+ "ctx 2 task 2 finished\n"
             }
           })
         })
       catch {
         err => {
-          buf.write_string("ctx 2 received error ")
+          buf <+ "ctx 2 received error "
           buf.write_string(@debug.to_string(err))
           buf.write_char('\n')
         }
       } noraise {
-        _ => buf.write_string("ctx 2 finished normally\n")
+        _ => buf <+ "ctx 2 finished normally\n"
       }
     })
   })
@@ -166,7 +166,7 @@ async test "recursive cancel" {
         root.spawn_bg(() => {
           for _ in 0..<2 {
             @async.sleep(400)
-            buf.write_string("tick\n")
+            buf <+ "tick\n"
           }
         })
         let task = root.spawn(() => {
@@ -176,11 +176,11 @@ async test "recursive cancel" {
           @async.sleep(1000) catch {
             err => buf.write_string("second sleep cancelled with \{err}\n")
           }
-          buf.write_string("task finished\n")
+          buf <+ "task finished\n"
         })
         @async.sleep(600)
         task.cancel()
-        buf.write_string("main task exit\n")
+        buf <+ "main task exit\n"
       }),
     ),
   )
@@ -208,9 +208,9 @@ async test "spawn directly error" {
           @async.with_task_group(group => {
             @async.sleep(1)
             group.spawn_bg(() => raise Err)
-            buf.write_string("after spawn\n")
+            buf <+ "after spawn\n"
             @async.sleep(400)
-            buf.write_string("main task exit\n")
+            buf <+ "main task exit\n"
           })
         })
         @async.sleep(200)
@@ -235,7 +235,7 @@ async test "error in cancellation" {
         root.spawn_bg(no_wait=true, () => {
           @async.sleep(1000) catch {
             _ => {
-              log.write_string("causing other error in cancellation handler\n")
+              log <+ "causing other error in cancellation handler\n"
               raise Err
             }
           }
@@ -259,11 +259,11 @@ async test "immediately cancelled" {
   @async.with_task_group(root => {
     let task = root.spawn(() => {
       defer log.write_string("task terminated\n")
-      log.write_string("task started\n")
+      log <+ "task started\n"
       @async.sleep(100)
-      log.write_string("task finished\n")
+      log <+ "task finished\n"
     })
-    log.write_string("task spawned\n")
+    log <+ "task spawned\n"
     task.cancel()
   })
   inspect(

--- a/src/cond_var/cond_var_test.mbt
+++ b/src/cond_var/cond_var_test.mbt
@@ -34,11 +34,11 @@ async test "cond var cancellation no_swallow" {
     let cond = @cond_var.Cond()
     let wait_task = root.spawn(() => {
       cond.wait()
-      log.write_string("waiter 1 succeed\n")
+      log <+ "waiter 1 succeed\n"
     })
     root.spawn_bg(no_wait=true, () => {
       cond.wait()
-      log.write_string("waiter 2 succeed\n")
+      log <+ "waiter 2 succeed\n"
     })
     @async.sleep(100)
     cond.signal()
@@ -62,14 +62,14 @@ async test "cond var fairness" {
     root.spawn_bg(() => {
       for _ in 0..<3 {
         cond.wait()
-        log.write_string("task 1 received signal\n")
+        log <+ "task 1 received signal\n"
       }
     })
     root.spawn_bg(() => {
       @async.sleep(100)
       for _ in 0..<3 {
         cond.wait()
-        log.write_string("task 2 received signal\n")
+        log <+ "task 2 received signal\n"
       }
     })
     @async.sleep(200)

--- a/src/group_defer_test.mbt
+++ b/src/group_defer_test.mbt
@@ -16,20 +16,20 @@
 async test "group defer basic" {
   let log = StringBuilder::new()
   @async.with_task_group(fn(root) {
-    root.add_defer(() => log.write_string("first group defer\n"))
+    root.add_defer(() => log <+ "first group defer\n")
     root.spawn_bg(() => {
       defer log.write_string("defer for first task\n")
       @async.sleep(200)
-      root.add_defer(() => log.write_string("third group defer\n"))
+      root.add_defer(() => log <+ "third group defer\n")
       @async.sleep(200)
-      log.write_string("first task finished\n")
+      log <+ "first task finished\n"
     })
     root.spawn_bg(() => {
       defer log.write_string("defer for second task\n")
       @async.sleep(100)
-      root.add_defer(() => log.write_string("second group defer\n"))
+      root.add_defer(() => log <+ "second group defer\n")
       @async.sleep(200)
-      log.write_string("second task finished\n")
+      log <+ "second task finished\n"
     })
     root.spawn_bg(no_wait=true, () => {
       defer log.write_string("defer for cancelled task\n")
@@ -58,20 +58,20 @@ async test "group defer error" {
   log.write_string(
     @debug.to_string(
       try? @async.with_task_group(fn(root) {
-        root.add_defer(() => log.write_string("first group defer\n"))
+        root.add_defer(() => log <+ "first group defer\n")
         root.spawn_bg(() => {
           defer log.write_string("defer for first task\n")
           @async.sleep(200)
-          root.add_defer(() => log.write_string("third group defer\n"))
+          root.add_defer(() => log <+ "third group defer\n")
           @async.sleep(200)
-          log.write_string("first task finished\n")
+          log <+ "first task finished\n"
         })
         root.spawn_bg(() => {
           defer log.write_string("defer for second task\n")
           @async.sleep(100)
-          root.add_defer(() => log.write_string("second group defer\n"))
+          root.add_defer(() => log <+ "second group defer\n")
           @async.sleep(200)
-          log.write_string("second task raise error\n")
+          log <+ "second task raise error\n"
           raise Err
         })
         root.spawn_bg(no_wait=true, () => {
@@ -103,7 +103,7 @@ async test "group defer cancelled" {
     root.spawn_bg(() => {
       for _ in 0..<4 {
         @async.sleep(200)
-        log.write_string("tick\n")
+        log <+ "tick\n"
       }
     })
     @async.with_timeout_opt(500, () => {
@@ -111,7 +111,7 @@ async test "group defer cancelled" {
         group.add_defer(() => {
           @async.protect_from_cancel(() => {
             @async.sleep(200)
-            log.write_string("protected async defer completed\n")
+            log <+ "protected async defer completed\n"
           })
         })
         group.add_defer(() => {
@@ -121,7 +121,7 @@ async test "group defer cancelled" {
               raise err
             }
           } noraise {
-            _ => log.write_string("normal async defer completed\n")
+            _ => log <+ "normal async defer completed\n"
           }
         })
         defer log.write_string("start group termination\n")
@@ -129,7 +129,7 @@ async test "group defer cancelled" {
       })
     })
     |> ignore
-    log.write_string("group terminated\n")
+    log <+ "group terminated\n"
   })
   inspect(
     log.to_string(),

--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -102,35 +102,35 @@ async test "request streaming" {
     }
 
     {
-      log.write_string("client sending GET request\n")
+      log <+ "client sending GET request\n"
       let (response, client) = @http.get_stream("http://localhost:\{port}/get")
       defer client.close()
       inspect(response.code, content="200")
       fetch_response(client)
     }
     {
-      log.write_string("client sending PUT request\n")
+      log <+ "client sending PUT request\n"
       let client = @http.put_stream("http://localhost:\{port}/put")
       defer client.close()
       @async.sleep(100)
-      log.write_string("client: sending PUT data part 1\n")
+      log <+ "client: sending PUT data part 1\n"
       client..write("PUT data part 1\n").flush()
       @async.sleep(100)
-      log.write_string("client: sending PUT data part 2\n")
+      log <+ "client: sending PUT data part 2\n"
       client.write("PUT data part 2\n")
       let response = client.end_request()
       inspect(response.code, content="200")
       fetch_response(client)
     }
     {
-      log.write_string("client sending POST request\n")
+      log <+ "client sending POST request\n"
       let client = @http.post_stream("http://localhost:\{port}/post")
       defer client.close()
       @async.sleep(100)
-      log.write_string("client: sending POST data part 1\n")
+      log <+ "client: sending POST data part 1\n"
       client..write("POST data part 1\n").flush()
       @async.sleep(100)
-      log.write_string("client: sending POST data part 2\n")
+      log <+ "client: sending POST data part 2\n"
       client.write("POST data part 2\n")
       let response = client.end_request()
       inspect(response.code, content="200")

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -141,13 +141,13 @@ async test "read_request stream" {
       ..write("User-Agent: MoonBit\r\n")
       .write("Transfer-Encoding: chunked\r\n\r\n")
       @async.sleep(50)
-      log.write_string("writing data...\n")
+      log <+ "writing data...\n"
       w.write("4\r\nabcd\r\n")
       @async.sleep(50)
-      log.write_string("writing data...\n")
+      log <+ "writing data...\n"
       w.write("4\r\nefgh\r\n")
       @async.sleep(50)
-      log.write_string("writing data...\n")
+      log <+ "writing data...\n"
       w.write("4\r\nijkl\r\n")
       w.write("0\r\n\r\n")
     })
@@ -191,13 +191,13 @@ async test "multiple request" {
       ..write("User-Agent: MoonBit\r\n")
       .write("Transfer-Encoding: chunked\r\n\r\n")
       @async.sleep(50)
-      log.write_string("writing data...\n")
+      log <+ "writing data...\n"
       w.write("4\r\nabcd\r\n")
       @async.sleep(50)
-      log.write_string("writing data...\n")
+      log <+ "writing data...\n"
       w.write("4\r\nefgh\r\n")
       @async.sleep(50)
-      log.write_string("writing data...\n")
+      log <+ "writing data...\n"
       w.write("4\r\nijkl\r\n")
       w.write("0\r\n\r\n")
       @async.sleep(50)
@@ -331,7 +331,7 @@ async test "read_response 204 No Content (no body)" {
     log_response(response, log)
     // Body should be Empty, not PassThrough
     let body_text = input.read_all().text()
-    log.write_string("body: ")
+    log <+ "body: "
     log.write_string(body_text)
   })
   inspect(
@@ -368,7 +368,7 @@ async test "read_response 205 Reset Content (no body)" {
     log_response(response, log)
     // Body should be Empty, not WaitConnectionClose
     let body_text = input.read_all().text()
-    log.write_string("body: ")
+    log <+ "body: "
     log.write_string(body_text)
   })
   inspect(
@@ -404,7 +404,7 @@ async test "read_response 304 Not Modified (no body)" {
     )
     log_response(response, log)
     let body_text = input.read_all().text()
-    log.write_string("body: ")
+    log <+ "body: "
     log.write_string(body_text)
   })
   inspect(
@@ -439,7 +439,7 @@ async test "read_response 100 Continue (no body)" {
     )
     log_response(response, log)
     let body_text = input.read_all().text()
-    log.write_string("body: ")
+    log <+ "body: "
     log.write_string(body_text)
   })
   inspect(
@@ -473,7 +473,7 @@ async test "read_response CONNECT 200 (no body, tunnel mode)" {
     log_response(response, log)
     // Body should be Empty, not WaitConnectionClose
     let body_text = input.read_all().text()
-    log.write_string("body: ")
+    log <+ "body: "
     log.write_string(body_text)
   })
   inspect(
@@ -509,7 +509,7 @@ async test "read_response HEAD 200 (no body)" {
     log_response(response, log)
     // Body should be Empty, not Fixed(1234)
     let body_text = input.read_all().text()
-    log.write_string("body: ")
+    log <+ "body: "
     log.write_string(body_text)
   })
   inspect(

--- a/src/internal/bytes_util/util.mbt
+++ b/src/internal/bytes_util/util.mbt
@@ -34,8 +34,8 @@ pub fn ascii_to_string(ascii : BytesView) -> String {
   for byte in ascii {
     match byte {
       b'\n' => builder.write_char('\n')
-      b'\r' => builder.write_string("\\r")
-      b'\t' => builder.write_string("\\t")
+      b'\r' => builder <+ "\\r"
+      b'\t' => builder <+ "\\t"
       32..=126 => builder.write_char(byte.to_int().unsafe_to_char())
       x =>
         builder

--- a/src/internal/coroutine/pause_test.mbt
+++ b/src/internal/coroutine/pause_test.mbt
@@ -18,18 +18,18 @@ test "coroutine ping-pong" {
   let coro = @coroutine.spawn(() => {
     @async.with_task_group(group => {
       group.spawn_bg(() => {
-        log.write_string("ping\n")
+        log <+ "ping\n"
         @async.pause()
-        log.write_string("ping\n")
+        log <+ "ping\n"
         @async.pause()
-        log.write_string("ping\n")
+        log <+ "ping\n"
       })
       group.spawn_bg(() => {
-        log.write_string("pong\n")
+        log <+ "pong\n"
         @async.pause()
-        log.write_string("pong\n")
+        log <+ "pong\n"
         @async.pause()
-        log.write_string("pong\n")
+        log <+ "pong\n"
       })
     })
   })

--- a/src/internal/event_loop/worker_wbtest.mbt
+++ b/src/internal/event_loop/worker_wbtest.mbt
@@ -35,11 +35,11 @@ async test "worker basic" {
     root.spawn_bg(() => {
       for _ in 0..<3 {
         @async.sleep(400)
-        log.write_string("tick\n")
+        log <+ "tick\n"
       }
     })
     perform_sleep_job(1000)
-    log.write_string("done\n")
+    log <+ "done\n"
   })
   inspect(
     log.to_string(),
@@ -60,7 +60,7 @@ async test "worker multiple" {
     root.spawn_bg(() => {
       for _ in 0..<3 {
         @async.sleep(200)
-        log.write_string("tick\n")
+        log <+ "tick\n"
       }
     })
     for i in 0..<3 {
@@ -91,7 +91,7 @@ async test "worker cancel1" {
     root.spawn_bg(() => {
       for _ in 0..<4 {
         @async.sleep(200)
-        log.write_string("tick\n")
+        log <+ "tick\n"
       }
     })
     let task = root.spawn(() => {
@@ -101,11 +101,11 @@ async test "worker cancel1" {
           raise err
         }
       } noraise {
-        _ => log.write_string("done\n")
+        _ => log <+ "done\n"
       }
     })
     @async.sleep(500)
-    log.write_string("trying to cancel\n")
+    log <+ "trying to cancel\n"
     task.cancel()
   })
   inspect(
@@ -129,7 +129,7 @@ async test "worker cancel2" {
     root.spawn_bg(() => {
       for _ in 0..<3 {
         @async.sleep(400)
-        log.write_string("tick\n")
+        log <+ "tick\n"
       }
     })
     root.spawn_bg(allow_failure=true, () => {
@@ -139,11 +139,11 @@ async test "worker cancel2" {
           raise err
         }
       } noraise {
-        _ => log.write_string("done\n")
+        _ => log <+ "done\n"
       }
     })
     @async.sleep(600)
-    log.write_string("trying to terminate now\n")
+    log <+ "trying to terminate now\n"
     root.return_immediately(())
   })
   inspect(

--- a/src/io/README.mbt.md
+++ b/src/io/README.mbt.md
@@ -387,13 +387,13 @@ async test "write_reader - copy from reader to writer" {
     root.spawn_bg(() => {
       defer w2.close()
       // Simulate a producer that emits three frames with pauses in between.
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"abcd")
       @async.sleep(300)
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"efgh")
       @async.sleep(300)
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"ijkl")
     })
   })
@@ -441,13 +441,13 @@ async test "BufferedWriter - basic buffering" {
     root.spawn_bg(() => {
       defer w.close()
       let w = @io.BufferedWriter::new(w, size=4)
-      log.write_string("2 bytes written\n")
+      log <+ "2 bytes written\n"
       w.write("ab")
       @async.sleep(20)
-      log.write_string("2 bytes written\n")
+      log <+ "2 bytes written\n"
       w.write("cd")
       @async.sleep(20)
-      log.write_string("2 bytes written\n")
+      log <+ "2 bytes written\n"
       w.write("ef")
       // Force the remaining bytes out of the buffer.
       w.flush()
@@ -532,13 +532,13 @@ async test "BufferedWriter::write_reader - buffered copy" {
     })
     root.spawn_bg(() => {
       defer w2.close()
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"abcd")
       @async.sleep(100)
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"efgh")
       @async.sleep(100)
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"ijkl")
     })
   })

--- a/src/io/buffered_writer_test.mbt
+++ b/src/io/buffered_writer_test.mbt
@@ -20,13 +20,13 @@ async test "BufferedWriter" {
     root.spawn_bg(() => {
       defer w.close()
       let w = @io.BufferedWriter::new(w, size=4)
-      log.write_string("2 bytes written\n")
+      log <+ "2 bytes written\n"
       w.write("ab")
       @async.sleep(20)
-      log.write_string("2 bytes written\n")
+      log <+ "2 bytes written\n"
       w.write("cd")
       @async.sleep(20)
-      log.write_string("2 bytes written\n")
+      log <+ "2 bytes written\n"
       w.write("ef")
       w.flush()
     })
@@ -72,13 +72,13 @@ async test "BufferedWriter::write_reader" {
     })
     root.spawn_bg(() => {
       defer w2.close()
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"abcd")
       @async.sleep(100)
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"efgh")
       @async.sleep(100)
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"ijkl")
     })
   })

--- a/src/io/read_all_test.mbt
+++ b/src/io/read_all_test.mbt
@@ -16,13 +16,13 @@
 async fn writer(log : StringBuilder, w : @io.PipeWrite) -> Unit {
   defer w.close()
   @async.sleep(20)
-  log.write_string("writing 4 bytes of data\n")
+  log <+ "writing 4 bytes of data\n"
   w.write(b"abcd")
   @async.sleep(20)
-  log.write_string("writing 4 bytes of data\n")
+  log <+ "writing 4 bytes of data\n"
   w.write(b"efgh")
   @async.sleep(20)
-  log.write_string("writing 4 bytes of data\n")
+  log <+ "writing 4 bytes of data\n"
   w.write(b"ijkl")
 }
 

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -48,13 +48,13 @@ async test "write reader" {
     })
     root.spawn_bg(() => {
       defer w2.close()
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"abcd")
       @async.sleep(300)
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"efgh")
       @async.sleep(300)
-      log.write_string("sending 4 bytes\n")
+      log <+ "sending 4 bytes\n"
       w2.write(b"ijkl")
     })
   })

--- a/src/no_wait_test.mbt
+++ b/src/no_wait_test.mbt
@@ -23,11 +23,11 @@ async test "no_wait cancelled" {
           raise err
         }
       } noraise {
-        _ => buf.write_string("`no_wait` task finished successfully\n")
+        _ => buf <+ "`no_wait` task finished successfully\n"
       }
     })
     @async.sleep(100)
-    buf.write_string("main task terminate\n")
+    buf <+ "main task terminate\n"
   })
   inspect(
     buf.to_string(),
@@ -50,11 +50,11 @@ async test "no_wait normal exit" {
           raise err
         }
       } noraise {
-        _ => buf.write_string("`no_wait` task finished successfully\n")
+        _ => buf <+ "`no_wait` task finished successfully\n"
       }
     })
     @async.sleep(200)
-    buf.write_string("main task terminate\n")
+    buf <+ "main task terminate\n"
   })
   inspect(
     buf.to_string(),

--- a/src/process/cancel_test.mbt
+++ b/src/process/cancel_test.mbt
@@ -32,7 +32,7 @@ async test "cancel process" {
     })
     @async.sleep(500)
     task.cancel()
-    log.write_string("cancelling task running process\n")
+    log <+ "cancelling task running process\n"
   })
   inspect(
     log.to_string(),
@@ -121,7 +121,7 @@ async test "orphan process" {
     defer r.close()
     inspect(@utf8.decode(r.read_exactly(5)), content="first")
     task.cancel()
-    log.write_string("cancelling task running process\n")
+    log <+ "cancelling task running process\n"
     inspect(r.read_all().text(), content="second")
   })
   inspect(

--- a/src/process/wait_test.mbt
+++ b/src/process/wait_test.mbt
@@ -52,7 +52,7 @@ async test "wait_pid" {
     group.spawn_bg(() => {
       for _ in 0..<2 {
         @async.sleep(800)
-        log.write_string("tick\n")
+        log <+ "tick\n"
       }
     })
     let pid = @process.spawn_orphan(test_prog, ["1000", "-exit-code", "42"])

--- a/src/process/windows.mbt
+++ b/src/process/windows.mbt
@@ -58,7 +58,7 @@ fn StringBuilder::write_arg_with_windows_escape(
     match arg.code_unit_at(index) {
       '"' => {
         flush(1)
-        builder.write_string("\\\"")
+        builder <+ "\\\""
       }
       '\\' => trailing_backslash += 1
       _ => trailing_backslash = 0
@@ -135,7 +135,7 @@ async fn raw_spawn(
       if inherit_env {
         env.write_string(curr_env)
       } else {
-        env.write_string("\u{0}")
+        env <+ "\u{0}"
       }
       Some(@os_string.encode(env.to_string()))
     }

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -24,15 +24,15 @@ async test "protect_from_cancel" {
             raise err
           }
         }
-        log.write_string("critical job finished\n")
+        log <+ "critical job finished\n"
       }) catch {
         err => {
-          log.write_string("job cancelled after critical part\n")
+          log <+ "job cancelled after critical part\n"
           raise err
         }
       }
       @async.sleep(200)
-      log.write_string("non-critial part of job finished\n")
+      log <+ "non-critial part of job finished\n"
     })
     root.spawn_bg(() => {
       @async.sleep(400) catch {
@@ -41,7 +41,7 @@ async test "protect_from_cancel" {
           raise err
         }
       }
-      log.write_string("non-critical job finished\n")
+      log <+ "non-critical job finished\n"
     })
     @async.sleep(200)
     raise Err
@@ -67,9 +67,9 @@ async test "protect_from_cancel wait" {
       try? @async.with_task_group(root => {
         root.spawn_bg(() => {
           @async.sleep(200)
-          log.write_string("200ms tick\n")
+          log <+ "200ms tick\n"
           @async.sleep(200)
-          log.write_string("400ms tick\n")
+          log <+ "400ms tick\n"
         })
         @async.with_task_group(group => {
           group.spawn_bg(() => {
@@ -81,12 +81,12 @@ async test "protect_from_cancel wait" {
           })
           @async.protect_from_cancel(() => {
             @async.sleep(500)
-            log.write_string("critial job finished\n")
+            log <+ "critial job finished\n"
           })
         }) catch {
           _ => ()
         }
-        log.write_string("task group containing critical job finished\n")
+        log <+ "task group containing critical job finished\n"
       }),
     ),
   )
@@ -109,18 +109,18 @@ async test "protect_from_cancel with_timeout" {
   @async.with_task_group(root => {
     root.spawn_bg(() => {
       @async.sleep(200)
-      log.write_string("200ms tick\n")
+      log <+ "200ms tick\n"
       @async.sleep(200)
-      log.write_string("400ms tick\n")
+      log <+ "400ms tick\n"
     })
     @async.with_timeout_opt(300, () => {
       @async.protect_from_cancel(() => {
         @async.sleep(500)
-        log.write_string("critial job finished\n")
+        log <+ "critial job finished\n"
       })
     })
     |> ignore
-    log.write_string("`with_timeout` containing critical job finished\n")
+    log <+ "`with_timeout` containing critical job finished\n"
   })
   inspect(
     log.to_string(),
@@ -140,14 +140,14 @@ async test "protect_from_cancel fail" {
   let result : Result[Unit, _] = try? @async.with_task_group(root => {
     root.spawn_bg(() => {
       @async.sleep(200)
-      log.write_string("200ms tick\n")
+      log <+ "200ms tick\n"
       @async.sleep(200)
-      log.write_string("400ms tick\n")
+      log <+ "400ms tick\n"
     })
     @async.with_timeout(300, () => {
       @async.protect_from_cancel(() => {
         @async.sleep(500)
-        log.write_string("critial job fail\n")
+        log <+ "critial job fail\n"
         raise Err
       })
     })
@@ -170,20 +170,20 @@ async test "protect_from_cancel nested1" {
   @async.with_task_group(root => {
     root.spawn_bg(() => {
       @async.sleep(200)
-      log.write_string("200ms tick\n")
+      log <+ "200ms tick\n"
       @async.sleep(200)
-      log.write_string("400ms tick\n")
+      log <+ "400ms tick\n"
     })
     @async.with_timeout_opt(300, () => {
       @async.protect_from_cancel(() => {
         @async.protect_from_cancel(() => {
           @async.sleep(500)
-          log.write_string("critial job finished\n")
+          log <+ "critial job finished\n"
         })
       })
     })
     |> ignore
-    log.write_string("`with_timeout` containing critical job finished\n")
+    log <+ "`with_timeout` containing critical job finished\n"
   })
   inspect(
     log.to_string(),
@@ -203,24 +203,24 @@ async test "protect_from_cancel nested2" {
   @async.with_task_group(root => {
     root.spawn_bg(() => {
       @async.sleep(200)
-      log.write_string("200ms tick\n")
+      log <+ "200ms tick\n"
       @async.sleep(200)
-      log.write_string("400ms tick\n")
+      log <+ "400ms tick\n"
       @async.sleep(200)
-      log.write_string("600ms tick\n")
+      log <+ "600ms tick\n"
     })
     @async.with_timeout_opt(100, () => {
       @async.protect_from_cancel(() => {
         @async.protect_from_cancel(() => {
           @async.sleep(300)
-          log.write_string("inner critial job finished\n")
+          log <+ "inner critial job finished\n"
         })
         @async.sleep(200)
-        log.write_string("outer critial job finished\n")
+        log <+ "outer critial job finished\n"
       })
     })
     |> ignore
-    log.write_string("`with_timeout` containing critical job finished\n")
+    log <+ "`with_timeout` containing critical job finished\n"
   })
   inspect(
     log.to_string(),
@@ -248,14 +248,14 @@ async test "protect_from_cancel in cancellation handler" {
               log.write_string("cancelled with error \{err}\n")
               @async.protect_from_cancel(() => {
                 @async.sleep(200)
-                log.write_string("critial cancellation handler terminated\n")
+                log <+ "critial cancellation handler terminated\n"
               })
               raise err
             }
           }
         })
         @async.sleep(200)
-        log.write_string("start cancellation\n")
+        log <+ "start cancellation\n"
       }),
     ),
   )
@@ -277,7 +277,7 @@ async test "cancel while scheduled" {
     root.spawn_bg(() => {
       for _ in 0..<2 {
         @async.sleep(200)
-        log.write_string("tick\n")
+        log <+ "tick\n"
       }
     })
     let task1 = root.spawn((
@@ -294,7 +294,7 @@ async test "cancel while scheduled" {
             // the scheduler will wakeup current coroutine immediately,
             // before the timer expires.
             @async.sleep(300)
-            log.write_string("async cleanup finished\n")
+            log <+ "async cleanup finished\n"
           })
           raise err
         }
@@ -321,7 +321,7 @@ async test "error in async cancel" {
     root.spawn_bg(() => {
       for _ in 0..<2 {
         @async.sleep(300)
-        log.write_string("tick\n")
+        log <+ "tick\n"
       }
     })
     log.write_string(
@@ -330,21 +330,21 @@ async test "error in async cancel" {
           group.spawn_bg(no_wait=true, allow_failure=true, () => {
             @async.sleep(1000) catch {
               _ => {
-                log.write_string("performing async cleanup\n")
+                log <+ "performing async cleanup\n"
                 @async.protect_from_cancel(() => {
                   @async.sleep(300)
-                  log.write_string("raising error from async cleanup\n")
+                  log <+ "raising error from async cleanup\n"
                   raise Err
                 })
               }
             }
           })
           @async.sleep(150)
-          log.write_string("main task of inner group done\n")
+          log <+ "main task of inner group done\n"
         }),
       ),
     )
-    log.write_string("\ngroup terminates\n")
+    log <+ "\ngroup terminates\n"
   })
   inspect(
     log.to_string(),

--- a/src/return_immediately_test.mbt
+++ b/src/return_immediately_test.mbt
@@ -24,7 +24,7 @@ async test "return_immediately basic" {
         })
         root.spawn_bg(() => {
           @async.sleep(300)
-          log.write_string("task finished\n")
+          log <+ "task finished\n"
         })
       }),
     ),
@@ -40,7 +40,7 @@ async test "return_immediately nested" {
       try? @async.with_task_group(root => {
         root.spawn_bg(() => {
           @async.sleep(300)
-          log.write_string("outer task finished\n")
+          log <+ "outer task finished\n"
         })
         @async.with_task_group(fn(group) {
           group.spawn_bg(() => {
@@ -49,7 +49,7 @@ async test "return_immediately nested" {
           })
           group.spawn_bg(() => {
             @async.sleep(300)
-            log.write_string("inner task finished\n")
+            log <+ "inner task finished\n"
           })
         })
       }),
@@ -71,11 +71,11 @@ async test "return_immediately error on cancel" {
         root.spawn_bg(() => {
           @async.sleep(300) catch {
             _ => {
-              log.write_string("task cancelled, causing other error\n")
+              log <+ "task cancelled, causing other error\n"
               raise Err
             }
           }
-          log.write_string("task finished\n")
+          log <+ "task finished\n"
         })
       }),
     ),

--- a/src/semaphore/semaphore_test.mbt
+++ b/src/semaphore/semaphore_test.mbt
@@ -27,7 +27,7 @@ async test "semaphore mutex" {
     }
     @async.sleep(150)
     for _ in 0..<3 {
-      log.write_string("tick\n")
+      log <+ "tick\n"
       @async.sleep(300)
     }
   })
@@ -60,7 +60,7 @@ async test "semaphore multiple value" {
     }
     @async.sleep(150)
     for _ in 0..<3 {
-      log.write_string("tick\n")
+      log <+ "tick\n"
       @async.sleep(300)
     }
   })
@@ -107,7 +107,7 @@ async test "semaphore cancellation no_swallow" {
     semaphore.acquire()
     let acquire_taskire_task = root.spawn(() => {
       semaphore.acquire()
-      log.write_string("acquire() succeed\n")
+      log <+ "acquire() succeed\n"
     })
     @async.sleep(100)
     semaphore.release()
@@ -132,7 +132,7 @@ async test "semaphore fairness" {
     root.spawn_bg(() => {
       for _ in 0..<3 {
         semaphore.acquire()
-        log.write_string("task 1 acquired resource\n")
+        log <+ "task 1 acquired resource\n"
         @async.sleep(200)
         semaphore.release()
       }
@@ -141,7 +141,7 @@ async test "semaphore fairness" {
       @async.sleep(100)
       for _ in 0..<3 {
         semaphore.acquire()
-        log.write_string("task 2 acquired resource\n")
+        log <+ "task 2 acquired resource\n"
         @async.sleep(200)
         semaphore.release()
       }

--- a/src/socket/resolve_host_test.mbt
+++ b/src/socket/resolve_host_test.mbt
@@ -31,7 +31,7 @@ async test "resolve cancel" {
     })
     lock.acquire() // make sure the task already started
     task.cancel()
-    log.write_string("host resolution cancelled\n")
+    log <+ "host resolution cancelled\n"
   })
   inspect(
     log.to_string(),

--- a/src/spawn_test.mbt
+++ b/src/spawn_test.mbt
@@ -18,7 +18,7 @@ async test "spawn error1" {
   let result = try? @async.with_task_group(root => {
     root.spawn_bg(() => {
       @async.sleep(1000)
-      buf.write_string("task 1 finished\n")
+      buf <+ "task 1 finished\n"
     })
     root.spawn_bg(() => {
       @async.sleep(200)
@@ -39,7 +39,7 @@ async test "spawn error2" {
     })
     root.spawn_bg(() => {
       @async.sleep(1000)
-      buf.write_string("task 1 finished\n")
+      buf <+ "task 1 finished\n"
     })
   })
   buf.write_string(@debug.to_string(result))

--- a/src/timer_test.mbt
+++ b/src/timer_test.mbt
@@ -18,19 +18,19 @@ async test "basic sleep" {
   let result = try? @async.with_task_group(root => {
     root.spawn_bg(() => {
       @async.sleep(100)
-      buf.write_string("task 1, tick 1\n")
+      buf <+ "task 1, tick 1\n"
       @async.sleep(200)
-      buf.write_string("task 1, tick 2\n")
+      buf <+ "task 1, tick 2\n"
       @async.sleep(200)
-      buf.write_string("task 1, tick 3\n")
+      buf <+ "task 1, tick 3\n"
     })
     root.spawn_bg(() => {
       @async.sleep(200)
-      buf.write_string("task 2, tick 1\n")
+      buf <+ "task 2, tick 1\n"
       @async.sleep(200)
-      buf.write_string("task 2, tick 2\n")
+      buf <+ "task 2, tick 2\n"
       @async.sleep(200)
-      buf.write_string("task 2, tick 3\n")
+      buf <+ "task 2, tick 3\n"
     })
   })
   debug_inspect(result, content="Ok(())")

--- a/src/wait_test.mbt
+++ b/src/wait_test.mbt
@@ -20,16 +20,16 @@ async test "wait basic" {
       try? @async.with_task_group(root => {
         root.spawn_bg(() => {
           @async.sleep(200)
-          buf.write_string("200ms tick\n")
+          buf <+ "200ms tick\n"
           @async.sleep(200)
-          buf.write_string("400ms tick\n")
+          buf <+ "400ms tick\n"
         })
         let task = root.spawn(no_wait=true, () => {
           @async.sleep(300)
-          buf.write_string("task finished\n")
+          buf <+ "task finished\n"
         })
         task.wait()
-        buf.write_string("main task exit\n")
+        buf <+ "main task exit\n"
       }),
     ),
   )
@@ -51,7 +51,7 @@ async test "wait cancelled" {
   @async.with_task_group(root => {
     let task = root.spawn(() => {
       @async.sleep(1000)
-      buf.write_string("task finished\n")
+      buf <+ "task finished\n"
     })
     root.spawn_bg(() => {
       task.wait() catch {

--- a/src/with_timeout_test.mbt
+++ b/src/with_timeout_test.mbt
@@ -37,7 +37,7 @@ async test "with_timeout failure" {
   @async.with_task_group(root => {
     root.spawn_bg(() => {
       @async.sleep(200)
-      log.write_string("200ms tick\n")
+      log <+ "200ms tick\n"
     })
     @async.with_timeout(300, () => {
       @async.sleep(100)
@@ -68,20 +68,20 @@ async test "with_timeout timeout" {
       try? @async.with_task_group(root => {
         root.spawn_bg(() => {
           @async.sleep(300)
-          log.write_string("300ms tick\n")
+          log <+ "300ms tick\n"
         })
         @async.with_timeout(200, () => {
           @async.sleep(400) catch {
             err => {
-              log.write_string("task cancelled\n")
+              log <+ "task cancelled\n"
               raise err
             }
           }
-          log.write_string("task finished\n")
+          log <+ "task finished\n"
         }) catch {
           err => log.write_string("`with_timeout` fail with \{err}\n")
         }
-        log.write_string("main task finished\n")
+        log <+ "main task finished\n"
       }),
     ),
   )
@@ -105,26 +105,26 @@ async test "with_timeout nested1" {
       try? @async.with_task_group(root => {
         root.spawn_bg(() => {
           @async.sleep(200)
-          log.write_string("200ms tick\n")
+          log <+ "200ms tick\n"
           @async.sleep(200)
-          log.write_string("400ms tick\n")
+          log <+ "400ms tick\n"
         })
         @async.with_timeout(300, () => {
           @async.with_timeout(500, () => {
             @async.sleep(2000) catch {
               err => {
-                log.write_string("task cancelled\n")
+                log <+ "task cancelled\n"
                 raise err
               }
             }
-            log.write_string("task finished after 2s\n")
+            log <+ "task finished after 2s\n"
           }) catch {
             err => log.write_string("inner `with_timeout` fail with \{err}\n")
           }
         }) catch {
           err => log.write_string("outer `with_timeout` fail with \{err}\n")
         }
-        log.write_string("main task finished\n")
+        log <+ "main task finished\n"
       }),
     ),
   )
@@ -150,26 +150,26 @@ async test "with_timeout nested2" {
       try? @async.with_task_group(root => {
         root.spawn_bg(() => {
           @async.sleep(300)
-          log.write_string("300ms tick\n")
+          log <+ "300ms tick\n"
           @async.sleep(300)
-          log.write_string("600ms tick\n")
+          log <+ "600ms tick\n"
         })
         @async.with_timeout(750, () => {
           @async.with_timeout(450, () => {
             @async.sleep(2000) catch {
               err => {
-                log.write_string("task cancelled\n")
+                log <+ "task cancelled\n"
                 raise err
               }
             }
-            log.write_string("task finished after 2s\n")
+            log <+ "task finished after 2s\n"
           }) catch {
             err => log.write_string("inner `with_timeout` fail with \{err}\n")
           }
         }) catch {
           err => log.write_string("outer `with_timeout` fail with \{err}\n")
         }
-        log.write_string("main task finished\n")
+        log <+ "main task finished\n"
       }),
     ),
   )
@@ -194,18 +194,18 @@ async test "with_timeout error_on_cancel" {
       try? @async.with_task_group(root => {
         root.spawn_bg(() => {
           @async.sleep(200)
-          log.write_string("200ms tick\n")
+          log <+ "200ms tick\n"
         })
         @async.with_timeout(100, () => {
           @async.sleep(2000) catch {
             _ => {
-              log.write_string("causing other error on cancellation\n")
+              log <+ "causing other error on cancellation\n"
               raise Err
             }
           }
-          log.write_string("task finished after 2s\n")
+          log <+ "task finished after 2s\n"
         })
-        log.write_string("main task finished\n")
+        log <+ "main task finished\n"
       }),
     ),
   )
@@ -226,17 +226,17 @@ async test "with_timeout error-on-timeout" {
       try? @async.with_task_group(root => {
         root.spawn_bg(() => {
           @async.sleep(200)
-          log.write_string("200ms tick\n")
+          log <+ "200ms tick\n"
         })
         defer log.write_string("main task terminates\n")
         @async.with_timeout(100, error=Err, () => {
           @async.sleep(2000) catch {
             err => {
-              log.write_string("task cancelled\n")
+              log <+ "task cancelled\n"
               raise err
             }
           }
-          log.write_string("task finished after 2s\n")
+          log <+ "task finished after 2s\n"
         })
       }),
     ),
@@ -277,7 +277,7 @@ async test "with_timeout_opt failure" {
   @async.with_task_group(root => {
     root.spawn_bg(() => {
       @async.sleep(200)
-      log.write_string("200ms tick\n")
+      log <+ "200ms tick\n"
     })
     @async.with_timeout(1000, () => {
       @async.sleep(100)


### PR DESCRIPTION
## Summary

- Replace simple literal `write_string(...)` calls with the existing `<+` writer/logger sugar.
- Keep interpolated strings, non-literal writes, chained writes, and `defer` writes unchanged to avoid changing evaluation order or string rendering.
- Covers tests, documentation examples, and small support-code builders.

## Validation

- `moon fmt`
- `moon check`
- `moon test`
- `moon info`

Note: the first `moon test` pass hit the known timing-sensitive `process/cancel_test` case; it passed in isolation and the full suite passed on rerun.
