### PR TITLE
[codex] apply callback sugar project-wide

### DIFF
--- a/src/all_any_test.mbt
+++ b/src/all_any_test.mbt
@@ -142,9 +142,9 @@ async test "all cancelled" {
     idx
   }
 
-  let result = @async.with_timeout_opt(300, () => {
-    @async.all([() => task(1, 450), () => task(2, 150)])
-  })
+  let result = @async.with_timeout_opt(300) <| () => {
+      @async.all([() => task(1, 450), () => task(2, 150)])
+    }
   debug_inspect(result, content="None")
   json_inspect(log, content=[
     "task #2 completed", "task #1 cancelled with Cancelled",
@@ -300,9 +300,9 @@ async test "any cancelled" {
     idx
   }
 
-  let result = @async.with_timeout_opt(200, () => {
-    @async.any([() => task(1, 400), () => task(2, 400)])
-  })
+  let result = @async.with_timeout_opt(200) <| () => {
+      @async.any([() => task(1, 400), () => task(2, 400)])
+    }
   debug_inspect(result, content="None")
   json_inspect(log, content=[
     "task #1 cancelled with Cancelled", "task #2 cancelled with Cancelled",

--- a/src/allow_failure_test.mbt
+++ b/src/allow_failure_test.mbt
@@ -15,11 +15,11 @@
 ///|
 async test "allow_failure ignored" {
   let buf = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(allow_failure=true, () => raise Err)
+  @async.with_task_group() <| root => {
+    root.spawn_bg(allow_failure=true) <| () => { raise Err }
     @async.sleep(100)
     buf <+ "main task terminate\n"
-  })
+  }
   inspect(
     buf.to_string(),
     content=(
@@ -34,8 +34,8 @@ async test "allow_failure waited" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        let task = root.spawn(allow_failure=true, () => raise Err)
+      try? (@async.with_task_group() <| root => {
+        let task = root.spawn(allow_failure=true) <| () => { raise Err }
         @async.sleep(100)
         task.wait()
         buf <+ "main task terminate\n"
@@ -50,11 +50,11 @@ async test "allow_failure no error" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(allow_failure=true, () => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg(allow_failure=true) <| () => {
           @async.sleep(1000)
           buf <+ "`allow_failure` task terminate\n"
-        })
+        }
         @async.sleep(100)
         buf <+ "main task terminate\n"
       }),

--- a/src/aqueue/aqueue_test.mbt
+++ b/src/aqueue/aqueue_test.mbt
@@ -15,21 +15,21 @@
 ///|
 async test "aqueue basic" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let queue = @aqueue.Queue(kind=Unbounded)
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       for _ in 0..<6 {
         log.write_string("get => \{queue.get()}\n")
       }
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       for x in 0..<6 {
         @async.sleep(70)
         queue.put(x)
         log.write_string("put(\{x})\n")
       }
-    })
-  })
+    }
+  }
   inspect(
     log.to_string(),
     content=(
@@ -53,21 +53,21 @@ async test "aqueue basic" {
 ///|
 async test "aqueue multi-reader" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let queue = @aqueue.Queue(kind=Unbounded)
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       @async.sleep(70)
       let x = queue.get()
       log.write_string("task 1: get => \{x}\n")
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       let x = queue.get()
       log.write_string("task 2: get => \{x}\n")
-    })
+    }
     @async.sleep(170)
     queue.put(1)
     queue.put(2)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -82,7 +82,7 @@ async test "aqueue multi-reader" {
 async test "aqueue cancellation" {
   let log = StringBuilder::new()
   let queue : @aqueue.Queue[Int] = @aqueue.Queue(kind=Unbounded)
-  @async.with_timeout(350, () => {
+  (@async.with_timeout(350) <| () => {
     let x = queue.get() catch {
       err => {
         log.write_string("`queue.get()` cancelled with \{err}\n")
@@ -107,15 +107,17 @@ async test "aqueue cancellation" {
 async test "aqueue cancellation no_swallow" {
   // `get` should not swallow the value
   let log = StringBuilder::new()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @aqueue.Queue(kind=Unbounded)
-    let get_task = group.spawn(() => log.write_string("get() => \{q.get()}\n"))
+    let get_task = group.spawn() <| () => {
+        log.write_string("get() => \{q.get()}\n")
+      }
     @async.sleep(100)
     q.put(42)
     get_task.cancel()
     @async.sleep(100)
     debug_inspect(q.try_get(), content="None")
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -128,27 +130,27 @@ async test "aqueue cancellation no_swallow" {
 ///|
 async test "aqueue fairness" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let queue = @aqueue.Queue(kind=Unbounded)
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       for _ in 0..<2 {
         let x = queue.get()
         log.write_string("task 1: get => \{x}\n")
       }
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       for _ in 0..<2 {
         let x = queue.get()
         log.write_string("task 2: get => \{x}\n")
       }
-    })
+    }
     @async.sleep(70)
     queue.put(1)
     queue.put(2)
     @async.sleep(70)
     queue.put(3)
     queue.put(4)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -164,18 +166,18 @@ async test "aqueue fairness" {
 ///|
 async test "aqueue fairness2" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let queue = @aqueue.Queue(kind=Unbounded)
     queue.put(1)
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       for _ in 0..<2 {
         let x = queue.get()
         log.write_string("task 1: get => \{x}\n")
         @async.sleep(200)
         queue.put(x + 1)
       }
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       @async.sleep(100)
       for _ in 0..<2 {
         let x = queue.get()
@@ -183,8 +185,8 @@ async test "aqueue fairness2" {
         @async.sleep(200)
         queue.put(x + 1)
       }
-    })
-  })
+    }
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/aqueue/blocking_test.mbt
+++ b/src/aqueue/blocking_test.mbt
@@ -15,22 +15,22 @@
 ///|
 async test "blocking unbuffered" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=Blocking(1))
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       for i in 0..<3 {
         q.put(i)
         log.push("put(\{i})")
       }
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       for _ in 0..<3 {
         let x = q.get()
         log.push("get() => \{x}")
         @async.sleep(100)
       }
-    })
-  })
+    }
+  }
   json_inspect(log, content=[
     "put(0)", "get() => 0", "put(1)", "get() => 1", "put(2)", "get() => 2",
   ])
@@ -39,22 +39,22 @@ async test "blocking unbuffered" {
 ///|
 async test "blocking buffered" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=Blocking(2))
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       for i in 0..<4 {
         q.put(i)
         log.push("put(\{i})")
       }
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       for _ in 0..<4 {
         let x = q.get()
         log.push("get() => \{x}")
         @async.sleep(100)
       }
-    })
-  })
+    }
+  }
   json_inspect(log, content=[
     "put(0)", "put(1)", "get() => 0", "put(2)", "get() => 1", "put(3)", "get() => 2",
     "get() => 3",
@@ -64,28 +64,28 @@ async test "blocking buffered" {
 ///|
 async test "blocking fairness" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=Blocking(1))
     q.put(0)
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       for i in 0..<3 {
         q.put(i)
         log.push("task 1 put(\{i})")
       }
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       for i in 0..<3 {
         q.put(i)
         log.push("task 2 put(\{i})")
       }
-    })
-    group.spawn_bg(no_wait=true, () => {
+    }
+    group.spawn_bg(no_wait=true) <| () => {
       for ;; {
         @async.sleep(100)
         ignore(q.get())
       }
-    })
-  })
+    }
+  }
   json_inspect(log, content=[
     "task 1 put(0)", "task 2 put(0)", "task 1 put(1)", "task 2 put(1)", "task 1 put(2)",
     "task 2 put(2)",
@@ -95,14 +95,14 @@ async test "blocking fairness" {
 ///|
 async test "blocking cancellation" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=Blocking(1))
     q.put(0)
-    group.spawn_bg(no_wait=true, () => {
+    group.spawn_bg(no_wait=true) <| () => {
       @async.sleep(250)
       ignore(q.get())
-    })
-    @async.with_timeout(500, () => {
+    }
+    (@async.with_timeout(500) <| () => {
       for ;; {
         q.put(0) catch {
           err => {
@@ -116,17 +116,17 @@ async test "blocking cancellation" {
       @async.TimeoutError => ()
       err => raise err
     }
-  })
+  }
   json_inspect(log, content=["put() completed", "put() cancelled"])
 }
 
 ///|
 async test "blocking fairness2" {
   let log = []
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let queue = @async.Queue(kind=Blocking(1))
     queue.put(0)
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       for i in 0..<2 {
         queue.put(i)
         log.push("task 1: put() completed")
@@ -134,8 +134,8 @@ async test "blocking fairness2" {
         let x = queue.get()
         log.push("task 1: get() => \{x}")
       }
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       @async.sleep(100)
       for i in 0..<2 {
         queue.put(i)
@@ -144,10 +144,10 @@ async test "blocking fairness2" {
         let x = queue.get()
         log.push("task 2: get() => \{x}")
       }
-    })
+    }
     @async.sleep(200)
     inspect(queue.get(), content="0")
-  })
+  }
   json_inspect(log, content=[
     "task 1: put() completed", "task 1: get() => 0", "task 2: put() completed", "task 2: get() => 0",
     "task 1: put() completed", "task 1: get() => 1", "task 2: put() completed", "task 2: get() => 1",
@@ -157,46 +157,46 @@ async test "blocking fairness2" {
 ///|
 async test "blocking immediate cancellation" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=Blocking(1))
     q.put(0)
-    let put_task = group.spawn(() => {
-      q.put(1) catch {
-        err => {
-          log.push("put() cancelled")
-          raise err
+    let put_task = group.spawn() <| () => {
+        q.put(1) catch {
+          err => {
+            log.push("put() cancelled")
+            raise err
+          }
         }
+        log.push("put() completed")
       }
-      log.push("put() completed")
-    })
     @async.sleep(100)
     let _ = q.get()
     put_task.cancel()
     @async.sleep(100)
     debug_inspect(q.try_get(), content="Some(1)")
-  })
+  }
   json_inspect(log, content=["put() completed"])
 }
 
 ///|
 async test "blocking zero buffered" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=Blocking(0))
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       for i in 0..<4 {
         q.put(i)
         log.push("put(\{i})")
       }
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       for _ in 0..<4 {
         let x = q.get()
         log.push("get() => \{x}")
         @async.sleep(100)
       }
-    })
-  })
+    }
+  }
   json_inspect(log, content=[
     "get() => 0", "put(0)", "get() => 1", "put(1)", "get() => 2", "put(2)", "get() => 3",
     "put(3)",
@@ -235,22 +235,22 @@ test "blocking try_put" {
 ///|
 async test "blocked zero buffered try_get" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=Blocking(0))
     @debug.assert_eq(None, q.try_get())
     for i in 0..<3 {
-      group.spawn_bg(() => {
+      group.spawn_bg() <| () => {
         q.put(i)
         log.push("put(\{i})")
-      })
+      }
     }
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       while q.try_get() is Some(x) {
         log.push("try_get() => \{x}")
       }
-    })
+    }
     @debug.assert_eq(None, q.try_get())
-  })
+  }
   json_inspect(log, content=[
     "try_get() => 0", "try_get() => 1", "try_get() => 2", "put(0)", "put(1)", "put(2)",
   ])
@@ -259,16 +259,16 @@ async test "blocked zero buffered try_get" {
 ///|
 async test "blocked zero buffered try_put" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=Blocking(0))
     assert_eq(false, q.try_put(-1))
     for _ in 0..<3 {
-      group.spawn_bg(() => {
+      group.spawn_bg() <| () => {
         let x = q.get()
         log.push("get() => \{x}")
-      })
+      }
     }
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       for i in 0..<3 {
         if q.try_put(i) {
           log.push("try_put(\{i})")
@@ -276,9 +276,9 @@ async test "blocked zero buffered try_put" {
           log.push("try_put(\{i}) => false")
         }
       }
-    })
+    }
     assert_eq(false, q.try_put(-1))
-  })
+  }
   json_inspect(log, content=[
     "try_put(0)", "try_put(1)", "try_put(2)", "get() => 0", "get() => 1", "get() => 2",
   ])
@@ -287,38 +287,38 @@ async test "blocked zero buffered try_put" {
 ///|
 async test "blocked zero buffered discard oldest try_get" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=DiscardOldest(0))
     @debug.assert_eq(None, q.try_get())
     for i in 0..<3 {
-      group.spawn_bg(() => {
+      group.spawn_bg() <| () => {
         q.put(i) // will be discarded since the buffer size is 0 and no waiting readers
         log.push("put(\{i})")
-      })
+      }
     }
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       while q.try_get() is Some(x) {
         log.push("try_get() => \{x}")
       }
-    })
+    }
     @debug.assert_eq(None, q.try_get())
-  })
+  }
   json_inspect(log, content=["put(0)", "put(1)", "put(2)"])
 }
 
 ///|
 async test "blocked zero buffered discard oldest try_put" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=DiscardOldest(0))
     @debug.assert_eq(false, q.try_put(-1))
     for _ in 0..<3 {
-      group.spawn_bg(() => {
+      group.spawn_bg() <| () => {
         let x = q.get()
         log.push("get() => \{x}")
-      })
+      }
     }
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       for i in 0..<3 {
         if q.try_put(i) {
           log.push("try_put(\{i})")
@@ -326,9 +326,9 @@ async test "blocked zero buffered discard oldest try_put" {
           log.push("try_put(\{i}) => false")
         }
       }
-    })
+    }
     @debug.assert_eq(false, q.try_put(-1))
-  })
+  }
   json_inspect(log, content=[
     "try_put(0)", "try_put(1)", "try_put(2)", "get() => 0", "get() => 1", "get() => 2",
   ])
@@ -337,16 +337,16 @@ async test "blocked zero buffered discard oldest try_put" {
 ///|
 async test "blocked zero buffered discard latest try_put" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let q = @async.Queue(kind=DiscardLatest(0))
     @debug.assert_eq(false, q.try_put(-1))
     for _ in 0..<3 {
-      group.spawn_bg(() => {
+      group.spawn_bg() <| () => {
         let x = q.get()
         log.push("get() => \{x}")
-      })
+      }
     }
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       for i in 0..<3 {
         if q.try_put(i) {
           log.push("try_put(\{i})")
@@ -354,9 +354,9 @@ async test "blocked zero buffered discard latest try_put" {
           log.push("try_put(\{i}) => false")
         }
       }
-    })
+    }
     @debug.assert_eq(false, q.try_put(-1))
-  })
+  }
   json_inspect(log, content=[
     "try_put(0)", "try_put(1)", "try_put(2)", "get() => 0", "get() => 1", "get() => 2",
   ])

--- a/src/aqueue/close_test.mbt
+++ b/src/aqueue/close_test.mbt
@@ -58,47 +58,47 @@ async test "try_get after hard close" {
 async test "close with blocking put" {
   let q = @async.Queue(kind=Blocking(1))
   q.put(1)
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let start = @async.now()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       @async.sleep(300)
       q.close()
-    })
+    }
     debug_inspect(try? q.put(2), content="Err(QueueAlreadyClosed)")
     let now = @async.now()
     let duration = (now + 50 - start) / 300
     inspect(duration, content="1")
-  })
+  }
 }
 
 ///|
 async test "close zero buffered with blocking put" {
   let q = @async.Queue(kind=Blocking(0))
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let start = @async.now()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       @async.sleep(300)
       q.close()
-    })
+    }
     debug_inspect(try? q.put(2), content="Err(QueueAlreadyClosed)")
     let now = @async.now()
     let duration = (now + 50 - start) / 300
     inspect(duration, content="1")
-  })
+  }
 }
 
 ///|
 async test "close with blocking get" {
   let q : @aqueue.Queue[Int] = @async.Queue(kind=Unbounded)
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let start = @async.now()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       @async.sleep(300)
       q.close()
-    })
+    }
     debug_inspect(try? q.get(), content="Err(QueueAlreadyClosed)")
     let now = @async.now()
     let duration = (now + 50 - start) / 300
     inspect(duration, content="1")
-  })
+  }
 }

--- a/src/async.mbt
+++ b/src/async.mbt
@@ -59,13 +59,13 @@ pub async fn[X] with_timeout(
   f : async () -> X,
   error? : Error = TimeoutError,
 ) -> X {
-  with_task_group(group => {
-    group.spawn_bg(no_wait=true, () => {
+  with_task_group() <| group => {
+    group.spawn_bg(no_wait=true) <| () => {
       sleep(time)
       raise error
-    })
+    }
     f()
-  })
+  }
 }
 
 ///|
@@ -79,13 +79,13 @@ pub async fn[X] with_timeout(
 /// - If `f` is still running after `timeout` milliseconds,
 /// ` with_timeout_opt` will return `None` immediately, and `f` will be cancelled.
 pub async fn[X] with_timeout_opt(time : Int, f : async () -> X) -> X? {
-  with_task_group(group => {
-    group.spawn_bg(no_wait=true, () => {
+  with_task_group() <| group => {
+    group.spawn_bg(no_wait=true) <| () => {
       sleep(time)
       group.return_immediately(None)
-    })
+    }
     Some(f())
-  })
+  }
 }
 
 ///|
@@ -229,21 +229,21 @@ pub async fn[X] all(
     None
   }
   let results = Array::make(tasks.length(), None)
-  with_task_group(tg => {
+  with_task_group() <| tg => {
     for i, task in tasks {
       if semaphore is Some(sem) {
         sem.acquire()
       }
-      tg.spawn_bg(() => {
+      tg.spawn_bg() <| () => {
         // We rely on the assumption that the task spawned will 100% executed
         // even if it is cancelled, so that we can release the semaphore properly.
         defer (if semaphore is Some(sem) { sem.release() })
         let result = task()
         results[i] = Some(result)
-      })
+      }
     }
-  })
-  results.map(r => r.unwrap())
+  }
+  results.map() <| r => { r.unwrap() }
 }
 
 ///|
@@ -277,12 +277,12 @@ pub async fn[X] any(
   }
   let mut result = None
   let mut last_err = None
-  with_task_group(tg => {
+  with_task_group() <| tg => {
     for task in tasks {
       if semaphore is Some(sem) {
         sem.acquire()
       }
-      tg.spawn_bg(allow_failure~, () => {
+      tg.spawn_bg(allow_failure~) <| () => {
         // We rely on the assumption that the task spawned will 100% executed
         // even if it is cancelled, so that we can release the semaphore properly.
         defer (if semaphore is Some(sem) { sem.release() })
@@ -293,9 +293,9 @@ pub async fn[X] any(
           }
         }
         tg.return_immediately(())
-      })
+      }
     }
-  })
+  }
   if result is Some(result) {
     result
   } else {

--- a/src/cancellation_test.mbt
+++ b/src/cancellation_test.mbt
@@ -15,18 +15,18 @@
 ///|
 async test "manual cancel" {
   let buf = StringBuilder::new()
-  let result = try? @async.with_task_group(root => {
-    let task = root.spawn(() => {
-      try {
-        @async.sleep(300)
-        buf <+ "task finished\n"
-      } catch {
-        err => {
-          buf.write_string("cancelled by error \{err}\n")
-          raise err
+  let result = try? (@async.with_task_group() <| root => {
+    let task = root.spawn() <| () => {
+        try {
+          @async.sleep(300)
+          buf <+ "task finished\n"
+        } catch {
+          err => {
+            buf.write_string("cancelled by error \{err}\n")
+            raise err
+          }
         }
       }
-    })
     @async.sleep(100)
     task.cancel()
     @async.sleep(200)
@@ -51,12 +51,12 @@ async test "error propagation" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(300)
           raise Err
-        })
-        root.spawn_bg(() => {
+        }
+        root.spawn_bg() <| () => {
           try {
             @async.sleep(200)
             buf <+ "task 2, tick 1\n"
@@ -70,7 +70,7 @@ async test "error propagation" {
           } noraise {
             _ => buf <+ "task 2 normal exit\n"
           }
-        })
+        }
       }),
     ),
   )
@@ -87,15 +87,15 @@ async test "error propagation" {
 ///|
 async test "multiple scope" {
   let buf = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       try
-        @async.with_task_group(fn(ctx) {
-          ctx.spawn_bg(() => {
+        @async.with_task_group() <| fn(ctx) {
+          ctx.spawn_bg() <| () => {
             @async.sleep(200)
             raise Err
-          })
-          ctx.spawn_bg(() => {
+          }
+          ctx.spawn_bg() <| () => {
             try @async.sleep(400) catch {
               err => {
                 buf.write_string("ctx 1 task 2 cancelled with \{err}\n")
@@ -104,8 +104,8 @@ async test "multiple scope" {
             } noraise {
               _ => buf <+ "ctx 1 task 2 finished\n"
             }
-          })
-        })
+          }
+        }
       catch {
         err => {
           buf <+ "ctx 1 received error "
@@ -115,15 +115,15 @@ async test "multiple scope" {
       } noraise {
         _ => buf <+ "ctx 1 finished normally\n"
       }
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       try
-        @async.with_task_group(fn(ctx) {
-          ctx.spawn_bg(() => {
+        @async.with_task_group() <| fn(ctx) {
+          ctx.spawn_bg() <| () => {
             @async.sleep(500)
             raise Err
-          })
-          ctx.spawn_bg(() => {
+          }
+          ctx.spawn_bg() <| () => {
             try @async.sleep(300) catch {
               err => {
                 buf.write_string("ctx 2 task 2 cancelled with \{err}\n")
@@ -132,8 +132,8 @@ async test "multiple scope" {
             } noraise {
               _ => buf <+ "ctx 2 task 2 finished\n"
             }
-          })
-        })
+          }
+        }
       catch {
         err => {
           buf <+ "ctx 2 received error "
@@ -143,8 +143,8 @@ async test "multiple scope" {
       } noraise {
         _ => buf <+ "ctx 2 finished normally\n"
       }
-    })
-  })
+    }
+  }
   inspect(
     buf.to_string(),
     content=(
@@ -162,22 +162,22 @@ async test "recursive cancel" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           for _ in 0..<2 {
             @async.sleep(400)
             buf <+ "tick\n"
           }
-        })
-        let task = root.spawn(() => {
-          @async.sleep(1000) catch {
-            err => buf.write_string("first sleep cancelled with \{err}\n")
+        }
+        let task = root.spawn() <| () => {
+            @async.sleep(1000) catch {
+              err => buf.write_string("first sleep cancelled with \{err}\n")
+            }
+            @async.sleep(1000) catch {
+              err => buf.write_string("second sleep cancelled with \{err}\n")
+            }
+            buf <+ "task finished\n"
           }
-          @async.sleep(1000) catch {
-            err => buf.write_string("second sleep cancelled with \{err}\n")
-          }
-          buf <+ "task finished\n"
-        })
         @async.sleep(600)
         task.cancel()
         buf <+ "main task exit\n"
@@ -203,16 +203,16 @@ async test "spawn directly error" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
-          @async.with_task_group(group => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
+          @async.with_task_group() <| group => {
             @async.sleep(1)
-            group.spawn_bg(() => raise Err)
+            group.spawn_bg() <| () => { raise Err }
             buf <+ "after spawn\n"
             @async.sleep(400)
             buf <+ "main task exit\n"
-          })
-        })
+          }
+        }
         @async.sleep(200)
       }),
     ),
@@ -231,15 +231,15 @@ async test "error in cancellation" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(no_wait=true, () => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg(no_wait=true) <| () => {
           @async.sleep(1000) catch {
             _ => {
               log <+ "causing other error in cancellation handler\n"
               raise Err
             }
           }
-        })
+        }
         @async.sleep(200)
       }),
     ),
@@ -256,16 +256,16 @@ async test "error in cancellation" {
 ///|
 async test "immediately cancelled" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    let task = root.spawn(() => {
-      defer log.write_string("task terminated\n")
-      log <+ "task started\n"
-      @async.sleep(100)
-      log <+ "task finished\n"
-    })
+  @async.with_task_group() <| root => {
+    let task = root.spawn() <| () => {
+        defer log.write_string("task terminated\n")
+        log <+ "task started\n"
+        @async.sleep(100)
+        log <+ "task finished\n"
+      }
     log <+ "task spawned\n"
     task.cancel()
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -279,9 +279,11 @@ async test "immediately cancelled" {
 
 ///|
 async test "immediate failure" {
-  let result = try? @async.with_task_group(group => {
-    group.spawn_bg(() => raise Failure::Failure("failure"))
-    group.spawn_bg(() => group.spawn_bg(() => @async.sleep(100)))
+  let result = try? (@async.with_task_group() <| group => {
+    group.spawn_bg() <| () => { raise Failure::Failure("failure") }
+    group.spawn_bg() <| () => {
+      group.spawn_bg() <| () => { @async.sleep(100) }
+    }
   })
   debug_inspect(
     result,
@@ -296,14 +298,14 @@ async test "immediate failure" {
 ///|
 async test "task group cancel & complete at the same time" {
   let log = []
-  @async.with_task_group(outer => {
-    @async.with_task_group(inner => {
-      outer.spawn_bg(no_wait=true, () => {
+  @async.with_task_group() <| outer => {
+    @async.with_task_group() <| inner => {
+      outer.spawn_bg(no_wait=true) <| () => {
         for i = 1; ; i = i + 1 {
           @async.pause()
           log.push("round #\{i}")
         }
-      })
+      }
       // At round #1, the following things will happen in order:
       // - `inner.return_immediately()` is called,
       //   and all tasks in `inner` are cancelled,
@@ -311,20 +313,20 @@ async test "task group cancel & complete at the same time" {
       // - `task1` starts and completes, waking the main task of `inner`
       // So here we will have `.cancer()` and `.wake()` called on the same coroutine,
       // but the coroutine should be woken only once in this case.
-      inner.spawn_bg(() => inner.return_immediately(()))
-      let task1 = inner.spawn(() => ())
+      inner.spawn_bg() <| () => { inner.return_immediately(()) }
+      let task1 = inner.spawn() <| () => { () }
       task1.wait() catch {
         err => {
           log.push("inner group main task cancelled")
-          @async.protect_from_cancel(() => {
+          @async.protect_from_cancel() <| () => {
             @async.pause()
             log.push("inner group main task cleanup completed")
             raise err
-          })
+          }
         }
       }
-    })
-  })
+    }
+  }
   json_inspect(log, content=[
     "round #1", "inner group main task cancelled", "round #2", "inner group main task cleanup completed",
     "round #3",

--- a/src/cond_var/cond_var_test.mbt
+++ b/src/cond_var/cond_var_test.mbt
@@ -14,37 +14,37 @@
 
 ///|
 async test "cond var cancellation" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let cond = @cond_var.Cond()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       @async.sleep(500)
       cond.signal()
-    })
+    }
     debug_inspect(
-      try? @async.with_timeout(250, () => cond.wait()),
+      try? (@async.with_timeout(250) <| () => { cond.wait() }),
       content="Err(TimeoutError)",
     )
-  })
+  }
 }
 
 ///|
 async test "cond var cancellation no_swallow" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let cond = @cond_var.Cond()
-    let wait_task = root.spawn(() => {
-      cond.wait()
-      log <+ "waiter 1 succeed\n"
-    })
-    root.spawn_bg(no_wait=true, () => {
+    let wait_task = root.spawn() <| () => {
+        cond.wait()
+        log <+ "waiter 1 succeed\n"
+      }
+    root.spawn_bg(no_wait=true) <| () => {
       cond.wait()
       log <+ "waiter 2 succeed\n"
-    })
+    }
     @async.sleep(100)
     cond.signal()
     wait_task.cancel()
     @async.sleep(100)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -57,27 +57,27 @@ async test "cond var cancellation no_swallow" {
 ///|
 async test "cond var fairness" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let cond = @cond_var.Cond()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       for _ in 0..<3 {
         cond.wait()
         log <+ "task 1 received signal\n"
       }
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       @async.sleep(100)
       for _ in 0..<3 {
         cond.wait()
         log <+ "task 2 received signal\n"
       }
-    })
+    }
     @async.sleep(200)
     for _ in 0..<6 {
       cond.signal()
       @async.sleep(50)
     }
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -95,17 +95,17 @@ async test "cond var fairness" {
 ///|
 async test "cond var broadcast" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let cond = @cond_var.Cond()
     for i in 0..<3 {
-      root.spawn_bg(() => {
+      root.spawn_bg() <| () => {
         cond.wait()
         log.write_string("task \{i} received signal\n")
-      })
+      }
     }
     @async.sleep(100)
     cond.broadcast()
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -120,17 +120,17 @@ async test "cond var broadcast" {
 ///|
 async test "cond var broadcast cancellation" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let cond = @cond_var.Cond()
     for i in 0..<3 {
-      root.spawn_bg(allow_failure=true, () => {
-        @async.with_timeout(200 * (i + 1), () => cond.wait())
+      root.spawn_bg(allow_failure=true) <| () => {
+        @async.with_timeout(200 * (i + 1)) <| () => { cond.wait() }
         log.write_string("task \{i} received signal\n")
-      })
+      }
     }
     @async.sleep(500)
     cond.broadcast()
-  })
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/fs/access_test.mbt
+++ b/src/fs/access_test.mbt
@@ -48,9 +48,9 @@ async test "can_execute" {
 #cfg(not(platform="windows"))
 async test "chmod" {
   let path = "_build/chmod_test"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateNew, permission=0o444)
-    group.add_defer(() => @fs.remove(path))
+    group.add_defer() <| () => { @fs.remove(path) }
     inspect(@fs.can_read(path), content="true")
     inspect(@fs.can_write(path), content="false")
     inspect(@fs.can_execute(path), content="false")
@@ -62,5 +62,5 @@ async test "chmod" {
     inspect(@fs.can_read(path), content="true")
     inspect(@fs.can_write(path), content="true")
     inspect(@fs.can_execute(path), content="true")
-  })
+  }
 }

--- a/src/fs/create_test.mbt
+++ b/src/fs/create_test.mbt
@@ -73,14 +73,14 @@ async test "wrapper test" {
 ///|
 async test "create_mode test" {
   let path = "_build/create_exclusive_test"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     for create_mode in [@fs.OpenExisting, @fs.TruncateExisting] {
       assert_true((try? @fs.open(path, mode=WriteOnly, create_mode~)) is Err(_))
     }
     {
       let file = @fs.create(path, allow_existing=false)
       defer file.close()
-      group.add_defer(() => @fs.remove(path))
+      group.add_defer() <| () => { @fs.remove(path) }
       file.write("abcd")
     }
     inspect(@fs.read_file(path).text(), content="abcd")
@@ -112,5 +112,5 @@ async test "create_mode test" {
       file.write("34")
     }
     inspect(@fs.read_file(path).text(), content="34")
-  })
+  }
 }

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -377,10 +377,10 @@ pub async fn walk(
   let context = "@fs.walk()"
   guard max_concurrency > 0
   let sem = @async.Semaphore(max_concurrency)
-  @async.with_task_group(fn(group) {
+  @async.with_task_group() <| fn(group) {
     fn handle_path(path : String) {
       guard !exclude(path) else {  }
-      group.spawn_bg(allow_failure~, () => {
+      group.spawn_bg(allow_failure~) <| () => {
         sem.acquire()
         defer sem.release()
         let dir = opendir_aux(path, context~)
@@ -398,9 +398,9 @@ pub async fn walk(
           files.push(ent.name)
         }
         f(path, files)
-      })
+      }
     }
 
     handle_path(path.to_owned())
-  })
+  }
 }

--- a/src/fs/dir_test.mbt
+++ b/src/fs/dir_test.mbt
@@ -16,9 +16,13 @@
 async test "read_all" {
   let dir = @fs.opendir("src/fs")
   defer dir.close()
-  let list = dir
-    .read_all()
-    .filter_map(x => if x is "target" { None } else { Some(x) })
+  let list = dir.read_all().filter_map() <| x => {
+      if x is "target" {
+        None
+      } else {
+        Some(x)
+      }
+    }
   list.sort()
   json_inspect(list, content=[
     "dir.c", "stub.c", "dir.mbt", "file.mbt", "moon.pkg", "README.md", "utils.mbt",
@@ -49,7 +53,7 @@ async test "as_dir" {
 
 ///|
 test "readdir clear errno" {
-  @event_loop.with_event_loop(() => {
+  @event_loop.with_event_loop() <| () => {
     // do something to set a non-zero errno
     try @fs.open("/this/file/does/not/exist", mode=ReadOnly) catch {
       _ => ()
@@ -65,5 +69,5 @@ test "readdir clear errno" {
         #|30
       ),
     )
-  })
+  }
 }

--- a/src/fs/lock_test.mbt
+++ b/src/fs/lock_test.mbt
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 ///|
-let lock_file_prog : @async.Lazy[String] = @async.Lazy(() => {
-  let code = @process.run("moon", [
-    "-C", "src/process/test_programs", "build", "lock_file", "--debug",
-  ])
-  if code != 0 {
-    fail("failed to build test program `lock_file`: \{code}")
+let lock_file_prog : @async.Lazy[String] = @async.Lazy() <| () => {
+    let code = @process.run("moon", [
+      "-C", "src/process/test_programs", "build", "lock_file", "--debug",
+    ])
+    if code != 0 {
+      fail("failed to build test program `lock_file`: \{code}")
+    }
+    "src/process/test_programs/_build/native/debug/build/lock_file/lock_file.exe"
   }
-  "src/process/test_programs/_build/native/debug/build/lock_file/lock_file.exe"
-})
 
 ///|
 async fn run_lock_file_prog(
@@ -41,28 +41,28 @@ async fn run_lock_file_prog(
     duration.to_string(),
     lock_kind,
   ])
-  group.spawn_bg(() => {
+  group.spawn_bg() <| () => {
     defer r.close()
     while r.read_until("\n") is Some(line) {
       log.push(prefix + line)
     }
-  })
+  }
 }
 
 ///|
 async test "flock exclusive vs exclusive" {
   let log = []
   let file_name = "_build/flock_ex_ex"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Exclusive, log)
     @async.sleep(250)
     log.push("try_lock() => \{file.try_lock(Exclusive)}")
     @async.sleep(500)
     log.push("try_lock() => \{file.try_lock(Exclusive)}")
-  })
+  }
   json_inspect(log, content=[
     "acquired lock", "try_lock() => false", "releasing lock", "try_lock() => true",
   ])
@@ -72,10 +72,10 @@ async test "flock exclusive vs exclusive" {
 async test "flock exclusive vs exclusive blocking" {
   let log = []
   let file_name = "_build/flock_ex_ex_blocking"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
@@ -83,7 +83,7 @@ async test "flock exclusive vs exclusive blocking" {
     defer file.unlock()
     @async.sleep(10)
     log.push("acquired lock")
-  })
+  }
   json_inspect(log, content=[
     "child: acquired lock", "attempting to acquire lock", "child: releasing lock",
     "acquired lock",
@@ -94,16 +94,16 @@ async test "flock exclusive vs exclusive blocking" {
 async test "flock shared vs exclusive" {
   let log = []
   let file_name = "_build/flock_sh_ex"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Shared, log)
     @async.sleep(250)
     log.push("try_lock() => \{file.try_lock(Exclusive)}")
     @async.sleep(500)
     log.push("try_lock() => \{file.try_lock(Exclusive)}")
-  })
+  }
   json_inspect(log, content=[
     "acquired lock", "try_lock() => false", "releasing lock", "try_lock() => true",
   ])
@@ -113,10 +113,10 @@ async test "flock shared vs exclusive" {
 async test "flock shared vs exclusive blocking" {
   let log = []
   let file_name = "_build/flock_sh_ex_blocking"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Shared, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
@@ -124,7 +124,7 @@ async test "flock shared vs exclusive blocking" {
     defer file.unlock()
     @async.sleep(10)
     log.push("acquired lock")
-  })
+  }
   json_inspect(log, content=[
     "child: acquired lock", "attempting to acquire lock", "child: releasing lock",
     "acquired lock",
@@ -135,16 +135,16 @@ async test "flock shared vs exclusive blocking" {
 async test "flock exclusive vs shared" {
   let log = []
   let file_name = "_build/flock_ex_sh"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Exclusive, log)
     @async.sleep(250)
     log.push("try_lock() => \{file.try_lock(Shared)}")
     @async.sleep(500)
     log.push("try_lock() => \{file.try_lock(Shared)}")
-  })
+  }
   json_inspect(log, content=[
     "acquired lock", "try_lock() => false", "releasing lock", "try_lock() => true",
   ])
@@ -154,10 +154,10 @@ async test "flock exclusive vs shared" {
 async test "flock exclusive vs shared blocking" {
   let log = []
   let file_name = "_build/flock_ex_sh_blocking"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
@@ -165,7 +165,7 @@ async test "flock exclusive vs shared blocking" {
     defer file.unlock()
     @async.sleep(10)
     log.push("acquired lock")
-  })
+  }
   json_inspect(log, content=[
     "child: acquired lock", "attempting to acquire lock", "child: releasing lock",
     "acquired lock",
@@ -176,14 +176,14 @@ async test "flock exclusive vs shared blocking" {
 async test "flock shared vs shared" {
   let log = []
   let file_name = "_build/flock_sh_sh"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Shared, log)
     @async.sleep(250)
     log.push("try_lock() => \{file.try_lock(Shared)}")
-  })
+  }
   json_inspect(log, content=[
     "acquired lock", "try_lock() => true", "releasing lock",
   ])
@@ -193,10 +193,10 @@ async test "flock shared vs shared" {
 async test "flock shared vs shared blocking" {
   let log = []
   let file_name = "_build/flock_sh_sh_blocking"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Shared, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
@@ -204,7 +204,7 @@ async test "flock shared vs shared blocking" {
     defer file.unlock()
     @async.sleep(10)
     log.push("acquired lock")
-  })
+  }
   json_inspect(log, content=[
     "child: acquired lock", "attempting to acquire lock", "acquired lock", "child: releasing lock",
   ])
@@ -214,10 +214,10 @@ async test "flock shared vs shared blocking" {
 async test "flock shared vs shared vs exclusive" {
   let log = []
   let file_name = "_build/flock_sh_sh_ex"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #1: ")
     @async.sleep(250)
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #2: ")
@@ -227,7 +227,7 @@ async test "flock shared vs shared vs exclusive" {
     log.push("try_lock() => \{file.try_lock(Exclusive)}")
     @async.sleep(450)
     log.push("try_lock() => \{file.try_lock(Exclusive)}")
-  })
+  }
   json_inspect(log, content=[
     "child #1: acquired lock", "child #2: acquired lock", "try_lock() => false",
     "child #1: releasing lock", "try_lock() => false", "child #2: releasing lock",
@@ -239,10 +239,10 @@ async test "flock shared vs shared vs exclusive" {
 async test "flock shared vs shared vs exclusive blocking" {
   let log = []
   let file_name = "_build/flock_sh_sh_ex_blocking"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #1: ")
     @async.sleep(250)
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #2: ")
@@ -252,7 +252,7 @@ async test "flock shared vs shared vs exclusive blocking" {
     defer file.unlock()
     @async.sleep(10)
     log.push("acquired lock")
-  })
+  }
   json_inspect(log, content=[
     "child #1: acquired lock", "child #2: acquired lock", "attempting to acquire lock",
     "child #1: releasing lock", "child #2: releasing lock", "acquired lock",
@@ -263,19 +263,19 @@ async test "flock shared vs shared vs exclusive blocking" {
 async test "flock cancelled" {
   let log = []
   let file_name = "_build/flock_cancel"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
-    let result = @async.with_timeout_opt(100, () => file.lock(Exclusive))
+    let result = @async.with_timeout_opt(100) <| () => { file.lock(Exclusive) }
     log.push("lock() with timeout: \{@debug.to_string(result)}")
     if result is Some(_) {
       file.unlock()
     }
-  })
+  }
   json_inspect(log, content=[
     "child: acquired lock", "attempting to acquire lock", "lock() with timeout: None",
     "child: releasing lock",
@@ -286,16 +286,16 @@ async test "flock cancelled" {
 async test "flock advisory" {
   let log = []
   let file_name = "_build/flock_advisory"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     @fs.write_file(file_name, create_mode=CreateOrTruncate, "abcd")
     let file = @fs.open(file_name, mode=ReadWrite)
     defer file.close()
-    group.add_defer(() => @fs.remove(file_name))
+    group.add_defer() <| () => { @fs.remove(file_name) }
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to read")
     log.push("read from file: \{file.read_all().text()}")
-  })
+  }
   json_inspect(log, content=[
     "child: acquired lock", "attempting to read", "read from file: abcd", "child: releasing lock",
   ])

--- a/src/fs/mkdir_test.mbt
+++ b/src/fs/mkdir_test.mbt
@@ -39,27 +39,27 @@ async test "rmdir recursive" {
 
 ///|
 async test "mkdir recursive" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let base_path = "_build/recursive_mkdir"
     let path = "\{base_path}/test//directory"
     @fs.mkdir(path, recursive=true)
-    group.add_defer(() => @fs.rmdir(base_path, recursive=true))
+    group.add_defer() <| () => { @fs.rmdir(base_path, recursive=true) }
     json_inspect(@fs.readdir(base_path), content=["test"])
     json_inspect(@fs.readdir("\{base_path}/test"), content=["directory"])
     json_inspect(@fs.readdir("\{base_path}/test/directory"), content=[])
-  })
+  }
 }
 
 ///|
 #cfg(platform="windows")
 async test "mkdir recursive windows" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let base_path = "_build\\recursive_mkdir_windows"
     let path = "\{base_path}\\test\\\\directory"
     @fs.mkdir(path, recursive=true)
-    group.add_defer(() => @fs.rmdir(base_path, recursive=true))
+    group.add_defer() <| () => { @fs.rmdir(base_path, recursive=true) }
     json_inspect(@fs.readdir(base_path), content=["test"])
     json_inspect(@fs.readdir("\{base_path}\\test"), content=["directory"])
     json_inspect(@fs.readdir("\{base_path}\\test/directory"), content=[])
-  })
+  }
 }

--- a/src/fs/named_pipe_test.mbt
+++ b/src/fs/named_pipe_test.mbt
@@ -20,17 +20,17 @@ extern "C" fn mkfifo(path : @os_string.OsString, mode : Int) -> Int = "mkfifo"
 ///|
 #cfg(not(platform="windows"))
 async test "cancel named fifo open" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let path = "_build/cancel_open_test"
     if mkfifo(@os_string.encode(path), 0o644) < 0 {
       @os_error.check_errno("mkfifo")
     }
-    group.add_defer(() => @fs.remove(path))
-    let result = @async.with_timeout_opt(500, () => {
-      @fs.open(path, mode=ReadOnly).close()
-    })
+    group.add_defer() <| () => { @fs.remove(path) }
+    let result = @async.with_timeout_opt(500) <| () => {
+        @fs.open(path, mode=ReadOnly).close()
+      }
     debug_inspect(result, content="None")
-  })
+  }
 }
 
 ///|
@@ -48,45 +48,45 @@ async test "cancel named pipe open" {
   defer (try! @fd_util.close(server, kind=Pipe, context~))
   let client1 = @fs.open(path, mode=ReadOnly)
   defer client1.close()
-  let result = @async.with_timeout_opt(500, () => {
-    @fs.open(path, mode=ReadOnly).close()
-  })
+  let result = @async.with_timeout_opt(500) <| () => {
+      @fs.open(path, mode=ReadOnly).close()
+    }
   debug_inspect(result, content="None")
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "named fifo" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let path = "_build/named_pipe_test"
     if mkfifo(@os_string.encode(path), 0o644) < 0 {
       @os_error.check_errno("mkfifo")
     }
-    group.add_defer(() => @fs.remove(path))
-    group.spawn_bg(() => {
+    group.add_defer() <| () => { @fs.remove(path) }
+    group.spawn_bg() <| () => {
       let r = @fs.open(path, mode=ReadOnly)
       defer r.close()
       inspect(r.read_until("\n").unwrap_or(""), content="abcd")
       debug_inspect(
-        @async.with_timeout_opt(250, () => r.read_all().text()),
+        @async.with_timeout_opt(250) <| () => { r.read_all().text() },
         content="None",
       )
       inspect(r.read_all().text(), content="efgh")
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       let w = @fs.open(path, mode=WriteOnly)
       defer w.close()
       w.write("abcd\n")
       @async.sleep(500)
       w.write("efgh")
-    })
-  })
+    }
+  }
 }
 
 ///|
 #cfg(platform="windows")
 async test "named pipe" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let context = "cancel named pipe open test"
     let path = "\\\\.\\pipe\\moonbitlang_async_named_pipe_test"
     let w = @fd_util.create_named_pipe_server(
@@ -96,17 +96,17 @@ async test "named pipe" {
     if !@fd_util.fd_is_valid(w) {
       @os_error.check_errno(context)
     }
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       let r = @fs.open(path, mode=ReadOnly)
       defer r.close()
       inspect(r.read_until("\n").unwrap_or(""), content="abcd")
       debug_inspect(
-        @async.with_timeout_opt(250, () => r.read_all().text()),
+        @async.with_timeout_opt(250) <| () => { r.read_all().text() },
         content="None",
       )
       inspect(r.read_all().text(), content="efgh")
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       // wait for the client to connect
       @async.sleep(200)
       let w = @event_loop.IoHandle::from_fd(w, kind=Pipe)
@@ -114,6 +114,6 @@ async test "named pipe" {
       ignore(w.write(b"abcd\n", offset=0, len=5, context=""))
       @async.sleep(500)
       ignore(w.write(b"efgh", offset=0, len=4, context=""))
-    })
-  })
+    }
+  }
 }

--- a/src/fs/realpath_test.mbt
+++ b/src/fs/realpath_test.mbt
@@ -26,7 +26,7 @@ async test "realpath absolute" {
 ///|
 #cfg(not(platform="windows"))
 async test "realpath link to absolute" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     guard @env.current_dir() is Some(cwd)
     let path = match cwd {
       [.., '/'] => cwd + "src/fs/realpath_test.mbt"
@@ -34,39 +34,39 @@ async test "realpath link to absolute" {
     }
     let link_path = "_build/realpath_test_link_to_absolute.test"
     @fs.symlink(link_path, target=path)
-    root.add_defer(() => @fs.remove(link_path))
+    root.add_defer() <| () => { @fs.remove(link_path) }
     let rp = @fs.realpath(link_path)
     assert_true(rp.has_prefix(cwd))
     inspect(rp[cwd.length():], content="/src/fs/realpath_test.mbt")
-  })
+  }
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "realpath link to relative" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     guard @env.current_dir() is Some(cwd)
     let rel_path = "../src/fs/realpath_test.mbt"
     let link_path = "_build/realpath_test_link_to_relative.test"
     @fs.symlink(link_path, target=rel_path)
-    root.add_defer(() => @fs.remove(link_path))
+    root.add_defer() <| () => { @fs.remove(link_path) }
     let rp = @fs.realpath(link_path)
     assert_true(rp.has_prefix(cwd))
     inspect(rp[cwd.length():], content="/src/fs/realpath_test.mbt")
-  })
+  }
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "realpath link to dir" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     guard @env.current_dir() is Some(cwd)
     let rel_path = "../src/fs"
     let link_path = "_build/realpath_test_link_to_dir.test"
     @fs.symlink(link_path, target=rel_path)
-    root.add_defer(() => @fs.remove(link_path))
+    root.add_defer() <| () => { @fs.remove(link_path) }
     let rp = @fs.realpath(link_path + "/realpath_test.mbt")
     assert_true(rp.has_prefix(cwd))
     inspect(rp[cwd.length():], content="/src/fs/realpath_test.mbt")
-  })
+  }
 }

--- a/src/fs/stat_test.mbt
+++ b/src/fs/stat_test.mbt
@@ -17,9 +17,9 @@
 async test "stat" {
   let link_path = "_build/fs_stat_test"
   @fs.symlink(link_path, target="../LICENSE")
-  @async.with_task_group(group => {
-    group.add_defer(() => @fs.remove(link_path))
+  @async.with_task_group() <| group => {
+    group.add_defer() <| () => { @fs.remove(link_path) }
     debug_inspect(@fs.kind(link_path), content="Regular")
     debug_inspect(@fs.kind(link_path, follow_symlink=false), content="SymLink")
-  })
+  }
 }

--- a/src/fs/text_file_test.mbt
+++ b/src/fs/text_file_test.mbt
@@ -14,10 +14,10 @@
 
 ///|
 async test "text file" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let path = "_build/basic_text_file_test"
-    root.add_defer(() => @fs.remove(path))
+    root.add_defer() <| () => { @fs.remove(path) }
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate)
     inspect(@fs.read_file(path).text(), content="abcd")
-  })
+  }
 }

--- a/src/fs/timestamp_test.mbt
+++ b/src/fs/timestamp_test.mbt
@@ -23,9 +23,9 @@ fn diff_timestamp(t1 : (Int64, Int), t2 : (Int64, Int)) -> Int64 {
 #cfg(not(platform="windows"))
 async test "timestamp for path" {
   let path = "/tmp/timestamp_test"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
-    group.add_defer(() => @fs.remove(path))
+    group.add_defer() <| () => { @fs.remove(path) }
     let mtime_1 = @fs.mtime(path)
     let ctime_1 = @fs.ctime(path)
     @async.sleep(600)
@@ -49,7 +49,7 @@ async test "timestamp for path" {
     let ctime_4 = @fs.ctime(path)
     @debug.assert_eq(mtime_4, mtime_3)
     assert_true(diff_timestamp(ctime_4, ctime_3) > 500_000_000)
-  })
+  }
 }
 
 ///|
@@ -57,9 +57,9 @@ async test "timestamp for path" {
 #cfg(platform="windows")
 async test "mtime for path" {
   let path = "_build/timestamp_test"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
-    group.add_defer(() => @fs.remove(path))
+    group.add_defer() <| () => { @fs.remove(path) }
     let mtime_1 = @fs.mtime(path)
     let ctime_1 = @fs.ctime(path)
     @async.sleep(600)
@@ -68,16 +68,16 @@ async test "mtime for path" {
     let ctime_2 = @fs.ctime(path)
     assert_true(diff_timestamp(mtime_2, mtime_1) > 500_000_000)
     assert_true(diff_timestamp(ctime_2, ctime_1) > 500_000_000)
-  })
+  }
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "timestamp for opened file" {
   let path = "/tmp/opened_file_timestamp_test"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
-    group.add_defer(() => @fs.remove(path))
+    group.add_defer() <| () => { @fs.remove(path) }
     let file = @fs.open(path, mode=ReadWrite, sync=Full)
     defer file.close()
     let mtime_1 = file.mtime()
@@ -104,7 +104,7 @@ async test "timestamp for opened file" {
     let ctime_4 = @fs.ctime(path)
     @debug.assert_eq(mtime_4, mtime_3)
     assert_true(diff_timestamp(ctime_4, ctime_3) > 500_000_000)
-  })
+  }
 }
 
 ///|
@@ -112,9 +112,9 @@ async test "timestamp for opened file" {
 #cfg(platform="windows")
 async test "mtime for opened file" {
   let path = "_build/opened_file_timestamp_test"
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
-    group.add_defer(() => @fs.remove(path))
+    group.add_defer() <| () => { @fs.remove(path) }
     let file = @fs.open(path, mode=ReadWrite, sync=Full)
     defer file.close()
     let mtime_1 = file.mtime()
@@ -125,5 +125,5 @@ async test "mtime for opened file" {
     let ctime_2 = file.mtime()
     assert_true(diff_timestamp(mtime_2, mtime_1) > 500_000_000)
     assert_true(diff_timestamp(ctime_2, ctime_1) > 500_000_000)
-  })
+  }
 }

--- a/src/fs/tmpdir_test.mbt
+++ b/src/fs/tmpdir_test.mbt
@@ -14,15 +14,15 @@
 
 ///|
 async test "tmpdir" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let t1 = @fs.tmpdir(prefix="tmp")
-    group.add_defer(() => {
-      @async.protect_from_cancel(() => @fs.rmdir(t1, recursive=true))
-    })
+    group.add_defer() <| () => {
+      @async.protect_from_cancel() <| () => { @fs.rmdir(t1, recursive=true) }
+    }
     let t2 = @fs.tmpdir(prefix="tmp")
-    group.add_defer(() => {
-      @async.protect_from_cancel(() => @fs.rmdir(t2, recursive=true))
-    })
+    group.add_defer() <| () => {
+      @async.protect_from_cancel() <| () => { @fs.rmdir(t2, recursive=true) }
+    }
     assert_not_eq(t1, t2)
     assert_true(@fs.exists(t1))
     assert_true(@fs.exists(t2))
@@ -33,5 +33,5 @@ async test "tmpdir" {
       permission=0o600,
     )
     json_inspect(@fs.readdir(t1), content=["file.txt"])
-  })
+  }
 }

--- a/src/fs/walk_test.mbt
+++ b/src/fs/walk_test.mbt
@@ -15,7 +15,7 @@
 ///|
 async test "walk sequential" {
   let dirs = []
-  @fs.walk("test_directory", max_concurrency=1, (path, files) => {
+  @fs.walk("test_directory", max_concurrency=1) <| ((path, files) => {
     files.sort()
     dirs.push((path, files))
   })
@@ -31,7 +31,7 @@ async test "walk parallel" {
   @async.sleep(300)
   let log = StringBuilder::new()
   let mut i = 0
-  @fs.walk("test_directory", max_concurrency=2, (path, _) => {
+  @fs.walk("test_directory", max_concurrency=2) <| ((path, _) => {
     i = i + 1
     log.write_string("handling \{path}\n")
     @async.sleep(if i == 1 { 200 } else { 300 })
@@ -55,10 +55,10 @@ async test "walk parallel" {
 async test "walk failure" {
   let log = StringBuilder::new()
   debug_inspect(
-    try? @fs.walk("test_directory", max_concurrency=1, (path, _) => {
+    try? (@fs.walk("test_directory", max_concurrency=1) <| ((path, _) => {
       log.write_string("handling \{path}\n")
       raise Failure::Failure("failure when handling directory")
-    }),
+    })),
     content=(
       #|Err(Failure("failure when handling directory"))
     ),
@@ -76,13 +76,13 @@ async test "walk failure" {
 async test "walk allow_failure" {
   let log = StringBuilder::new()
   debug_inspect(
-    try? @fs.walk("test_directory", allow_failure=true, max_concurrency=1, (
+    try? (@fs.walk("test_directory", allow_failure=true, max_concurrency=1) <| ((
       path,
       _,
     ) => {
       log.write_string("handling \{path}\n")
       raise Failure::Failure("failure when handling directory")
-    }),
+    })),
     content="Ok(())",
   )
   inspect(
@@ -99,7 +99,7 @@ async test "walk allow_failure" {
 ///|
 async test "walk exclude 1" {
   let walked = []
-  @fs.walk("test_directory", exclude=p => p is [.., '1'], (path, _) => {
+  @fs.walk("test_directory", exclude=p => p is [.., '1']) <| ((path, _) => {
     walked.push(path)
   })
   json_inspect(walked, content=["test_directory"])
@@ -108,7 +108,7 @@ async test "walk exclude 1" {
 ///|
 async test "walk exclude 2" {
   let walked = []
-  @fs.walk("test_directory", exclude=p => p is [.., '2'], (path, _) => {
+  @fs.walk("test_directory", exclude=p => p is [.., '2']) <| ((path, _) => {
     walked.push(path)
   })
   json_inspect(walked, content=["test_directory", "test_directory/inner1"])

--- a/src/group_defer_test.mbt
+++ b/src/group_defer_test.mbt
@@ -15,27 +15,27 @@
 ///|
 async test "group defer basic" {
   let log = StringBuilder::new()
-  @async.with_task_group(fn(root) {
-    root.add_defer(() => log <+ "first group defer\n")
-    root.spawn_bg(() => {
+  @async.with_task_group() <| fn(root) {
+    root.add_defer() <| () => { log <+ "first group defer\n" }
+    root.spawn_bg() <| () => {
       defer log.write_string("defer for first task\n")
       @async.sleep(200)
-      root.add_defer(() => log <+ "third group defer\n")
+      root.add_defer() <| () => { log <+ "third group defer\n" }
       @async.sleep(200)
       log <+ "first task finished\n"
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer log.write_string("defer for second task\n")
       @async.sleep(100)
-      root.add_defer(() => log <+ "second group defer\n")
+      root.add_defer() <| () => { log <+ "second group defer\n" }
       @async.sleep(200)
       log <+ "second task finished\n"
-    })
-    root.spawn_bg(no_wait=true, () => {
+    }
+    root.spawn_bg(no_wait=true) <| () => {
       defer log.write_string("defer for cancelled task\n")
       @async.sleep(1000)
-    })
-  })
+    }
+  }
   inspect(
     log.to_string(),
     content=(
@@ -57,27 +57,27 @@ async test "group defer error" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(fn(root) {
-        root.add_defer(() => log <+ "first group defer\n")
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| fn(root) {
+        root.add_defer() <| () => { log <+ "first group defer\n" }
+        root.spawn_bg() <| () => {
           defer log.write_string("defer for first task\n")
           @async.sleep(200)
-          root.add_defer(() => log <+ "third group defer\n")
+          root.add_defer() <| () => { log <+ "third group defer\n" }
           @async.sleep(200)
           log <+ "first task finished\n"
-        })
-        root.spawn_bg(() => {
+        }
+        root.spawn_bg() <| () => {
           defer log.write_string("defer for second task\n")
           @async.sleep(100)
-          root.add_defer(() => log <+ "second group defer\n")
+          root.add_defer() <| () => { log <+ "second group defer\n" }
           @async.sleep(200)
           log <+ "second task raise error\n"
           raise Err
-        })
-        root.spawn_bg(no_wait=true, () => {
+        }
+        root.spawn_bg(no_wait=true) <| () => {
           defer log.write_string("defer for cancelled task\n")
           @async.sleep(1000)
-        })
+        }
       }),
     ),
   )
@@ -99,22 +99,22 @@ async test "group defer error" {
 ///|
 async test "group defer cancelled" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       for _ in 0..<4 {
         @async.sleep(200)
         log <+ "tick\n"
       }
-    })
-    @async.with_timeout_opt(500, () => {
-      @async.with_task_group(group => {
-        group.add_defer(() => {
-          @async.protect_from_cancel(() => {
+    }
+    (@async.with_timeout_opt(500) <| () => {
+      @async.with_task_group() <| group => {
+        group.add_defer() <| () => {
+          @async.protect_from_cancel() <| () => {
             @async.sleep(200)
             log <+ "protected async defer completed\n"
-          })
-        })
-        group.add_defer(() => {
+          }
+        }
+        group.add_defer() <| () => {
           try @async.sleep(200) catch {
             err => {
               log.write_string("normal async defer cancelled with \{err}\n")
@@ -123,14 +123,14 @@ async test "group defer cancelled" {
           } noraise {
             _ => log <+ "normal async defer completed\n"
           }
-        })
+        }
         defer log.write_string("start group termination\n")
         @async.sleep(2000)
-      })
+      }
     })
     |> ignore
     log <+ "group terminated\n"
-  })
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/gzip/gzip_test.mbt
+++ b/src/gzip/gzip_test.mbt
@@ -15,48 +15,48 @@
 ///|
 #cfg(target="native")
 async fn node_gzip(mode : String, input : Bytes) -> Bytes {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (stdin, we_write) = @process.write_to_process()
-    let runner = group.spawn(() => {
-      @process.collect_output("node", ["src/gzip/node_gzip.js", mode], stdin~)
-    })
-    group.spawn_bg(() => {
+    let runner = group.spawn() <| () => {
+        @process.collect_output("node", ["src/gzip/node_gzip.js", mode], stdin~)
+      }
+    group.spawn_bg() <| () => {
       defer we_write.close()
       we_write.write(input)
-    })
+    }
     let (code, stdout, stderr) = runner.wait()
     assert_eq(code, 0)
     assert_eq(stderr.binary().length(), 0)
     stdout.binary()
-  })
+  }
 }
 
 ///|
 #cfg(target="native")
 async fn encode_with_moonbit(input : Bytes) -> Bytes {
   let (r, w) = @io.pipe()
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       defer w.close()
       @gzip.Encoder(w)..write(input).end()
-    })
+    }
     defer r.close()
     r.read_all().binary()
-  })
+  }
 }
 
 ///|
 #cfg(target="native")
 async fn decode_with_moonbit(input : Bytes) -> Bytes {
   let (r, w) = @io.pipe()
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       defer w.close()
       w.write(input)
-    })
+    }
     defer r.close()
     @gzip.Decoder(r).read_all().binary()
-  })
+  }
 }
 
 ///|
@@ -71,10 +71,10 @@ async fn assert_node_compatibility(input : Bytes) -> Unit {
 
 ///|
 async test "encode decode roundtrip" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let source_chunks = ["hello ", "gzip ", "world"]
     let (compressed_r, compressed_w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer compressed_w.close()
       let encoder = @gzip.Encoder(
         compressed_w,
@@ -86,38 +86,38 @@ async test "encode decode roundtrip" {
         @async.sleep(10)
       }
       encoder.end()
-    })
+    }
 
     let decoder = @gzip.Decoder(compressed_r)
     inspect(decoder.read_all().text(), content="hello gzip world")
     compressed_r.close()
-  })
+  }
 }
 
 ///|
 async test "encoder uses valid blocks across large writes" {
-  @async.with_task_group(root => {
-    let payload = Bytes::makei(70000, i => (i % 251).to_byte())
+  @async.with_task_group() <| root => {
+    let payload = Bytes::makei(70000) <| i => { (i % 251).to_byte() }
     let (compressed_r, compressed_w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer compressed_w.close()
       let encoder = @gzip.Encoder(compressed_w)
       encoder.write(payload)
       encoder.end()
-    })
+    }
 
     let decoder = @gzip.Decoder(compressed_r)
     inspect(decoder.read_all().binary() == payload, content="true")
     compressed_r.close()
-  })
+  }
 }
 
 ///|
 async test "encoder emits output when flushed" {
   let log : Array[String] = []
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       log.push("start init")
       let encoder = @gzip.Encoder(w)
@@ -132,14 +132,14 @@ async test "encoder emits output when flushed" {
       @async.sleep(60)
       log.push("end")
       encoder.end()
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(chunk) {
         log.push("receive compressed \{chunk.length()}")
       }
-    })
-  })
+    }
+  }
   json_inspect(log, content=[
     "start init", "encoder ready", "write plain ab", "receive compressed 13", "write plain cd",
     "receive compressed 3", "end", "receive compressed 10",
@@ -149,9 +149,9 @@ async test "encoder emits output when flushed" {
 ///|
 async test "decoder yields plain chunks lazily across delayed chunks" {
   let log : Array[String] = []
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (compressed_r, compressed_w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer compressed_w.close()
       compressed_w.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff")
       @async.sleep(20)
@@ -167,7 +167,7 @@ async test "decoder yields plain chunks lazily across delayed chunks" {
       log.push("finish")
       compressed_w.write(b"\x01\x00\x00\xff\xff")
       compressed_w.write(b"\xef\x39\x8e\x4b\x06\x00\x00\x00")
-    })
+    }
     let decoder = @gzip.Decoder(compressed_r)
     match decoder.read_some(max_len=2) {
       Some(chunk) => log.push("read plain \{@utf8.decode(chunk)}")
@@ -182,7 +182,7 @@ async test "decoder yields plain chunks lazily across delayed chunks" {
       None => assert_true(false)
     }
     debug_inspect(decoder.read_some(max_len=2), content="None")
-  })
+  }
   json_inspect(log, content=[
     "write plain ab", "read plain ab", "write plain cd", "read plain cd", "write plain ef",
     "read plain ef", "finish",
@@ -191,9 +191,9 @@ async test "decoder yields plain chunks lazily across delayed chunks" {
 
 ///|
 async test "decoder supports reads smaller than writer chunks" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (compressed_r, compressed_w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer compressed_w.close()
       compressed_w.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff")
       compressed_w.write(b"\x00\x04\x00\xfb\xffabcd")
@@ -201,7 +201,7 @@ async test "decoder supports reads smaller than writer chunks" {
       compressed_w.write(b"\x00\x04\x00\xfb\xffefgh")
       compressed_w.write(b"\x01\x00\x00\xff\xff")
       compressed_w.write(b"\x50\x2a\xef\xae\x08\x00\x00\x00")
-    })
+    }
     let decoder = @gzip.Decoder(compressed_r)
     debug_inspect(
       decoder.read_some(max_len=2),
@@ -228,7 +228,7 @@ async test "decoder supports reads smaller than writer chunks" {
       ),
     )
     debug_inspect(decoder.read_some(max_len=2), content="None")
-  })
+  }
 }
 
 ///|
@@ -241,7 +241,9 @@ async test "node compatibility on source text file" {
 ///|
 #cfg(target="native")
 async test "node compatibility on generated binary data" {
-  let input = Bytes::makei(65536 + 257, i => ((i * 73 + 19) & 0xff).to_byte())
+  let input = Bytes::makei(65536 + 257) <| i => {
+      ((i * 73 + 19) & 0xff).to_byte()
+    }
   assert_node_compatibility(input)
 }
 

--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -16,8 +16,8 @@
 #cfg(target="native")
 async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
   let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
-  group.spawn_bg(no_wait=true, () => {
-    server.run_forever((request, body, conn) => {
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever() <| ((request, body, conn) => {
       let meth = @debug.to_string(request.meth).to_upper()
       log.write_string("server received request: \{meth} \{request.path}\n")
       while body.read_some() is Some(data) {
@@ -31,7 +31,7 @@ async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
       log.write_string("server: sending \{meth} response part 2\n")
       conn.write("\{meth} response part 2\n")
     })
-  })
+  }
   server.addr.port()
 }
 
@@ -84,15 +84,15 @@ extern "js" fn Server::create(
 ///|
 #cfg(target="js")
 async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
-  let server = Server::create(msg => log.write_string(msg)).wait()
-  group.add_defer(() => server.close())
+  let server = (Server::create() <| msg => { log.write_string(msg) }).wait()
+  group.add_defer() <| () => { server.close() }
   server.port()
 }
 
 ///|
 async test "request streaming" {
   let log = StringBuilder::new()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let port = test_server(group, log)
     async fn fetch_response(client : @http.Client) {
       while client.read_some() is Some(data) {
@@ -139,7 +139,7 @@ async test "request streaming" {
     // give some time for the client to close,
     // so that the port occupied by the server can be reused immediately.
     @async.sleep(200)
-  })
+  }
   inspect(
     log,
     content=(

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -34,21 +34,21 @@ fn log_response(req : Response, logger : &Logger) -> Unit {
 ///|
 async test "read_request basic" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("GET / HTTP/1.1\r\n")
       ..write("Host: x.y.org\r\n")
       .write("User-Agent: MoonBit\r\n\r\n")
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let request = input.read_request()
     log_request(request, log)
     log.write_string(input.read_all().text())
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -63,9 +63,9 @@ async test "read_request basic" {
 ///|
 async test "read_request fixed body" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("GET / HTTP/1.1\r\n")
@@ -73,13 +73,13 @@ async test "read_request fixed body" {
       ..write("User-Agent: MoonBit\r\n")
       ..write("Content-Length: 7\r\n\r\n")
       .write("message")
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let request = input.read_request()
     log_request(request, log)
     log.write_string(input.read_all().text())
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -95,9 +95,9 @@ async test "read_request fixed body" {
 ///|
 async test "read_request chunked" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("GET / HTTP/1.1\r\n")
@@ -109,13 +109,13 @@ async test "read_request chunked" {
       ..write("10\r\n")
       ..write("abcdefghijklmnop\r\n")
       .write("0\r\n\r\n")
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let request = input.read_request()
     log_request(request, log)
     log.write_string(input.read_all().text())
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -131,9 +131,9 @@ async test "read_request chunked" {
 ///|
 async test "read_request stream" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("GET / HTTP/1.1\r\n")
@@ -150,7 +150,7 @@ async test "read_request stream" {
       log <+ "writing data...\n"
       w.write("4\r\nijkl\r\n")
       w.write("0\r\n\r\n")
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let request = input.read_request()
@@ -159,7 +159,7 @@ async test "read_request stream" {
       let data = @utf8.decode(data)
       log.write_string("received \{data} from body\n")
     }
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -181,9 +181,9 @@ async test "read_request stream" {
 ///|
 async test "multiple request" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("GET / HTTP/1.1\r\n")
@@ -207,7 +207,7 @@ async test "multiple request" {
       ..write("User-Agent: MoonBit\r\n")
       ..write("Content-Length: 8\r\n\r\n")
       .write("message2")
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let request = input.read_request()
@@ -216,7 +216,7 @@ async test "multiple request" {
     let request = input.read_request()
     log_request(request, log)
     log.write_string(input.read_all().text())
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -243,15 +243,15 @@ async test "multiple request" {
 ///|
 async test "read_response basic" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 200 OK\r\n")
       ..write("Content-Length: 7\r\n\r\n")
       .write("message")
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let response = input.read_response(
@@ -260,7 +260,7 @@ async test "read_response basic" {
     )
     log_response(response, log)
     log.write_string(input.read_all().text())
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -274,9 +274,9 @@ async test "read_response basic" {
 ///|
 async test "read_response passthrough fallback (no length headers)" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 200 OK\r\n")
@@ -285,7 +285,7 @@ async test "read_response passthrough fallback (no length headers)" {
       // No Content-Length or Transfer-Encoding
       // Body ends when connection closes
       .write("Hello, World!")
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let response = input.read_response(
@@ -296,7 +296,7 @@ async test "read_response passthrough fallback (no length headers)" {
 
     // Read body via PassThrough fallback (reads until EOF/connection close)
     log.write_string(input.read_all().text())
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -311,9 +311,9 @@ async test "read_response passthrough fallback (no length headers)" {
 ///|
 async test "read_response 204 No Content (no body)" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 204 No Content\r\n")
@@ -321,7 +321,7 @@ async test "read_response 204 No Content (no body)" {
       .write("Date: Mon, 15 Feb 2026 00:00:00 GMT\r\n\r\n")
       // 204 responses MUST NOT contain a message body
       // Connection remains open for next request
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let response = input.read_response(
@@ -333,7 +333,7 @@ async test "read_response 204 No Content (no body)" {
     let body_text = input.read_all().text()
     log <+ "body: "
     log.write_string(body_text)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -348,9 +348,9 @@ async test "read_response 204 No Content (no body)" {
 ///|
 async test "read_response 205 Reset Content (no body)" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 205 Reset Content\r\n")
@@ -358,7 +358,7 @@ async test "read_response 205 Reset Content (no body)" {
       .write("Date: Mon, 15 Feb 2026 00:00:00 GMT\r\n\r\n")
       // 205 responses MUST NOT contain a message body
       // Connection remains open for next request
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let response = input.read_response(
@@ -370,7 +370,7 @@ async test "read_response 205 Reset Content (no body)" {
     let body_text = input.read_all().text()
     log <+ "body: "
     log.write_string(body_text)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -385,9 +385,9 @@ async test "read_response 205 Reset Content (no body)" {
 ///|
 async test "read_response 304 Not Modified (no body)" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 304 Not Modified\r\n")
@@ -395,7 +395,7 @@ async test "read_response 304 Not Modified (no body)" {
       ..write("ETag: \"abc123\"\r\n")
       .write("Cache-Control: max-age=3600\r\n\r\n")
       // 304 responses MUST NOT contain a message body
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let response = input.read_response(
@@ -406,7 +406,7 @@ async test "read_response 304 Not Modified (no body)" {
     let body_text = input.read_all().text()
     log <+ "body: "
     log.write_string(body_text)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -422,15 +422,15 @@ async test "read_response 304 Not Modified (no body)" {
 ///|
 async test "read_response 100 Continue (no body)" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 100 Continue\r\n")
       .write("\r\n")
       // 1xx responses MUST NOT contain a message body
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let response = input.read_response(
@@ -441,7 +441,7 @@ async test "read_response 100 Continue (no body)" {
     let body_text = input.read_all().text()
     log <+ "body: "
     log.write_string(body_text)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -454,16 +454,16 @@ async test "read_response 100 Continue (no body)" {
 ///|
 async test "read_response CONNECT 200 (no body, tunnel mode)" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 200 Connection Established\r\n")
       .write("\r\n")
       // Successful CONNECT responses switch to tunnel mode
       // Connection remains open for tunneled traffic
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let response = input.read_response(
@@ -475,7 +475,7 @@ async test "read_response CONNECT 200 (no body, tunnel mode)" {
     let body_text = input.read_all().text()
     log <+ "body: "
     log.write_string(body_text)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -488,9 +488,9 @@ async test "read_response CONNECT 200 (no body, tunnel mode)" {
 ///|
 async test "read_response HEAD 200 (no body)" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 200 OK\r\n")
@@ -499,7 +499,7 @@ async test "read_response HEAD 200 (no body)" {
       .write("\r\n")
       // HEAD responses never have a body, even with Content-Length
       // Connection remains open for next request
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let response = input.read_response(
@@ -511,7 +511,7 @@ async test "read_response HEAD 200 (no body)" {
     let body_text = input.read_all().text()
     log <+ "body: "
     log.write_string(body_text)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -729,18 +729,18 @@ test "should_read_body_until_close - false cases (HEAD requests)" {
 
 ///|
 async test "gzip split between chunks" {
-  let compressed = @async.with_task_group(group => {
-    let (r, w) = @io.pipe()
-    group.spawn_bg(() => {
-      defer w.close()
-      @gzip_stream.Encoder(w)..write("A simple message to compress").end()
-    })
-    defer r.close()
-    r.read_all().binary()
-  })
+  let compressed = @async.with_task_group() <| group => {
+      let (r, w) = @io.pipe()
+      group.spawn_bg() <| () => {
+        defer w.close()
+        @gzip_stream.Encoder(w)..write("A simple message to compress").end()
+      }
+      defer r.close()
+      r.read_all().binary()
+    }
   let (r, w) = @io.pipe()
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 200 OK\r\n")
@@ -750,7 +750,7 @@ async test "gzip split between chunks" {
         w..write("1\r\n")..write(compressed[i:i + 1]).write("\r\n")
       }
       w.write("0\r\n\r\n")
-    })
+    }
     defer r.close()
     let r = Reader::new(r)
     let response = r.read_response(
@@ -764,14 +764,14 @@ async test "gzip split between chunks" {
         #|A simple message to compress
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "read_response parse cookie" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @io.pipe()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer w.close()
       w
       ..write("HTTP/1.1 200 OK\r\n")
@@ -784,7 +784,7 @@ async test "read_response parse cookie" {
       )
       ..write("Set-Cookie: Cookie4=value four; ExtNoArg; ExtWithArg=xxx\r\n")
       .write("Content-Length: 0\r\n\r\n")
-    })
+    }
     defer r.close()
     let input = Reader::new(r)
     let response = input.read_response(
@@ -842,5 +842,5 @@ async test "read_response parse cookie" {
         #|]
       ),
     )
-  })
+  }
 }

--- a/src/http/proxy_test.mbt
+++ b/src/http/proxy_test.mbt
@@ -15,10 +15,10 @@
 ///|
 async test "passthrough mode" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let server_addr = server.addr
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       let conn = @http.ServerConnection::new(conn)
@@ -32,7 +32,7 @@ async test "passthrough mode" {
         let packet = @utf8.decode(packet)
         log.push("server received: \{packet}")
       }
-    })
+    }
     let client = @http.Client("http://localhost:\{server_addr.port()}")
     defer client.close()
     let response = client..request(Connect, "/path").end_request()
@@ -43,7 +43,7 @@ async test "passthrough mode" {
       client.write(packet)
       @async.sleep(200)
     }
-  })
+  }
   json_inspect(log, content=[
     "client sending: abcd", "server received: abcd", "client sending: efgh", "server received: efgh",
     "client sending: ijkl", "server received: ijkl",
@@ -52,10 +52,10 @@ async test "passthrough mode" {
 
 ///|
 async test "passthrough mode remaining data" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let server_addr = server.addr
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       let conn = @http.ServerConnection::new(conn)
@@ -65,13 +65,13 @@ async test "passthrough mode remaining data" {
       inspect(request.path, content="/")
       conn.enter_passthrough_mode()
       inspect(conn.read_all().text(), content="remaining data")
-    })
+    }
     let client = @socket.Tcp::connect(
       @socket.Addr::parse("127.0.0.1:\{server_addr.port()}"),
     )
     defer client.close()
     client.write("GET / HTTP/1.1\r\n\r\nremaining data")
-  })
+  }
 }
 
 ///|
@@ -103,31 +103,31 @@ async fn handle_connect(
   log.push("proxy server: connected to \{request.path} successfully")
   conn..send_response(200, "OK").end_response()
   conn.enter_passthrough_mode()
-  @async.with_task_group(group => {
-    group.spawn_bg(() => conn.write_reader(client))
-    group.spawn_bg(() => client.write_reader(conn))
-  })
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => { conn.write_reader(client) }
+    group.spawn_bg() <| () => { client.write_reader(conn) }
+  }
 }
 
 ///|
 async test "proxied https request" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(no_wait=true, () => {
-      server.run_forever((req, body, conn) => {
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((req, body, conn) => {
         handle_connect(log, req, body, conn)
       })
-    })
-    let (_, result) = @async.with_timeout(10000, () => {
-      @http.get(
-        "https://www.moonbitlang.com",
-        proxy=@http.Client("http://localhost:\{port}"),
-      )
-    })
+    }
+    let (_, result) = @async.with_timeout(10000) <| () => {
+        @http.get(
+          "https://www.moonbitlang.com",
+          proxy=@http.Client("http://localhost:\{port}"),
+        )
+      }
     assert_true(result.text().has_prefix("<!doctype html>"))
-  })
+  }
   json_inspect(log, content=[
     "proxy server: connected to www.moonbitlang.com:443 successfully",
   ])
@@ -136,20 +136,20 @@ async test "proxied https request" {
 ///|
 async test "proxied http request" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(no_wait=true, () => {
-      server.run_forever((req, body, conn) => {
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((req, body, conn) => {
         handle_connect(log, req, body, conn)
       })
-    })
+    }
     let (_, result) = @http.get(
       "http://www.example.org",
       proxy=@http.Client("http://localhost:\{port}"),
     )
     assert_true(result.text().has_prefix("<!doctype html>"))
-  })
+  }
   json_inspect(log, content=[
     "proxy server: connected to www.example.org:80 successfully",
   ])
@@ -162,14 +162,14 @@ async test "proxied misc request" {
   let proxy_server_addr = proxy_server.addr
   let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
   let port = server.addr.port()
-  @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, () => {
-      proxy_server.run_forever((req, body, conn) => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg(no_wait=true) <| () => {
+      proxy_server.run_forever() <| ((req, body, conn) => {
         handle_connect(log, req, body, conn)
       })
-    })
-    group.spawn_bg(no_wait=true, () => {
-      server.run_forever((conn, _) => {
+    }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((conn, _) => {
         let conn = @http.ServerConnection::new(conn)
         for ;; {
           let request = conn.read_request()
@@ -180,7 +180,7 @@ async test "proxied misc request" {
           conn..send_response(200, "OK").end_response()
         }
       })
-    })
+    }
     async fn proxy() {
       @http.Client("http://localhost:\{proxy_server_addr.port()}")
     }
@@ -188,7 +188,7 @@ async test "proxied misc request" {
     let _ = @http.get("http://localhost:\{port}", proxy=proxy())
     let _ = @http.put("http://localhost:\{port}", "abcd", proxy=proxy())
     let _ = @http.post("http://localhost:\{port}", "efgh", proxy=proxy())
-  })
+  }
   for i in 0..<log.length() {
     log[i] = log[i].replace_all(old=":\{port}", new=":XXXXX")
   }
@@ -203,13 +203,13 @@ async test "proxied misc request" {
 async test "proxy error" {
   let proxy_server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
   let port = proxy_server.addr.port()
-  @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, () => {
-      proxy_server.run_forever((_, _, conn) => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg(no_wait=true) <| () => {
+      proxy_server.run_forever() <| ((_, _, conn) => {
         conn.send_response(407, "ProxyAuthenticationRequired")
         conn.end_response()
       })
-    })
+    }
     try
       @http.get(
         "https://www.moonbitlang.com",
@@ -226,5 +226,5 @@ async test "proxy error" {
     } noraise {
       _ => raise Failure::Failure("expected error, but nothing happens")
     }
-  })
+  }
 }

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -27,11 +27,11 @@ async test "http request" {
 ///|
 async test "request cancel" {
   let start = @async.now()
-  let _ = @async.with_timeout_opt(200, () => {
-    @http.get(
-      "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz",
-    )
-  })
+  let _ = @async.with_timeout_opt(200) <| () => {
+      @http.get(
+        "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz",
+      )
+    }
   let end = @async.now()
   assert_true((end - start).to_int() < 250)
 }

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -14,9 +14,9 @@
 
 ///|
 async test "send_request basic" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       let sender = Sender::new(w)
       let _ = sender.send_request(Get, "/", extra_headers={
@@ -24,7 +24,7 @@ async test "send_request basic" {
         "User-Agent": "MoonBit",
       })
       sender.end_body()
-    })
+    }
     defer r.close()
     inspect(
       r.read_all().binary() |> @bytes_util.ascii_to_string,
@@ -37,14 +37,14 @@ async test "send_request basic" {
         #|
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "send_request stream" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       let sender = Sender::new(w)
       let file = @fs.open("LICENSE", mode=ReadOnly)
@@ -54,7 +54,7 @@ async test "send_request stream" {
         "User-Agent": "MoonBit",
       })
       sender..write_reader(file).end_body()
-    })
+    }
     defer r.close()
     inspect(
       r.read_all().binary() |> @bytes_util.ascii_to_string,
@@ -296,14 +296,14 @@ async test "send_request stream" {
         #|
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "send_request stream2" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       let sender = Sender::new(w)
       let _ = sender.send_request(Get, "/", extra_headers={
@@ -316,7 +316,7 @@ async test "send_request stream2" {
       @async.sleep(50)
       sender.write("ijkl")
       sender.end_body()
-    })
+    }
     defer r.close()
     inspect(
       r.read_all().binary() |> @bytes_util.ascii_to_string,
@@ -338,14 +338,14 @@ async test "send_request stream2" {
         #|
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "send invalid header" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       let sender = Sender::new(w, headers={ "Content-Encoding": "chunked" })
       let _ = sender.send_request(Get, "/", extra_headers={
@@ -354,7 +354,7 @@ async test "send invalid header" {
         "Content-Encoding": "chunked",
       })
       sender.end_body()
-    })
+    }
     defer r.close()
     inspect(
       r.read_all().binary() |> @bytes_util.ascii_to_string,
@@ -367,14 +367,14 @@ async test "send invalid header" {
         #|
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "send fixed length" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @io.pipe()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer w.close()
       let sender = Sender::new(w)
       let license_file = @fs.open("LICENSE", mode=ReadOnly)
@@ -392,7 +392,7 @@ async test "send fixed length" {
       ..write_reader(license_file)
       ..write(trailer)
       .end_body()
-    })
+    }
     defer r.close()
     inspect(
       r.read_all().binary() |> @bytes_util.ascii_to_string,
@@ -608,19 +608,19 @@ async test "send fixed length" {
         #|
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "sender write incorrect length" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @io.pipe()
-    group.spawn_bg(no_wait=true, () => {
+    group.spawn_bg(no_wait=true) <| () => {
       defer r.close()
       while r.read_some() is Some(_) {
 
       }
-    })
+    }
     defer w.close()
     let sender = Sender::new(w)
     sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={
@@ -634,19 +634,19 @@ async test "sender write incorrect length" {
         #|Err(IncorrectBodyLength)
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "sender write_reader incorrect length" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @io.pipe()
-    group.spawn_bg(no_wait=true, () => {
+    group.spawn_bg(no_wait=true) <| () => {
       defer r.close()
       while r.read_some() is Some(_) {
 
       }
-    })
+    }
     defer w.close()
     let sender = Sender::new(w)
     let license_file = @fs.open("LICENSE", mode=ReadOnly)
@@ -660,19 +660,19 @@ async test "sender write_reader incorrect length" {
         #|Err(IncorrectBodyLength)
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "sender end_body incorrect length" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @io.pipe()
-    group.spawn_bg(no_wait=true, () => {
+    group.spawn_bg(no_wait=true) <| () => {
       defer r.close()
       while r.read_some() is Some(_) {
 
       }
-    })
+    }
     defer w.close()
     let sender = Sender::new(w)
     sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={
@@ -684,7 +684,7 @@ async test "sender end_body incorrect length" {
         #|Err(IncorrectBodyLength)
       ),
     )
-  })
+  }
 }
 
 ///|
@@ -707,14 +707,14 @@ async test "send_response cookies" {
     ),
     Cookie("Cookie4", "value four", extensions=["ExtNoArg", "ExtWithArg=xxx"]),
   ]
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @io.pipe()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer w.close()
       let sender = Sender::new(w)
       let _ = sender.send_response(200, "OK", cookies~, request_method=Get, extra_headers={})
       sender.end_body()
-    })
+    }
     defer r.close()
     inspect(
       r.read_all().binary() |> @bytes_util.ascii_to_string,
@@ -729,14 +729,14 @@ async test "send_response cookies" {
         #|
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "send_request empty body" {
   @async.with_task_group <| group => {
     let (r, w) = @io.pipe()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer w.close()
       let sender = Sender::new(w)
       let _ = sender.send_request(Get, "/", extra_headers={})
@@ -745,7 +745,7 @@ async test "send_request empty body" {
       sender.end_body()
       let _ = sender.send_request(Post, "/", extra_headers={})
       sender.end_body()
-    })
+    }
     defer r.close()
     inspect(
       r.read_all().binary() |> @bytes_util.ascii_to_string,
@@ -770,7 +770,7 @@ async test "send_request empty body" {
 async test "send_response empty body" {
   @async.with_task_group <| group => {
     let (r, w) = @io.pipe()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer w.close()
       let sender = Sender::new(w)
       let _ = sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={})
@@ -783,7 +783,7 @@ async test "send_response empty body" {
       sender..write("").end_body()
       let _ = sender.send_response(304, "OK", cookies=[], request_method=Get, extra_headers={})
       sender.end_body()
-    })
+    }
     defer r.close()
     inspect(
       r.read_all().binary() |> @bytes_util.ascii_to_string,
@@ -807,9 +807,9 @@ async test "send_response empty body" {
 
 ///|
 async test "sender persistent header" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       let sender = Sender::new(w, headers={
         "Host": "x.y.org",
@@ -817,7 +817,7 @@ async test "sender persistent header" {
       })
       let _ = sender.send_request(Get, "/", extra_headers={})
       sender.end_body()
-    })
+    }
     defer r.close()
     inspect(
       r.read_all().binary() |> @bytes_util.ascii_to_string,
@@ -830,5 +830,5 @@ async test "sender persistent header" {
         #|
       ),
     )
-  })
+  }
 }

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -263,7 +263,7 @@ pub async fn Server::run_forever(
   allow_failure? : Bool,
   max_connections? : Int,
 ) -> Unit {
-  self.server.run_forever(allow_failure?, max_connections?, (conn, _) => {
+  self.server.run_forever(allow_failure?, max_connections?) <| ((conn, _) => {
     let conn = ServerConnection::new(conn, headers=self.headers)
     defer conn.close()
     for ;; {

--- a/src/integration.mbt
+++ b/src/integration.mbt
@@ -19,7 +19,7 @@
 #cfg(target="native")
 #doc(hidden)
 pub fn run_async_main(main : async () -> Unit) -> Unit {
-  @event_loop.with_event_loop(() => main()) catch {
+  (@event_loop.with_event_loop() <| () => { main() }) catch {
     @event_loop.KilledBySignal(signal) => exit(128 + signal)
     err => {
       // TODO: output the error to stderr

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -78,12 +78,12 @@ pub async fn pause() -> Unit {
   if coro.cancelled && !coro.shielded {
     raise Cancelled
   }
-  async_suspend(fn(ok_cont, err_cont) {
+  async_suspend() <| fn(ok_cont, err_cont) {
     guard coro.state is Running
     coro.state = Suspend(ok_cont~, err_cont~)
     coro.ready = true
     scheduler.run_later.push_back(coro)
-  })
+  }
 }
 
 ///|
@@ -96,10 +96,10 @@ pub async fn suspend() -> Unit {
   defer {
     scheduler.blocking -= 1
   }
-  async_suspend(fn(ok_cont, err_cont) {
+  async_suspend() <| fn(ok_cont, err_cont) {
     guard coro.state is Running
     coro.state = Suspend(ok_cont~, err_cont~)
-  })
+  }
 }
 
 ///|
@@ -114,7 +114,7 @@ pub fn spawn(f : async () -> Unit) -> Coroutine {
     cancelled: false,
   }
   fn run(_) {
-    run_async(() => {
+    run_async() <| () => {
       coro.shielded = false
       try f() catch {
         err => coro.state = Fail(err)
@@ -125,7 +125,7 @@ pub fn spawn(f : async () -> Unit) -> Coroutine {
         coro.wake()
       }
       coro.downstream.clear()
-    })
+    }
   }
 
   coro.state = Suspend(ok_cont=run, err_cont=_ => ())

--- a/src/internal/coroutine/pause_test.mbt
+++ b/src/internal/coroutine/pause_test.mbt
@@ -15,24 +15,24 @@
 ///|
 test "coroutine ping-pong" {
   let log = StringBuilder::new()
-  let coro = @coroutine.spawn(() => {
-    @async.with_task_group(group => {
-      group.spawn_bg(() => {
-        log <+ "ping\n"
-        @async.pause()
-        log <+ "ping\n"
-        @async.pause()
-        log <+ "ping\n"
-      })
-      group.spawn_bg(() => {
-        log <+ "pong\n"
-        @async.pause()
-        log <+ "pong\n"
-        @async.pause()
-        log <+ "pong\n"
-      })
-    })
-  })
+  let coro = @coroutine.spawn() <| () => {
+      @async.with_task_group() <| group => {
+        group.spawn_bg() <| () => {
+          log <+ "ping\n"
+          @async.pause()
+          log <+ "ping\n"
+          @async.pause()
+          log <+ "ping\n"
+        }
+        group.spawn_bg() <| () => {
+          log <+ "pong\n"
+          @async.pause()
+          log <+ "pong\n"
+          @async.pause()
+          log <+ "pong\n"
+        }
+      }
+    }
   while !@coroutine.no_more_work() {
     @coroutine.reschedule()
   }

--- a/src/internal/event_loop/cancel_before_submit_test.mbt
+++ b/src/internal/event_loop/cancel_before_submit_test.mbt
@@ -17,10 +17,10 @@ async test "cancel before submit" {
   let file = @fs.open("LICENSE", mode=ReadOnly)
   defer file.close()
   let buf = FixedArray::make(1, b'\x00')
-  let result = @async.with_timeout_opt(1, () => {
-    while file._direct_read(buf, offset=0, max_len=1) is 1 {
+  let result = @async.with_timeout_opt(1) <| () => {
+      while file._direct_read(buf, offset=0, max_len=1) is 1 {
 
+      }
     }
-  })
   debug_inspect(result, content="None")
 }

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -193,16 +193,16 @@ pub fn with_event_loop(f : async () -> Unit) -> Unit raise {
     }
   }
   let signal_handler = setup_signal_handler()
-  let main = @coroutine.spawn(() => {
-    try f() catch {
-      err => {
-        evloop.terminate_signal_handler(signal_handler)
-        raise err
+  let main = @coroutine.spawn() <| () => {
+      try f() catch {
+        err => {
+          evloop.terminate_signal_handler(signal_handler)
+          raise err
+        }
+      } noraise {
+        _ => evloop.terminate_signal_handler(signal_handler)
       }
-    } noraise {
-      _ => evloop.terminate_signal_handler(signal_handler)
     }
-  })
   evloop.main = Some(main)
   evloop.run_forever()
   main.unwrap()
@@ -438,10 +438,10 @@ async fn EventLoop::wait_for_job(
           for ;; {
             let status = cancel_func(job_id) catch {
               err =>
-                @coroutine.protect_from_cancel(() => {
+                @coroutine.protect_from_cancel() <| () => {
                   @coroutine.suspend()
                   raise err
-                })
+                }
             }
             match status {
               NeedWait => {

--- a/src/internal/event_loop/missing_close_test.mbt
+++ b/src/internal/event_loop/missing_close_test.mbt
@@ -15,21 +15,21 @@
 ///|
 test "missing_close" {
   let log = StringBuilder::new()
-  @event_loop.with_event_loop(() => {
-    @async.with_task_group(root => {
+  @event_loop.with_event_loop() <| () => {
+    @async.with_task_group() <| root => {
       let (r, w) = @pipe.pipe()
-      root.spawn_bg(() => {
+      root.spawn_bg() <| () => {
         let data = r.read_exactly(4) |> @utf8.decode
         @async.sleep(10)
         log.write_string("received \{data}\n")
-      })
-      root.spawn_bg(() => {
+      }
+      root.spawn_bg() <| () => {
         let data = "abcd"
         w.write(data)
         log.write_string("written \{data}\n")
-      })
-    })
-  })
+      }
+    }
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -58,14 +58,14 @@ fn setup_signal_handler() -> @coroutine.Coroutine {
   if !global_signal_handler_initialized.val {
     set_global_cancellation_signals(all_signals)
   }
-  @coroutine.spawn(() => {
+  @coroutine.spawn() <| () => {
     let context = "sigwait thread"
     fn cancel(job_id) raise {
       guard curr_loop.val is Some(evloop)
       evloop.cancel_job_in_worker(job_id, context~)
     }
     let _ = perform_job_in_worker(Job::sigwait(all_signals), context~, cancel~)
-  })
+  }
 }
 
 ///|
@@ -75,7 +75,7 @@ async fn EventLoop::terminate_signal_handler(
   sigwait_task : @coroutine.Coroutine,
 ) -> Unit {
   sigwait_task.cancel()
-  @coroutine.protect_from_cancel(() => sigwait_task.wait()) catch {
+  (@coroutine.protect_from_cancel() <| () => { sigwait_task.wait() }) catch {
     @coroutine.Cancelled => ()
     err => raise err
   }

--- a/src/internal/event_loop/starvation_test.mbt
+++ b/src/internal/event_loop/starvation_test.mbt
@@ -15,18 +15,18 @@
 ///|
 async test "starvation" {
   let log = []
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       @async.sleep(50)
       log.push("sleep completed")
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       let start = @async.now()
       while @async.now() - start < 100 {
         @async.pause()
       }
       log.push("busy wait completed")
-    })
-  })
+    }
+  }
   json_inspect(log, content=["sleep completed", "busy wait completed"])
 }

--- a/src/internal/event_loop/timer.js.mbt
+++ b/src/internal/event_loop/timer.js.mbt
@@ -22,10 +22,10 @@ extern "js" fn set_timeout(duration : Int, f : () -> Unit) -> Timer =
 
 ///|
 pub fn Timer::new(duration : Int, f : () -> Unit) -> Timer {
-  set_timeout(duration, () => {
+  set_timeout(duration) <| () => {
     f()
     reschedule()
-  })
+  }
 }
 
 ///|

--- a/src/internal/event_loop/worker_wbtest.mbt
+++ b/src/internal/event_loop/worker_wbtest.mbt
@@ -31,16 +31,16 @@ async fn perform_sleep_job(t : Int) -> Unit {
 ///|
 async test "worker basic" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       for _ in 0..<3 {
         @async.sleep(400)
         log <+ "tick\n"
       }
-    })
+    }
     perform_sleep_job(1000)
     log <+ "done\n"
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -56,20 +56,20 @@ async test "worker basic" {
 ///|
 async test "worker multiple" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       for _ in 0..<3 {
         @async.sleep(200)
         log <+ "tick\n"
       }
-    })
+    }
     for i in 0..<3 {
-      root.spawn_bg(() => {
+      root.spawn_bg() <| () => {
         perform_sleep_job(100 + i * 200)
         log.write_string("#\{i} done\n")
-      })
+      }
     }
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -87,27 +87,27 @@ async test "worker multiple" {
 ///|
 async test "worker cancel1" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       for _ in 0..<4 {
         @async.sleep(200)
         log <+ "tick\n"
       }
-    })
-    let task = root.spawn(() => {
-      try perform_sleep_job(1000) catch {
-        err => {
-          log.write_string("sleep cancelled with \{err}\n")
-          raise err
+    }
+    let task = root.spawn() <| () => {
+        try perform_sleep_job(1000) catch {
+          err => {
+            log.write_string("sleep cancelled with \{err}\n")
+            raise err
+          }
+        } noraise {
+          _ => log <+ "done\n"
         }
-      } noraise {
-        _ => log <+ "done\n"
       }
-    })
     @async.sleep(500)
     log <+ "trying to cancel\n"
     task.cancel()
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -125,14 +125,14 @@ async test "worker cancel1" {
 ///|
 async test "worker cancel2" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       for _ in 0..<3 {
         @async.sleep(400)
         log <+ "tick\n"
       }
-    })
-    root.spawn_bg(allow_failure=true, () => {
+    }
+    root.spawn_bg(allow_failure=true) <| () => {
       try perform_sleep_job(1000) catch {
         err => {
           log.write_string("sleep cancelled with \{err}\n")
@@ -141,11 +141,11 @@ async test "worker cancel2" {
       } noraise {
         _ => log <+ "done\n"
       }
-    })
+    }
     @async.sleep(600)
     log <+ "trying to terminate now\n"
     root.return_immediately(())
-  })
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/internal/gzip_internal/crc32.mbt
+++ b/src/internal/gzip_internal/crc32.mbt
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 ///|
-let crc32_table : FixedArray[UInt] = FixedArray::makei(256, i => {
-  let mut crc = i.reinterpret_as_uint()
-  for _ in 0..<8 {
-    crc = if (crc & 1U) == 0U { crc >> 1 } else { (crc >> 1) ^ 0xedb88320U }
+let crc32_table : FixedArray[UInt] = FixedArray::makei(256) <| i => {
+    let mut crc = i.reinterpret_as_uint()
+    for _ in 0..<8 {
+      crc = if (crc & 1U) == 0U { crc >> 1 } else { (crc >> 1) ^ 0xedb88320U }
+    }
+    crc
   }
-  crc
-})
 
 ///|
 fn crc32_update(current : UInt, chunk : BytesView) -> UInt {

--- a/src/internal/gzip_internal/huffman.mbt
+++ b/src/internal/gzip_internal/huffman.mbt
@@ -92,7 +92,7 @@ fn build_huffman_tree_or_abort(lengths : FixedArray[Int]) -> HuffmanTree {
 
 ///|
 let fixed_literal_tree : HuffmanTree = build_huffman_tree_or_abort(
-  FixedArray::makei(288, i => {
+  FixedArray::makei(288) <| i => {
     if i < 144 {
       8
     } else if i < 256 {
@@ -102,7 +102,7 @@ let fixed_literal_tree : HuffmanTree = build_huffman_tree_or_abort(
     } else {
       8
     }
-  }),
+  },
 )
 
 ///|

--- a/src/io/buffered_writer_test.mbt
+++ b/src/io/buffered_writer_test.mbt
@@ -15,9 +15,9 @@
 ///|
 async test "BufferedWriter" {
   let log = StringBuilder::new()
-  @async.with_task_group(fn(root) {
+  @async.with_task_group() <| fn(root) {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       let w = @io.BufferedWriter::new(w, size=4)
       log <+ "2 bytes written\n"
@@ -29,14 +29,14 @@ async test "BufferedWriter" {
       log <+ "2 bytes written\n"
       w.write("ef")
       w.flush()
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(data) {
         log.write_string("received: \{@utf8.decode(data)}\n")
       }
-    })
-  })
+    }
+  }
   inspect(
     log.to_string(),
     content=(
@@ -53,24 +53,24 @@ async test "BufferedWriter" {
 ///|
 async test "BufferedWriter::write_reader" {
   let log = StringBuilder::new()
-  @async.with_task_group(fn(root) {
+  @async.with_task_group() <| fn(root) {
     let (r1, w1) = @io.pipe()
     let (r2, w2) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer r2.close()
       defer w1.close()
       let w1 = @io.BufferedWriter::new(w1, size=6)
       w1.write_reader(r2)
       w1.flush()
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer r1.close()
       while r1.read_some() is Some(data) {
         let data = @utf8.decode(data)
         log.write_string("received \{data}\n")
       }
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer w2.close()
       log <+ "sending 4 bytes\n"
       w2.write(b"abcd")
@@ -80,8 +80,8 @@ async test "BufferedWriter::write_reader" {
       @async.sleep(100)
       log <+ "sending 4 bytes\n"
       w2.write(b"ijkl")
-    })
-  })
+    }
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/io/read_all_test.mbt
+++ b/src/io/read_all_test.mbt
@@ -29,23 +29,23 @@ async fn writer(log : StringBuilder, w : @io.PipeWrite) -> Unit {
 ///|
 async test "read_all basic" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg(() => writer(log, w))
+    root.spawn_bg() <| () => { writer(log, w) }
     inspect(r.read_all().text(), content="abcdefghijkl")
-  })
+  }
 }
 
 ///|
 async test "read_all large data" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w.write(Bytes::make(4097, 0))
-    })
+    }
     inspect(r.read_all().binary().length(), content="4097")
-  })
+  }
 }

--- a/src/io/read_some_test.mbt
+++ b/src/io/read_some_test.mbt
@@ -15,14 +15,14 @@
 ///|
 async test "read_some basic" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg(() => writer(log, w))
+    root.spawn_bg() <| () => { writer(log, w) }
     while r.read_some() is Some(chunk) {
       log.write_string("received chunk: \{@utf8.decode(chunk)}\n")
     }
-  })
+  }
   inspect(
     log,
     content=(
@@ -40,14 +40,14 @@ async test "read_some basic" {
 ///|
 async test "read_some length limit 1" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg(() => writer(log, w))
+    root.spawn_bg() <| () => { writer(log, w) }
     while r.read_some(max_len=2) is Some(chunk) {
       log.write_string("received chunk: \{@utf8.decode(chunk)}\n")
     }
-  })
+  }
   inspect(
     log,
     content=(
@@ -68,15 +68,15 @@ async test "read_some length limit 1" {
 ///|
 async test "read_some length limit 2" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg(() => writer(log, w))
+    root.spawn_bg() <| () => { writer(log, w) }
     for max_len = 2; ; max_len = max_len * 2 {
       guard r.read_some(max_len~) is Some(chunk) else { break }
       log.write_string("received chunk: \{@utf8.decode(chunk)}\n")
     }
-  })
+  }
   inspect(
     log,
     content=(
@@ -95,18 +95,18 @@ async test "read_some length limit 2" {
 ///|
 async test "read_some length limit 3" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w.write("abcdefghijkl")
-    })
+    }
     for max_len = 2; ; max_len = max_len * 2 {
       guard r.read_some(max_len~) is Some(chunk) else { break }
       log.write_string("received chunk: \{@utf8.decode(chunk)}\n")
     }
-  })
+  }
   inspect(
     log,
     content=(

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -14,39 +14,39 @@
 
 ///|
 async test "write large data" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       let data = Bytes::make(1024 * 16, 0)
       w.write(data)
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer r.close()
       inspect(r.read_all().binary().length(), content="16384")
-    })
-  })
+    }
+  }
 }
 
 ///|
 async test "write reader" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r1, w1) = @io.pipe()
     let (r2, w2) = @io.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer r2.close()
       defer w1.close()
       w1.write_reader(r2)
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer r1.close()
       while r1.read_some() is Some(data) {
         let data = @utf8.decode(data)
         log.write_string("received \{data}\n")
       }
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer w2.close()
       log <+ "sending 4 bytes\n"
       w2.write(b"abcd")
@@ -56,8 +56,8 @@ async test "write reader" {
       @async.sleep(300)
       log <+ "sending 4 bytes\n"
       w2.write(b"ijkl")
-    })
-  })
+    }
+  }
   inspect(
     log.to_string(),
     content=(
@@ -90,7 +90,7 @@ impl @io.Writer for DummyWriter with write_once(self, buf, offset~, len~) {
 async test "write cancel" {
   let log = StringBuilder::new()
   let writer = { logger: log, base_timeout: 300 }
-  @async.with_timeout_opt(450, () => writer.write(b"abcd")) |> ignore
+  (@async.with_timeout_opt(450) <| () => { writer.write(b"abcd") }) |> ignore
   // The `write` here is partial and corrupted,
   // but we have no choice because making `write` atomic may cause hang
   inspect(
@@ -104,13 +104,13 @@ async test "write cancel" {
 
 ///|
 async test "write_string" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       w.write("abcd中文☺")
-    })
+    }
     inspect(r.read_all().text(), content="abcd中文☺")
-  })
+  }
 }

--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -201,20 +201,20 @@ pub fn[X] Promise::from_async(
   f : async () -> X,
   abort_signal? : AbortSignal,
 ) -> Promise[X] {
-  let promise = JsValue::new_promise((resolve, reject) => {
-    let coro = @coroutine.spawn(() => {
-      try f() catch {
-        @coroutine.Cancelled if @coroutine.is_being_cancelled() =>
-          reject(JsValue::abort_error())
-        err => reject(JsValue::make(err.to_string()))
-      } noraise {
-        ret => resolve(JsValue::make(ret))
+  let promise = JsValue::new_promise() <| ((resolve, reject) => {
+      let coro = @coroutine.spawn() <| () => {
+          try f() catch {
+            @coroutine.Cancelled if @coroutine.is_being_cancelled() =>
+              reject(JsValue::abort_error())
+            err => reject(JsValue::make(err.to_string()))
+          } noraise {
+            ret => resolve(JsValue::make(ret))
+          }
+        }
+      if abort_signal is Some(signal) {
+        signal.on_abort() <| () => { coro.cancel() }
       }
     })
-    if abort_signal is Some(signal) {
-      signal.on_abort(() => coro.cancel())
-    }
-  })
   @coroutine.reschedule()
   promise.cast()
 }

--- a/src/js_async/js_async_test.mbt
+++ b/src/js_async/js_async_test.mbt
@@ -14,25 +14,25 @@
 
 ///|
 async test "Promise::from_async" {
-  let result = @js_async.run_promise(abort_signal => {
-    @js_async.Promise::from_async(abort_signal~, () => {
-      @async.sleep(100)
-      42
-    })
-  })
+  let result = @js_async.run_promise() <| abort_signal => {
+      @js_async.Promise::from_async(abort_signal~) <| () => {
+        @async.sleep(100)
+        42
+      }
+    }
   inspect(result, content="42")
 }
 
 ///|
 async test "Promise::from_async cancellation" {
   let mut worker_finished = false
-  let result = try? @async.with_timeout(100, () => {
-    @js_async.run_promise(abort_signal => {
-      @js_async.Promise::from_async(abort_signal~, () => {
+  let result = try? (@async.with_timeout(100) <| () => {
+    @js_async.run_promise() <| abort_signal => {
+      @js_async.Promise::from_async(abort_signal~) <| () => {
         @async.sleep(200)
         worker_finished = true
-      })
-    })
+      }
+    }
   })
   debug_inspect(result, content="Err(TimeoutError)")
   assert_false(worker_finished)
@@ -41,9 +41,9 @@ async test "Promise::from_async cancellation" {
 ///|
 async test "Promise::from_async cancellation 2" {
   let controller = @js_async.AbortController::new()
-  let p = @js_async.Promise::from_async(abort_signal=controller.signal(), () => {
-    @async.sleep(200)
-  })
+  let p = @js_async.Promise::from_async(abort_signal=controller.signal()) <| () => {
+      @async.sleep(200)
+    }
   @async.sleep(100)
   controller.abort()
   debug_inspect(
@@ -57,9 +57,9 @@ async test "Promise::from_async cancellation 2" {
 ///|
 async test "Promise::from_async cancellation 3" {
   let controller = @js_async.AbortController::new()
-  let p = @js_async.Promise::from_async(abort_signal=controller.signal(), () => {
-    @async.sleep(100)
-  })
+  let p = @js_async.Promise::from_async(abort_signal=controller.signal()) <| () => {
+      @async.sleep(100)
+    }
   @async.sleep(200)
   controller.abort()
   debug_inspect(try? p.wait(), content="Ok(())")
@@ -79,9 +79,9 @@ async test "read dir" {
 
 ///|
 async test "read file" {
-  let content = @js_async.run_promise(signal => {
-    (fsPromises.readFile)("LICENSE", { encoding: "utf8", signal })
-  })
+  let content = @js_async.run_promise() <| signal => {
+      (fsPromises.readFile)("LICENSE", { encoding: "utf8", signal })
+    }
   inspect(
     content,
     content=(

--- a/src/js_async/readable_stream.mbt
+++ b/src/js_async/readable_stream.mbt
@@ -103,15 +103,15 @@ pub fn ReadableStream::from_js(stream : JsReadableStream) -> ReadableStream {
   // because the `.read()` method of `StreamReader` is NOT cancellable.
   // It can only be cancelled by cancelling the whole stream.
   // So we use a `@io.pipe` in the middle to provide proper cancellation support.
-  let worker = @coroutine.spawn(() => {
-    defer w.close()
-    defer stream.cancel()
-    let reader = stream.get_reader()
-    defer reader.release_lock()
-    while reader.read() is Some(chunk) {
-      w.write(chunk)
+  let worker = @coroutine.spawn() <| () => {
+      defer w.close()
+      defer stream.cancel()
+      let reader = stream.get_reader()
+      defer reader.release_lock()
+      while reader.read() is Some(chunk) {
+        w.write(chunk)
+      }
     }
-  })
   { read_end: r, worker }
 }
 
@@ -152,12 +152,12 @@ pub fn JsReadableStream::new_pipe() -> (JsReadableStream, @io.PipeWrite) {
   let abort_signal = abort_controller.signal()
   let (pipe_r, pipe_w) = @io.pipe()
   fn pull(controller : ReadableStreamController) {
-    Promise::from_async(abort_signal~, () => {
+    Promise::from_async(abort_signal~) <| () => {
       guard pipe_r.read_some(max_len=1024) is Some(chunk) else {
         controller.close()
       }
       controller.enqueue(chunk)
-    })
+    }
   }
   fn cancel(_reason) {
     pipe_r.close()

--- a/src/js_async/readable_stream_test.mbt
+++ b/src/js_async/readable_stream_test.mbt
@@ -17,12 +17,12 @@ async test "ReadableStream roundtrip" {
   let log = []
   let (r, w) = @js_async.JsReadableStream::new_pipe()
   let r = @js_async.ReadableStream::from_js(r)
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let start = @async.now()
     fn tick() {
       ((@async.now() - start).to_int() + 50) / 200
     }
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer w.close()
       async fn write(msg : String) {
         w.write(msg)
@@ -34,15 +34,15 @@ async test "ReadableStream roundtrip" {
       write("message3")
       @async.sleep(400)
       write("message4")
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       defer r.close()
       @async.sleep(200)
       while r.read_some() is Some(data) {
         log.push("reader: \{@utf8.decode(data)} at tick #\{tick()}")
       }
-    })
-  })
+    }
+  }
   json_inspect(log, content=[
     "writer: message1 at tick #0", "writer: message2 at tick #0", "reader: message1 at tick #1",
     "writer: message3 at tick #1", "reader: message2 at tick #1", "reader: message3 at tick #1",
@@ -56,9 +56,12 @@ async test "ReadableStream read cancelled" {
   let r = @js_async.ReadableStream::from_js(r)
   defer w.close()
   defer r.close()
-  json_inspect(@async.with_timeout_opt(300, () => r.read_some()), content=null)
+  json_inspect(
+    @async.with_timeout_opt(300) <| () => { r.read_some() },
+    content=null,
+  )
   w.write("message")
-  json_inspect(@async.with_timeout_opt(300, () => r.read_some()), content=[
+  json_inspect(@async.with_timeout_opt(300) <| () => { r.read_some() }, content=[
     ["message"],
   ])
 }
@@ -73,17 +76,18 @@ async test "ReadableStream write cancelled" {
   w.write("message1")
   w.write("message2")
   json_inspect(
-    @async.with_timeout_opt(300, () => w.write("message3")),
+    @async.with_timeout_opt(300) <| () => { w.write("message3") },
     content=null,
   )
   for _ in 0..<2 {
     msgs.push(r.read_some())
   }
-  @async.with_task_group(group => {
-    group.spawn_bg(() => msgs.push(r.read_some()))
-    json_inspect(@async.with_timeout_opt(300, () => w.write("message4")), content=[
-      null,
-    ])
-  })
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => { msgs.push(r.read_some()) }
+    json_inspect(
+      @async.with_timeout_opt(300) <| () => { w.write("message4") },
+      content=[null],
+    )
+  }
   json_inspect(msgs, content=[["message1"], ["message2"], ["message4"]])
 }

--- a/src/lazy_init.mbt
+++ b/src/lazy_init.mbt
@@ -46,21 +46,21 @@ pub async fn[X] Lazy::wait(self : Lazy[X]) -> X {
     Fail(err) => raise err
     Running(_) => ()
     Uninitialized => {
-      let coro = @coroutine.spawn(() => {
-        try (self.worker)() catch {
-          err =>
-            if err is @coroutine.Cancelled && is_being_cancelled() {
-              self.state = Uninitialized
-            } else {
-              self.state = Fail(err)
-            }
-        } noraise {
-          ret => self.state = Done(ret)
+      let coro = @coroutine.spawn() <| () => {
+          try (self.worker)() catch {
+            err =>
+              if err is @coroutine.Cancelled && is_being_cancelled() {
+                self.state = Uninitialized
+              } else {
+                self.state = Fail(err)
+              }
+          } noraise {
+            ret => self.state = Done(ret)
+          }
+          for waiter in self.waiters {
+            waiter.wake()
+          }
         }
-        for waiter in self.waiters {
-          waiter.wake()
-        }
-      })
       self.state = Running(coro)
     }
   }

--- a/src/lazy_init_test.mbt
+++ b/src/lazy_init_test.mbt
@@ -20,11 +20,11 @@ async test "lazy init basic" {
     (@async.now() - start + 20).to_int() / 200
   }
 
-  let x = @async.Lazy(() => {
-    log.push("lazy init started at tick \{current_tick()}")
-    @async.sleep(200)
-    log.push("lazy init completed at tick \{current_tick()}")
-  })
+  let x = @async.Lazy() <| () => {
+      log.push("lazy init started at tick \{current_tick()}")
+      @async.sleep(200)
+      log.push("lazy init completed at tick \{current_tick()}")
+    }
   @async.sleep(200)
   x.wait()
   log.push("got lazy init result at tick \{current_tick()}")
@@ -38,10 +38,10 @@ async test "lazy init basic" {
 
 ///|
 async test "lazy init failure" {
-  let x : @async.Lazy[Unit] = @async.Lazy(() => {
-    @async.sleep(200)
-    raise Failure::Failure("msg")
-  })
+  let x : @async.Lazy[Unit] = @async.Lazy() <| () => {
+      @async.sleep(200)
+      raise Failure::Failure("msg")
+    }
   let start = @async.now()
   fn current_tick() -> Int {
     (@async.now() - start + 20).to_int() / 200
@@ -73,17 +73,20 @@ async test "lazy init cancelled" {
     (@async.now() - start + 20).to_int() / 200
   }
 
-  let x = @async.Lazy(() => {
-    log.push("lazy init started at tick \{current_tick()}")
-    @async.sleep(400) catch {
-      err => {
-        log.push("lazy init cancelled at tick \{current_tick()}")
-        raise err
+  let x = @async.Lazy() <| () => {
+      log.push("lazy init started at tick \{current_tick()}")
+      @async.sleep(400) catch {
+        err => {
+          log.push("lazy init cancelled at tick \{current_tick()}")
+          raise err
+        }
       }
+      log.push("lazy init completed at tick \{current_tick()}")
     }
-    log.push("lazy init completed at tick \{current_tick()}")
-  })
-  debug_inspect(@async.with_timeout_opt(200, () => x.wait()), content="None")
+  debug_inspect(
+    @async.with_timeout_opt(200) <| () => { x.wait() },
+    content="None",
+  )
   @async.sleep(100)
   // the previous attempt is already cancelled,
   // this `wait` will trigger a new attempt
@@ -102,23 +105,23 @@ async test "lazy init multiple waiters 1" {
     (@async.now() - start + 20).to_int() / 200
   }
 
-  let x = @async.Lazy(() => {
-    log.push("lazy init started at tick \{current_tick()}")
-    @async.sleep(400) catch {
-      err => {
-        log.push("lazy init cancelled at tick \{current_tick()}")
-        raise err
+  let x = @async.Lazy() <| () => {
+      log.push("lazy init started at tick \{current_tick()}")
+      @async.sleep(400) catch {
+        err => {
+          log.push("lazy init cancelled at tick \{current_tick()}")
+          raise err
+        }
       }
+      log.push("lazy init completed at tick \{current_tick()}")
     }
-    log.push("lazy init completed at tick \{current_tick()}")
-  })
-  let result = @async.with_task_group(group => {
-    group.spawn_bg(() => {
-      x.wait()
-      log.push("got lazy init value at tick \{current_tick()}")
-    })
-    @async.with_timeout_opt(200, () => x.wait())
-  })
+  let result = @async.with_task_group() <| group => {
+      group.spawn_bg() <| () => {
+        x.wait()
+        log.push("got lazy init value at tick \{current_tick()}")
+      }
+      @async.with_timeout_opt(200) <| () => { x.wait() }
+    }
   debug_inspect(result, content="None")
   json_inspect(log, content=[
     "lazy init started at tick 0", "lazy init completed at tick 2", "got lazy init value at tick 2",
@@ -133,30 +136,30 @@ async test "lazy init multiple waiters 2" {
     (@async.now() - start + 20).to_int() / 200
   }
 
-  let x = @async.Lazy(() => {
-    log.push("lazy init started at tick \{current_tick()}")
-    @async.sleep(600) catch {
-      err => {
-        log.push("lazy init cancelled at tick \{current_tick()}")
-        raise err
+  let x = @async.Lazy() <| () => {
+      log.push("lazy init started at tick \{current_tick()}")
+      @async.sleep(600) catch {
+        err => {
+          log.push("lazy init cancelled at tick \{current_tick()}")
+          raise err
+        }
       }
+      log.push("lazy init completed at tick \{current_tick()}")
     }
-    log.push("lazy init completed at tick \{current_tick()}")
-  })
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       debug_inspect(
-        @async.with_timeout_opt(200, () => x.wait()),
+        @async.with_timeout_opt(200) <| () => { x.wait() },
         content="None",
       )
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       debug_inspect(
-        @async.with_timeout_opt(400, () => x.wait()),
+        @async.with_timeout_opt(400) <| () => { x.wait() },
         content="None",
       )
-    })
-  })
+    }
+  }
   json_inspect(log, content=[
     "lazy init started at tick 0", "lazy init cancelled at tick 2",
   ])

--- a/src/no_wait_test.mbt
+++ b/src/no_wait_test.mbt
@@ -15,8 +15,8 @@
 ///|
 async test "no_wait cancelled" {
   let buf = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(no_wait=true, () => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg(no_wait=true) <| () => {
       try @async.sleep(1000) catch {
         err => {
           buf.write_string("`no_wait` task cancelled with \{err}\n")
@@ -25,10 +25,10 @@ async test "no_wait cancelled" {
       } noraise {
         _ => buf <+ "`no_wait` task finished successfully\n"
       }
-    })
+    }
     @async.sleep(100)
     buf <+ "main task terminate\n"
-  })
+  }
   inspect(
     buf.to_string(),
     content=(
@@ -42,8 +42,8 @@ async test "no_wait cancelled" {
 ///|
 async test "no_wait normal exit" {
   let buf = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(no_wait=true, () => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg(no_wait=true) <| () => {
       try @async.sleep(100) catch {
         err => {
           buf.write_string("`no_wait` task cancelled with \{err}\n")
@@ -52,10 +52,10 @@ async test "no_wait normal exit" {
       } noraise {
         _ => buf <+ "`no_wait` task finished successfully\n"
       }
-    })
+    }
     @async.sleep(200)
     buf <+ "main task terminate\n"
-  })
+  }
   inspect(
     buf.to_string(),
     content=(

--- a/src/pipe/read_exactly_test.mbt
+++ b/src/pipe/read_exactly_test.mbt
@@ -19,10 +19,10 @@ async test "read_exactly" {
     buf..write_string(msg).write_char('\n')
   }
 
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @pipe.pipe()
     // reader
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer r.close()
       let msg1 = r.read_exactly(4) |> @utf8.decode
       log("first message: \{msg1}")
@@ -30,17 +30,17 @@ async test "read_exactly" {
       log("second message: \{msg2}")
       let msg3 = r.read_exactly(4) |> @utf8.decode
       log("third message: \{msg3}")
-    })
+    }
     // writer
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       log("first message sent")
       w.write("abcdef")
       @async.sleep(100)
       log("second message sent")
       w.write("ghijkl")
-    })
-  })
+    }
+  }
   inspect(
     buf.to_string(),
     content=(
@@ -61,10 +61,10 @@ async test "read_exactly failure" {
     buf..write_string(msg).write_char('\n')
   }
 
-  @async.with_task_group(root => {
+  (@async.with_task_group() <| root => {
     let (r, w) = @pipe.pipe()
     // reader
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer r.close()
       let msg1 = r.read_exactly(4) |> @utf8.decode
       log("first message: \{msg1}")
@@ -72,13 +72,13 @@ async test "read_exactly failure" {
       log("second message: \{msg2}")
       let msg3 = r.read_exactly(4) |> @utf8.decode
       log("third message: \{msg3}")
-    })
+    }
     // writer
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer w.close()
       log("first message sent")
       w.write("abcdef")
-    })
+    }
   }) catch {
     err => log(err.to_string())
   }

--- a/src/process/basic_test.mbt
+++ b/src/process/basic_test.mbt
@@ -15,7 +15,7 @@
 
 ///|
 async test "basic_ls" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
     defer r.close()
     @process.spawn(group, shell, ["-c", "\{ls} src/process"], stdout=w, extra_env={
@@ -38,25 +38,25 @@ async test "basic_ls" {
       "commands_for_test.mbt", "unimplemented_test.mbt", "spawn_in_group_test.mbt",
       "windows_escape_wbtest.mbt",
     ])
-  })
+  }
 }
 
 ///|
 async test "basic_cat" {
   let cat = cat.wait()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (cat_read, we_write) = @process.write_to_process()
     let (we_read, cat_write) = @process.read_from_process()
     @process.spawn(group, cat, [], stdin=cat_read, stdout=cat_write) |> ignore
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer we_write.close()
       we_write.write(b"abcd")
       @async.sleep(50)
       we_write.write(b"efgh")
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       defer we_read.close()
       inspect(we_read.read_all().text(), content="abcdefgh")
-    })
-  })
+    }
+  }
 }

--- a/src/process/cancel_test.mbt
+++ b/src/process/cancel_test.mbt
@@ -17,23 +17,23 @@
 async test "cancel process" {
   let test_prog = sleep_prog.wait()
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn(() => {
-      defer log.write_string("process terminates\n")
-      @process.run(test_prog, ["10000"], stdout=w)
-    })
-    root.spawn_bg(() => {
+    let task = root.spawn() <| () => {
+        defer log.write_string("process terminates\n")
+        @process.run(test_prog, ["10000"], stdout=w)
+      }
+    root.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(data) {
         let data = @utf8.decode(data).replace_all(old="\r\n", new="\n")
         log.write_string("from process: \{data}")
       }
-    })
+    }
     @async.sleep(500)
     task.cancel()
     log <+ "cancelling task running process\n"
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -48,24 +48,24 @@ async test "cancel process" {
 ///|
 async test "cancel process timeout" {
   let test_prog = sleep_prog.wait()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn(() => {
-      @process.run(
-        test_prog,
-        ["-swallow-cancel-signal", "10000"],
-        stdout=w,
-        cancel_handler=@process.graceful_cancel(timeout=500),
-      )
-    })
-    let t_receive_graceful_termination = root.spawn(() => {
-      defer r.close()
-      guard r.read_some() is Some(data)
-      let data = @utf8.decode(data).trim_end(chars="\r\n")
-      let t = @async.now()
-      inspect(data, content="received termination signal")
-      t
-    })
+    let task = root.spawn() <| () => {
+        @process.run(
+          test_prog,
+          ["-swallow-cancel-signal", "10000"],
+          stdout=w,
+          cancel_handler=@process.graceful_cancel(timeout=500),
+        )
+      }
+    let t_receive_graceful_termination = root.spawn() <| () => {
+        defer r.close()
+        guard r.read_some() is Some(data)
+        let data = @utf8.decode(data).trim_end(chars="\r\n")
+        let t = @async.now()
+        inspect(data, content="received termination signal")
+        t
+      }
     @async.sleep(500)
     let t_cancel = @async.now()
     task.cancel()
@@ -75,55 +75,55 @@ async test "cancel process timeout" {
     let t2 = t_process_terminates - t_cancel
     inspect(t1 / 250, content="0")
     inspect(t2 / 250, content="2")
-  })
+  }
 }
 
 ///|
 async test "cancel process hard" {
   let test_prog = sleep_prog.wait()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn(() => {
-      @process.run(
-        test_prog,
-        ["10000"],
-        stdout=w,
-        cancel_handler=@process.hard_cancel(),
-      )
-    })
-    root.spawn_bg(() => {
+    let task = root.spawn() <| () => {
+        @process.run(
+          test_prog,
+          ["10000"],
+          stdout=w,
+          cancel_handler=@process.hard_cancel(),
+        )
+      }
+    root.spawn_bg() <| () => {
       defer r.close()
       inspect(r.read_all().text(), content="")
-    })
+    }
     @async.sleep(500)
     let t0 = @async.now()
     task.cancel()
     debug_inspect(try? task.wait(), content="Err(Cancelled)")
     let t1 = @async.now()
     inspect((t1 - t0) / 250, content="0")
-  })
+  }
 }
 
 ///|
 async test "orphan process" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn(() => {
-      defer log.write_string("process terminates\n")
-      let pid = @process.spawn_orphan(
-        shell,
-        ["-c", "\{write_stdout} first; sleep 1; \{write_stdout} second"],
-        stdout=w,
-      )
-      @process.wait_pid(pid)
-    })
+    let task = root.spawn() <| () => {
+        defer log.write_string("process terminates\n")
+        let pid = @process.spawn_orphan(
+          shell,
+          ["-c", "\{write_stdout} first; sleep 1; \{write_stdout} second"],
+          stdout=w,
+        )
+        @process.wait_pid(pid)
+      }
     defer r.close()
     inspect(@utf8.decode(r.read_exactly(5)), content="first")
     task.cancel()
     log <+ "cancelling task running process\n"
     inspect(r.read_all().text(), content="second")
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -141,7 +141,7 @@ async test "kill children on hard cancel" {
   let sleep = sleep_prog.wait()
   let (r, w) = @process.read_from_process()
   defer r.close()
-  @async.with_timeout(300, () => {
+  (@async.with_timeout(300) <| () => {
     @process.run(
       spawn,
       [sleep, "450", "-print-after-sleep", "after sleep"],
@@ -162,7 +162,7 @@ async test "do not kill orphan children on hard cancel" {
   let sleep = sleep_prog.wait()
   let (r, w) = @process.read_from_process()
   defer r.close()
-  @async.with_timeout(300, () => {
+  (@async.with_timeout(300) <| () => {
     @process.run(
       spawn,
       ["-orphan", sleep, "450", "-print-after-sleep", "after sleep"],

--- a/src/process/commands_for_test.mbt
+++ b/src/process/commands_for_test.mbt
@@ -38,7 +38,7 @@ let ls : String = if is_windows { "Get-ChildItem -Name" } else { "ls" }
 
 ///|
 fn make_test_prog(name : String) -> @async.Lazy[String] {
-  @async.Lazy(() => {
+  @async.Lazy() <| () => {
     let code = @process.run("moon", [
       "-C",
       "src/process/test_programs",
@@ -50,7 +50,7 @@ fn make_test_prog(name : String) -> @async.Lazy[String] {
       fail("failed to build test program `\{name}`: \{code}")
     }
     "src/process/test_programs/_build/native/debug/build/\{name}/\{name}.exe"
-  })
+  }
 }
 
 ///|

--- a/src/process/cwd_test.mbt
+++ b/src/process/cwd_test.mbt
@@ -15,18 +15,18 @@
 
 ///|
 async test "set cwd" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     // FIXME(upstram): missing codelens here
     guard @env.current_dir() is Some(prev_cwd)
     let (r, w) = @process.read_from_process()
     defer r.close()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       let _ = @process.run(shell, ["-c", ls], stdout=w, cwd="src/process", extra_env={
         "LC_ALL": "C",
       })
       guard @env.current_dir() is Some(new_cwd)
       guard prev_cwd == new_cwd
-    })
+    }
     let files = r
       .read_all()
       .text()
@@ -43,5 +43,5 @@ async test "set cwd" {
       "commands_for_test.mbt", "unimplemented_test.mbt", "spawn_in_group_test.mbt",
       "windows_escape_wbtest.mbt",
     ])
-  })
+  }
 }

--- a/src/process/env_test.mbt
+++ b/src/process/env_test.mbt
@@ -15,7 +15,7 @@
 
 ///|
 async test "set_env" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
     defer r.close()
     let env_var = if is_windows { "$env:MAGIC_VAR" } else { "$MAGIC_VAR" }
@@ -27,13 +27,13 @@ async test "set_env" {
       extra_env={ "MAGIC_VAR": "MAGIC_VALUE" },
     )
     inspect(r.read_all().text(), content="MAGIC_VALUE")
-  })
+  }
 }
 
 ///|
 async test "set_env no inherit" {
   let test_prog = dump_env_prog.wait()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
     defer r.close()
     let _ = @process.spawn(
@@ -59,5 +59,5 @@ async test "set_env no inherit" {
         #|
       ),
     )
-  })
+  }
 }

--- a/src/process/helper_test.mbt
+++ b/src/process/helper_test.mbt
@@ -57,15 +57,15 @@ async test "collect_output_merged" {
 ///|
 async test "collect_output blocked" {
   let test_prog = cat.wait()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (cat_read, we_write) = @process.write_to_process()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer we_write.close()
       let chunk = Bytes::make(1024, 0)
       for _ in 0..<1024 {
         we_write.write(chunk)
       }
-    })
+    }
     let (code, stdout, stderr) = @process.collect_output(
       test_prog,
       ["-stderr"],
@@ -74,5 +74,5 @@ async test "collect_output blocked" {
     inspect(code, content="0")
     inspect(stdout.text(), content="")
     inspect(stderr.binary().length(), content="1048576")
-  })
+  }
 }

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -135,12 +135,12 @@ pub async fn run(
   let pid = process.pid()
   process.wait_pid(context~) catch {
     _ if @coroutine.is_being_cancelled() =>
-      @async.protect_from_cancel(() => {
-        @async.with_task_group(group => {
-          group.spawn_bg(no_wait=true, () => cancel_handler(pid))
+      @async.protect_from_cancel() <| () => {
+        @async.with_task_group() <| group => {
+          group.spawn_bg(no_wait=true) <| () => { cancel_handler(pid) }
           process.wait_pid(context~)
-        })
-      })
+        }
+      }
     err => raise err
   }
 }
@@ -215,19 +215,19 @@ pub async fn[X] spawn(
     context~,
   )
   let pid = process.pid()
-  let result = group.spawn(no_wait?, () => {
-    defer process.close()
-    process.wait_pid(context~) catch {
-      _ if @coroutine.is_being_cancelled() =>
-        @async.protect_from_cancel(() => {
-          @async.with_task_group(group => {
-            group.spawn_bg(no_wait=true, () => cancel_handler(pid))
-            process.wait_pid(context~)
-          })
-        })
-      err => raise err
+  let result = group.spawn(no_wait?) <| () => {
+      defer process.close()
+      process.wait_pid(context~) catch {
+        _ if @coroutine.is_being_cancelled() =>
+          @async.protect_from_cancel() <| () => {
+            @async.with_task_group() <| group => {
+              group.spawn_bg(no_wait=true) <| () => { cancel_handler(pid) }
+              process.wait_pid(context~)
+            }
+          }
+        err => raise err
+      }
     }
-  })
   { pid, result }
 }
 
@@ -246,14 +246,23 @@ pub async fn collect_stdout(
   cwd? : StringView,
 ) -> (Int, &@io.Data) {
   let (r, w) = read_from_process()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     defer r.close()
-    let exit_code = group.spawn(() => {
-      run(cmd, args, extra_env~, inherit_env~, stdin?, stdout=w, stderr?, cwd?)
-    })
+    let exit_code = group.spawn() <| () => {
+        run(
+          cmd,
+          args,
+          extra_env~,
+          inherit_env~,
+          stdin?,
+          stdout=w,
+          stderr?,
+          cwd?,
+        )
+      }
     let output = r.read_all()
     (exit_code.wait(), output)
-  })
+  }
 }
 
 ///|
@@ -271,14 +280,23 @@ pub async fn collect_stderr(
   cwd? : StringView,
 ) -> (Int, &@io.Data) {
   let (r, w) = read_from_process()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     defer r.close()
-    let exit_code = group.spawn(() => {
-      run(cmd, args, extra_env~, inherit_env~, stdin?, stdout?, stderr=w, cwd?)
-    })
+    let exit_code = group.spawn() <| () => {
+        run(
+          cmd,
+          args,
+          extra_env~,
+          inherit_env~,
+          stdin?,
+          stdout?,
+          stderr=w,
+          cwd?,
+        )
+      }
     let output = r.read_all()
     (exit_code.wait(), output)
-  })
+  }
 }
 
 ///|
@@ -297,29 +315,29 @@ pub async fn collect_output(
 ) -> (Int, &@io.Data, &@io.Data) {
   let (r_out, w_out) = read_from_process()
   let (r_err, w_err) = read_from_process()
-  @async.with_task_group(group => {
-    let exit_code = group.spawn(() => {
-      run(
-        cmd,
-        args,
-        extra_env~,
-        inherit_env~,
-        stdin?,
-        stdout=w_out,
-        stderr=w_err,
-        cwd?,
-      )
-    })
-    let stdout = group.spawn(() => {
-      defer r_out.close()
-      r_out.read_all()
-    })
-    let stderr = group.spawn(() => {
-      defer r_err.close()
-      r_err.read_all()
-    })
+  @async.with_task_group() <| group => {
+    let exit_code = group.spawn() <| () => {
+        run(
+          cmd,
+          args,
+          extra_env~,
+          inherit_env~,
+          stdin?,
+          stdout=w_out,
+          stderr=w_err,
+          cwd?,
+        )
+      }
+    let stdout = group.spawn() <| () => {
+        defer r_out.close()
+        r_out.read_all()
+      }
+    let stderr = group.spawn() <| () => {
+        defer r_err.close()
+        r_err.read_all()
+      }
     (exit_code.wait(), stdout.wait(), stderr.wait())
-  })
+  }
 }
 
 ///|
@@ -337,12 +355,21 @@ pub async fn collect_output_merged(
   cwd? : StringView,
 ) -> (Int, &@io.Data) {
   let (r, w) = read_from_process()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     defer r.close()
-    let exit_code = group.spawn(() => {
-      run(cmd, args, extra_env~, inherit_env~, stdin?, stdout=w, stderr=w, cwd?)
-    })
+    let exit_code = group.spawn() <| () => {
+        run(
+          cmd,
+          args,
+          extra_env~,
+          inherit_env~,
+          stdin?,
+          stdout=w,
+          stderr=w,
+          cwd?,
+        )
+      }
     let output = r.read_all()
     (exit_code.wait(), output)
-  })
+  }
 }

--- a/src/process/redirect_test.mbt
+++ b/src/process/redirect_test.mbt
@@ -15,9 +15,9 @@
 
 ///|
 async test "merge multiple" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (r, w) = @pipe.pipe()
-    root.spawn_bg(no_wait=true, () => {
+    root.spawn_bg(no_wait=true) <| () => {
       defer r.close()
       inspect(
         r.read_all().text(),
@@ -27,9 +27,9 @@ async test "merge multiple" {
           #|
         ),
       )
-    })
+    }
     defer w.close()
-    @async.with_task_group(group => {
+    @async.with_task_group() <| group => {
       @process.spawn(group, shell, ["-c", "echo abcd"], stdout=w, extra_env={
         "LANG": "en_US.UTF-8",
       })
@@ -38,18 +38,18 @@ async test "merge multiple" {
         "LANG": "en_US.UTF-8",
       })
       |> ignore
-    })
-  })
+    }
+  }
 }
 
 ///|
 async test "redirect to file" {
   let cat = cat.wait()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let input_file = "_build/process_redirect_test_in.txt"
     let output_file = "_build/process_redirect_test_out.txt"
-    root.add_defer(() => @fs.remove(input_file))
-    root.add_defer(() => @fs.remove(output_file))
+    root.add_defer() <| () => { @fs.remove(input_file) }
+    root.add_defer() <| () => { @fs.remove(output_file) }
     @fs.write_file(input_file, "abcd", create_mode=CreateOrTruncate)
     let _ = @process.run(
       cat,
@@ -61,12 +61,12 @@ async test "redirect to file" {
       ),
     )
     inspect(@fs.read_file(output_file).text(), content="abcd")
-  })
+  }
 }
 
 ///|
 async test "merge stdout and stderr" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
     defer r.close()
     let _ = @process.spawn(
@@ -77,5 +77,5 @@ async test "merge stdout and stderr" {
       stderr=w,
     )
     inspect(r.read_all().text(), content="abcdefgh")
-  })
+  }
 }

--- a/src/process/spawn_in_group_test.mbt
+++ b/src/process/spawn_in_group_test.mbt
@@ -17,12 +17,12 @@ async test "spawn_in_group wait" {
   let log = []
   let sleep = sleep_prog.wait()
   let t0 = @async.now()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let _ = @process.spawn(group, sleep, ["500"])
     @async.sleep(250)
     let t = (@async.now() - t0).to_int() / 250
     log.push("main task completed at tick #\{t}")
-  })
+  }
   let t = (@async.now() - t0).to_int() / 250
   log.push("`with_task_group` completed at tick #\{t}")
   json_inspect(log, content=[
@@ -33,24 +33,24 @@ async test "spawn_in_group wait" {
 ///|
 async test "spawn_in_group cancel" {
   let sleep = sleep_prog.wait()
-  @async.with_task_group(outer => {
+  @async.with_task_group() <| outer => {
     let (r, w) = @process.read_from_process()
-    outer.spawn_bg(() => {
+    outer.spawn_bg() <| () => {
       defer r.close()
       inspect(r.read_all().text().trim(), content="received termination signal")
-    })
-    @async.with_task_group(inner => {
+    }
+    @async.with_task_group() <| inner => {
       let _ = @process.spawn(inner, sleep, ["10000"], stdout=w, no_wait=true)
       @async.sleep(300)
-    })
-  })
+    }
+  }
 }
 
 ///|
 async test "Process::wait" {
   let sleep = sleep_prog.wait()
   let mut t0 = 0L
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let child = @process.spawn(group, sleep, ["500", "-exit-code", "42"])
     t0 = @async.now()
     let result = child.wait()
@@ -59,36 +59,36 @@ async test "Process::wait" {
     inspect(result, content="42")
     // `.wait()` should be idempotent
     inspect(child.wait(), content="42")
-  })
+  }
 }
 
 ///|
 async test "Process::try_wait" {
   let sleep = sleep_prog.wait()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let child = @process.spawn(group, sleep, ["450", "-exit-code", "42"])
     @async.sleep(300)
     debug_inspect(child.try_wait(), content="None")
     @async.sleep(300)
     debug_inspect(child.try_wait(), content="Some(42)")
-  })
+  }
 }
 
 ///|
 async test "Process:cancel" {
   let sleep = sleep_prog.wait()
   let mut t0 = 0L
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer r.close()
       inspect(r.read_all().text().trim(), content="received termination signal")
-    })
+    }
     let child = @process.spawn(group, sleep, ["10000"], stdout=w)
     t0 = @async.now()
     @async.sleep(500)
     child.cancel()
-  })
+  }
   let t = (@async.now() - t0).to_int() / 500
   inspect(t, content="1")
 }

--- a/src/process/test_programs/setup_sanitizer_check/main.mbt
+++ b/src/process/test_programs/setup_sanitizer_check/main.mbt
@@ -43,7 +43,7 @@ async fn main {
     }
   }
 
-  @fs.walk(".", exclude~, (path, files) => {
+  @fs.walk(".", exclude~) <| ((path, files) => {
     for file in files {
       guard file is "moon.pkg" else {  }
       let full_path = "\{path}/\{file}"

--- a/src/process/wait_test.mbt
+++ b/src/process/wait_test.mbt
@@ -17,17 +17,17 @@
 async test "basic wait" {
   let log = StringBuilder::new()
   let test_prog = sleep_prog.wait()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       for i in 0..<2 {
         @async.sleep(750)
         log.write_string("\{(i + 1) * 750}ms tick\n")
       }
-    })
+    }
     @async.sleep(10)
     let result = @process.run(test_prog, ["750"])
     log.write_string("process completed with \{result}\n")
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -48,16 +48,16 @@ async test "wait exitcode" {
 async test "wait_pid" {
   let log = StringBuilder::new()
   let test_prog = sleep_prog.wait()
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       for _ in 0..<2 {
         @async.sleep(800)
         log <+ "tick\n"
       }
-    })
+    }
     let pid = @process.spawn_orphan(test_prog, ["1000", "-exit-code", "42"])
     log.write_string("process terminated with \{@process.wait_pid(pid)}\n")
-  })
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -15,9 +15,9 @@
 ///|
 async test "protect_from_cancel" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
-      @async.protect_from_cancel(() => {
+  (@async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
+      (@async.protect_from_cancel() <| () => {
         @async.sleep(400) catch {
           err => {
             log.write_string("critial job cancelled with error \{err}\n")
@@ -33,8 +33,8 @@ async test "protect_from_cancel" {
       }
       @async.sleep(200)
       log <+ "non-critial part of job finished\n"
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       @async.sleep(400) catch {
         err => {
           log.write_string("non-critial job cancelled with error \{err}\n")
@@ -42,7 +42,7 @@ async test "protect_from_cancel" {
         }
       }
       log <+ "non-critical job finished\n"
-    })
+    }
     @async.sleep(200)
     raise Err
   }) catch {
@@ -64,25 +64,25 @@ async test "protect_from_cancel wait" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(200)
           log <+ "200ms tick\n"
           @async.sleep(200)
           log <+ "400ms tick\n"
-        })
-        @async.with_task_group(group => {
-          group.spawn_bg(() => {
+        }
+        (@async.with_task_group() <| group => {
+          group.spawn_bg() <| () => {
             @async.sleep(300)
             log.write_string(
               "trying to cancel the group containing critial job\n",
             )
             raise Err
-          })
-          @async.protect_from_cancel(() => {
+          }
+          @async.protect_from_cancel() <| () => {
             @async.sleep(500)
             log <+ "critial job finished\n"
-          })
+          }
         }) catch {
           _ => ()
         }
@@ -106,22 +106,22 @@ async test "protect_from_cancel wait" {
 ///|
 async test "protect_from_cancel with_timeout" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       log <+ "200ms tick\n"
       @async.sleep(200)
       log <+ "400ms tick\n"
-    })
-    @async.with_timeout_opt(300, () => {
-      @async.protect_from_cancel(() => {
+    }
+    (@async.with_timeout_opt(300) <| () => {
+      @async.protect_from_cancel() <| () => {
         @async.sleep(500)
         log <+ "critial job finished\n"
-      })
+      }
     })
     |> ignore
     log <+ "`with_timeout` containing critical job finished\n"
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -137,20 +137,20 @@ async test "protect_from_cancel with_timeout" {
 ///|
 async test "protect_from_cancel fail" {
   let log = StringBuilder::new()
-  let result : Result[Unit, _] = try? @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  let result : Result[Unit, _] = try? (@async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       log <+ "200ms tick\n"
       @async.sleep(200)
       log <+ "400ms tick\n"
-    })
-    @async.with_timeout(300, () => {
-      @async.protect_from_cancel(() => {
+    }
+    @async.with_timeout(300) <| () => {
+      @async.protect_from_cancel() <| () => {
         @async.sleep(500)
         log <+ "critial job fail\n"
         raise Err
-      })
-    })
+      }
+    }
   })
   log.write_string(@debug.to_string(result))
   inspect(
@@ -167,24 +167,24 @@ async test "protect_from_cancel fail" {
 ///|
 async test "protect_from_cancel nested1" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       log <+ "200ms tick\n"
       @async.sleep(200)
       log <+ "400ms tick\n"
-    })
-    @async.with_timeout_opt(300, () => {
-      @async.protect_from_cancel(() => {
-        @async.protect_from_cancel(() => {
+    }
+    (@async.with_timeout_opt(300) <| () => {
+      @async.protect_from_cancel() <| () => {
+        @async.protect_from_cancel() <| () => {
           @async.sleep(500)
           log <+ "critial job finished\n"
-        })
-      })
+        }
+      }
     })
     |> ignore
     log <+ "`with_timeout` containing critical job finished\n"
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -200,28 +200,28 @@ async test "protect_from_cancel nested1" {
 ///|
 async test "protect_from_cancel nested2" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       log <+ "200ms tick\n"
       @async.sleep(200)
       log <+ "400ms tick\n"
       @async.sleep(200)
       log <+ "600ms tick\n"
-    })
-    @async.with_timeout_opt(100, () => {
-      @async.protect_from_cancel(() => {
-        @async.protect_from_cancel(() => {
+    }
+    (@async.with_timeout_opt(100) <| () => {
+      @async.protect_from_cancel() <| () => {
+        @async.protect_from_cancel() <| () => {
           @async.sleep(300)
           log <+ "inner critial job finished\n"
-        })
+        }
         @async.sleep(200)
         log <+ "outer critial job finished\n"
-      })
+      }
     })
     |> ignore
     log <+ "`with_timeout` containing critical job finished\n"
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -241,19 +241,19 @@ async test "protect_from_cancel in cancellation handler" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(no_wait=true, () => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg(no_wait=true) <| () => {
           @async.sleep(400) catch {
             err => {
               log.write_string("cancelled with error \{err}\n")
-              @async.protect_from_cancel(() => {
+              @async.protect_from_cancel() <| () => {
                 @async.sleep(200)
                 log <+ "critial cancellation handler terminated\n"
-              })
+              }
               raise err
             }
           }
-        })
+        }
         @async.sleep(200)
         log <+ "start cancellation\n"
       }),
@@ -273,35 +273,34 @@ async test "protect_from_cancel in cancellation handler" {
 ///|
 async test "cancel while scheduled" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       for _ in 0..<2 {
         @async.sleep(200)
         log <+ "tick\n"
       }
-    })
-    let task1 = root.spawn((
-    // after calling `pause`, current coroutine would be in `run_later`,
-    // and it will receive cancellation in this situation
-    ) => {
-      @async.pause() catch {
-        err => {
-          log.write_string("`pause` cancelled with \{err}\n")
-          @async.protect_from_cancel(() => {
-            // Now, due to `protect_from_cancel`,
-            // we are allowed to suspend inside cancellation handler.
-            // However, since current coroutine is still in `run_later`,
-            // the scheduler will wakeup current coroutine immediately,
-            // before the timer expires.
-            @async.sleep(300)
-            log <+ "async cleanup finished\n"
-          })
-          raise err
+    }
+    let task1 = root.spawn() <| () => {
+        // after calling `pause`, current coroutine would be in `run_later`,
+        // and it will receive cancellation in this situation
+        @async.pause() catch {
+          err => {
+            log.write_string("`pause` cancelled with \{err}\n")
+            @async.protect_from_cancel() <| () => {
+              // Now, due to `protect_from_cancel`,
+              // we are allowed to suspend inside cancellation handler.
+              // However, since current coroutine is still in `run_later`,
+              // the scheduler will wakeup current coroutine immediately,
+              // before the timer expires.
+              @async.sleep(300)
+              log <+ "async cleanup finished\n"
+            }
+            raise err
+          }
         }
       }
-    })
-    root.spawn_bg(() => task1.cancel())
-  })
+    root.spawn_bg() <| () => { task1.cancel() }
+  }
   inspect(
     log.to_string(),
     content=(
@@ -317,35 +316,35 @@ async test "cancel while scheduled" {
 ///|
 async test "error in async cancel" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       for _ in 0..<2 {
         @async.sleep(300)
         log <+ "tick\n"
       }
-    })
+    }
     log.write_string(
       @debug.to_string(
-        try? @async.with_task_group(group => {
-          group.spawn_bg(no_wait=true, allow_failure=true, () => {
+        try? (@async.with_task_group() <| group => {
+          group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
             @async.sleep(1000) catch {
               _ => {
                 log <+ "performing async cleanup\n"
-                @async.protect_from_cancel(() => {
+                @async.protect_from_cancel() <| () => {
                   @async.sleep(300)
                   log <+ "raising error from async cleanup\n"
                   raise Err
-                })
+                }
               }
             }
-          })
+          }
           @async.sleep(150)
           log <+ "main task of inner group done\n"
         }),
       ),
     )
     log <+ "\ngroup terminates\n"
-  })
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/raw_fd/raw_fd_test.mbt
+++ b/src/raw_fd/raw_fd_test.mbt
@@ -23,7 +23,7 @@ async test "pipe as raw fd" {
   assert_true(@event_loop.kind_of_fd(r, context="kind_of_fd") is Pipe)
   assert_true(@event_loop.kind_of_fd(w, context="kind_of_fd") is Pipe)
   @async.with_task_group <| group => {
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       let r = @raw_fd.RawFd(r)
       defer r.close()
       let buf = FixedArray::make(1024, b'\x00')
@@ -34,8 +34,8 @@ async test "pipe as raw fd" {
         let data = buf.unsafe_reinterpret_as_bytes()[:n]
         log.push("read() => \{@utf8.decode(data).escape()}")
       }
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       let w = @raw_fd.RawFd(w)
       defer w.close()
       for data in [b"abcd", b"1234", b"ABCD"] {
@@ -46,7 +46,7 @@ async test "pipe as raw fd" {
         }
         log.push("write(\{@utf8.decode(data).escape()})")
       }
-    })
+    }
   }
   json_inspect(log, content=[
     "write(\"abcd\")", "read() => \"abcd\"", "write(\"1234\")", "read() => \"1234\"",
@@ -94,7 +94,7 @@ async test "socket as raw fd" {
   let server = @socket.UdpServer(@socket.Addr::parse("127.0.0.1:0"))
   let port = server.addr.port()
   @async.with_task_group <| group => {
-    group.spawn_bg(no_wait=true, () => {
+    group.spawn_bg(no_wait=true) <| () => {
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for ;; {
@@ -105,7 +105,7 @@ async test "socket as raw fd" {
         log.push("server received \{@utf8.decode(data).escape()}")
         server.sendto(buf_bytes, addr, len=n)
       }
-    })
+    }
     let sock = make_udp_socket()
     guard @fd_util.fd_is_valid(sock) else {
       @os_error.check_errno("make_udp_socket()")

--- a/src/retry_test.mbt
+++ b/src/retry_test.mbt
@@ -16,13 +16,13 @@
 async test "retry immediate" {
   let log = StringBuilder::new()
   let mut i = 0
-  @async.retry(Immediate, () => {
+  @async.retry(Immediate) <| () => {
     log.write_string("tick \{i}\n")
     i = i + 1
     if i < 3 {
       raise Err
     }
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -42,13 +42,13 @@ async test "retry fixed" {
     (@async.now() - start + 50).to_int() / 200
   }
   let mut i = 0
-  @async.retry(FixedDelay(200), () => {
+  @async.retry(FixedDelay(200)) <| () => {
     log.push("loop \{i} at tick #\{tick()}")
     i = i + 1
     if i < 3 {
       raise Err
     }
-  })
+  }
   log.push("retry completed at tick #\{tick()}")
   json_inspect(log, content=[
     "loop 0 at tick #0", "loop 1 at tick #1", "loop 2 at tick #2", "retry completed at tick #2",
@@ -63,13 +63,13 @@ async test "retry exponential" {
     (@async.now() - start + 50).to_int() / 200
   }
   let mut i = 0
-  @async.retry(ExponentialDelay(initial=200, factor=2, maximum=600), () => {
+  @async.retry(ExponentialDelay(initial=200, factor=2, maximum=600)) <| () => {
     log.push("loop \{i} at tick #\{tick()}")
     i = i + 1
     if i < 4 {
       raise Err
     }
-  })
+  }
   log.push("retry completed at tick #\{tick()}")
   json_inspect(log, content=[
     "loop 0 at tick #0", "loop 1 at tick #1", "loop 2 at tick #3", "loop 3 at tick #6",
@@ -81,13 +81,13 @@ async test "retry exponential" {
 async test "retry cancelled1" {
   let log = StringBuilder::new()
   let mut i = 0
-  @async.with_timeout(500, () => {
-    @async.retry(Immediate, () => {
+  (@async.with_timeout(500) <| () => {
+    @async.retry(Immediate) <| () => {
       @async.sleep(200)
       log.write_string("loop \{i}\n")
       i = i + 1
       raise Err
-    })
+    }
   }) catch {
     @async.TimeoutError => ()
     err => raise err
@@ -106,12 +106,12 @@ async test "retry cancelled1" {
 async test "retry cancelled2" {
   let log = StringBuilder::new()
   let mut i = 0
-  @async.with_timeout(500, () => {
-    @async.retry(FixedDelay(200), () => {
+  (@async.with_timeout(500) <| () => {
+    @async.retry(FixedDelay(200)) <| () => {
       log.write_string("loop \{i}\n")
       i = i + 1
       raise Err
-    })
+    }
   }) catch {
     @async.TimeoutError => ()
     err => raise err
@@ -139,7 +139,7 @@ async test "retry fatal_error" {
     log.write_string("worker run #\{i}\n")
     i = i + 1
     if i < 3 {
-      @async.with_timeout(100, () => @async.sleep(1000))
+      @async.with_timeout(100) <| () => { @async.sleep(1000) }
     } else {
       raise Failure::Failure("fatal error")
     }

--- a/src/return_immediately_test.mbt
+++ b/src/return_immediately_test.mbt
@@ -17,15 +17,15 @@ async test "return_immediately basic" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(200)
           root.return_immediately(())
-        })
-        root.spawn_bg(() => {
+        }
+        root.spawn_bg() <| () => {
           @async.sleep(300)
           log <+ "task finished\n"
-        })
+        }
       }),
     ),
   )
@@ -37,21 +37,21 @@ async test "return_immediately nested" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(300)
           log <+ "outer task finished\n"
-        })
-        @async.with_task_group(fn(group) {
-          group.spawn_bg(() => {
+        }
+        @async.with_task_group() <| fn(group) {
+          group.spawn_bg() <| () => {
             @async.sleep(200)
             root.return_immediately(())
-          })
-          group.spawn_bg(() => {
+          }
+          group.spawn_bg() <| () => {
             @async.sleep(300)
             log <+ "inner task finished\n"
-          })
-        })
+          }
+        }
       }),
     ),
   )
@@ -63,12 +63,12 @@ async test "return_immediately error on cancel" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(200)
           root.return_immediately(())
-        })
-        root.spawn_bg(() => {
+        }
+        root.spawn_bg() <| () => {
           @async.sleep(300) catch {
             _ => {
               log <+ "task cancelled, causing other error\n"
@@ -76,7 +76,7 @@ async test "return_immediately error on cancel" {
             }
           }
           log <+ "task finished\n"
-        })
+        }
       }),
     ),
   )
@@ -92,12 +92,12 @@ async test "return_immediately error on cancel" {
 ///|
 async test "return_immediately recursive cancel" {
   let log = []
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       @async.sleep(100)
       log.push("100ms tick")
-    })
-    @async.with_task_group(group => {
+    }
+    (@async.with_task_group() <| group => {
       group.return_immediately(()) catch {
         _ => @async.sleep(200)
       }
@@ -105,22 +105,22 @@ async test "return_immediately recursive cancel" {
       _ => ()
     }
     log.push("inner group finished")
-  })
+  }
   json_inspect(log, content=["inner group finished", "100ms tick"])
 }
 
 ///|
 async test "return_immediately called outside" {
   let log = []
-  @async.with_task_group(outer => {
-    outer.spawn_bg(() => {
+  @async.with_task_group() <| outer => {
+    outer.spawn_bg() <| () => {
       @async.sleep(100)
       log.push("100ms tick")
-    })
-    @async.with_task_group(inner => {
-      outer.spawn_bg(() => inner.return_immediately(()))
-    })
+    }
+    @async.with_task_group() <| inner => {
+      outer.spawn_bg() <| () => { inner.return_immediately(()) }
+    }
     log.push("inner group finished")
-  })
+  }
   json_inspect(log, content=["inner group finished", "100ms tick"])
 }

--- a/src/semaphore/semaphore_test.mbt
+++ b/src/semaphore/semaphore_test.mbt
@@ -15,22 +15,22 @@
 ///|
 async test "semaphore mutex" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let semaphore = @semaphore.Semaphore(1)
     for i in 0..<3 {
-      root.spawn_bg(() => {
+      root.spawn_bg() <| () => {
         semaphore.acquire()
         log.write_string("task \{i} obtained resource\n")
         @async.sleep(300)
         semaphore.release()
-      })
+      }
     }
     @async.sleep(150)
     for _ in 0..<3 {
       log <+ "tick\n"
       @async.sleep(300)
     }
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -48,22 +48,22 @@ async test "semaphore mutex" {
 ///|
 async test "semaphore multiple value" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let semaphore = @semaphore.Semaphore(2)
     for i in 0..<6 {
-      root.spawn_bg(() => {
+      root.spawn_bg() <| () => {
         semaphore.acquire()
         log.write_string("task \{i} obtained resource\n")
         @async.sleep(300)
         semaphore.release()
-      })
+      }
     }
     @async.sleep(150)
     for _ in 0..<3 {
       log <+ "tick\n"
       @async.sleep(300)
     }
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -83,38 +83,38 @@ async test "semaphore multiple value" {
 
 ///|
 async test "semaphore cancellation" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let semaphore = @semaphore.Semaphore(1)
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       semaphore.acquire()
       @async.sleep(500)
       semaphore.release()
-    })
+    }
     debug_inspect(
-      try? @async.with_timeout(250, () => semaphore.acquire()),
+      try? (@async.with_timeout(250) <| () => { semaphore.acquire() }),
       content="Err(TimeoutError)",
     )
     @async.sleep(500)
     inspect(semaphore.try_acquire(), content="true")
-  })
+  }
 }
 
 ///|
 async test "semaphore cancellation no_swallow" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let semaphore = @semaphore.Semaphore(1)
     semaphore.acquire()
-    let acquire_taskire_task = root.spawn(() => {
-      semaphore.acquire()
-      log <+ "acquire() succeed\n"
-    })
+    let acquire_taskire_task = root.spawn() <| () => {
+        semaphore.acquire()
+        log <+ "acquire() succeed\n"
+      }
     @async.sleep(100)
     semaphore.release()
     acquire_taskire_task.cancel()
     @async.sleep(100)
     inspect(semaphore.try_acquire(), content="false")
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -127,17 +127,17 @@ async test "semaphore cancellation no_swallow" {
 ///|
 async test "semaphore fairness" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let semaphore = @semaphore.Semaphore(1)
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       for _ in 0..<3 {
         semaphore.acquire()
         log <+ "task 1 acquired resource\n"
         @async.sleep(200)
         semaphore.release()
       }
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       @async.sleep(100)
       for _ in 0..<3 {
         semaphore.acquire()
@@ -145,8 +145,8 @@ async test "semaphore fairness" {
         @async.sleep(200)
         semaphore.release()
       }
-    })
-  })
+    }
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/signal/signal.mbt
+++ b/src/signal/signal.mbt
@@ -46,5 +46,7 @@ pub fn Signal::to_int(signal : Signal) -> Int {
 ///
 /// The default list is all supported signals.
 pub fn set_global_cancellation_signals(signals : ReadOnlyArray[Signal]) -> Unit {
-  @event_loop.set_global_cancellation_signals(signals.map(sig => sig.to_int()))
+  @event_loop.set_global_cancellation_signals(
+    signals.map() <| sig => { sig.to_int() },
+  )
 }

--- a/src/signal/signal_test.mbt
+++ b/src/signal/signal_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 fn make_test_prog(name : String) -> @async.Lazy[String] {
-  @async.Lazy(() => {
+  @async.Lazy() <| () => {
     let code = @process.run("moon", [
       "-C",
       "src/process/test_programs",
@@ -26,7 +26,7 @@ fn make_test_prog(name : String) -> @async.Lazy[String] {
       fail("failed to build test program `\{name}`: \{code}")
     }
     "src/process/test_programs/_build/native/debug/build/\{name}/\{name}.exe"
-  })
+  }
 }
 
 ///|
@@ -36,26 +36,26 @@ let sleep_prog : @async.Lazy[String] = make_test_prog("sleep")
 async test "cancel with default signal" {
   let test_prog = sleep_prog.wait()
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
-    let task = group.spawn(() => {
-      defer log.push("process terminates")
-      @process.run(test_prog, stdout=w, [
-        "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
-        "before exit",
-      ])
-    })
-    group.spawn_bg(() => {
+    let task = group.spawn() <| () => {
+        defer log.push("process terminates")
+        @process.run(test_prog, stdout=w, [
+          "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
+          "before exit",
+        ])
+      }
+    group.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(data) {
         let data = @utf8.decode(data).replace_all(old="\r\n", new="\n").trim()
         log.push("from process: \{data}")
       }
-    })
+    }
     @async.sleep(500)
     task.cancel()
     log.push("cancelling task running process")
-  })
+  }
   json_inspect(log, content=[
     "cancelling task running process", "from process: before exit", "process terminates",
   ])
@@ -67,30 +67,30 @@ async test "cancel with default signal" {
 async test "cancel with ctrl+c" {
   let test_prog = sleep_prog.wait()
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
-    let task = group.spawn(() => {
-      defer log.push("process terminates")
-      let cancel_handler = @process.graceful_cancel(
-        timeout=5000,
-        signal=@signal.SIGINT,
-      )
-      @process.run(test_prog, stdout=w, cancel_handler~, [
-        "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
-        "before exit",
-      ])
-    })
-    group.spawn_bg(() => {
+    let task = group.spawn() <| () => {
+        defer log.push("process terminates")
+        let cancel_handler = @process.graceful_cancel(
+          timeout=5000,
+          signal=@signal.SIGINT,
+        )
+        @process.run(test_prog, stdout=w, cancel_handler~, [
+          "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
+          "before exit",
+        ])
+      }
+    group.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(data) {
         let data = @utf8.decode(data).replace_all(old="\r\n", new="\n").trim()
         log.push("from process: \{data}")
       }
-    })
+    }
     @async.sleep(500)
     task.cancel()
     log.push("cancelling task running process")
-  })
+  }
   json_inspect(log, content=[
     "cancelling task running process", "from process: before exit", "process terminates",
   ])
@@ -102,30 +102,30 @@ async test "cancel with ctrl+c" {
 async test "cancel with SIGHUP" {
   let test_prog = sleep_prog.wait()
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
-    let task = group.spawn(() => {
-      defer log.push("process terminates")
-      let cancel_handler = @process.graceful_cancel(
-        timeout=5000,
-        signal=@signal.SIGHUP,
-      )
-      @process.run(test_prog, stdout=w, cancel_handler~, [
-        "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
-        "before exit",
-      ])
-    })
-    group.spawn_bg(() => {
+    let task = group.spawn() <| () => {
+        defer log.push("process terminates")
+        let cancel_handler = @process.graceful_cancel(
+          timeout=5000,
+          signal=@signal.SIGHUP,
+        )
+        @process.run(test_prog, stdout=w, cancel_handler~, [
+          "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
+          "before exit",
+        ])
+      }
+    group.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(data) {
         let data = @utf8.decode(data).replace_all(old="\r\n", new="\n").trim()
         log.push("from process: \{data}")
       }
-    })
+    }
     @async.sleep(500)
     task.cancel()
     log.push("cancelling task running process")
-  })
+  }
   json_inspect(log, content=[
     "cancelling task running process", "from process: before exit", "process terminates",
   ])

--- a/src/socket/connect_burst_test.mbt
+++ b/src/socket/connect_burst_test.mbt
@@ -18,7 +18,7 @@ suberror ServerTerminate
 ///|
 async fn server_main(server : @socket.TcpServer) -> Int {
   let mut num_connection = 0
-  server.run_forever(allow_failure=false, (conn, _) => {
+  (server.run_forever(allow_failure=false) <| ((conn, _) => {
     num_connection += 1
     while conn.read_some() is Some(msg) {
       if msg == b"exit" {
@@ -26,7 +26,7 @@ async fn server_main(server : @socket.TcpServer) -> Int {
         raise ServerTerminate
       }
     }
-  }) catch {
+  })) catch {
     ServerTerminate => return num_connection
     err => raise err
   }
@@ -43,40 +43,40 @@ async fn client(msg : Bytes, addr : @socket.Addr) -> Unit {
 ///|
 async test "connection burst" {
   let mut result = 0
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg(() => result = server_main(server))
-    root.spawn_bg(() => {
-      @async.with_task_group(fn(ctx) {
+    root.spawn_bg() <| () => { result = server_main(server) }
+    root.spawn_bg() <| () => {
+      @async.with_task_group() <| fn(ctx) {
         for _ in 0..<6 {
-          ctx.spawn_bg(() => client(b"ping", addr))
+          ctx.spawn_bg() <| () => { client(b"ping", addr) }
         }
-      })
-      root.spawn_bg(() => client(b"exit", addr))
-    })
-  })
+      }
+      root.spawn_bg() <| () => { client(b"exit", addr) }
+    }
+  }
   inspect(result, content="7")
 }
 
 ///|
 async test "connection burst with ipv6" {
   let mut result = 0
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let server = @socket.TcpServer(
       @socket.Addr::parse("[::1]:0"),
       dual_stack=false,
     )
     let addr = server.addr
-    root.spawn_bg(() => result = server_main(server))
-    root.spawn_bg(() => {
-      @async.with_task_group(fn(ctx) {
+    root.spawn_bg() <| () => { result = server_main(server) }
+    root.spawn_bg() <| () => {
+      @async.with_task_group() <| fn(ctx) {
         for _ in 0..<6 {
-          ctx.spawn_bg(() => client(b"ping", addr))
+          ctx.spawn_bg() <| () => { client(b"ping", addr) }
         }
-      })
-      root.spawn_bg(() => client(b"exit", addr))
-    })
-  })
+      }
+      root.spawn_bg() <| () => { client(b"exit", addr) }
+    }
+  }
   inspect(result, content="7")
 }

--- a/src/socket/dual_stack_test.mbt
+++ b/src/socket/dual_stack_test.mbt
@@ -23,18 +23,18 @@ let all_protocol_preferences : FixedArray[@socket.IpProtocolPreference] = [
 ///|
 async test "Only_V4 server" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let server = @socket.TcpServer(@socket.Addr::parse("0.0.0.0:0"))
     let port = server.addr.port()
-    root.spawn_bg(no_wait=true, () => {
-      server.run_forever((conn, addr) => {
+    root.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((conn, addr) => {
         let addr_str = addr.to_string()
         guard addr_str.rev_find(":") is Some(ip_end)
         let ip = addr_str[:ip_end]
         let msg = conn.read_all().text()
         log.write_string("server received \{msg.escape()} from \{ip}\n")
       })
-    })
+    }
     async fn client(protocol) {
       let conn = @socket.Tcp::connect_to_host("localhost", port~, protocol~) catch {
         @os_error.OSError(_) as err if err.is_ECONNREFUSED() =>
@@ -54,7 +54,7 @@ async test "Only_V4 server" {
     }
     // give some time for the server to process the last connection
     @async.sleep(300)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -73,21 +73,21 @@ async test "Only_V4 server" {
 ///|
 async test "Only_V6 server" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let server = @socket.TcpServer(
       @socket.Addr::parse("[::]:0"),
       dual_stack=false,
     )
     let port = server.addr.port()
-    root.spawn_bg(no_wait=true, () => {
-      server.run_forever((conn, addr) => {
+    root.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((conn, addr) => {
         let addr_str = addr.to_string()
         guard addr_str.rev_find(":") is Some(ip_end)
         let ip = addr_str[:ip_end]
         let msg = conn.read_all().text()
         log.write_string("server received \{msg.escape()} from \{ip}\n")
       })
-    })
+    }
     async fn client(protocol) {
       let conn = @socket.Tcp::connect_to_host("localhost", port~, protocol~) catch {
         @os_error.OSError(_) as err if err.is_ECONNREFUSED() =>
@@ -107,7 +107,7 @@ async test "Only_V6 server" {
     }
     // give some time for the server to process the last connection
     @async.sleep(300)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -126,18 +126,18 @@ async test "Only_V6 server" {
 ///|
 async test "dual stack server" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let server = @socket.TcpServer(@socket.Addr::parse("[::]:0"))
     let port = server.addr.port()
-    root.spawn_bg(no_wait=true, () => {
-      server.run_forever((conn, addr) => {
+    root.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((conn, addr) => {
         let addr_str = addr.to_string()
         guard addr_str.rev_find(":") is Some(ip_end)
         let ip = addr_str[:ip_end]
         let msg = conn.read_all().text()
         log.write_string("server received \{msg.escape()} from \{ip}\n")
       })
-    })
+    }
     async fn client(protocol) {
       let conn = @socket.Tcp::connect_to_host("localhost", port~, protocol~)
       defer conn.close()
@@ -153,7 +153,7 @@ async test "dual stack server" {
     }
     // give some time for the server to process the last connection
     @async.sleep(300)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -173,10 +173,10 @@ async test "dual stack server" {
 ///|
 async test "Only_V4 UDP server" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let server = @socket.UdpServer(@socket.Addr::parse("0.0.0.0:0"))
     let port = server.addr.port()
-    root.spawn_bg(no_wait=true, () => {
+    root.spawn_bg(no_wait=true) <| () => {
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for ;; {
@@ -187,7 +187,7 @@ async test "Only_V4 UDP server" {
         let ip = addr_str[:ip_end]
         log.write_string("server received \{msg.escape()} from \{ip}\n")
       }
-    })
+    }
     async fn client(protocol) {
       let addr = @socket.Addr::resolve("localhost", port~, protocol~)
       let client = @socket.UdpClient(addr)
@@ -204,7 +204,7 @@ async test "Only_V4 UDP server" {
     }
     // give some time for the server to process the last connection
     @async.sleep(300)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -222,13 +222,13 @@ async test "Only_V4 UDP server" {
 ///|
 async test "Only_V6 UDP server" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let server = @socket.UdpServer(
       @socket.Addr::parse("[::]:0"),
       dual_stack=false,
     )
     let port = server.addr.port()
-    root.spawn_bg(no_wait=true, () => {
+    root.spawn_bg(no_wait=true) <| () => {
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for ;; {
@@ -239,7 +239,7 @@ async test "Only_V6 UDP server" {
         let ip = addr_str[:ip_end]
         log.write_string("server received \{msg.escape()} from \{ip}\n")
       }
-    })
+    }
     async fn client(protocol) {
       let addr = @socket.Addr::resolve("localhost", port~, protocol~)
       let client = @socket.UdpClient(addr)
@@ -256,7 +256,7 @@ async test "Only_V6 UDP server" {
     }
     // give some time for the server to process the last connection
     @async.sleep(300)
-  })
+  }
   inspect(
     log.to_string(),
     content=(
@@ -274,10 +274,10 @@ async test "Only_V6 UDP server" {
 ///|
 async test "dual stack UDP server" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let server = @socket.UdpServer(@socket.Addr::parse("[::]:0"))
     let port = server.addr.port()
-    root.spawn_bg(no_wait=true, () => {
+    root.spawn_bg(no_wait=true) <| () => {
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for ;; {
@@ -288,7 +288,7 @@ async test "dual stack UDP server" {
         let ip = addr_str[:ip_end]
         log.write_string("server received \{msg.escape()} from \{ip}\n")
       }
-    })
+    }
     async fn client(protocol) {
       let addr = @socket.Addr::resolve("localhost", port~, protocol~)
       let client = @socket.UdpClient(addr)
@@ -305,7 +305,7 @@ async test "dual stack UDP server" {
     }
     // give some time for the server to process the last connection
     @async.sleep(300)
-  })
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/socket/getsockname_test.mbt
+++ b/src/socket/getsockname_test.mbt
@@ -14,51 +14,51 @@
 
 ///|
 async test "getsockname TCP" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let server_addr = server.addr
     guard server_addr.to_string() is [.. "127.0.0.1:", ..] else {
       raise Failure::Failure("incorrect server address \{server_addr}")
     }
-    let client_addr_from_server = group.spawn(() => {
-      defer server.close()
-      let (conn, peer_addr) = server.accept()
-      assert_eq(conn.addr, server_addr)
-      inspect(conn.read_all().text(), content="abcd")
-      peer_addr
-    })
-    let client_addr = group.spawn(() => {
-      let client = @socket.Tcp::connect(server_addr)
-      defer client.close()
-      client.write("abcd")
-      client.addr
-    })
+    let client_addr_from_server = group.spawn() <| () => {
+        defer server.close()
+        let (conn, peer_addr) = server.accept()
+        assert_eq(conn.addr, server_addr)
+        inspect(conn.read_all().text(), content="abcd")
+        peer_addr
+      }
+    let client_addr = group.spawn() <| () => {
+        let client = @socket.Tcp::connect(server_addr)
+        defer client.close()
+        client.write("abcd")
+        client.addr
+      }
     assert_eq(client_addr_from_server.wait(), client_addr.wait())
-  })
+  }
 }
 
 ///|
 async test "getsockname UDP" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @socket.UdpServer(@socket.Addr::parse("127.0.0.1:0"))
     let server_addr = server.addr
     guard server_addr.to_string() is [.. "127.0.0.1:", ..] else {
       raise Failure::Failure("incorrect server address \{server_addr}")
     }
-    let client_addr_from_server = group.spawn(() => {
-      defer server.close()
-      let buf = FixedArray::make(1024, b'\x00')
-      let (n, peer_addr) = server.recvfrom(buf)
-      let data = buf.unsafe_reinterpret_as_bytes()[:n]
-      inspect(@utf8.decode(data), content="abcd")
-      peer_addr
-    })
-    let client_addr = group.spawn(() => {
-      let client = @socket.UdpClient(server_addr)
-      defer client.close()
-      client.send(b"abcd")
-      client.addr
-    })
+    let client_addr_from_server = group.spawn() <| () => {
+        defer server.close()
+        let buf = FixedArray::make(1024, b'\x00')
+        let (n, peer_addr) = server.recvfrom(buf)
+        let data = buf.unsafe_reinterpret_as_bytes()[:n]
+        inspect(@utf8.decode(data), content="abcd")
+        peer_addr
+      }
+    let client_addr = group.spawn() <| () => {
+        let client = @socket.UdpClient(server_addr)
+        defer client.close()
+        client.send(b"abcd")
+        client.addr
+      }
     assert_eq(client_addr_from_server.wait(), client_addr.wait())
-  })
+  }
 }

--- a/src/socket/happy_eyeball.mbt
+++ b/src/socket/happy_eyeball.mbt
@@ -40,7 +40,7 @@ pub async fn Tcp::connect_to_host(
   let mut result = None
   let mut conn_err = None
   async fn connect_with_protocol(protocol : IpProtocolPreference) {
-    @async.with_task_group(group => {
+    @async.with_task_group() <| group => {
       for ai = ai; !ai.is_null(); ai = ai.next() {
         let addr = ai.to_addr(port)
         match (protocol, addr.is_ipv6()) {
@@ -48,7 +48,7 @@ pub async fn Tcp::connect_to_host(
           (OnlyV6 | FavorV6, false) => continue
           _ => ()
         }
-        group.spawn_bg(allow_failure=true, () => {
+        group.spawn_bg(allow_failure=true) <| () => {
           let conn = Tcp::connect(addr) catch {
             err => {
               if conn_err is None {
@@ -59,10 +59,10 @@ pub async fn Tcp::connect_to_host(
           }
           result = Some(conn)
           group.return_immediately(())
-        })
+        }
         @async.sleep(250)
       }
-    })
+    }
   }
 
   match protocol {

--- a/src/socket/multicast_test.mbt
+++ b/src/socket/multicast_test.mbt
@@ -61,7 +61,7 @@ async test "multicast discovery then unicast" {
     defer server.close()
     let multicast_addr = @socket.Addr::parse("239.0.0.1:\{server.addr.port()}")
     server.join_multicast_group(multicast_addr, interface_addr~)
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       let client = @socket.UdpClient(multicast_addr)
       defer client.close()
       client.set_multicast_interface(interface_addr)
@@ -78,7 +78,7 @@ async test "multicast discovery then unicast" {
       let n = client.recv(buf)
       let data = buf.unsafe_reinterpret_as_bytes()[:n]
       log.push("client received \{@utf8.decode(data)} from server")
-    })
+    }
     let buf = FixedArray::make(1024, b'\x00')
     let (n, peer_addr) = server.recvfrom(buf)
     let data = buf.unsafe_reinterpret_as_bytes()[:n]
@@ -108,7 +108,7 @@ async test "multicast no loopback" {
     let server = @socket.UdpServer::multicast(
       @socket.Addr::parse("239.0.0.1:0"),
     )
-    group.spawn_bg(no_wait=true, () => {
+    group.spawn_bg(no_wait=true) <| () => {
       defer server.close()
       let buf = FixedArray::make(1024, b'\x00')
       for ;; {
@@ -116,7 +116,7 @@ async test "multicast no loopback" {
         let data = buf.unsafe_reinterpret_as_bytes()[:n]
         log.push("server received: \{@utf8.decode(data)}")
       }
-    })
+    }
     let client = @socket.UdpClient(
       @socket.Addr::parse("239.0.0.1:\{server.addr.port()}"),
     )
@@ -158,7 +158,7 @@ async test "multicast discovery then unicast v6" {
     let multicast_addr = @socket.Addr::parse("[ff02::1]:\{server.addr.port()}")
     server.join_multicast_group_v6(multicast_addr, interface=test_interface)
     server.set_multicast_ttl(0)
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       let client = @socket.UdpClient(
         @socket.Addr::parse("[ff02::1%\{test_interface}]:\{port}"),
       )
@@ -178,7 +178,7 @@ async test "multicast discovery then unicast v6" {
       let n = client.recv(buf)
       let data = buf.unsafe_reinterpret_as_bytes()[:n]
       log.push("client received \{@utf8.decode(data)} from server")
-    })
+    }
     let buf = FixedArray::make(1024, b'\x00')
     let (n, peer_addr) = server.recvfrom(buf)
     let data = buf.unsafe_reinterpret_as_bytes()[:n]
@@ -208,7 +208,7 @@ async test "multicast no loopback v6" {
     let server = @socket.UdpServer(@socket.Addr::parse("[::]:0"))
     let port = server.addr.port()
     let multicast_addr = @socket.Addr::parse("[ff02::1]:\{port}")
-    group.spawn_bg(no_wait=true, () => {
+    group.spawn_bg(no_wait=true) <| () => {
       defer server.close()
       server.join_multicast_group_v6(multicast_addr, interface=test_interface)
       let buf = FixedArray::make(1024, b'\x00')
@@ -217,7 +217,7 @@ async test "multicast no loopback v6" {
         let data = buf.unsafe_reinterpret_as_bytes()[:n]
         log.push("server received: \{@utf8.decode(data)}")
       }
-    })
+    }
     let client = @socket.UdpClient(
       @socket.Addr::parse("[ff02::1%\{test_interface}]:\{port}"),
     )

--- a/src/socket/read_exactly_test.mbt
+++ b/src/socket/read_exactly_test.mbt
@@ -19,11 +19,11 @@ async test "read_exactly" {
     buf..write_string(msg).write_char('\n')
   }
 
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     // server
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -36,9 +36,9 @@ async test "read_exactly" {
       let msg3 = conn.read_exactly(4) |> @utf8.decode
       @async.sleep(10)
       log("third message: \{msg3}")
-    })
+    }
     // client
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       let conn = @socket.Tcp::connect(addr)
       defer conn.close()
       conn.write("abcdef")
@@ -46,8 +46,8 @@ async test "read_exactly" {
       @async.sleep(100)
       conn.write("ghijkl")
       log("second message sent")
-    })
-  })
+    }
+  }
   inspect(
     buf.to_string(),
     content=(
@@ -68,11 +68,11 @@ async test "read_exactly failure" {
     buf..write_string(msg).write_char('\n')
   }
 
-  @async.with_task_group(root => {
+  (@async.with_task_group() <| root => {
     // server
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -88,14 +88,14 @@ async test "read_exactly failure" {
       // let the client close first to avoid socket entering `TIME_WAIT` state,
       // occupying the address.
       @async.sleep(20)
-    })
+    }
     // client
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       let conn = @socket.Tcp::connect(addr)
       defer conn.close()
       conn.write("abcdef")
       log("first message sent")
-    })
+    }
   }) catch {
     err => log(err.to_string())
   }

--- a/src/socket/resolve_host_test.mbt
+++ b/src/socket/resolve_host_test.mbt
@@ -23,16 +23,16 @@ async test "resolve mooncakes.io" {
 ///|
 async test "resolve cancel" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let lock = @async.Semaphore(1, initial_value=1)
-    let task = root.spawn(() => {
-      lock.release()
-      log.write_object(@socket.Addr::resolve("does.not.exist", port=443))
-    })
+    let task = root.spawn() <| () => {
+        lock.release()
+        log.write_object(@socket.Addr::resolve("does.not.exist", port=443))
+      }
     lock.acquire() // make sure the task already started
     task.cancel()
     log <+ "host resolution cancelled\n"
-  })
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/socket/reuse_addr_test.mbt
+++ b/src/socket/reuse_addr_test.mbt
@@ -15,8 +15,8 @@
 ///|
 async test "reuse addr" {
   let mut port = 0
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       for _ in 0..<2 {
         let server = @socket.TcpServer(
           @socket.Addr::parse("127.0.0.1:\{port}"),
@@ -28,12 +28,12 @@ async test "reuse addr" {
         defer conn.close()
         conn.write("abcd")
       }
-    })
+    }
     for _ in 0..<2 {
       @async.sleep(100)
       let conn = @socket.Tcp::connect(@socket.Addr::parse("127.0.0.1:\{port}"))
       defer conn.close()
       inspect(conn.read_all().text(), content="abcd")
     }
-  })
+  }
 }

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -138,13 +138,13 @@ pub async fn TcpServer::run_forever(
     None => None
     Some(n) => Some(@async.Semaphore(n))
   }
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     for ;; {
       let (conn, addr) = self.accept()
       if conn_limit is Some(limit) {
         limit.acquire()
       }
-      group.spawn_bg(allow_failure~, () => {
+      group.spawn_bg(allow_failure~) <| () => {
         defer conn.close()
         if conn_limit is Some(limit) {
           defer limit.release()
@@ -152,9 +152,9 @@ pub async fn TcpServer::run_forever(
         } else {
           f(conn, addr)
         }
-      })
+      }
     }
-  })
+  }
 }
 
 ///|

--- a/src/spawn_loop_test.mbt
+++ b/src/spawn_loop_test.mbt
@@ -17,15 +17,15 @@ async test "spawn_loop basic" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
+      try? (@async.with_task_group() <| root => {
         let mut i = 0
-        root.spawn_loop(() => {
+        root.spawn_loop() <| () => {
           log.write_string("tick \{i}\n")
           i = i + 1
           if i >= 3 {
             raise @async.BreakFromSpawnLoop
           }
-        })
+        }
       }),
     ),
   )
@@ -45,15 +45,15 @@ async test "spawn_loop basic-error" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
+      try? (@async.with_task_group() <| root => {
         let mut i = 0
-        root.spawn_loop(() => {
+        root.spawn_loop() <| () => {
           log.write_string("tick \{i}\n")
           i = i + 1
           if i >= 3 {
             raise Err
           }
-        })
+        }
       }),
     ),
   )
@@ -71,7 +71,7 @@ async test "spawn_loop basic-error" {
 ///|
 async test "spawn_loop retry-exponential" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let mut i = 0
     let start = @async.now()
     fn tick() {
@@ -90,7 +90,7 @@ async test "spawn_loop retry-exponential" {
         }
       },
     )
-  })
+  }
   json_inspect(log, content=[
     "loop 0 at tick #0", "loop 1 at tick #1", "loop 2 at tick #3", "loop 3 at tick #6",
     "loop 4 at tick #6", "loop 5 at tick #7", "loop 6 at tick #9",

--- a/src/spawn_test.mbt
+++ b/src/spawn_test.mbt
@@ -15,15 +15,15 @@
 ///|
 async test "spawn error1" {
   let buf = StringBuilder::new()
-  let result = try? @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  let result = try? (@async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(1000)
       buf <+ "task 1 finished\n"
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       raise Err
-    })
+    }
   })
   buf.write_string(@debug.to_string(result))
   inspect(buf.to_string(), content="Err(Err)")
@@ -32,15 +32,15 @@ async test "spawn error1" {
 ///|
 async test "spawn error2" {
   let buf = StringBuilder::new()
-  let result = try? @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  let result = try? (@async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       raise Err
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       @async.sleep(1000)
       buf <+ "task 1 finished\n"
-    })
+    }
   })
   buf.write_string(@debug.to_string(result))
   inspect(buf.to_string(), content="Err(Err)")
@@ -49,20 +49,20 @@ async test "spawn error2" {
 ///|
 async test "spawn after cancelled" {
   let log = []
-  let _ : Result[Unit, _] = try? @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  let _ : Result[Unit, _] = try? (@async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       // emulate a non-cancellable job,
       // or a job that happens to be completed on cancellation,
       // such that discarding the result may lead to data loss
       @async.protect_from_cancel(() => @async.sleep(300), resume_on_cancel=true)
       // even if control flow enters here normally,
       // current task and the whole group may be in a cancelled state
-      group.spawn_bg(allow_failure=true, () => {
+      group.spawn_bg(allow_failure=true) <| () => {
         log.push("enter child task after cancelled")
         @async.sleep(100)
         log.push("child task completed")
-      })
-    })
+      }
+    }
     @async.sleep(150)
     raise Failure::Failure("failure")
   })

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 ///|
-let cat : @async.Lazy[String] = @async.Lazy(() => {
-  // Note: the `cat` example program lies in another MoonBit module.
-  // Currently, dependencies of a module is built locally in that module,
-  // so there will be no build lock conflict between this test and the `cat` program.
-  let exit_code = @process.run("moon", [
-    "-C", "src/process/test_programs", "build", "--debug", "cat",
-  ])
-  guard exit_code is 0 else {
-    fail("failed to build `cat` program: \{exit_code}")
+let cat : @async.Lazy[String] = @async.Lazy() <| () => {
+    // Note: the `cat` example program lies in another MoonBit module.
+    // Currently, dependencies of a module is built locally in that module,
+    // so there will be no build lock conflict between this test and the `cat` program.
+    let exit_code = @process.run("moon", [
+      "-C", "src/process/test_programs", "build", "--debug", "cat",
+    ])
+    guard exit_code is 0 else {
+      fail("failed to build `cat` program: \{exit_code}")
+    }
+    "./src/process/test_programs/_build/native/debug/build/cat/cat.exe"
   }
-  "./src/process/test_programs/_build/native/debug/build/cat/cat.exe"
-})
 
 ///|
 async test "redirect_file" {
@@ -45,20 +45,20 @@ async test "redirect_file" {
 
 ///|
 async test "redirect pipe" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let cat = cat.wait()
     let (cat_read, we_write) = @process.write_to_process()
     let (we_read, cat_write) = @process.read_from_process()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       let code = @process.run(cat, [], stdin=cat_read, stdout=cat_write)
       inspect(code, content="0")
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer we_write.close()
       we_write.write(b"abcd\n")
       @async.sleep(50)
       we_write.write(b"defg\n")
-    })
+    }
     defer we_read.close()
     inspect(
       we_read.read_all().text(),
@@ -68,16 +68,16 @@ async test "redirect pipe" {
         #|
       ),
     )
-  })
+  }
 }
 
 ///|
 async test "stdio cancel" {
   let cat = cat.wait()
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (cat_read, we_write) = @process.write_to_process()
     let (we_read, cat_write) = @process.read_from_process()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       let code = @process.run(
         cat,
         ["-timeout", "500"],
@@ -85,7 +85,7 @@ async test "stdio cancel" {
         stdout=cat_write,
       )
       inspect(code, content="1")
-    })
+    }
     defer we_write.close()
     defer we_read.close()
     we_write.write("abcd")
@@ -100,5 +100,5 @@ async test "stdio cancel" {
       we_read.read_all().text().trim(chars="\r\n"),
       content="TimeoutError",
     )
-  })
+  }
 }

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -229,12 +229,12 @@ pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X) -> X {
     result: None,
     group_defer: [],
   }
-  tg.spawn_bg(() => {
+  tg.spawn_bg() <| () => {
     let value = f(tg)
     if tg.result is None {
       tg.result = Some(value)
     }
-  })
+  }
   @coroutine.suspend() catch {
     err => {
       if tg.state is Running {
@@ -306,7 +306,7 @@ pub fn[X] TaskGroup::spawn_loop(
   max_retry? : Int,
   fatal_error? : (Error) -> Bool,
 ) -> Unit {
-  self.spawn_bg(no_wait~, allow_failure~, () => {
+  self.spawn_bg(no_wait~, allow_failure~) <| () => {
     try {
       match retry {
         None =>
@@ -326,7 +326,7 @@ pub fn[X] TaskGroup::spawn_loop(
       BreakFromSpawnLoop => ()
       err => raise err
     }
-  })
+  }
 }
 
 ///|

--- a/src/timer.mbt
+++ b/src/timer.mbt
@@ -18,7 +18,7 @@
 /// If current task is cancelled, `sleep` will return early with an error.
 pub async fn sleep(duration : Int) -> Unit {
   let coro = @coroutine.current_coroutine()
-  let timer = @event_loop.Timer::new(duration, () => coro.wake())
+  let timer = @event_loop.Timer::new(duration) <| () => { coro.wake() }
   defer timer.cancel()
   @coroutine.suspend()
 }
@@ -100,7 +100,9 @@ pub async fn Timer::wait(timer : Timer) -> Unit {
       let duration = timer.expire_time - @time.ms_since_epoch()
       guard duration > 0 else { return }
       timer.state = Running(
-        @event_loop.Timer::new(duration.to_int(), () => timer.wake(Terminated)),
+        @event_loop.Timer::new(duration.to_int()) <| () => {
+          timer.wake(Terminated)
+        },
       )
     }
     Terminated => return
@@ -134,7 +136,7 @@ pub fn Timer::refresh(timer : Timer) -> Unit {
     timer.state = Detached
   } else {
     timer.state = Running(
-      @event_loop.Timer::new(timer.duration, () => timer.wake(Terminated)),
+      @event_loop.Timer::new(timer.duration) <| () => { timer.wake(Terminated) },
     )
   }
 }

--- a/src/timer_test.mbt
+++ b/src/timer_test.mbt
@@ -15,23 +15,23 @@
 ///|
 async test "basic sleep" {
   let buf = StringBuilder::new()
-  let result = try? @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  let result = try? (@async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(100)
       buf <+ "task 1, tick 1\n"
       @async.sleep(200)
       buf <+ "task 1, tick 2\n"
       @async.sleep(200)
       buf <+ "task 1, tick 3\n"
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       buf <+ "task 2, tick 1\n"
       @async.sleep(200)
       buf <+ "task 2, tick 2\n"
       @async.sleep(200)
       buf <+ "task 2, tick 3\n"
-    })
+    }
   })
   debug_inspect(result, content="Ok(())")
   inspect(
@@ -51,29 +51,29 @@ async test "basic sleep" {
 ///|
 async test "Timer basic" {
   let log = []
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       @async.sleep(150)
       log.push("sleep: tick #1")
       @async.sleep(300)
       log.push("sleep: tick #2")
       @async.sleep(300)
       log.push("sleep: tick #3")
-    })
+    }
     @async.sleep(300)
     log.push("creating timer")
     let timer = @async.Timer(300)
-    @async.with_task_group(group => {
+    @async.with_task_group() <| group => {
       for _ in 0..<3 {
-        group.spawn_bg(() => {
+        group.spawn_bg() <| () => {
           timer.wait()
           log.push("timer completed")
-        })
+        }
       }
-    })
-    let result = @async.with_timeout_opt(0, () => timer.wait())
+    }
+    let result = @async.with_timeout_opt(0) <| () => { timer.wait() }
     log.push("wait again: \{@debug.to_string(result)}")
-  })
+  }
   json_inspect(log, content=[
     "sleep: tick #1", "creating timer", "sleep: tick #2", "timer completed", "timer completed",
     "timer completed", "wait again: Some(())", "sleep: tick #3",
@@ -85,7 +85,7 @@ async test "Timer no waiter" {
   let timer = @async.Timer(200)
   @async.sleep(400)
   debug_inspect(
-    @async.with_timeout_opt(0, () => timer.wait()),
+    @async.with_timeout_opt(0) <| () => { timer.wait() },
     content=(
       #|Some(())
     ),
@@ -101,17 +101,17 @@ async test "Timer no one waiting" {
 ///|
 async test "Timer waiter cancelled 1" {
   let timer = @async.Timer(600)
-  assert_true(@async.with_timeout_opt(200, () => timer.wait()) is None)
+  assert_true((@async.with_timeout_opt(200) <| () => { timer.wait() }) is None)
   @async.sleep(200)
-  assert_false(@async.with_timeout_opt(300, () => timer.wait()) is None)
+  assert_false((@async.with_timeout_opt(300) <| () => { timer.wait() }) is None)
 }
 
 ///|
 async test "Timer waiter cancelled 2" {
   let timer = @async.Timer(300)
-  assert_true(@async.with_timeout_opt(200, () => timer.wait()) is None)
+  assert_true((@async.with_timeout_opt(200) <| () => { timer.wait() }) is None)
   @async.sleep(200)
-  assert_false(@async.with_timeout_opt(0, () => timer.wait()) is None)
+  assert_false((@async.with_timeout_opt(0) <| () => { timer.wait() }) is None)
 }
 
 ///|
@@ -119,16 +119,16 @@ async test "Timer::cancel" {
   let log = []
   let start = @async.now()
   let timer = @async.Timer(450)
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       @async.sleep(150)
       timer.cancel()
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       let result = try? timer.wait()
       let tick = (@async.now() - start + 50).to_int() / 150
       log.push("Timer::wait(): \{@debug.to_string(result)} at tick #\{tick}")
-    })
+    }
     @async.sleep(600)
     let tick = (@async.now() - start + 50).to_int() / 150
     log.push(
@@ -138,7 +138,7 @@ async test "Timer::cancel" {
     log.push(
       "at tick #\{tick}: Timer::wait(): \{@debug.to_string(try? timer.wait())}",
     )
-  })
+  }
   json_inspect(log, content=[
     "Timer::wait(): Err(TimerCancelled) at tick #1", "at tick #4: Timer::wait(): Err(TimerCancelled)",
     "at tick #4: Timer::wait(): Err(TimerCancelled)",
@@ -154,22 +154,22 @@ async test "Timer::refresh has waiter" {
   }
 
   let timer = @async.Timer(300)
-  @async.with_task_group(group => {
-    group.spawn_bg(() => {
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
       timer.wait()
       log.push("Timer::wait() completed at tick #\{tick()}")
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       @async.sleep(150)
       log.push("refresh timer at #\{tick()}")
       timer.refresh()
-    })
-    group.spawn_bg(() => {
+    }
+    group.spawn_bg() <| () => {
       @async.sleep(300)
       log.push("refresh timer at #\{tick()}")
       timer.refresh()
-    })
-  })
+    }
+  }
   json_inspect(log, content=[
     "refresh timer at #1", "refresh timer at #2", "Timer::wait() completed at tick #4",
   ])
@@ -219,7 +219,7 @@ async test "Timer::refresh already cancelled" {
   timer.cancel()
   timer.refresh()
   debug_inspect(
-    @async.with_timeout_opt(0, () => try? timer.wait()),
+    @async.with_timeout_opt(0) <| () => { try? timer.wait() },
     content=(
       #|Some(Err(TimerCancelled))
     ),

--- a/src/tls/certificate_test.mbt
+++ b/src/tls/certificate_test.mbt
@@ -14,11 +14,11 @@
 
 ///|
 async test "get_peer_certificate" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (client_read_from_server, server_write_to_client) = @pipe.pipe()
     let (server_read_from_client, client_write_to_server) = @pipe.pipe()
     // server
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer {
         server_read_from_client.close()
         server_write_to_client.close()
@@ -26,12 +26,12 @@ async test "get_peer_certificate" {
       let server = test_server(server_read_from_client, server_write_to_client)
       defer server.close()
       debug_inspect(
-        server.get_peer_certificate().map(cert => cert.length()),
+        server.get_peer_certificate().map() <| cert => { cert.length() },
         content="None",
       )
-    })
+    }
     // client
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer {
         client_read_from_server.close()
         client_write_to_server.close()
@@ -43,12 +43,12 @@ async test "get_peer_certificate" {
       )
       defer client.close()
       debug_inspect(
-        client.get_peer_certificate().map(cert => cert.length()),
+        client.get_peer_certificate().map() <| cert => { cert.length() },
         content=(
           #|Some(1447)
         ),
       )
       client.shutdown()
-    })
-  })
+    }
+  }
 }

--- a/src/tls/channel_binding_test.mbt
+++ b/src/tls/channel_binding_test.mbt
@@ -14,46 +14,48 @@
 
 ///|
 async test "channel binding" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let (client_read_from_server, server_write_to_client) = @pipe.pipe()
     let (server_read_from_client, client_write_to_server) = @pipe.pipe()
     // server
-    let server_task = group.spawn(() => {
-      defer {
-        server_read_from_client.close()
-        server_write_to_client.close()
+    let server_task = group.spawn() <| () => {
+        defer {
+          server_read_from_client.close()
+          server_write_to_client.close()
+        }
+        let server = test_server(
+          server_read_from_client, server_write_to_client,
+        )
+        defer server.close()
+        (
+          server.unique_channel_binding(),
+          server.server_endpoint_channel_binding(),
+        )
       }
-      let server = test_server(server_read_from_client, server_write_to_client)
-      defer server.close()
-      (
-        server.unique_channel_binding(),
-        server.server_endpoint_channel_binding(),
-      )
-    })
     // client
-    let client_task = group.spawn(() => {
-      defer {
-        client_read_from_server.close()
-        client_write_to_server.close()
+    let client_task = group.spawn() <| () => {
+        defer {
+          client_read_from_server.close()
+          client_write_to_server.close()
+        }
+        let client = @tls.Tls::client_from_pair(
+          client_read_from_server,
+          client_write_to_server,
+          trust=NoVerification,
+        )
+        defer client.close()
+        let binding = (
+          client.unique_channel_binding(),
+          client.server_endpoint_channel_binding(),
+        )
+        client.shutdown()
+        binding
       }
-      let client = @tls.Tls::client_from_pair(
-        client_read_from_server,
-        client_write_to_server,
-        trust=NoVerification,
-      )
-      defer client.close()
-      let binding = (
-        client.unique_channel_binding(),
-        client.server_endpoint_channel_binding(),
-      )
-      client.shutdown()
-      binding
-    })
     let (unique_binding_for_server, endpoint_binding_for_server) = server_task.wait()
     let (unique_binding_for_client, endpoint_binding_for_client) = client_task.wait()
     assert_eq(unique_binding_for_client, unique_binding_for_server)
     assert_true(unique_binding_for_client.length() > 0)
     assert_eq(endpoint_binding_for_client, endpoint_binding_for_server)
     assert_true(endpoint_binding_for_client.length() > 0)
-  })
+  }
 }

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -651,5 +651,5 @@ pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
 let _unused : Unit = {
   ignore(@os_error.check_errno)
   ignore(@os_string.encode)
-  ignore((_ : @fs.File) => ())
+  ignore() <| ((_ : @fs.File) => ())
 }

--- a/src/tls/openssl_loader.mbt
+++ b/src/tls/openssl_loader.mbt
@@ -57,7 +57,7 @@ fn load_openssl() -> Unit {
 #cfg(not(platform="windows"))
 fn init {
   load_openssl()
-  init_bio_method((bio, dst, len) => bio.read(dst, len), (bio, src, len) => {
+  init_bio_method((bio, dst, len) => bio.read(dst, len)) <| ((bio, src, len) => {
     bio.write(src, len)
   })
 }

--- a/src/tls/shutdown_test.mbt
+++ b/src/tls/shutdown_test.mbt
@@ -14,11 +14,11 @@
 
 ///|
 async test "peer close connection" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     // server
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -26,7 +26,7 @@ async test "peer close connection" {
       defer server.close()
       server.write("1234")
       inspect(server.read_all().text(), content="abcd")
-    })
+    }
     // client
     let conn = @socket.Tcp::connect(addr)
     defer conn.close()
@@ -43,5 +43,5 @@ async test "peer close connection" {
     inspect(@utf8.decode(client.read_exactly(4)), content="1234")
     client.write("abcd")
     // close the underlying connection directly
-  })
+  }
 }

--- a/src/tls/tls_test.mbt
+++ b/src/tls/tls_test.mbt
@@ -34,11 +34,11 @@ async fn test_server(r : &@io.Reader, w : &@io.Writer) -> @tls.Tls {
 ///|
 async test "one way" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (client_read_from_server, server_write_to_client) = @pipe.pipe()
     let (server_read_from_client, client_write_to_server) = @pipe.pipe()
     // server
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         server_read_from_client.close()
         server_write_to_client.close()
@@ -51,9 +51,9 @@ async test "one way" {
       } nobreak {
         server.shutdown()
       }
-    })
+    }
     // client
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         client_read_from_server.close()
         client_write_to_server.close()
@@ -71,8 +71,8 @@ async test "one way" {
       client.write(b"ijkl")
       client.shutdown()
       inspect(client.read_all().text(), content="")
-    })
-  })
+    }
+  }
   inspect(
     log.to_string(),
     content=(
@@ -87,11 +87,11 @@ async test "one way" {
 ///|
 async test "echo" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (client_read_from_server, server_write_to_client) = @pipe.pipe()
     let (server_read_from_client, client_write_to_server) = @pipe.pipe()
     // server
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         server_read_from_client.close()
         server_write_to_client.close()
@@ -104,9 +104,9 @@ async test "echo" {
       } nobreak {
         server.shutdown()
       }
-    })
+    }
     // client
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         client_read_from_server.close()
         client_write_to_server.close()
@@ -124,8 +124,8 @@ async test "echo" {
       }
       client.shutdown()
       inspect(client.read_all().text(), content="")
-    })
-  })
+    }
+  }
   inspect(
     log.to_string(),
     content=(
@@ -139,20 +139,20 @@ async test "echo" {
 
 ///|
 async test "`connect` accidental close" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (client_read_from_server, server_write_to_client) = @pipe.pipe()
     let (server_read_from_client, client_write_to_server) = @pipe.pipe()
     // server
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         server_read_from_client.close()
         server_write_to_client.close()
       }
       let _ = server_read_from_client.read_some()
       @async.sleep(100)
-    })
+    }
     // client
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         client_read_from_server.close()
         client_write_to_server.close()
@@ -169,26 +169,26 @@ async test "`connect` accidental close" {
         }
         Err(err) => inspect(err, content="ConnectionClosed")
       }
-    })
-  })
+    }
+  }
 }
 
 ///|
 async test "`read` already closed" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (client_read_from_server, server_write_to_client) = @pipe.pipe()
     let (server_read_from_client, client_write_to_server) = @pipe.pipe()
     // server
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         server_read_from_client.close()
         server_write_to_client.close()
       }
       let server = test_server(server_read_from_client, server_write_to_client)
       server.close()
-    })
+    }
     // client
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         client_read_from_server.close()
         client_write_to_server.close()
@@ -200,8 +200,8 @@ async test "`read` already closed" {
       )
       defer client.close()
       debug_inspect(try? client.read_some(), content="Ok(None)")
-    })
-  })
+    }
+  }
 }
 
 ///|
@@ -244,10 +244,10 @@ async fn other_root_test_server(r : &@io.Reader, w : &@io.Writer) -> @tls.Tls {
 
 ///|
 async test "client custom root certificate" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (client_read_from_server, server_write_to_client) = @pipe.pipe()
     let (server_read_from_client, client_write_to_server) = @pipe.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         server_read_from_client.close()
         server_write_to_client.close()
@@ -258,8 +258,8 @@ async test "client custom root certificate" {
       defer server.close()
       assert_eq(server.read_exactly(2), b"ok")
       server.shutdown()
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer {
         client_read_from_server.close()
         client_write_to_server.close()
@@ -274,16 +274,16 @@ async test "client custom root certificate" {
       client.write(b"ok")
       client.shutdown()
       inspect(client.read_all().text(), content="")
-    })
-  })
+    }
+  }
 }
 
 ///|
 async test "client custom root certificate rejects different root" {
-  @async.with_task_group(root => {
+  @async.with_task_group() <| root => {
     let (client_read_from_server, server_write_to_client) = @pipe.pipe()
     let (server_read_from_client, client_write_to_server) = @pipe.pipe()
-    root.spawn_bg(() => {
+    root.spawn_bg() <| () => {
       defer {
         server_read_from_client.close()
         server_write_to_client.close()
@@ -292,8 +292,8 @@ async test "client custom root certificate rejects different root" {
         server_read_from_client, server_write_to_client,
       )
       assert_true(server is Err(_))
-    })
-    root.spawn_bg(() => {
+    }
+    root.spawn_bg() <| () => {
       defer {
         client_read_from_server.close()
         client_write_to_server.close()
@@ -305,6 +305,6 @@ async test "client custom root certificate rejects different root" {
         trust=CustomPemFile("test_keys/valid_root_cert.pem"),
       )
       assert_true(client is Err(_))
-    })
-  })
+    }
+  }
 }

--- a/src/wait_test.mbt
+++ b/src/wait_test.mbt
@@ -17,17 +17,17 @@ async test "wait basic" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(200)
           buf <+ "200ms tick\n"
           @async.sleep(200)
           buf <+ "400ms tick\n"
-        })
-        let task = root.spawn(no_wait=true, () => {
-          @async.sleep(300)
-          buf <+ "task finished\n"
-        })
+        }
+        let task = root.spawn(no_wait=true) <| () => {
+            @async.sleep(300)
+            buf <+ "task finished\n"
+          }
         task.wait()
         buf <+ "main task exit\n"
       }),
@@ -48,19 +48,19 @@ async test "wait basic" {
 ///|
 async test "wait cancelled" {
   let buf = StringBuilder::new()
-  @async.with_task_group(root => {
-    let task = root.spawn(() => {
-      @async.sleep(1000)
-      buf <+ "task finished\n"
-    })
-    root.spawn_bg(() => {
+  (@async.with_task_group() <| root => {
+    let task = root.spawn() <| () => {
+        @async.sleep(1000)
+        buf <+ "task finished\n"
+      }
+    root.spawn_bg() <| () => {
       task.wait() catch {
         err => {
           buf.write_string("`wait` cancelled with \{err}\n")
           raise err
         }
       }
-    })
+    }
     @async.sleep(20)
     raise Err
   }) catch {
@@ -78,19 +78,19 @@ async test "wait cancelled" {
 ///|
 async test "try_wait" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    let task = root.spawn(no_wait=true, () => {
-      @async.sleep(450)
-      42
-    })
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    let task = root.spawn(no_wait=true) <| () => {
+        @async.sleep(450)
+        42
+      }
+    root.spawn_bg() <| () => {
       @async.sleep(300)
       log.write_string("300ms: \{@debug.to_string(task.try_wait())}\n")
       @async.sleep(300)
       log.write_string("600ms: \{@debug.to_string(task.try_wait())}\n")
-    })
+    }
     log.write_string("task finished with \{task.wait()}\n")
-  })
+  }
   inspect(
     log.to_string(),
     content=(

--- a/src/websocket/bad_client_test.mbt
+++ b/src/websocket/bad_client_test.mbt
@@ -14,12 +14,12 @@
 
 ///|
 async test "bad client" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
     let server_result_queue = @async.Queue(kind=Unbounded)
-    group.spawn_bg(no_wait=true, () => {
-      server.run_forever((req, _, conn) => {
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((req, _, conn) => {
         let ws = @websocket.from_http_server(req, conn)
         defer ws.close()
         let result = try? ({
@@ -32,20 +32,20 @@ async test "bad client" {
         // so that the client has enough time to react to the CLOSE frame
         @async.sleep(50)
       })
-    })
+    }
     async fn test_bad_frames(frames : Array[Bytes]) {
       let http_client = @http.Client("http://localhost:\{port}")
       defer http_client.close()
       let ws_client = @websocket.from_http_client(http_client, "/")
       defer ws_client.close()
-      @async.with_task_group(group => {
-        group.spawn_bg(() => {
+      @async.with_task_group() <| group => {
+        group.spawn_bg() <| () => {
           for frame in frames {
             http_client.write(frame)
           }
-        })
+        }
         try? ws_client.recv().read_all().text()
-      })
+      }
     }
 
     async fn test_bad_frame(frame) {
@@ -279,5 +279,5 @@ async test "bad client" {
         #|Err(ConnectionClosed(ProtocolError, Some("Invalid payload length format")))
       ),
     )
-  })
+  }
 }

--- a/src/websocket/control_test.mbt
+++ b/src/websocket/control_test.mbt
@@ -14,10 +14,10 @@
 
 ///|
 async test "ping auto-reply" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -25,7 +25,7 @@ async test "ping auto-reply" {
       let ws = @websocket.from_http_server(request, conn)
       defer ws.close()
       inspect(ws.recv().read_all().text(), content="1234")
-    })
+    }
     let http_client = @http.Client("http://localhost:\{port}")
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
@@ -34,15 +34,15 @@ async test "ping auto-reply" {
     json_inspect(http_client.read_exactly(2).to_array(), content=[0x8a, 0x04])
     inspect(@utf8.decode(http_client.read_exactly(4)), content="abcd")
     ws_client.send_text("1234")
-  })
+  }
 }
 
 ///|
 async test "pong ignored" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -51,7 +51,7 @@ async test "pong ignored" {
       defer ws.close()
       inspect(ws.recv().read_all().text(), content="1234")
       ws.send_text("1234")
-    })
+    }
     let http_client = @http.Client("http://localhost:\{port}")
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
@@ -59,30 +59,30 @@ async test "pong ignored" {
     http_client.write(ping_frame)
     ws_client.send_text("1234")
     inspect(ws_client.recv().read_all().text(), content="1234")
-  })
+  }
 }
 
 ///|
 async test "ping auto-reply race-with-write" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
       let request = conn.read_request()
       let ws = @websocket.from_http_server(request, conn)
       defer ws.close()
-      @async.with_task_group(group => {
+      @async.with_task_group() <| group => {
         // currently, auto-reply is only triggered when the user is actually reading.
-        group.spawn_bg(no_wait=true, () => ignore(ws.recv().read_all()))
+        group.spawn_bg(no_wait=true) <| () => { ignore(ws.recv().read_all()) }
         ws.start_message(Text)
         ws.write("1234")
         @async.sleep(400)
         ws.end_message()
-      })
-    })
+      }
+    }
     let http_client = @http.Client("http://localhost:\{port}")
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
@@ -96,37 +96,37 @@ async test "ping auto-reply race-with-write" {
     inspect(@utf8.decode(http_client.read_exactly(4)), content="abcd")
     json_inspect(http_client.read_exactly(2).to_array(), content=[0x81, 0x04])
     inspect(@utf8.decode(http_client.read_exactly(4)), content="1234")
-  })
+  }
 }
 
 ///|
 async test "close test" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
       let request = conn.read_request()
       let ws = @websocket.from_http_server(request, conn)
       defer ws.close()
-      @async.with_task_group(group => {
+      @async.with_task_group() <| group => {
         // currently, auto-reply is only triggered when the user is actually reading.
-        group.spawn_bg(() => {
+        group.spawn_bg() <| () => {
           debug_inspect(
             try? ws.recv().read_all().text(),
             content=(
               #|Err(ConnectionClosed(Normal, Some("abcd")))
             ),
           )
-        })
+        }
         ws.start_message(Text)
         ws.write("1234")
         @async.sleep(400)
         ws.end_message()
-      })
-    })
+      }
+    }
     let http_client = @http.Client("http://localhost:\{port}")
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
@@ -139,15 +139,15 @@ async test "close test" {
     guard http_client.read_exactly(2) is [u16be(code)]
     inspect(code, content="1000")
     inspect(@utf8.decode(http_client.read_exactly(4)), content="abcd")
-  })
+  }
 }
 
 ///|
 async test "send ping" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -156,25 +156,25 @@ async test "send ping" {
       defer ws.close()
       inspect(ws.recv().read_all().text(), content="1234")
       ws.send_text("abcd")
-    })
+    }
     let ws = @websocket.connect("ws://localhost:\{port}")
     defer ws.close()
-    @async.with_task_group(group => {
-      group.spawn_bg(() => {
+    @async.with_task_group() <| group => {
+      group.spawn_bg() <| () => {
         ws.ping()
         ws.send_text("1234")
-      })
+      }
       inspect(ws.recv().read_all().text(), content="abcd")
-    })
-  })
+    }
+  }
 }
 
 ///|
 async test "ping inside message" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -183,24 +183,24 @@ async test "ping inside message" {
       defer ws.close()
       inspect(ws.recv().read_all().text(), content="1234")
       ws.send_text("abcd")
-    })
+    }
     let ws = @websocket.connect("ws://localhost:\{port}")
     defer ws.close()
-    @async.with_task_group(group => {
-      group.spawn_bg(() => {
+    @async.with_task_group() <| group => {
+      group.spawn_bg() <| () => {
         ws..start_message(Text)..ping()..write("1234").end_message()
-      })
+      }
       inspect(ws.recv().read_all().text(), content="abcd")
-    })
-  })
+    }
+  }
 }
 
 ///|
 async test "multiple ping" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -210,28 +210,28 @@ async test "multiple ping" {
       @async.sleep(100)
       inspect(ws.recv().read_all().text(), content="1234")
       ws.send_text("abcd")
-    })
+    }
     let ws = @websocket.connect("ws://localhost:\{port}")
     defer ws.close()
-    @async.with_task_group(group => {
-      group.spawn_bg(() => {
-        @async.with_task_group(inner => {
-          inner.spawn_bg(() => ws.ping())
-          inner.spawn_bg(() => ws.ping())
-        })
+    @async.with_task_group() <| group => {
+      group.spawn_bg() <| () => {
+        @async.with_task_group() <| inner => {
+          inner.spawn_bg() <| () => { ws.ping() }
+          inner.spawn_bg() <| () => { ws.ping() }
+        }
         ws.send_text("1234")
-      })
+      }
       inspect(ws.recv().read_all().text(), content="abcd")
-    })
-  })
+    }
+  }
 }
 
 ///|
 async test "ping cancelled" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -241,27 +241,29 @@ async test "ping cancelled" {
       @async.sleep(200)
       inspect(ws.recv().read_all().text(), content="1234")
       ws.send_text("abcd")
-    })
+    }
     let ws = @websocket.connect("ws://localhost:\{port}")
     defer ws.close()
-    @async.with_task_group(group => {
-      group.spawn_bg(() => inspect(ws.recv().read_all().text(), content="abcd"))
+    @async.with_task_group() <| group => {
+      group.spawn_bg() <| () => {
+        inspect(ws.recv().read_all().text(), content="abcd")
+      }
       debug_inspect(
-        @async.with_timeout_opt(100, () => ws.ping(msg=b"1")),
+        @async.with_timeout_opt(100) <| () => { ws.ping(msg=b"1") },
         content="None",
       )
       ws.ping(msg=b"1")
       ws.send_text("1234")
-    })
-  })
+    }
+  }
 }
 
 ///|
 async test "duplicated ping" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -271,25 +273,25 @@ async test "duplicated ping" {
       @async.sleep(100)
       inspect(ws.recv().read_all().text(), content="1234")
       ws.send_text("abcd")
-    })
+    }
     let ws = @websocket.connect("ws://localhost:\{port}")
     defer ws.close()
-    @async.with_task_group(group => {
-      group.spawn_bg(() => {
-        @async.with_task_group(inner => {
-          inner.spawn_bg(() => ws.ping(msg=b"1"))
-          inner.spawn_bg(() => {
+    @async.with_task_group() <| group => {
+      group.spawn_bg() <| () => {
+        @async.with_task_group() <| inner => {
+          inner.spawn_bg() <| () => { ws.ping(msg=b"1") }
+          inner.spawn_bg() <| () => {
             debug_inspect(
               try? ws.ping(msg=b"1"),
               content=(
                 #|Err(Failure("A PING request with the same payload is already pending"))
               ),
             )
-          })
-        })
+          }
+        }
         ws.send_text("1234")
-      })
+      }
       inspect(ws.recv().read_all().text(), content="abcd")
-    })
-  })
+    }
+  }
 }

--- a/src/websocket/external_client_test.mbt
+++ b/src/websocket/external_client_test.mbt
@@ -15,11 +15,11 @@
 ///|
 async test "external client" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(no_wait=true, () => {
-      server.run_forever((request, _, conn) => {
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((request, _, conn) => {
         log.push("new client to \{request.path}")
         let ws = @websocket.from_http_server(request, conn)
         defer ws.close()
@@ -30,7 +30,7 @@ async test "external client" {
           ws..start_message(msg.kind)..write(data).end_message()
         }
       })
-    })
+    }
     let (_, output) = @process.collect_stdout("node", [
       "src/websocket/client.ts",
       "ws://localhost:\{port}",
@@ -44,6 +44,6 @@ async test "external client" {
         #|
       ),
     )
-  })
+  }
   json_inspect(log, content=["new client to /", "Text: Hello, Server!"])
 }

--- a/src/websocket/utf8_validation_test.mbt
+++ b/src/websocket/utf8_validation_test.mbt
@@ -15,10 +15,10 @@
 ///|
 async test "UTF8 validation" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    group.spawn_bg(no_wait=true, () => {
+    group.spawn_bg(no_wait=true) <| () => {
       defer server.close()
       for ;; {
         let (conn, _) = server.accept()
@@ -43,7 +43,7 @@ async test "UTF8 validation" {
           }
         }
       }
-    })
+    }
     async fn send_bad_message(msg : Bytes) {
       let client = @websocket.connect("ws://localhost:\{addr.port()}")
       defer client.close()
@@ -64,7 +64,7 @@ async test "UTF8 validation" {
     send_bad_message([0xf0, 0x80, 0x80, 0x80, 0x80])
     send_bad_message([0xf0, 0x80, 0x80, 0x79])
     send_bad_message([0xf0, 0x79, 0x80, 0x80])
-  })
+  }
   json_inspect(log, content=[
     "server failed with ProtocolError(Text message is not valid UTF8) at byte 0",
     "client: [0x80] => Err(\n  ConnectionClosed(\n    InvalidFramePayload,\n    Some(\"Text message is not valid UTF8\"),\n  ),\n)",
@@ -89,31 +89,31 @@ async test "UTF8 validation" {
 
 ///|
 async test "UTF8 validation large message" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let port = server.addr.port()
-    group.spawn_bg(no_wait=true, () => {
-      server.run_forever((req, _, conn) => {
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((req, _, conn) => {
         let ws = @websocket.from_http_server(req, conn)
         defer ws.close()
         let msg = ws.recv()
         debug_inspect(msg.kind, content="Text")
         ws..start_message(Text)..write_reader(msg).end_message()
       })
-    })
+    }
     let client = @websocket.connect("ws://localhost:\{port}")
     defer client.close()
-    @async.with_task_group(group => {
+    @async.with_task_group() <| group => {
       let chunk_text = String::make(1024, '☺')
       let chunk_bin = @utf8.encode(chunk_text)
-      group.spawn_bg(() => {
+      group.spawn_bg() <| () => {
         client.start_message(Text)
         client.write("a")
         for n = 0; n < 10240; n = n + chunk_bin.length() {
           client.write(chunk_bin)
         }
         client.end_message()
-      })
+      }
       let reply = client.recv()
       inspect(@utf8.decode(reply.read_exactly(1)), content="a")
       for n = 0; n < 10240; n = n + chunk_bin.length() {
@@ -121,6 +121,6 @@ async test "UTF8 validation large message" {
         assert_eq(@utf8.decode(reply_chunk), chunk_text)
       }
       debug_inspect(reply.read_some(), content="None")
-    })
-  })
+    }
+  }
 }

--- a/src/websocket/websocket_test.mbt
+++ b/src/websocket/websocket_test.mbt
@@ -14,10 +14,10 @@
 
 ///|
 async test "websocket basic" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -39,7 +39,7 @@ async test "websocket basic" {
       } noraise {
         _ => raise Failure::Failure("expected error, but nothing happens")
       }
-    })
+    }
     let client = @websocket.connect("ws://localhost:\{addr.port()}")
     defer client.close()
     client.send_binary(b"abcd")
@@ -51,15 +51,15 @@ async test "websocket basic" {
     debug_inspect(msg.kind, content="Text")
     inspect(msg.read_all().text(), content="abcd")
     client.send_close()
-  })
+  }
 }
 
 ///|
 async test "single frame multiple read" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -73,22 +73,22 @@ async test "single frame multiple read" {
       debug_inspect(msg.kind, content="Text")
       json_inspect(msg.read_exactly(2), content="ab")
       json_inspect(msg.read_exactly(2), content="cd")
-    })
+    }
     let client = @websocket.connect("ws://localhost:\{addr.port()}")
     defer client.close()
     client.send_text("abc")
     @async.sleep(200)
     client.send_text("abcd")
     client.send_close()
-  })
+  }
 }
 
 ///|
 async test "ignored message" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -102,23 +102,23 @@ async test "ignored message" {
       // trying to read from `msg1` here should result in panic
       debug_inspect(msg2.kind, content="Text")
       inspect(msg2.read_all().text(), content="1234")
-    })
+    }
     let client = @websocket.connect("ws://localhost:\{addr.port()}")
     defer client.close()
     client.send_text("abcd")
     @async.sleep(200)
     client.send_text("1234")
     client.send_close()
-  })
+  }
 }
 
 ///|
 async test "write buffering" {
   let log = []
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    group.spawn_bg(() => {
+    group.spawn_bg() <| () => {
       defer server.close()
       let (conn, _) = server.accept()
       defer conn.close()
@@ -136,7 +136,7 @@ async test "write buffering" {
           log.push("server received: \{chunk}")
         }
       }
-    })
+    }
     let client = @websocket.connect("ws://localhost:\{addr.port()}")
     defer client.close()
     client..start_message(Text).write("ab")
@@ -146,7 +146,7 @@ async test "write buffering" {
 
     // close the channel
     client.send_close()
-  })
+  }
   json_inspect(log, content=[
     "server received new message: Text", "server received: abcd",
   ])
@@ -154,30 +154,30 @@ async test "write buffering" {
 
 ///|
 async test "large message" {
-  @async.with_task_group(group => {
+  @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    let server_checksum = group.spawn(() => {
-      defer server.close()
-      let (conn, _) = server.accept()
-      defer conn.close()
-      let request = conn.read_request()
-      let ws = @websocket.from_http_server(request, conn)
-      defer ws.close()
-      let msg = ws.recv()
-      debug_inspect(msg.kind, content="Binary")
-      let mut checksum = 0
-      while msg.read_some() is Some(chunk) {
-        for byte in chunk {
-          checksum += byte.to_int()
+    let server_checksum = group.spawn() <| () => {
+        defer server.close()
+        let (conn, _) = server.accept()
+        defer conn.close()
+        let request = conn.read_request()
+        let ws = @websocket.from_http_server(request, conn)
+        defer ws.close()
+        let msg = ws.recv()
+        debug_inspect(msg.kind, content="Binary")
+        let mut checksum = 0
+        while msg.read_some() is Some(chunk) {
+          for byte in chunk {
+            checksum += byte.to_int()
+          }
         }
+        checksum
       }
-      checksum
-    })
     let client = @websocket.connect("ws://localhost:\{addr.port()}")
     defer client.close()
     client.start_message(Binary)
-    let chunk = Bytes::makei(1500, i => (i % 0x100).to_byte())
+    let chunk = Bytes::makei(1500) <| i => { (i % 0x100).to_byte() }
     let mut checksum = 0
     for _ in 0..<20 {
       for byte in chunk {
@@ -188,5 +188,5 @@ async test "large message" {
     client.end_message()
     inspect(checksum, content="3745800")
     inspect(server_checksum.wait(), content="3745800")
-  })
+  }
 }

--- a/src/with_timeout_test.mbt
+++ b/src/with_timeout_test.mbt
@@ -15,17 +15,17 @@
 ///|
 async test "with_timeout normal exit" {
   let log = []
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(300)
       log.push("300ms tick")
-    })
-    @async.with_timeout(400, () => {
+    }
+    @async.with_timeout(400) <| () => {
       @async.sleep(200)
       log.push("task finished after 200ms")
-    })
+    }
     log.push("main task finished")
-  })
+  }
   json_inspect(log, content=[
     "task finished after 200ms", "main task finished", "300ms tick",
   ])
@@ -34,12 +34,12 @@ async test "with_timeout normal exit" {
 ///|
 async test "with_timeout failure" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  (@async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       log <+ "200ms tick\n"
-    })
-    @async.with_timeout(300, () => {
+    }
+    (@async.with_timeout(300) <| () => {
       @async.sleep(100)
       raise Err
     }) catch {
@@ -65,12 +65,12 @@ async test "with_timeout timeout" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(300)
           log <+ "300ms tick\n"
-        })
-        @async.with_timeout(200, () => {
+        }
+        (@async.with_timeout(200) <| () => {
           @async.sleep(400) catch {
             err => {
               log <+ "task cancelled\n"
@@ -102,15 +102,15 @@ async test "with_timeout nested1" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(200)
           log <+ "200ms tick\n"
           @async.sleep(200)
           log <+ "400ms tick\n"
-        })
-        @async.with_timeout(300, () => {
-          @async.with_timeout(500, () => {
+        }
+        (@async.with_timeout(300) <| () => {
+          (@async.with_timeout(500) <| () => {
             @async.sleep(2000) catch {
               err => {
                 log <+ "task cancelled\n"
@@ -147,15 +147,15 @@ async test "with_timeout nested2" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(300)
           log <+ "300ms tick\n"
           @async.sleep(300)
           log <+ "600ms tick\n"
-        })
-        @async.with_timeout(750, () => {
-          @async.with_timeout(450, () => {
+        }
+        (@async.with_timeout(750) <| () => {
+          (@async.with_timeout(450) <| () => {
             @async.sleep(2000) catch {
               err => {
                 log <+ "task cancelled\n"
@@ -191,12 +191,12 @@ async test "with_timeout error_on_cancel" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(200)
           log <+ "200ms tick\n"
-        })
-        @async.with_timeout(100, () => {
+        }
+        @async.with_timeout(100) <| () => {
           @async.sleep(2000) catch {
             _ => {
               log <+ "causing other error on cancellation\n"
@@ -204,7 +204,7 @@ async test "with_timeout error_on_cancel" {
             }
           }
           log <+ "task finished after 2s\n"
-        })
+        }
         log <+ "main task finished\n"
       }),
     ),
@@ -223,13 +223,13 @@ async test "with_timeout error-on-timeout" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? @async.with_task_group(root => {
-        root.spawn_bg(() => {
+      try? (@async.with_task_group() <| root => {
+        root.spawn_bg() <| () => {
           @async.sleep(200)
           log <+ "200ms tick\n"
-        })
+        }
         defer log.write_string("main task terminates\n")
-        @async.with_timeout(100, error=Err, () => {
+        @async.with_timeout(100, error=Err) <| () => {
           @async.sleep(2000) catch {
             err => {
               log <+ "task cancelled\n"
@@ -237,7 +237,7 @@ async test "with_timeout error-on-timeout" {
             }
           }
           log <+ "task finished after 2s\n"
-        })
+        }
       }),
     ),
   )
@@ -254,18 +254,18 @@ async test "with_timeout error-on-timeout" {
 ///|
 async test "with_timeout_opt normal exit" {
   let log = []
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       log.push("200ms tick")
-    })
-    let result = @async.with_timeout_opt(1000, () => {
-      @async.sleep(100)
-      log.push("task finished after 100ms")
-      42
-    })
+    }
+    let result = @async.with_timeout_opt(1000) <| () => {
+        @async.sleep(100)
+        log.push("task finished after 100ms")
+        42
+      }
     log.push(@debug.to_string(result))
-  })
+  }
   json_inspect(log, content=[
     "task finished after 100ms", "Some(42)", "200ms tick",
   ])
@@ -274,12 +274,12 @@ async test "with_timeout_opt normal exit" {
 ///|
 async test "with_timeout_opt failure" {
   let log = StringBuilder::new()
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  (@async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       log <+ "200ms tick\n"
-    })
-    @async.with_timeout(1000, () => {
+    }
+    (@async.with_timeout(1000) <| () => {
       @async.sleep(100)
       raise Err
     }) catch {
@@ -303,25 +303,25 @@ async test "with_timeout_opt failure" {
 ///|
 async test "with_timeout_opt timeout" {
   let log = []
-  @async.with_task_group(root => {
-    root.spawn_bg(() => {
+  @async.with_task_group() <| root => {
+    root.spawn_bg() <| () => {
       @async.sleep(200)
       log.push("200ms tick")
-    })
-    let result = @async.with_timeout_opt(100, () => {
-      try @async.sleep(2000) catch {
-        err => {
-          log.push("task cancelled")
-          raise err
-        }
-      } noraise {
-        _ => {
-          log.push("task finished after 2s")
-          42
+    }
+    let result = @async.with_timeout_opt(100) <| () => {
+        try @async.sleep(2000) catch {
+          err => {
+            log.push("task cancelled")
+            raise err
+          }
+        } noraise {
+          _ => {
+            log.push("task finished after 2s")
+            42
+          }
         }
       }
-    })
     log.push(@debug.to_string(result))
-  })
+  }
   json_inspect(log, content=["task cancelled", "None", "200ms tick"])
 }


### PR DESCRIPTION
## Summary

- Apply `<|` callback sugar throughout `src` for positional callbacks passed as the final argument.
- Wrap expression-bodied callbacks in block closures where needed so they parse after `<|`.
- Leave forms that cannot use the sugar cleanly, such as labeled callbacks, non-final callbacks, and method-chain cases that do not type-check with `method() <|`.

## Validation

- `moon fmt`
- `moon fmt --manifest-path src/process/test_programs/moon.mod.json`
- `moon check`
- `moon check --target wasm --deny-warn`
- `moon check --target js --deny-warn`
- `moon test` (first post-fix run hit timing-sensitive `fs/lock_test` ordering assertions; rerun passed 488/488)
