### PR TITLE
[codex] Use callback sugar in examples

### DIFF
--- a/examples/http_file_server/main.mbt
+++ b/examples/http_file_server/main.mbt
@@ -85,7 +85,7 @@ async fn serve_zip(conn : @http.ServerConnection, path : String) -> Unit {
   } else {
     path
   }
-  @async.with_task_group(group => {
+  @async.with_task_group <| group => {
     let (we_read_from_zip, zip_write_to_us) = @process.read_from_process()
     defer we_read_from_zip.close()
     if is_windows {
@@ -112,7 +112,7 @@ async fn serve_zip(conn : @http.ServerConnection, path : String) -> Unit {
     })
     ..write_reader(we_read_from_zip)
     .end_response()
-  })
+  }
 }
 
 ///|
@@ -133,7 +133,7 @@ pub async fn server_main(
   log? : (String) -> Unit = println,
 ) -> Unit {
   let base_path = path
-  server.run_forever((request, _body, conn) => {
+  server.run_forever() <| ((request, _body, conn) => {
     let (path, download_zip) = match request.path {
       [.. path, .. "?download_zip"] => (path.to_owned(), true)
       path => (path, false)

--- a/examples/http_file_server/server_wbtest.mbt
+++ b/examples/http_file_server/server_wbtest.mbt
@@ -44,10 +44,10 @@ async test "basic" {
   }
 
   let client_log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group <| root => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg(no_wait=true, () => server_main(server, path=".", log~))
+    root.spawn_bg(no_wait=true) <| () => { server_main(server, path=".", log~) }
     @async.sleep(50)
     client_log <+ "client: GET /examples/http_file_server\n"
     client(addr, "/examples/http_file_server", client_log)
@@ -57,7 +57,7 @@ async test "basic" {
     client_log <+ "\n\n"
     let tmp_file_name = "examples/test.zip"
     let tmp_file = @fs.create(tmp_file_name, permission=0o644)
-    root.add_defer(() => @fs.remove(tmp_file_name))
+    root.add_defer() <| () => { @fs.remove(tmp_file_name) }
     client(addr, "/examples/http_file_server?download_zip", client_log, handle_response=body => {
       tmp_file.write_reader(body)
     })
@@ -95,7 +95,7 @@ async test "basic" {
     for file in zip_content {
       client_log..write_string(file).write_string("\n")
     }
-  })
+  }
   inspect(
     client_log,
     content=(

--- a/examples/http_server_benchmark/http_server_benchmark.mbt
+++ b/examples/http_server_benchmark/http_server_benchmark.mbt
@@ -18,7 +18,7 @@ let port : Int = 30001
 ///|
 async fn main {
   let server = @http.Server(@socket.Addr::parse("0.0.0.0:\{port}"))
-  server.run_forever((request, _body, conn) => {
+  server.run_forever() <| ((request, _body, conn) => {
     match (request.meth, request.path) {
       (Get, "/") => conn.send_response(200, "OK")
       _ => conn.send_response(404, "NotFound")

--- a/examples/idle_timeout/main.mbt
+++ b/examples/idle_timeout/main.mbt
@@ -14,15 +14,15 @@
 
 ///|
 async fn main {
-  @async.with_task_group(group => {
+  @async.with_task_group <| group => {
     let idle_timer = @async.Timer(5000)
-    group.spawn_bg(no_wait=true, () => {
+    group.spawn_bg(no_wait=true) <| () => {
       idle_timer.wait()
       println("You have not type anything for 5 seconds, exit now...")
       group.return_immediately(())
-    })
+    }
     while @stdio.stdin.read_some() is Some(_) {
       idle_timer.refresh()
     }
-  })
+  }
 }

--- a/examples/tcp_echo_server/main.mbt
+++ b/examples/tcp_echo_server/main.mbt
@@ -14,7 +14,8 @@
 
 ///|
 async fn main {
-  @socket.TcpServer(@socket.Addr::parse("0.0.0.0:42000")).run_forever((conn, _) => {
-    conn.write_reader(conn)
-  })
+  @socket.TcpServer(@socket.Addr::parse("0.0.0.0:42000")).run_forever() <| ((
+    conn,
+    _,
+  ) => conn.write_reader(conn))
 }

--- a/examples/tcp_ping_pong/main.mbt
+++ b/examples/tcp_ping_pong/main.mbt
@@ -20,7 +20,7 @@ pub(all) struct Printer((String) -> Unit)
 
 ///|
 async fn server_main(server : @socket.TcpServer, println : Printer) -> Unit {
-  server.run_forever(allow_failure=false, (conn, _) => {
+  (server.run_forever(allow_failure=false) <| ((conn, _) => {
     println("received new connection")
     while conn.read_some() is Some(msg) {
       @async.sleep(10)
@@ -36,7 +36,7 @@ async fn server_main(server : @socket.TcpServer, println : Printer) -> Unit {
     } nobreak {
       println("server: connection closed by peer")
     }
-  }) catch {
+  })) catch {
     err => {
       println("server terminate: \{err}")
       raise err
@@ -71,20 +71,20 @@ async fn client(
 
 ///|
 pub async fn main_prog(println : Printer) -> Unit {
-  @async.with_task_group(root => {
+  (@async.with_task_group <| root => {
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg(() => server_main(server, println))
-    root.spawn_bg(() => {
-      @async.with_task_group(ctx => {
+    root.spawn_bg() <| () => { server_main(server, println) }
+    root.spawn_bg() <| () => {
+      @async.with_task_group <| ctx => {
         for i in 0..<6 {
           let msg = if i % 3 == 1 { "pong" } else { "ping" }
-          ctx.spawn_bg(() => client(addr, println, i, msg))
+          ctx.spawn_bg() <| () => { client(addr, println, i, msg) }
           @async.sleep(100)
         }
-      })
-      root.spawn_bg(() => client(addr, println, 6, "exit"))
-    })
+      }
+      root.spawn_bg() <| () => { client(addr, println, 6, "exit") }
+    }
   }) catch {
     ServerTerminate => ()
     err => raise err

--- a/examples/tcp_server_benchmark/main.mbt
+++ b/examples/tcp_server_benchmark/main.mbt
@@ -25,43 +25,43 @@ async fn client(
 ) -> (Int64, Double) {
   let mut throughput_sum : Int64 = 0
   let mut latency_sum : Int64 = 0
-  @async.with_task_group(group => {
+  @async.with_task_group <| group => {
     let mut remaining = total_conn
     for _ in 0..<max_concurrent_conn {
-      group.spawn_bg(() => {
+      group.spawn_bg() <| () => {
         let buf = FixedArray::make(1024, b'0')
         while remaining > 0 {
           remaining -= 1
           @async.sleep(rand.int(limit=conn_duration / 10))
           let conn = @socket.Tcp::connect(dst)
           defer conn.close()
-          @async.with_task_group(conn_group => {
+          @async.with_task_group <| conn_group => {
             let mut send_count : Int64 = 0
             let mut recv_count : Int64 = 0
             let mut before : Int64 = 0
-            conn_group.spawn_loop(no_wait=true, () => {
+            conn_group.spawn_loop(no_wait=true) <| () => {
               if send_count == 0 {
                 before = @async.now()
               }
               conn.write(data)
               send_count += data.length().to_int64()
-            })
-            conn_group.spawn_loop(no_wait=true, () => {
+            }
+            conn_group.spawn_loop(no_wait=true) <| () => {
               let n = conn.read(buf)
               if recv_count == 0 {
                 latency_sum += @async.now() - before
               }
               recv_count += n.to_int64()
-            })
+            }
             @async.sleep(conn_duration)
             throughput_sum += (send_count + recv_count) *
               1000 /
               conn_duration.to_int64()
-          })
+          }
         }
-      })
+      }
     }
-  })
+  }
   (
     throughput_sum / total_conn.to_int64(),
     latency_sum.to_double() / total_conn.to_double(),

--- a/examples/udp_echo_server/main.mbt
+++ b/examples/udp_echo_server/main.mbt
@@ -14,16 +14,16 @@
 
 ///|
 async fn main {
-  @async.with_task_group(root => {
+  @async.with_task_group <| root => {
     let server = @socket.UdpServer(@socket.Addr::parse("0.0.0.0:4200"))
     defer server.close()
     for ;; {
       let buf = FixedArray::make(1024, b'0')
       let (n, addr) = server.recvfrom(buf)
-      root.spawn_bg(() => {
+      root.spawn_bg() <| () => {
         let buf = buf.unsafe_reinterpret_as_bytes()
         server.sendto(buf[0:n].to_owned(), addr)
-      })
+      }
     }
-  })
+  }
 }

--- a/examples/udp_ping_pong/main.mbt
+++ b/examples/udp_ping_pong/main.mbt
@@ -20,11 +20,11 @@ pub(all) struct Printer((String) -> Unit)
 
 ///|
 async fn server_main(server : @socket.UdpServer, println : Printer) -> Unit {
-  @async.with_task_group(group => {
+  (@async.with_task_group <| group => {
     defer server.close()
     let buf = FixedArray::make(1024, b'0')
     while server.recvfrom(buf) is (n, addr) && n > 0 {
-      group.spawn_bg(() => {
+      group.spawn_bg() <| () => {
         @async.sleep(10)
         let msg = buf.unsafe_reinterpret_as_bytes()[0:n]
         println("server received: \{@utf8.decode(msg)}")
@@ -35,7 +35,7 @@ async fn server_main(server : @socket.UdpServer, println : Printer) -> Unit {
           println("server initiate terminate")
           raise ServerTerminate
         }
-      })
+      }
     } nobreak {
       println("server: connection closed by peer")
     }
@@ -70,20 +70,20 @@ async fn client(
 
 ///|
 pub async fn main_prog(println : Printer) -> Unit {
-  @async.with_task_group(root => {
+  (@async.with_task_group <| root => {
     let server = @socket.UdpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg(() => server_main(server, println))
-    root.spawn_bg(() => {
-      @async.with_task_group(ctx => {
+    root.spawn_bg() <| () => { server_main(server, println) }
+    root.spawn_bg() <| () => {
+      @async.with_task_group <| ctx => {
         for i in 0..<6 {
           let msg = if i % 3 == 1 { "pong" } else { "ping" }
-          ctx.spawn_bg(() => client(addr, println, i, msg))
+          ctx.spawn_bg() <| () => { client(addr, println, i, msg) }
           @async.sleep(100)
         }
-      })
-      root.spawn_bg(() => client(addr, println, 6, "exit"))
-    })
+      }
+      root.spawn_bg() <| () => { client(addr, println, 6, "exit") }
+    }
   }) catch {
     ServerTerminate => ()
     err => raise err

--- a/examples/websocket_echo_server/main.mbt
+++ b/examples/websocket_echo_server/main.mbt
@@ -40,7 +40,7 @@ async fn main {
 async fn start_echo_server(port? : Int = 9001) -> Unit {
   println("Starting WebSocket echo server on localhost:\{port}")
   let server = @http.Server(@socket.Addr::parse("127.0.0.1:\{port}"))
-  server.run_forever((request, _, conn) => {
+  server.run_forever() <| ((request, _, conn) => {
     let client_addr = conn.client_addr()
     println("New WebSocket connection from \{client_addr}")
     let ws = @websocket.from_http_server(request, conn)

--- a/examples/websocket_echo_server/server_wbtest.mbt
+++ b/examples/websocket_echo_server/server_wbtest.mbt
@@ -14,8 +14,8 @@
 
 ///|
 async test "test server" {
-  @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, () => start_echo_server(port=49001))
+  @async.with_task_group <| group => {
+    group.spawn_bg(no_wait=true) <| () => { start_echo_server(port=49001) }
     let client = @websocket.connect("ws://localhost:49001")
     defer client.close()
     client.send_binary(b"abcd")
@@ -27,5 +27,5 @@ async test "test server" {
     debug_inspect(msg.kind, content="Text")
     inspect(msg.read_all().text(), content="abcd")
     client.send_close()
-  })
+  }
 }

--- a/examples/xargs/main.mbt
+++ b/examples/xargs/main.mbt
@@ -53,15 +53,15 @@ async fn main {
     { "args": args, .. } => args
     _ => []
   }
-  @async.with_task_group(group => {
+  @async.with_task_group <| group => {
     while @stdio.stdin.read_until("\n") is Some(line) {
       if max_jobs is Some(limit) {
         limit.acquire()
       }
-      group.spawn_bg(() => {
+      group.spawn_bg() <| () => {
         defer (if max_jobs is Some(limit) { limit.release() })
         ignore(@process.run(cmd, [..args, line]))
-      })
+      }
     }
-  })
+  }
 }


### PR DESCRIPTION
## Summary

- Convert example callbacks that are the final argument to use `<|` sugar.
- Keep this separate from the argparse conversions so review can focus on syntax-only callback changes.
- Cover server callbacks, task groups, background tasks, loops, and example whitebox tests.
- Rebased onto current `main` after the argparse examples change landed.

## Validation

- `moon check`
- `moon test` (first run hit unrelated timing/order-sensitive `fs/lock_test.mbt` expectations, rerun passed: 488/488)
