### PR TITLE
[codex] Use argparse in examples

### DIFF
--- a/examples/cat/main.mbt
+++ b/examples/cat/main.mbt
@@ -14,10 +14,20 @@
 
 ///|
 async fn main {
-  let args = @env.args()
-  match args {
-    [] | [_] => @stdio.stdout.write_reader(@stdio.stdin)
-    [_, .. files] =>
+  let matches = @argparse.Command(
+    "cat",
+    about="Concatenate files to standard output.",
+    positionals=[
+      PositionArg(
+        "file",
+        about="file to read",
+        num_args=@argparse.ValueRange(lower=0),
+        allow_hyphen_values=true,
+      ),
+    ],
+  ).parse()
+  match matches.values {
+    { "file": files, .. } if !files.is_empty() =>
       for file in files {
         if file == "-" {
           @stdio.stdout.write_reader(@stdio.stdin)
@@ -27,5 +37,6 @@ async fn main {
           @stdio.stdout.write_reader(file)
         }
       }
+    _ => @stdio.stdout.write_reader(@stdio.stdin)
   }
 }

--- a/examples/cat/moon.pkg
+++ b/examples/cat/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "moonbitlang/core/env",
+  "moonbitlang/core/argparse",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/stdio",

--- a/examples/http_file_server/main.mbt
+++ b/examples/http_file_server/main.mbt
@@ -161,9 +161,16 @@ pub async fn server_main(
 
 ///|
 async fn main {
-  let path = match @env.args() {
-    [] | [_] => "."
-    [_, path, ..] => path
+  let matches = @argparse.Command(
+    "http_file_server",
+    about="Serve a directory over HTTP.",
+    positionals=[
+      PositionArg("path", about="directory to serve", default_values=["."]),
+    ],
+  ).parse()
+  let path = match matches.values {
+    { "path": [path], .. } => path
+    _ => "."
   }
   let server = @http.Server(@socket.Addr::parse("0.0.0.0:8000"))
   server_main(server, path~) catch {

--- a/examples/http_file_server/moon.pkg
+++ b/examples/http_file_server/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "moonbitlang/core/env",
+  "moonbitlang/core/argparse",
   "moonbitlang/async",
   "moonbitlang/async/socket",
   "moonbitlang/async/fs",

--- a/examples/line_processing/main.mbt
+++ b/examples/line_processing/main.mbt
@@ -14,28 +14,7 @@
 
 ///|
 struct Options {
-  mut contains : String?
-}
-
-///|
-async fn print_usage() -> Unit {
-  @stdio.stdout.write(
-    (
-      #|Line-based stream processing example.
-      #|
-      #|Usage:
-      #|  moon -C examples run line_processing -- [OPTIONS] [FILE...]
-      #|
-      #|Options:
-      #|  -c, --contains PATTERN    Only output lines that contain PATTERN
-      #|  -h, --help                Show this help text
-      #|
-      #|Notes:
-      #|  - Use "-" to read from stdin.
-      #|  - Input is processed incrementally via `read_until("\\n")`.
-      #|
-    ),
-  )
+  contains : String?
 }
 
 ///|
@@ -86,32 +65,37 @@ async fn process_input(
 
 ///|
 async fn main {
-  let options : Options = { contains: None }
-  let inputs : Array[String] = []
-  for args = @env.args()[1:] {
-    match args {
-      [] => break
-      ["-h", ..] | ["--help", ..] => {
-        print_usage()
-        return
-      }
-      ["-c", .. rest] | ["--contains", .. rest] => {
-        guard rest is [pattern, .. rest] else {
-          fail("expected PATTERN after --contains")
-        }
-        options.contains = Some(pattern)
-        continue rest
-      }
-      [opt, ..] if opt.has_prefix("-") && opt != "-" =>
-        fail("unknown option `\{opt}`")
-      [path, .. rest] => {
-        inputs.push(path)
-        continue rest
-      }
-    }
+  let matches = @argparse.Command(
+    "line_processing",
+    about=(
+      #|Line-based stream processing example.
+      #|Use "-" to read from stdin.
+      #|Input is processed incrementally via read_until("\\n").
+    ),
+    options=[
+      OptionArg(
+        "contains",
+        short='c',
+        about="only output lines that contain PATTERN",
+      ),
+    ],
+    positionals=[
+      PositionArg(
+        "file",
+        about="file to process",
+        num_args=@argparse.ValueRange(lower=0),
+      ),
+    ],
+  ).parse()
+  let options : Options = {
+    contains: match matches.values {
+      { "contains": [pattern], .. } => Some(pattern)
+      _ => None
+    },
   }
-  if inputs.is_empty() {
-    inputs.push("-")
+  let inputs = match matches.values {
+    { "file": files, .. } if !files.is_empty() => files
+    _ => ["-"]
   }
   let show_name = inputs.length() > 1
   let out = @io.BufferedWriter::new(@stdio.stdout, size=16 * 1024)

--- a/examples/line_processing/moon.pkg
+++ b/examples/line_processing/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "moonbitlang/core/env",
+  "moonbitlang/core/argparse",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/io",

--- a/examples/tcp_server_benchmark/main.mbt
+++ b/examples/tcp_server_benchmark/main.mbt
@@ -70,45 +70,43 @@ async fn client(
 
 ///|
 async fn main {
-  let mut total_conn = 1000
-  let mut max_concurrent_conn = 100
-  let mut conn_duration = 500
-  let mut addr_str = ""
-  for args = @env.args()[1:] {
-    match args {
-      [] => break
-      ["-total-conn", .. rest] => {
-        guard rest is [n, .. rest] else {
-          fail("expected total connection number")
-        }
-        total_conn = @string.parse_int(n)
-        continue rest
-      }
-      ["-max-concurrent", .. rest] => {
-        guard rest is [n, .. rest] else {
-          fail("expected max concurrent connection count")
-        }
-        max_concurrent_conn = @string.parse_int(n)
-        continue rest
-      }
-      ["-conn-duration", .. rest] => {
-        guard rest is [n, .. rest] else {
-          fail("expected duration of connection in milliseconds")
-        }
-        conn_duration = @string.parse_int(n)
-        continue rest
-      }
-      [opt, ..] if opt.has_prefix("-") => fail("unknown option `\{opt}`")
-      [addr, .. rest] => {
-        guard addr_str == "" else {
-          fail("server addres supplied multiple times")
-        }
-        addr_str = addr
-        continue rest
-      }
-    }
+  let matches = @argparse.Command(
+    "tcp_server_benchmark",
+    about="Measure TCP echo server throughput and latency.",
+    options=[
+      OptionArg("total-conn", about="total connection count", default_values=[
+        "1000",
+      ]),
+      OptionArg("max-concurrent", about="max concurrent connection count", default_values=[
+        "100",
+      ]),
+      OptionArg(
+        "conn-duration",
+        about="duration of each connection in milliseconds",
+        default_values=["500"],
+      ),
+    ],
+    positionals=[
+      PositionArg(
+        "addr",
+        about="server address",
+        num_args=@argparse.ValueRange::single(),
+      ),
+    ],
+  ).parse()
+  guard matches.values
+    is {
+      "addr": [addr_str],
+      "total-conn": [total_conn_str],
+      "max-concurrent": [max_concurrent_conn_str],
+      "conn-duration": [conn_duration_str],
+      ..
+    } else {
+    fail("invalid arguments")
   }
-  guard addr_str != "" else { fail("server address not supplied") }
+  let total_conn = @string.parse_int(total_conn_str)
+  let max_concurrent_conn = @string.parse_int(max_concurrent_conn_str)
+  let conn_duration = @string.parse_int(conn_duration_str)
   let addr = @socket.Addr::parse(addr_str)
   let rand = {
     let seed = @buffer.new()

--- a/examples/tcp_server_benchmark/moon.pkg
+++ b/examples/tcp_server_benchmark/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/argparse",
   "moonbitlang/core/random",
   "moonbitlang/core/env",
   "moonbitlang/core/buffer",

--- a/examples/xargs/main.mbt
+++ b/examples/xargs/main.mbt
@@ -14,42 +14,45 @@
 // limitations under the License.
 
 ///|
-let help_message : String =
-  #|Usage: xargs OPTIONS COMMAND ..ARGS
-  #|Run COMMAND with initial arguments ARGS and more arguments read from stdin.
-  #|  COMMAND will be run once for every line in the input.
-  #|
-  #|Options:
-  #|   -j COUNT,
-  #|   --jobs COUNT    limit the max number of parallel jobs to `COUNT`
-  #|
-  #|   -h, --help      show this help message
-  #|   --              treat all remaining arguments as the command line to run
-
-///|
 async fn main {
-  let mut max_jobs = None
-  let command_and_args = for args = @env.args()[1:] {
-    match args {
-      ["-j" | "--jobs" as opt, .. rest] => {
-        guard rest is [count, .. rest] else {
-          fail("expected max job count after `\{opt}`")
-        }
-        let count = @string.parse_int(count)
-        // Use a semaphore to limit the max number of parallel jobs
-        max_jobs = Some(@async.Semaphore(count))
-        continue rest
-      }
-      ["-h" | "--help", ..] => {
-        println(help_message)
-        return
-      }
-      ["--", .. command_and_args] => break command_and_args
-      [['-', ..] as opt, ..] => fail("unknown option: `\{opt}`")
-      command_and_args => break command_and_args
-    }
+  let matches = @argparse.Command(
+    "xargs",
+    about=(
+      #|Run COMMAND with initial arguments ARGS and more arguments read from stdin.
+      #|COMMAND will be run once for every line in the input.
+    ),
+    options=[
+      OptionArg(
+        "jobs",
+        short='j',
+        about="limit the max number of parallel jobs to COUNT",
+      ),
+    ],
+    positionals=[
+      PositionArg(
+        "cmd",
+        about="command to run",
+        num_args=@argparse.ValueRange::single(),
+      ),
+      PositionArg(
+        "args",
+        about="initial arguments for the command",
+        num_args=@argparse.ValueRange(lower=0),
+        allow_hyphen_values=true,
+      ),
+    ],
+  ).parse()
+  let max_jobs = match matches.values {
+    { "jobs": [count], .. } => Some(@async.Semaphore(@string.parse_int(count)))
+    _ => None
   }
-  guard command_and_args is [cmd, .. args] else { fail("no command specified") }
+  guard matches.values is { "cmd": [cmd], .. } else {
+    fail("no command specified")
+  }
+  let args = match matches.values {
+    { "args": args, .. } => args
+    _ => []
+  }
   @async.with_task_group(group => {
     while @stdio.stdin.read_until("\n") is Some(line) {
       if max_jobs is Some(limit) {

--- a/examples/xargs/moon.pkg
+++ b/examples/xargs/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "moonbitlang/core/env",
+  "moonbitlang/core/argparse",
   "moonbitlang/core/string",
   "moonbitlang/async",
   "moonbitlang/async/process",


### PR DESCRIPTION
## Summary

- Replace hand-rolled `@env.args()` parsing in example CLIs with `moonbitlang/core/argparse` declarations.
- Add argparse imports to the affected example packages.
- Preserve existing defaults and stdin handling for examples like `cat`, `line_processing`, `xargs`, `http_file_server`, and `tcp_server_benchmark`.

## Validation

- `moon check`
- `moon test` (first run hit timing-sensitive `spawn_in_group_test.mbt` expectations, rerun passed: 488/488)
