### PR TITLE
revert some undesirable use of reverse pipe

### DIFF
--- a/examples/http_file_server/server_wbtest.mbt
+++ b/examples/http_file_server/server_wbtest.mbt
@@ -47,7 +47,7 @@ async test "basic" {
   @async.with_task_group <| root => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg(no_wait=true) <| () => { server_main(server, path=".", log~) }
+    root.spawn_bg(no_wait=true, () => server_main(server, path=".", log~))
     @async.sleep(50)
     client_log <+ "client: GET /examples/http_file_server\n"
     client(addr, "/examples/http_file_server", client_log)
@@ -57,7 +57,7 @@ async test "basic" {
     client_log <+ "\n\n"
     let tmp_file_name = "examples/test.zip"
     let tmp_file = @fs.create(tmp_file_name, permission=0o644)
-    root.add_defer() <| () => { @fs.remove(tmp_file_name) }
+    root.add_defer(() => @fs.remove(tmp_file_name))
     client(addr, "/examples/http_file_server?download_zip", client_log, handle_response=body => {
       tmp_file.write_reader(body)
     })

--- a/examples/tcp_echo_server/main.mbt
+++ b/examples/tcp_echo_server/main.mbt
@@ -14,8 +14,7 @@
 
 ///|
 async fn main {
-  @socket.TcpServer(@socket.Addr::parse("0.0.0.0:42000")).run_forever() <| ((
-    conn,
-    _,
-  ) => conn.write_reader(conn))
+  @socket.TcpServer(@socket.Addr::parse("0.0.0.0:42000")).run_forever((conn, _) => {
+    conn.write_reader(conn)
+  })
 }

--- a/examples/tcp_ping_pong/main.mbt
+++ b/examples/tcp_ping_pong/main.mbt
@@ -20,7 +20,7 @@ pub(all) struct Printer((String) -> Unit)
 
 ///|
 async fn server_main(server : @socket.TcpServer, println : Printer) -> Unit {
-  (server.run_forever(allow_failure=false) <| ((conn, _) => {
+  server.run_forever(allow_failure=false, (conn, _) => {
     println("received new connection")
     while conn.read_some() is Some(msg) {
       @async.sleep(10)
@@ -36,7 +36,7 @@ async fn server_main(server : @socket.TcpServer, println : Printer) -> Unit {
     } nobreak {
       println("server: connection closed by peer")
     }
-  })) catch {
+  }) catch {
     err => {
       println("server terminate: \{err}")
       raise err
@@ -71,19 +71,19 @@ async fn client(
 
 ///|
 pub async fn main_prog(println : Printer) -> Unit {
-  (@async.with_task_group <| root => {
+  @async.with_task_group(root => {
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg() <| () => { server_main(server, println) }
+    root.spawn_bg(() => server_main(server, println))
     root.spawn_bg() <| () => {
       @async.with_task_group <| ctx => {
         for i in 0..<6 {
           let msg = if i % 3 == 1 { "pong" } else { "ping" }
-          ctx.spawn_bg() <| () => { client(addr, println, i, msg) }
+          ctx.spawn_bg(() => client(addr, println, i, msg))
           @async.sleep(100)
         }
       }
-      root.spawn_bg() <| () => { client(addr, println, 6, "exit") }
+      root.spawn_bg(() => client(addr, println, 6, "exit"))
     }
   }) catch {
     ServerTerminate => ()

--- a/examples/udp_ping_pong/main.mbt
+++ b/examples/udp_ping_pong/main.mbt
@@ -20,7 +20,7 @@ pub(all) struct Printer((String) -> Unit)
 
 ///|
 async fn server_main(server : @socket.UdpServer, println : Printer) -> Unit {
-  (@async.with_task_group <| group => {
+  @async.with_task_group(group => {
     defer server.close()
     let buf = FixedArray::make(1024, b'0')
     while server.recvfrom(buf) is (n, addr) && n > 0 {
@@ -70,19 +70,19 @@ async fn client(
 
 ///|
 pub async fn main_prog(println : Printer) -> Unit {
-  (@async.with_task_group <| root => {
+  @async.with_task_group(root => {
     let server = @socket.UdpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg() <| () => { server_main(server, println) }
+    root.spawn_bg(() => server_main(server, println))
     root.spawn_bg() <| () => {
       @async.with_task_group <| ctx => {
         for i in 0..<6 {
           let msg = if i % 3 == 1 { "pong" } else { "ping" }
-          ctx.spawn_bg() <| () => { client(addr, println, i, msg) }
+          ctx.spawn_bg(() => client(addr, println, i, msg))
           @async.sleep(100)
         }
       }
-      root.spawn_bg() <| () => { client(addr, println, 6, "exit") }
+      root.spawn_bg(() => client(addr, println, 6, "exit"))
     }
   }) catch {
     ServerTerminate => ()

--- a/examples/websocket_echo_server/server_wbtest.mbt
+++ b/examples/websocket_echo_server/server_wbtest.mbt
@@ -15,7 +15,7 @@
 ///|
 async test "test server" {
   @async.with_task_group <| group => {
-    group.spawn_bg(no_wait=true) <| () => { start_echo_server(port=49001) }
+    group.spawn_bg(no_wait=true, () => start_echo_server(port=49001))
     let client = @websocket.connect("ws://localhost:49001")
     defer client.close()
     client.send_binary(b"abcd")

--- a/src/all_any_test.mbt
+++ b/src/all_any_test.mbt
@@ -142,9 +142,9 @@ async test "all cancelled" {
     idx
   }
 
-  let result = @async.with_timeout_opt(300) <| () => {
-      @async.all([() => task(1, 450), () => task(2, 150)])
-    }
+  let result = @async.with_timeout_opt(300, () => {
+    @async.all([() => task(1, 450), () => task(2, 150)])
+  })
   debug_inspect(result, content="None")
   json_inspect(log, content=[
     "task #2 completed", "task #1 cancelled with Cancelled",
@@ -300,9 +300,9 @@ async test "any cancelled" {
     idx
   }
 
-  let result = @async.with_timeout_opt(200) <| () => {
-      @async.any([() => task(1, 400), () => task(2, 400)])
-    }
+  let result = @async.with_timeout_opt(200, () => {
+    @async.any([() => task(1, 400), () => task(2, 400)])
+  })
   debug_inspect(result, content="None")
   json_inspect(log, content=[
     "task #1 cancelled with Cancelled", "task #2 cancelled with Cancelled",

--- a/src/allow_failure_test.mbt
+++ b/src/allow_failure_test.mbt
@@ -16,7 +16,7 @@
 async test "allow_failure ignored" {
   let buf = StringBuilder::new()
   @async.with_task_group() <| root => {
-    root.spawn_bg(allow_failure=true) <| () => { raise Err }
+    root.spawn_bg(allow_failure=true, () => raise Err)
     @async.sleep(100)
     buf <+ "main task terminate\n"
   }
@@ -34,8 +34,8 @@ async test "allow_failure waited" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
-        let task = root.spawn(allow_failure=true) <| () => { raise Err }
+      try? @async.with_task_group(root => {
+        let task = root.spawn(allow_failure=true, () => raise Err)
         @async.sleep(100)
         task.wait()
         buf <+ "main task terminate\n"
@@ -50,7 +50,7 @@ async test "allow_failure no error" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg(allow_failure=true) <| () => {
           @async.sleep(1000)
           buf <+ "`allow_failure` task terminate\n"

--- a/src/aqueue/aqueue_test.mbt
+++ b/src/aqueue/aqueue_test.mbt
@@ -82,7 +82,7 @@ async test "aqueue multi-reader" {
 async test "aqueue cancellation" {
   let log = StringBuilder::new()
   let queue : @aqueue.Queue[Int] = @aqueue.Queue(kind=Unbounded)
-  (@async.with_timeout(350) <| () => {
+  @async.with_timeout(350, () => {
     let x = queue.get() catch {
       err => {
         log.write_string("`queue.get()` cancelled with \{err}\n")
@@ -109,9 +109,7 @@ async test "aqueue cancellation no_swallow" {
   let log = StringBuilder::new()
   @async.with_task_group() <| group => {
     let q = @aqueue.Queue(kind=Unbounded)
-    let get_task = group.spawn() <| () => {
-        log.write_string("get() => \{q.get()}\n")
-      }
+    let get_task = group.spawn(() => log.write_string("get() => \{q.get()}\n"))
     @async.sleep(100)
     q.put(42)
     get_task.cancel()

--- a/src/aqueue/blocking_test.mbt
+++ b/src/aqueue/blocking_test.mbt
@@ -102,7 +102,7 @@ async test "blocking cancellation" {
       @async.sleep(250)
       ignore(q.get())
     }
-    (@async.with_timeout(500) <| () => {
+    @async.with_timeout(500, () => {
       for ;; {
         q.put(0) catch {
           err => {
@@ -160,15 +160,15 @@ async test "blocking immediate cancellation" {
   @async.with_task_group() <| group => {
     let q = @async.Queue(kind=Blocking(1))
     q.put(0)
-    let put_task = group.spawn() <| () => {
-        q.put(1) catch {
-          err => {
-            log.push("put() cancelled")
-            raise err
-          }
+    let put_task = group.spawn(() => {
+      q.put(1) catch {
+        err => {
+          log.push("put() cancelled")
+          raise err
         }
-        log.push("put() completed")
       }
+      log.push("put() completed")
+    })
     @async.sleep(100)
     let _ = q.get()
     put_task.cancel()

--- a/src/async.mbt
+++ b/src/async.mbt
@@ -243,7 +243,7 @@ pub async fn[X] all(
       }
     }
   }
-  results.map() <| r => { r.unwrap() }
+  results.map(r => r.unwrap())
 }
 
 ///|

--- a/src/cancellation_test.mbt
+++ b/src/cancellation_test.mbt
@@ -15,18 +15,18 @@
 ///|
 async test "manual cancel" {
   let buf = StringBuilder::new()
-  let result = try? (@async.with_task_group() <| root => {
-    let task = root.spawn() <| () => {
-        try {
-          @async.sleep(300)
-          buf <+ "task finished\n"
-        } catch {
-          err => {
-            buf.write_string("cancelled by error \{err}\n")
-            raise err
-          }
+  let result = try? @async.with_task_group(root => {
+    let task = root.spawn(() => {
+      try {
+        @async.sleep(300)
+        buf <+ "task finished\n"
+      } catch {
+        err => {
+          buf.write_string("cancelled by error \{err}\n")
+          raise err
         }
       }
+    })
     @async.sleep(100)
     task.cancel()
     @async.sleep(200)
@@ -51,7 +51,7 @@ async test "error propagation" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(300)
           raise Err
@@ -162,22 +162,22 @@ async test "recursive cancel" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           for _ in 0..<2 {
             @async.sleep(400)
             buf <+ "tick\n"
           }
         }
-        let task = root.spawn() <| () => {
-            @async.sleep(1000) catch {
-              err => buf.write_string("first sleep cancelled with \{err}\n")
-            }
-            @async.sleep(1000) catch {
-              err => buf.write_string("second sleep cancelled with \{err}\n")
-            }
-            buf <+ "task finished\n"
+        let task = root.spawn(() => {
+          @async.sleep(1000) catch {
+            err => buf.write_string("first sleep cancelled with \{err}\n")
           }
+          @async.sleep(1000) catch {
+            err => buf.write_string("second sleep cancelled with \{err}\n")
+          }
+          buf <+ "task finished\n"
+        })
         @async.sleep(600)
         task.cancel()
         buf <+ "main task exit\n"
@@ -203,11 +203,11 @@ async test "spawn directly error" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.with_task_group() <| group => {
             @async.sleep(1)
-            group.spawn_bg() <| () => { raise Err }
+            group.spawn_bg(() => raise Err)
             buf <+ "after spawn\n"
             @async.sleep(400)
             buf <+ "main task exit\n"
@@ -231,7 +231,7 @@ async test "error in cancellation" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg(no_wait=true) <| () => {
           @async.sleep(1000) catch {
             _ => {
@@ -257,12 +257,12 @@ async test "error in cancellation" {
 async test "immediately cancelled" {
   let log = StringBuilder::new()
   @async.with_task_group() <| root => {
-    let task = root.spawn() <| () => {
-        defer log.write_string("task terminated\n")
-        log <+ "task started\n"
-        @async.sleep(100)
-        log <+ "task finished\n"
-      }
+    let task = root.spawn(() => {
+      defer log.write_string("task terminated\n")
+      log <+ "task started\n"
+      @async.sleep(100)
+      log <+ "task finished\n"
+    })
     log <+ "task spawned\n"
     task.cancel()
   }
@@ -279,11 +279,9 @@ async test "immediately cancelled" {
 
 ///|
 async test "immediate failure" {
-  let result = try? (@async.with_task_group() <| group => {
-    group.spawn_bg() <| () => { raise Failure::Failure("failure") }
-    group.spawn_bg() <| () => {
-      group.spawn_bg() <| () => { @async.sleep(100) }
-    }
+  let result = try? @async.with_task_group(group => {
+    group.spawn_bg(() => raise Failure::Failure("failure"))
+    group.spawn_bg(() => group.spawn_bg(() => @async.sleep(100)))
   })
   debug_inspect(
     result,
@@ -313,8 +311,8 @@ async test "task group cancel & complete at the same time" {
       // - `task1` starts and completes, waking the main task of `inner`
       // So here we will have `.cancer()` and `.wake()` called on the same coroutine,
       // but the coroutine should be woken only once in this case.
-      inner.spawn_bg() <| () => { inner.return_immediately(()) }
-      let task1 = inner.spawn() <| () => { () }
+      inner.spawn_bg(() => inner.return_immediately(()))
+      let task1 = inner.spawn(() => ())
       task1.wait() catch {
         err => {
           log.push("inner group main task cancelled")

--- a/src/cond_var/cond_var_test.mbt
+++ b/src/cond_var/cond_var_test.mbt
@@ -21,7 +21,7 @@ async test "cond var cancellation" {
       cond.signal()
     }
     debug_inspect(
-      try? (@async.with_timeout(250) <| () => { cond.wait() }),
+      try? @async.with_timeout(250, () => cond.wait()),
       content="Err(TimeoutError)",
     )
   }
@@ -32,10 +32,10 @@ async test "cond var cancellation no_swallow" {
   let log = StringBuilder::new()
   @async.with_task_group() <| root => {
     let cond = @cond_var.Cond()
-    let wait_task = root.spawn() <| () => {
-        cond.wait()
-        log <+ "waiter 1 succeed\n"
-      }
+    let wait_task = root.spawn(() => {
+      cond.wait()
+      log <+ "waiter 1 succeed\n"
+    })
     root.spawn_bg(no_wait=true) <| () => {
       cond.wait()
       log <+ "waiter 2 succeed\n"
@@ -124,7 +124,7 @@ async test "cond var broadcast cancellation" {
     let cond = @cond_var.Cond()
     for i in 0..<3 {
       root.spawn_bg(allow_failure=true) <| () => {
-        @async.with_timeout(200 * (i + 1)) <| () => { cond.wait() }
+        @async.with_timeout(200 * (i + 1), () => cond.wait())
         log.write_string("task \{i} received signal\n")
       }
     }

--- a/src/fs/access_test.mbt
+++ b/src/fs/access_test.mbt
@@ -50,7 +50,7 @@ async test "chmod" {
   let path = "_build/chmod_test"
   @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateNew, permission=0o444)
-    group.add_defer() <| () => { @fs.remove(path) }
+    group.add_defer(() => @fs.remove(path))
     inspect(@fs.can_read(path), content="true")
     inspect(@fs.can_write(path), content="false")
     inspect(@fs.can_execute(path), content="false")

--- a/src/fs/create_test.mbt
+++ b/src/fs/create_test.mbt
@@ -80,7 +80,7 @@ async test "create_mode test" {
     {
       let file = @fs.create(path, allow_existing=false)
       defer file.close()
-      group.add_defer() <| () => { @fs.remove(path) }
+      group.add_defer(() => @fs.remove(path))
       file.write("abcd")
     }
     inspect(@fs.read_file(path).text(), content="abcd")

--- a/src/fs/dir_test.mbt
+++ b/src/fs/dir_test.mbt
@@ -16,13 +16,9 @@
 async test "read_all" {
   let dir = @fs.opendir("src/fs")
   defer dir.close()
-  let list = dir.read_all().filter_map() <| x => {
-      if x is "target" {
-        None
-      } else {
-        Some(x)
-      }
-    }
+  let list = dir
+    .read_all()
+    .filter_map(x => if x is "target" { None } else { Some(x) })
   list.sort()
   json_inspect(list, content=[
     "dir.c", "stub.c", "dir.mbt", "file.mbt", "moon.pkg", "README.md", "utils.mbt",

--- a/src/fs/lock_test.mbt
+++ b/src/fs/lock_test.mbt
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 ///|
-let lock_file_prog : @async.Lazy[String] = @async.Lazy() <| () => {
-    let code = @process.run("moon", [
-      "-C", "src/process/test_programs", "build", "lock_file", "--debug",
-    ])
-    if code != 0 {
-      fail("failed to build test program `lock_file`: \{code}")
-    }
-    "src/process/test_programs/_build/native/debug/build/lock_file/lock_file.exe"
+let lock_file_prog : @async.Lazy[String] = @async.Lazy(() => {
+  let code = @process.run("moon", [
+    "-C", "src/process/test_programs", "build", "lock_file", "--debug",
+  ])
+  if code != 0 {
+    fail("failed to build test program `lock_file`: \{code}")
   }
+  "src/process/test_programs/_build/native/debug/build/lock_file/lock_file.exe"
+})
 
 ///|
 async fn run_lock_file_prog(
@@ -56,7 +56,7 @@ async test "flock exclusive vs exclusive" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log)
     @async.sleep(250)
     log.push("try_lock() => \{file.try_lock(Exclusive)}")
@@ -75,7 +75,7 @@ async test "flock exclusive vs exclusive blocking" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
@@ -97,7 +97,7 @@ async test "flock shared vs exclusive" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log)
     @async.sleep(250)
     log.push("try_lock() => \{file.try_lock(Exclusive)}")
@@ -116,7 +116,7 @@ async test "flock shared vs exclusive blocking" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
@@ -138,7 +138,7 @@ async test "flock exclusive vs shared" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log)
     @async.sleep(250)
     log.push("try_lock() => \{file.try_lock(Shared)}")
@@ -157,7 +157,7 @@ async test "flock exclusive vs shared blocking" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
@@ -179,7 +179,7 @@ async test "flock shared vs shared" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log)
     @async.sleep(250)
     log.push("try_lock() => \{file.try_lock(Shared)}")
@@ -196,7 +196,7 @@ async test "flock shared vs shared blocking" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
@@ -217,7 +217,7 @@ async test "flock shared vs shared vs exclusive" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #1: ")
     @async.sleep(250)
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #2: ")
@@ -242,7 +242,7 @@ async test "flock shared vs shared vs exclusive blocking" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #1: ")
     @async.sleep(250)
     run_lock_file_prog(group, file_name, Shared, log, prefix="child #2: ")
@@ -266,11 +266,11 @@ async test "flock cancelled" {
   @async.with_task_group() <| group => {
     let file = @fs.open(file_name, create_mode=CreateOrTruncate, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to acquire lock")
-    let result = @async.with_timeout_opt(100) <| () => { file.lock(Exclusive) }
+    let result = @async.with_timeout_opt(100, () => file.lock(Exclusive))
     log.push("lock() with timeout: \{@debug.to_string(result)}")
     if result is Some(_) {
       file.unlock()
@@ -290,7 +290,7 @@ async test "flock advisory" {
     @fs.write_file(file_name, create_mode=CreateOrTruncate, "abcd")
     let file = @fs.open(file_name, mode=ReadWrite)
     defer file.close()
-    group.add_defer() <| () => { @fs.remove(file_name) }
+    group.add_defer(() => @fs.remove(file_name))
     run_lock_file_prog(group, file_name, Exclusive, log, prefix="child: ")
     @async.sleep(250)
     log.push("attempting to read")

--- a/src/fs/mkdir_test.mbt
+++ b/src/fs/mkdir_test.mbt
@@ -43,7 +43,7 @@ async test "mkdir recursive" {
     let base_path = "_build/recursive_mkdir"
     let path = "\{base_path}/test//directory"
     @fs.mkdir(path, recursive=true)
-    group.add_defer() <| () => { @fs.rmdir(base_path, recursive=true) }
+    group.add_defer(() => @fs.rmdir(base_path, recursive=true))
     json_inspect(@fs.readdir(base_path), content=["test"])
     json_inspect(@fs.readdir("\{base_path}/test"), content=["directory"])
     json_inspect(@fs.readdir("\{base_path}/test/directory"), content=[])
@@ -57,7 +57,7 @@ async test "mkdir recursive windows" {
     let base_path = "_build\\recursive_mkdir_windows"
     let path = "\{base_path}\\test\\\\directory"
     @fs.mkdir(path, recursive=true)
-    group.add_defer() <| () => { @fs.rmdir(base_path, recursive=true) }
+    group.add_defer(() => @fs.rmdir(base_path, recursive=true))
     json_inspect(@fs.readdir(base_path), content=["test"])
     json_inspect(@fs.readdir("\{base_path}\\test"), content=["directory"])
     json_inspect(@fs.readdir("\{base_path}\\test/directory"), content=[])

--- a/src/fs/named_pipe_test.mbt
+++ b/src/fs/named_pipe_test.mbt
@@ -25,10 +25,10 @@ async test "cancel named fifo open" {
     if mkfifo(@os_string.encode(path), 0o644) < 0 {
       @os_error.check_errno("mkfifo")
     }
-    group.add_defer() <| () => { @fs.remove(path) }
-    let result = @async.with_timeout_opt(500) <| () => {
-        @fs.open(path, mode=ReadOnly).close()
-      }
+    group.add_defer(() => @fs.remove(path))
+    let result = @async.with_timeout_opt(500, () => {
+      @fs.open(path, mode=ReadOnly).close()
+    })
     debug_inspect(result, content="None")
   }
 }
@@ -48,9 +48,9 @@ async test "cancel named pipe open" {
   defer (try! @fd_util.close(server, kind=Pipe, context~))
   let client1 = @fs.open(path, mode=ReadOnly)
   defer client1.close()
-  let result = @async.with_timeout_opt(500) <| () => {
-      @fs.open(path, mode=ReadOnly).close()
-    }
+  let result = @async.with_timeout_opt(500, () => {
+    @fs.open(path, mode=ReadOnly).close()
+  })
   debug_inspect(result, content="None")
 }
 
@@ -62,13 +62,13 @@ async test "named fifo" {
     if mkfifo(@os_string.encode(path), 0o644) < 0 {
       @os_error.check_errno("mkfifo")
     }
-    group.add_defer() <| () => { @fs.remove(path) }
+    group.add_defer(() => @fs.remove(path))
     group.spawn_bg() <| () => {
       let r = @fs.open(path, mode=ReadOnly)
       defer r.close()
       inspect(r.read_until("\n").unwrap_or(""), content="abcd")
       debug_inspect(
-        @async.with_timeout_opt(250) <| () => { r.read_all().text() },
+        @async.with_timeout_opt(250, () => r.read_all().text()),
         content="None",
       )
       inspect(r.read_all().text(), content="efgh")
@@ -101,7 +101,7 @@ async test "named pipe" {
       defer r.close()
       inspect(r.read_until("\n").unwrap_or(""), content="abcd")
       debug_inspect(
-        @async.with_timeout_opt(250) <| () => { r.read_all().text() },
+        @async.with_timeout_opt(250, () => r.read_all().text()),
         content="None",
       )
       inspect(r.read_all().text(), content="efgh")

--- a/src/fs/realpath_test.mbt
+++ b/src/fs/realpath_test.mbt
@@ -34,7 +34,7 @@ async test "realpath link to absolute" {
     }
     let link_path = "_build/realpath_test_link_to_absolute.test"
     @fs.symlink(link_path, target=path)
-    root.add_defer() <| () => { @fs.remove(link_path) }
+    root.add_defer(() => @fs.remove(link_path))
     let rp = @fs.realpath(link_path)
     assert_true(rp.has_prefix(cwd))
     inspect(rp[cwd.length():], content="/src/fs/realpath_test.mbt")
@@ -49,7 +49,7 @@ async test "realpath link to relative" {
     let rel_path = "../src/fs/realpath_test.mbt"
     let link_path = "_build/realpath_test_link_to_relative.test"
     @fs.symlink(link_path, target=rel_path)
-    root.add_defer() <| () => { @fs.remove(link_path) }
+    root.add_defer(() => @fs.remove(link_path))
     let rp = @fs.realpath(link_path)
     assert_true(rp.has_prefix(cwd))
     inspect(rp[cwd.length():], content="/src/fs/realpath_test.mbt")
@@ -64,7 +64,7 @@ async test "realpath link to dir" {
     let rel_path = "../src/fs"
     let link_path = "_build/realpath_test_link_to_dir.test"
     @fs.symlink(link_path, target=rel_path)
-    root.add_defer() <| () => { @fs.remove(link_path) }
+    root.add_defer(() => @fs.remove(link_path))
     let rp = @fs.realpath(link_path + "/realpath_test.mbt")
     assert_true(rp.has_prefix(cwd))
     inspect(rp[cwd.length():], content="/src/fs/realpath_test.mbt")

--- a/src/fs/stat_test.mbt
+++ b/src/fs/stat_test.mbt
@@ -18,7 +18,7 @@ async test "stat" {
   let link_path = "_build/fs_stat_test"
   @fs.symlink(link_path, target="../LICENSE")
   @async.with_task_group() <| group => {
-    group.add_defer() <| () => { @fs.remove(link_path) }
+    group.add_defer(() => @fs.remove(link_path))
     debug_inspect(@fs.kind(link_path), content="Regular")
     debug_inspect(@fs.kind(link_path, follow_symlink=false), content="SymLink")
   }

--- a/src/fs/text_file_test.mbt
+++ b/src/fs/text_file_test.mbt
@@ -16,7 +16,7 @@
 async test "text file" {
   @async.with_task_group() <| root => {
     let path = "_build/basic_text_file_test"
-    root.add_defer() <| () => { @fs.remove(path) }
+    root.add_defer(() => @fs.remove(path))
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate)
     inspect(@fs.read_file(path).text(), content="abcd")
   }

--- a/src/fs/timestamp_test.mbt
+++ b/src/fs/timestamp_test.mbt
@@ -25,7 +25,7 @@ async test "timestamp for path" {
   let path = "/tmp/timestamp_test"
   @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
-    group.add_defer() <| () => { @fs.remove(path) }
+    group.add_defer(() => @fs.remove(path))
     let mtime_1 = @fs.mtime(path)
     let ctime_1 = @fs.ctime(path)
     @async.sleep(600)
@@ -59,7 +59,7 @@ async test "mtime for path" {
   let path = "_build/timestamp_test"
   @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
-    group.add_defer() <| () => { @fs.remove(path) }
+    group.add_defer(() => @fs.remove(path))
     let mtime_1 = @fs.mtime(path)
     let ctime_1 = @fs.ctime(path)
     @async.sleep(600)
@@ -77,7 +77,7 @@ async test "timestamp for opened file" {
   let path = "/tmp/opened_file_timestamp_test"
   @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
-    group.add_defer() <| () => { @fs.remove(path) }
+    group.add_defer(() => @fs.remove(path))
     let file = @fs.open(path, mode=ReadWrite, sync=Full)
     defer file.close()
     let mtime_1 = file.mtime()
@@ -114,7 +114,7 @@ async test "mtime for opened file" {
   let path = "_build/opened_file_timestamp_test"
   @async.with_task_group() <| group => {
     @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
-    group.add_defer() <| () => { @fs.remove(path) }
+    group.add_defer(() => @fs.remove(path))
     let file = @fs.open(path, mode=ReadWrite, sync=Full)
     defer file.close()
     let mtime_1 = file.mtime()

--- a/src/fs/tmpdir_test.mbt
+++ b/src/fs/tmpdir_test.mbt
@@ -17,11 +17,11 @@ async test "tmpdir" {
   @async.with_task_group() <| group => {
     let t1 = @fs.tmpdir(prefix="tmp")
     group.add_defer() <| () => {
-      @async.protect_from_cancel() <| () => { @fs.rmdir(t1, recursive=true) }
+      @async.protect_from_cancel(() => @fs.rmdir(t1, recursive=true))
     }
     let t2 = @fs.tmpdir(prefix="tmp")
     group.add_defer() <| () => {
-      @async.protect_from_cancel() <| () => { @fs.rmdir(t2, recursive=true) }
+      @async.protect_from_cancel(() => @fs.rmdir(t2, recursive=true))
     }
     assert_not_eq(t1, t2)
     assert_true(@fs.exists(t1))

--- a/src/fs/walk_test.mbt
+++ b/src/fs/walk_test.mbt
@@ -15,7 +15,7 @@
 ///|
 async test "walk sequential" {
   let dirs = []
-  @fs.walk("test_directory", max_concurrency=1) <| ((path, files) => {
+  @fs.walk("test_directory", max_concurrency=1, (path, files) => {
     files.sort()
     dirs.push((path, files))
   })
@@ -31,7 +31,7 @@ async test "walk parallel" {
   @async.sleep(300)
   let log = StringBuilder::new()
   let mut i = 0
-  @fs.walk("test_directory", max_concurrency=2) <| ((path, _) => {
+  @fs.walk("test_directory", max_concurrency=2, (path, _) => {
     i = i + 1
     log.write_string("handling \{path}\n")
     @async.sleep(if i == 1 { 200 } else { 300 })
@@ -55,10 +55,10 @@ async test "walk parallel" {
 async test "walk failure" {
   let log = StringBuilder::new()
   debug_inspect(
-    try? (@fs.walk("test_directory", max_concurrency=1) <| ((path, _) => {
+    try? @fs.walk("test_directory", max_concurrency=1, (path, _) => {
       log.write_string("handling \{path}\n")
       raise Failure::Failure("failure when handling directory")
-    })),
+    }),
     content=(
       #|Err(Failure("failure when handling directory"))
     ),
@@ -76,13 +76,13 @@ async test "walk failure" {
 async test "walk allow_failure" {
   let log = StringBuilder::new()
   debug_inspect(
-    try? (@fs.walk("test_directory", allow_failure=true, max_concurrency=1) <| ((
+    try? @fs.walk("test_directory", allow_failure=true, max_concurrency=1, (
       path,
       _,
     ) => {
       log.write_string("handling \{path}\n")
       raise Failure::Failure("failure when handling directory")
-    })),
+    }),
     content="Ok(())",
   )
   inspect(
@@ -99,7 +99,7 @@ async test "walk allow_failure" {
 ///|
 async test "walk exclude 1" {
   let walked = []
-  @fs.walk("test_directory", exclude=p => p is [.., '1']) <| ((path, _) => {
+  @fs.walk("test_directory", exclude=p => p is [.., '1'], (path, _) => {
     walked.push(path)
   })
   json_inspect(walked, content=["test_directory"])
@@ -108,7 +108,7 @@ async test "walk exclude 1" {
 ///|
 async test "walk exclude 2" {
   let walked = []
-  @fs.walk("test_directory", exclude=p => p is [.., '2']) <| ((path, _) => {
+  @fs.walk("test_directory", exclude=p => p is [.., '2'], (path, _) => {
     walked.push(path)
   })
   json_inspect(walked, content=["test_directory", "test_directory/inner1"])

--- a/src/group_defer_test.mbt
+++ b/src/group_defer_test.mbt
@@ -16,18 +16,18 @@
 async test "group defer basic" {
   let log = StringBuilder::new()
   @async.with_task_group() <| fn(root) {
-    root.add_defer() <| () => { log <+ "first group defer\n" }
+    root.add_defer(() => log <+ "first group defer\n")
     root.spawn_bg() <| () => {
       defer log.write_string("defer for first task\n")
       @async.sleep(200)
-      root.add_defer() <| () => { log <+ "third group defer\n" }
+      root.add_defer(() => log <+ "third group defer\n")
       @async.sleep(200)
       log <+ "first task finished\n"
     }
     root.spawn_bg() <| () => {
       defer log.write_string("defer for second task\n")
       @async.sleep(100)
-      root.add_defer() <| () => { log <+ "second group defer\n" }
+      root.add_defer(() => log <+ "second group defer\n")
       @async.sleep(200)
       log <+ "second task finished\n"
     }
@@ -57,19 +57,19 @@ async test "group defer error" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| fn(root) {
-        root.add_defer() <| () => { log <+ "first group defer\n" }
+      try? @async.with_task_group(fn(root) {
+        root.add_defer(() => log <+ "first group defer\n")
         root.spawn_bg() <| () => {
           defer log.write_string("defer for first task\n")
           @async.sleep(200)
-          root.add_defer() <| () => { log <+ "third group defer\n" }
+          root.add_defer(() => log <+ "third group defer\n")
           @async.sleep(200)
           log <+ "first task finished\n"
         }
         root.spawn_bg() <| () => {
           defer log.write_string("defer for second task\n")
           @async.sleep(100)
-          root.add_defer() <| () => { log <+ "second group defer\n" }
+          root.add_defer(() => log <+ "second group defer\n")
           @async.sleep(200)
           log <+ "second task raise error\n"
           raise Err
@@ -106,15 +106,15 @@ async test "group defer cancelled" {
         log <+ "tick\n"
       }
     }
-    (@async.with_timeout_opt(500) <| () => {
-      @async.with_task_group() <| group => {
-        group.add_defer() <| () => {
+    @async.with_timeout_opt(500, () => {
+      @async.with_task_group(group => {
+        group.add_defer(() => {
           @async.protect_from_cancel() <| () => {
             @async.sleep(200)
             log <+ "protected async defer completed\n"
           }
-        }
-        group.add_defer() <| () => {
+        })
+        group.add_defer(() => {
           try @async.sleep(200) catch {
             err => {
               log.write_string("normal async defer cancelled with \{err}\n")
@@ -123,10 +123,10 @@ async test "group defer cancelled" {
           } noraise {
             _ => log <+ "normal async defer completed\n"
           }
-        }
+        })
         defer log.write_string("start group termination\n")
         @async.sleep(2000)
-      }
+      })
     })
     |> ignore
     log <+ "group terminated\n"

--- a/src/gzip/gzip_test.mbt
+++ b/src/gzip/gzip_test.mbt
@@ -17,9 +17,9 @@
 async fn node_gzip(mode : String, input : Bytes) -> Bytes {
   @async.with_task_group() <| group => {
     let (stdin, we_write) = @process.write_to_process()
-    let runner = group.spawn() <| () => {
-        @process.collect_output("node", ["src/gzip/node_gzip.js", mode], stdin~)
-      }
+    let runner = group.spawn(() => {
+      @process.collect_output("node", ["src/gzip/node_gzip.js", mode], stdin~)
+    })
     group.spawn_bg() <| () => {
       defer we_write.close()
       we_write.write(input)
@@ -97,7 +97,7 @@ async test "encode decode roundtrip" {
 ///|
 async test "encoder uses valid blocks across large writes" {
   @async.with_task_group() <| root => {
-    let payload = Bytes::makei(70000) <| i => { (i % 251).to_byte() }
+    let payload = Bytes::makei(70000, i => (i % 251).to_byte())
     let (compressed_r, compressed_w) = @io.pipe()
     root.spawn_bg() <| () => {
       defer compressed_w.close()
@@ -241,9 +241,7 @@ async test "node compatibility on source text file" {
 ///|
 #cfg(target="native")
 async test "node compatibility on generated binary data" {
-  let input = Bytes::makei(65536 + 257) <| i => {
-      ((i * 73 + 19) & 0xff).to_byte()
-    }
+  let input = Bytes::makei(65536 + 257, i => ((i * 73 + 19) & 0xff).to_byte())
   assert_node_compatibility(input)
 }
 

--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -84,8 +84,8 @@ extern "js" fn Server::create(
 ///|
 #cfg(target="js")
 async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
-  let server = (Server::create() <| msg => { log.write_string(msg) }).wait()
-  group.add_defer() <| () => { server.close() }
+  let server = Server::create(msg => log.write_string(msg)).wait()
+  group.add_defer(() => server.close())
   server.port()
 }
 

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -729,15 +729,15 @@ test "should_read_body_until_close - false cases (HEAD requests)" {
 
 ///|
 async test "gzip split between chunks" {
-  let compressed = @async.with_task_group() <| group => {
-      let (r, w) = @io.pipe()
-      group.spawn_bg() <| () => {
-        defer w.close()
-        @gzip_stream.Encoder(w)..write("A simple message to compress").end()
-      }
-      defer r.close()
-      r.read_all().binary()
+  let compressed = @async.with_task_group(group => {
+    let (r, w) = @io.pipe()
+    group.spawn_bg() <| () => {
+      defer w.close()
+      @gzip_stream.Encoder(w)..write("A simple message to compress").end()
     }
+    defer r.close()
+    r.read_all().binary()
+  })
   let (r, w) = @io.pipe()
   @async.with_task_group() <| group => {
     group.spawn_bg() <| () => {

--- a/src/http/proxy_test.mbt
+++ b/src/http/proxy_test.mbt
@@ -104,8 +104,8 @@ async fn handle_connect(
   conn..send_response(200, "OK").end_response()
   conn.enter_passthrough_mode()
   @async.with_task_group() <| group => {
-    group.spawn_bg() <| () => { conn.write_reader(client) }
-    group.spawn_bg() <| () => { client.write_reader(conn) }
+    group.spawn_bg(() => conn.write_reader(client))
+    group.spawn_bg(() => client.write_reader(conn))
   }
 }
 
@@ -120,12 +120,12 @@ async test "proxied https request" {
         handle_connect(log, req, body, conn)
       })
     }
-    let (_, result) = @async.with_timeout(10000) <| () => {
-        @http.get(
-          "https://www.moonbitlang.com",
-          proxy=@http.Client("http://localhost:\{port}"),
-        )
-      }
+    let (_, result) = @async.with_timeout(10000, () => {
+      @http.get(
+        "https://www.moonbitlang.com",
+        proxy=@http.Client("http://localhost:\{port}"),
+      )
+    })
     assert_true(result.text().has_prefix("<!doctype html>"))
   }
   json_inspect(log, content=[

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -27,11 +27,11 @@ async test "http request" {
 ///|
 async test "request cancel" {
   let start = @async.now()
-  let _ = @async.with_timeout_opt(200) <| () => {
-      @http.get(
-        "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz",
-      )
-    }
+  let _ = @async.with_timeout_opt(200, () => {
+    @http.get(
+      "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz",
+    )
+  })
   let end = @async.now()
   assert_true((end - start).to_int() < 250)
 }

--- a/src/integration.mbt
+++ b/src/integration.mbt
@@ -19,7 +19,7 @@
 #cfg(target="native")
 #doc(hidden)
 pub fn run_async_main(main : async () -> Unit) -> Unit {
-  (@event_loop.with_event_loop() <| () => { main() }) catch {
+  @event_loop.with_event_loop(() => main()) catch {
     @event_loop.KilledBySignal(signal) => exit(128 + signal)
     err => {
       // TODO: output the error to stderr

--- a/src/internal/coroutine/pause_test.mbt
+++ b/src/internal/coroutine/pause_test.mbt
@@ -15,24 +15,24 @@
 ///|
 test "coroutine ping-pong" {
   let log = StringBuilder::new()
-  let coro = @coroutine.spawn() <| () => {
-      @async.with_task_group() <| group => {
-        group.spawn_bg() <| () => {
-          log <+ "ping\n"
-          @async.pause()
-          log <+ "ping\n"
-          @async.pause()
-          log <+ "ping\n"
-        }
-        group.spawn_bg() <| () => {
-          log <+ "pong\n"
-          @async.pause()
-          log <+ "pong\n"
-          @async.pause()
-          log <+ "pong\n"
-        }
+  let coro = @coroutine.spawn(() => {
+    @async.with_task_group(group => {
+      group.spawn_bg() <| () => {
+        log <+ "ping\n"
+        @async.pause()
+        log <+ "ping\n"
+        @async.pause()
+        log <+ "ping\n"
       }
-    }
+      group.spawn_bg() <| () => {
+        log <+ "pong\n"
+        @async.pause()
+        log <+ "pong\n"
+        @async.pause()
+        log <+ "pong\n"
+      }
+    })
+  })
   while !@coroutine.no_more_work() {
     @coroutine.reschedule()
   }

--- a/src/internal/event_loop/cancel_before_submit_test.mbt
+++ b/src/internal/event_loop/cancel_before_submit_test.mbt
@@ -17,10 +17,10 @@ async test "cancel before submit" {
   let file = @fs.open("LICENSE", mode=ReadOnly)
   defer file.close()
   let buf = FixedArray::make(1, b'\x00')
-  let result = @async.with_timeout_opt(1) <| () => {
-      while file._direct_read(buf, offset=0, max_len=1) is 1 {
+  let result = @async.with_timeout_opt(1, () => {
+    while file._direct_read(buf, offset=0, max_len=1) is 1 {
 
-      }
     }
+  })
   debug_inspect(result, content="None")
 }

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -193,16 +193,16 @@ pub fn with_event_loop(f : async () -> Unit) -> Unit raise {
     }
   }
   let signal_handler = setup_signal_handler()
-  let main = @coroutine.spawn() <| () => {
-      try f() catch {
-        err => {
-          evloop.terminate_signal_handler(signal_handler)
-          raise err
-        }
-      } noraise {
-        _ => evloop.terminate_signal_handler(signal_handler)
+  let main = @coroutine.spawn(() => {
+    try f() catch {
+      err => {
+        evloop.terminate_signal_handler(signal_handler)
+        raise err
       }
+    } noraise {
+      _ => evloop.terminate_signal_handler(signal_handler)
     }
+  })
   evloop.main = Some(main)
   evloop.run_forever()
   main.unwrap()

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -75,7 +75,7 @@ async fn EventLoop::terminate_signal_handler(
   sigwait_task : @coroutine.Coroutine,
 ) -> Unit {
   sigwait_task.cancel()
-  (@coroutine.protect_from_cancel() <| () => { sigwait_task.wait() }) catch {
+  @coroutine.protect_from_cancel(() => sigwait_task.wait()) catch {
     @coroutine.Cancelled => ()
     err => raise err
   }

--- a/src/internal/event_loop/worker_wbtest.mbt
+++ b/src/internal/event_loop/worker_wbtest.mbt
@@ -94,16 +94,16 @@ async test "worker cancel1" {
         log <+ "tick\n"
       }
     }
-    let task = root.spawn() <| () => {
-        try perform_sleep_job(1000) catch {
-          err => {
-            log.write_string("sleep cancelled with \{err}\n")
-            raise err
-          }
-        } noraise {
-          _ => log <+ "done\n"
+    let task = root.spawn(() => {
+      try perform_sleep_job(1000) catch {
+        err => {
+          log.write_string("sleep cancelled with \{err}\n")
+          raise err
         }
+      } noraise {
+        _ => log <+ "done\n"
       }
+    })
     @async.sleep(500)
     log <+ "trying to cancel\n"
     task.cancel()

--- a/src/internal/gzip_internal/crc32.mbt
+++ b/src/internal/gzip_internal/crc32.mbt
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 ///|
-let crc32_table : FixedArray[UInt] = FixedArray::makei(256) <| i => {
-    let mut crc = i.reinterpret_as_uint()
-    for _ in 0..<8 {
-      crc = if (crc & 1U) == 0U { crc >> 1 } else { (crc >> 1) ^ 0xedb88320U }
-    }
-    crc
+let crc32_table : FixedArray[UInt] = FixedArray::makei(256, i => {
+  let mut crc = i.reinterpret_as_uint()
+  for _ in 0..<8 {
+    crc = if (crc & 1U) == 0U { crc >> 1 } else { (crc >> 1) ^ 0xedb88320U }
   }
+  crc
+})
 
 ///|
 fn crc32_update(current : UInt, chunk : BytesView) -> UInt {

--- a/src/io/read_all_test.mbt
+++ b/src/io/read_all_test.mbt
@@ -32,7 +32,7 @@ async test "read_all basic" {
   @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg() <| () => { writer(log, w) }
+    root.spawn_bg(() => writer(log, w))
     inspect(r.read_all().text(), content="abcdefghijkl")
   }
 }

--- a/src/io/read_some_test.mbt
+++ b/src/io/read_some_test.mbt
@@ -18,7 +18,7 @@ async test "read_some basic" {
   @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg() <| () => { writer(log, w) }
+    root.spawn_bg(() => writer(log, w))
     while r.read_some() is Some(chunk) {
       log.write_string("received chunk: \{@utf8.decode(chunk)}\n")
     }
@@ -43,7 +43,7 @@ async test "read_some length limit 1" {
   @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg() <| () => { writer(log, w) }
+    root.spawn_bg(() => writer(log, w))
     while r.read_some(max_len=2) is Some(chunk) {
       log.write_string("received chunk: \{@utf8.decode(chunk)}\n")
     }
@@ -71,7 +71,7 @@ async test "read_some length limit 2" {
   @async.with_task_group() <| root => {
     let (r, w) = @io.pipe()
     defer r.close()
-    root.spawn_bg() <| () => { writer(log, w) }
+    root.spawn_bg(() => writer(log, w))
     for max_len = 2; ; max_len = max_len * 2 {
       guard r.read_some(max_len~) is Some(chunk) else { break }
       log.write_string("received chunk: \{@utf8.decode(chunk)}\n")

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -90,7 +90,7 @@ impl @io.Writer for DummyWriter with write_once(self, buf, offset~, len~) {
 async test "write cancel" {
   let log = StringBuilder::new()
   let writer = { logger: log, base_timeout: 300 }
-  (@async.with_timeout_opt(450) <| () => { writer.write(b"abcd") }) |> ignore
+  @async.with_timeout_opt(450, () => writer.write(b"abcd")) |> ignore
   // The `write` here is partial and corrupted,
   // but we have no choice because making `write` atomic may cause hang
   inspect(

--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -201,20 +201,20 @@ pub fn[X] Promise::from_async(
   f : async () -> X,
   abort_signal? : AbortSignal,
 ) -> Promise[X] {
-  let promise = JsValue::new_promise() <| ((resolve, reject) => {
-      let coro = @coroutine.spawn() <| () => {
-          try f() catch {
-            @coroutine.Cancelled if @coroutine.is_being_cancelled() =>
-              reject(JsValue::abort_error())
-            err => reject(JsValue::make(err.to_string()))
-          } noraise {
-            ret => resolve(JsValue::make(ret))
-          }
-        }
-      if abort_signal is Some(signal) {
-        signal.on_abort() <| () => { coro.cancel() }
+  let promise = JsValue::new_promise((resolve, reject) => {
+    let coro = @coroutine.spawn(() => {
+      try f() catch {
+        @coroutine.Cancelled if @coroutine.is_being_cancelled() =>
+          reject(JsValue::abort_error())
+        err => reject(JsValue::make(err.to_string()))
+      } noraise {
+        ret => resolve(JsValue::make(ret))
       }
     })
+    if abort_signal is Some(signal) {
+      signal.on_abort(() => coro.cancel())
+    }
+  })
   @coroutine.reschedule()
   promise.cast()
 }

--- a/src/js_async/js_async_test.mbt
+++ b/src/js_async/js_async_test.mbt
@@ -14,19 +14,19 @@
 
 ///|
 async test "Promise::from_async" {
-  let result = @js_async.run_promise() <| abort_signal => {
-      @js_async.Promise::from_async(abort_signal~) <| () => {
-        @async.sleep(100)
-        42
-      }
+  let result = @js_async.run_promise(abort_signal => {
+    @js_async.Promise::from_async(abort_signal~) <| () => {
+      @async.sleep(100)
+      42
     }
+  })
   inspect(result, content="42")
 }
 
 ///|
 async test "Promise::from_async cancellation" {
   let mut worker_finished = false
-  let result = try? (@async.with_timeout(100) <| () => {
+  let result = try? @async.with_timeout(100, () => {
     @js_async.run_promise() <| abort_signal => {
       @js_async.Promise::from_async(abort_signal~) <| () => {
         @async.sleep(200)
@@ -41,9 +41,9 @@ async test "Promise::from_async cancellation" {
 ///|
 async test "Promise::from_async cancellation 2" {
   let controller = @js_async.AbortController::new()
-  let p = @js_async.Promise::from_async(abort_signal=controller.signal()) <| () => {
-      @async.sleep(200)
-    }
+  let p = @js_async.Promise::from_async(abort_signal=controller.signal(), () => {
+    @async.sleep(200)
+  })
   @async.sleep(100)
   controller.abort()
   debug_inspect(
@@ -57,9 +57,9 @@ async test "Promise::from_async cancellation 2" {
 ///|
 async test "Promise::from_async cancellation 3" {
   let controller = @js_async.AbortController::new()
-  let p = @js_async.Promise::from_async(abort_signal=controller.signal()) <| () => {
-      @async.sleep(100)
-    }
+  let p = @js_async.Promise::from_async(abort_signal=controller.signal(), () => {
+    @async.sleep(100)
+  })
   @async.sleep(200)
   controller.abort()
   debug_inspect(try? p.wait(), content="Ok(())")
@@ -79,9 +79,9 @@ async test "read dir" {
 
 ///|
 async test "read file" {
-  let content = @js_async.run_promise() <| signal => {
-      (fsPromises.readFile)("LICENSE", { encoding: "utf8", signal })
-    }
+  let content = @js_async.run_promise(signal => {
+    (fsPromises.readFile)("LICENSE", { encoding: "utf8", signal })
+  })
   inspect(
     content,
     content=(

--- a/src/js_async/readable_stream.mbt
+++ b/src/js_async/readable_stream.mbt
@@ -103,15 +103,15 @@ pub fn ReadableStream::from_js(stream : JsReadableStream) -> ReadableStream {
   // because the `.read()` method of `StreamReader` is NOT cancellable.
   // It can only be cancelled by cancelling the whole stream.
   // So we use a `@io.pipe` in the middle to provide proper cancellation support.
-  let worker = @coroutine.spawn() <| () => {
-      defer w.close()
-      defer stream.cancel()
-      let reader = stream.get_reader()
-      defer reader.release_lock()
-      while reader.read() is Some(chunk) {
-        w.write(chunk)
-      }
+  let worker = @coroutine.spawn(() => {
+    defer w.close()
+    defer stream.cancel()
+    let reader = stream.get_reader()
+    defer reader.release_lock()
+    while reader.read() is Some(chunk) {
+      w.write(chunk)
     }
+  })
   { read_end: r, worker }
 }
 

--- a/src/js_async/readable_stream_test.mbt
+++ b/src/js_async/readable_stream_test.mbt
@@ -56,12 +56,9 @@ async test "ReadableStream read cancelled" {
   let r = @js_async.ReadableStream::from_js(r)
   defer w.close()
   defer r.close()
-  json_inspect(
-    @async.with_timeout_opt(300) <| () => { r.read_some() },
-    content=null,
-  )
+  json_inspect(@async.with_timeout_opt(300, () => r.read_some()), content=null)
   w.write("message")
-  json_inspect(@async.with_timeout_opt(300) <| () => { r.read_some() }, content=[
+  json_inspect(@async.with_timeout_opt(300, () => r.read_some()), content=[
     ["message"],
   ])
 }
@@ -76,18 +73,17 @@ async test "ReadableStream write cancelled" {
   w.write("message1")
   w.write("message2")
   json_inspect(
-    @async.with_timeout_opt(300) <| () => { w.write("message3") },
+    @async.with_timeout_opt(300, () => w.write("message3")),
     content=null,
   )
   for _ in 0..<2 {
     msgs.push(r.read_some())
   }
   @async.with_task_group() <| group => {
-    group.spawn_bg() <| () => { msgs.push(r.read_some()) }
-    json_inspect(
-      @async.with_timeout_opt(300) <| () => { w.write("message4") },
-      content=[null],
-    )
+    group.spawn_bg(() => msgs.push(r.read_some()))
+    json_inspect(@async.with_timeout_opt(300, () => w.write("message4")), content=[
+      null,
+    ])
   }
   json_inspect(msgs, content=[["message1"], ["message2"], ["message4"]])
 }

--- a/src/lazy_init.mbt
+++ b/src/lazy_init.mbt
@@ -46,21 +46,21 @@ pub async fn[X] Lazy::wait(self : Lazy[X]) -> X {
     Fail(err) => raise err
     Running(_) => ()
     Uninitialized => {
-      let coro = @coroutine.spawn() <| () => {
-          try (self.worker)() catch {
-            err =>
-              if err is @coroutine.Cancelled && is_being_cancelled() {
-                self.state = Uninitialized
-              } else {
-                self.state = Fail(err)
-              }
-          } noraise {
-            ret => self.state = Done(ret)
-          }
-          for waiter in self.waiters {
-            waiter.wake()
-          }
+      let coro = @coroutine.spawn(() => {
+        try (self.worker)() catch {
+          err =>
+            if err is @coroutine.Cancelled && is_being_cancelled() {
+              self.state = Uninitialized
+            } else {
+              self.state = Fail(err)
+            }
+        } noraise {
+          ret => self.state = Done(ret)
         }
+        for waiter in self.waiters {
+          waiter.wake()
+        }
+      })
       self.state = Running(coro)
     }
   }

--- a/src/lazy_init_test.mbt
+++ b/src/lazy_init_test.mbt
@@ -20,11 +20,11 @@ async test "lazy init basic" {
     (@async.now() - start + 20).to_int() / 200
   }
 
-  let x = @async.Lazy() <| () => {
-      log.push("lazy init started at tick \{current_tick()}")
-      @async.sleep(200)
-      log.push("lazy init completed at tick \{current_tick()}")
-    }
+  let x = @async.Lazy(() => {
+    log.push("lazy init started at tick \{current_tick()}")
+    @async.sleep(200)
+    log.push("lazy init completed at tick \{current_tick()}")
+  })
   @async.sleep(200)
   x.wait()
   log.push("got lazy init result at tick \{current_tick()}")
@@ -38,10 +38,10 @@ async test "lazy init basic" {
 
 ///|
 async test "lazy init failure" {
-  let x : @async.Lazy[Unit] = @async.Lazy() <| () => {
-      @async.sleep(200)
-      raise Failure::Failure("msg")
-    }
+  let x : @async.Lazy[Unit] = @async.Lazy(() => {
+    @async.sleep(200)
+    raise Failure::Failure("msg")
+  })
   let start = @async.now()
   fn current_tick() -> Int {
     (@async.now() - start + 20).to_int() / 200
@@ -73,20 +73,17 @@ async test "lazy init cancelled" {
     (@async.now() - start + 20).to_int() / 200
   }
 
-  let x = @async.Lazy() <| () => {
-      log.push("lazy init started at tick \{current_tick()}")
-      @async.sleep(400) catch {
-        err => {
-          log.push("lazy init cancelled at tick \{current_tick()}")
-          raise err
-        }
+  let x = @async.Lazy(() => {
+    log.push("lazy init started at tick \{current_tick()}")
+    @async.sleep(400) catch {
+      err => {
+        log.push("lazy init cancelled at tick \{current_tick()}")
+        raise err
       }
-      log.push("lazy init completed at tick \{current_tick()}")
     }
-  debug_inspect(
-    @async.with_timeout_opt(200) <| () => { x.wait() },
-    content="None",
-  )
+    log.push("lazy init completed at tick \{current_tick()}")
+  })
+  debug_inspect(@async.with_timeout_opt(200, () => x.wait()), content="None")
   @async.sleep(100)
   // the previous attempt is already cancelled,
   // this `wait` will trigger a new attempt
@@ -105,23 +102,23 @@ async test "lazy init multiple waiters 1" {
     (@async.now() - start + 20).to_int() / 200
   }
 
-  let x = @async.Lazy() <| () => {
-      log.push("lazy init started at tick \{current_tick()}")
-      @async.sleep(400) catch {
-        err => {
-          log.push("lazy init cancelled at tick \{current_tick()}")
-          raise err
-        }
+  let x = @async.Lazy(() => {
+    log.push("lazy init started at tick \{current_tick()}")
+    @async.sleep(400) catch {
+      err => {
+        log.push("lazy init cancelled at tick \{current_tick()}")
+        raise err
       }
-      log.push("lazy init completed at tick \{current_tick()}")
     }
-  let result = @async.with_task_group() <| group => {
-      group.spawn_bg() <| () => {
-        x.wait()
-        log.push("got lazy init value at tick \{current_tick()}")
-      }
-      @async.with_timeout_opt(200) <| () => { x.wait() }
+    log.push("lazy init completed at tick \{current_tick()}")
+  })
+  let result = @async.with_task_group(group => {
+    group.spawn_bg() <| () => {
+      x.wait()
+      log.push("got lazy init value at tick \{current_tick()}")
     }
+    @async.with_timeout_opt(200, () => x.wait())
+  })
   debug_inspect(result, content="None")
   json_inspect(log, content=[
     "lazy init started at tick 0", "lazy init completed at tick 2", "got lazy init value at tick 2",
@@ -136,26 +133,26 @@ async test "lazy init multiple waiters 2" {
     (@async.now() - start + 20).to_int() / 200
   }
 
-  let x = @async.Lazy() <| () => {
-      log.push("lazy init started at tick \{current_tick()}")
-      @async.sleep(600) catch {
-        err => {
-          log.push("lazy init cancelled at tick \{current_tick()}")
-          raise err
-        }
+  let x = @async.Lazy(() => {
+    log.push("lazy init started at tick \{current_tick()}")
+    @async.sleep(600) catch {
+      err => {
+        log.push("lazy init cancelled at tick \{current_tick()}")
+        raise err
       }
-      log.push("lazy init completed at tick \{current_tick()}")
     }
+    log.push("lazy init completed at tick \{current_tick()}")
+  })
   @async.with_task_group() <| group => {
     group.spawn_bg() <| () => {
       debug_inspect(
-        @async.with_timeout_opt(200) <| () => { x.wait() },
+        @async.with_timeout_opt(200, () => x.wait()),
         content="None",
       )
     }
     group.spawn_bg() <| () => {
       debug_inspect(
-        @async.with_timeout_opt(400) <| () => { x.wait() },
+        @async.with_timeout_opt(400, () => x.wait()),
         content="None",
       )
     }

--- a/src/process/cancel_test.mbt
+++ b/src/process/cancel_test.mbt
@@ -19,10 +19,10 @@ async test "cancel process" {
   let log = StringBuilder::new()
   @async.with_task_group() <| root => {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn() <| () => {
-        defer log.write_string("process terminates\n")
-        @process.run(test_prog, ["10000"], stdout=w)
-      }
+    let task = root.spawn(() => {
+      defer log.write_string("process terminates\n")
+      @process.run(test_prog, ["10000"], stdout=w)
+    })
     root.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(data) {
@@ -50,22 +50,22 @@ async test "cancel process timeout" {
   let test_prog = sleep_prog.wait()
   @async.with_task_group() <| root => {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn() <| () => {
-        @process.run(
-          test_prog,
-          ["-swallow-cancel-signal", "10000"],
-          stdout=w,
-          cancel_handler=@process.graceful_cancel(timeout=500),
-        )
-      }
-    let t_receive_graceful_termination = root.spawn() <| () => {
-        defer r.close()
-        guard r.read_some() is Some(data)
-        let data = @utf8.decode(data).trim_end(chars="\r\n")
-        let t = @async.now()
-        inspect(data, content="received termination signal")
-        t
-      }
+    let task = root.spawn(() => {
+      @process.run(
+        test_prog,
+        ["-swallow-cancel-signal", "10000"],
+        stdout=w,
+        cancel_handler=@process.graceful_cancel(timeout=500),
+      )
+    })
+    let t_receive_graceful_termination = root.spawn(() => {
+      defer r.close()
+      guard r.read_some() is Some(data)
+      let data = @utf8.decode(data).trim_end(chars="\r\n")
+      let t = @async.now()
+      inspect(data, content="received termination signal")
+      t
+    })
     @async.sleep(500)
     let t_cancel = @async.now()
     task.cancel()
@@ -83,14 +83,14 @@ async test "cancel process hard" {
   let test_prog = sleep_prog.wait()
   @async.with_task_group() <| root => {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn() <| () => {
-        @process.run(
-          test_prog,
-          ["10000"],
-          stdout=w,
-          cancel_handler=@process.hard_cancel(),
-        )
-      }
+    let task = root.spawn(() => {
+      @process.run(
+        test_prog,
+        ["10000"],
+        stdout=w,
+        cancel_handler=@process.hard_cancel(),
+      )
+    })
     root.spawn_bg() <| () => {
       defer r.close()
       inspect(r.read_all().text(), content="")
@@ -109,15 +109,15 @@ async test "orphan process" {
   let log = StringBuilder::new()
   @async.with_task_group() <| root => {
     let (r, w) = @process.read_from_process()
-    let task = root.spawn() <| () => {
-        defer log.write_string("process terminates\n")
-        let pid = @process.spawn_orphan(
-          shell,
-          ["-c", "\{write_stdout} first; sleep 1; \{write_stdout} second"],
-          stdout=w,
-        )
-        @process.wait_pid(pid)
-      }
+    let task = root.spawn(() => {
+      defer log.write_string("process terminates\n")
+      let pid = @process.spawn_orphan(
+        shell,
+        ["-c", "\{write_stdout} first; sleep 1; \{write_stdout} second"],
+        stdout=w,
+      )
+      @process.wait_pid(pid)
+    })
     defer r.close()
     inspect(@utf8.decode(r.read_exactly(5)), content="first")
     task.cancel()
@@ -141,7 +141,7 @@ async test "kill children on hard cancel" {
   let sleep = sleep_prog.wait()
   let (r, w) = @process.read_from_process()
   defer r.close()
-  (@async.with_timeout(300) <| () => {
+  @async.with_timeout(300, () => {
     @process.run(
       spawn,
       [sleep, "450", "-print-after-sleep", "after sleep"],

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -137,7 +137,7 @@ pub async fn run(
     _ if @coroutine.is_being_cancelled() =>
       @async.protect_from_cancel() <| () => {
         @async.with_task_group() <| group => {
-          group.spawn_bg(no_wait=true) <| () => { cancel_handler(pid) }
+          group.spawn_bg(no_wait=true, () => cancel_handler(pid))
           process.wait_pid(context~)
         }
       }
@@ -215,19 +215,19 @@ pub async fn[X] spawn(
     context~,
   )
   let pid = process.pid()
-  let result = group.spawn(no_wait?) <| () => {
-      defer process.close()
-      process.wait_pid(context~) catch {
-        _ if @coroutine.is_being_cancelled() =>
-          @async.protect_from_cancel() <| () => {
-            @async.with_task_group() <| group => {
-              group.spawn_bg(no_wait=true) <| () => { cancel_handler(pid) }
-              process.wait_pid(context~)
-            }
+  let result = group.spawn(no_wait?, () => {
+    defer process.close()
+    process.wait_pid(context~) catch {
+      _ if @coroutine.is_being_cancelled() =>
+        @async.protect_from_cancel() <| () => {
+          @async.with_task_group() <| group => {
+            group.spawn_bg(no_wait=true, () => cancel_handler(pid))
+            process.wait_pid(context~)
           }
-        err => raise err
-      }
+        }
+      err => raise err
     }
+  })
   { pid, result }
 }
 
@@ -248,18 +248,9 @@ pub async fn collect_stdout(
   let (r, w) = read_from_process()
   @async.with_task_group() <| group => {
     defer r.close()
-    let exit_code = group.spawn() <| () => {
-        run(
-          cmd,
-          args,
-          extra_env~,
-          inherit_env~,
-          stdin?,
-          stdout=w,
-          stderr?,
-          cwd?,
-        )
-      }
+    let exit_code = group.spawn(() => {
+      run(cmd, args, extra_env~, inherit_env~, stdin?, stdout=w, stderr?, cwd?)
+    })
     let output = r.read_all()
     (exit_code.wait(), output)
   }
@@ -282,18 +273,9 @@ pub async fn collect_stderr(
   let (r, w) = read_from_process()
   @async.with_task_group() <| group => {
     defer r.close()
-    let exit_code = group.spawn() <| () => {
-        run(
-          cmd,
-          args,
-          extra_env~,
-          inherit_env~,
-          stdin?,
-          stdout?,
-          stderr=w,
-          cwd?,
-        )
-      }
+    let exit_code = group.spawn(() => {
+      run(cmd, args, extra_env~, inherit_env~, stdin?, stdout?, stderr=w, cwd?)
+    })
     let output = r.read_all()
     (exit_code.wait(), output)
   }
@@ -316,26 +298,26 @@ pub async fn collect_output(
   let (r_out, w_out) = read_from_process()
   let (r_err, w_err) = read_from_process()
   @async.with_task_group() <| group => {
-    let exit_code = group.spawn() <| () => {
-        run(
-          cmd,
-          args,
-          extra_env~,
-          inherit_env~,
-          stdin?,
-          stdout=w_out,
-          stderr=w_err,
-          cwd?,
-        )
-      }
-    let stdout = group.spawn() <| () => {
-        defer r_out.close()
-        r_out.read_all()
-      }
-    let stderr = group.spawn() <| () => {
-        defer r_err.close()
-        r_err.read_all()
-      }
+    let exit_code = group.spawn(() => {
+      run(
+        cmd,
+        args,
+        extra_env~,
+        inherit_env~,
+        stdin?,
+        stdout=w_out,
+        stderr=w_err,
+        cwd?,
+      )
+    })
+    let stdout = group.spawn(() => {
+      defer r_out.close()
+      r_out.read_all()
+    })
+    let stderr = group.spawn(() => {
+      defer r_err.close()
+      r_err.read_all()
+    })
     (exit_code.wait(), stdout.wait(), stderr.wait())
   }
 }
@@ -357,18 +339,9 @@ pub async fn collect_output_merged(
   let (r, w) = read_from_process()
   @async.with_task_group() <| group => {
     defer r.close()
-    let exit_code = group.spawn() <| () => {
-        run(
-          cmd,
-          args,
-          extra_env~,
-          inherit_env~,
-          stdin?,
-          stdout=w,
-          stderr=w,
-          cwd?,
-        )
-      }
+    let exit_code = group.spawn(() => {
+      run(cmd, args, extra_env~, inherit_env~, stdin?, stdout=w, stderr=w, cwd?)
+    })
     let output = r.read_all()
     (exit_code.wait(), output)
   }

--- a/src/process/redirect_test.mbt
+++ b/src/process/redirect_test.mbt
@@ -48,8 +48,8 @@ async test "redirect to file" {
   @async.with_task_group() <| root => {
     let input_file = "_build/process_redirect_test_in.txt"
     let output_file = "_build/process_redirect_test_out.txt"
-    root.add_defer() <| () => { @fs.remove(input_file) }
-    root.add_defer() <| () => { @fs.remove(output_file) }
+    root.add_defer(() => @fs.remove(input_file))
+    root.add_defer(() => @fs.remove(output_file))
     @fs.write_file(input_file, "abcd", create_mode=CreateOrTruncate)
     let _ = @process.run(
       cat,

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -15,9 +15,9 @@
 ///|
 async test "protect_from_cancel" {
   let log = StringBuilder::new()
-  (@async.with_task_group() <| root => {
+  @async.with_task_group(root => {
     root.spawn_bg() <| () => {
-      (@async.protect_from_cancel() <| () => {
+      @async.protect_from_cancel(() => {
         @async.sleep(400) catch {
           err => {
             log.write_string("critial job cancelled with error \{err}\n")
@@ -64,14 +64,14 @@ async test "protect_from_cancel wait" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(200)
           log <+ "200ms tick\n"
           @async.sleep(200)
           log <+ "400ms tick\n"
         }
-        (@async.with_task_group() <| group => {
+        @async.with_task_group(group => {
           group.spawn_bg() <| () => {
             @async.sleep(300)
             log.write_string(
@@ -113,7 +113,7 @@ async test "protect_from_cancel with_timeout" {
       @async.sleep(200)
       log <+ "400ms tick\n"
     }
-    (@async.with_timeout_opt(300) <| () => {
+    @async.with_timeout_opt(300, () => {
       @async.protect_from_cancel() <| () => {
         @async.sleep(500)
         log <+ "critial job finished\n"
@@ -137,20 +137,20 @@ async test "protect_from_cancel with_timeout" {
 ///|
 async test "protect_from_cancel fail" {
   let log = StringBuilder::new()
-  let result : Result[Unit, _] = try? (@async.with_task_group() <| root => {
+  let result : Result[Unit, _] = try? @async.with_task_group(root => {
     root.spawn_bg() <| () => {
       @async.sleep(200)
       log <+ "200ms tick\n"
       @async.sleep(200)
       log <+ "400ms tick\n"
     }
-    @async.with_timeout(300) <| () => {
+    @async.with_timeout(300, () => {
       @async.protect_from_cancel() <| () => {
         @async.sleep(500)
         log <+ "critial job fail\n"
         raise Err
       }
-    }
+    })
   })
   log.write_string(@debug.to_string(result))
   inspect(
@@ -174,7 +174,7 @@ async test "protect_from_cancel nested1" {
       @async.sleep(200)
       log <+ "400ms tick\n"
     }
-    (@async.with_timeout_opt(300) <| () => {
+    @async.with_timeout_opt(300, () => {
       @async.protect_from_cancel() <| () => {
         @async.protect_from_cancel() <| () => {
           @async.sleep(500)
@@ -209,7 +209,7 @@ async test "protect_from_cancel nested2" {
       @async.sleep(200)
       log <+ "600ms tick\n"
     }
-    (@async.with_timeout_opt(100) <| () => {
+    @async.with_timeout_opt(100, () => {
       @async.protect_from_cancel() <| () => {
         @async.protect_from_cancel() <| () => {
           @async.sleep(300)
@@ -241,7 +241,7 @@ async test "protect_from_cancel in cancellation handler" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg(no_wait=true) <| () => {
           @async.sleep(400) catch {
             err => {
@@ -280,26 +280,26 @@ async test "cancel while scheduled" {
         log <+ "tick\n"
       }
     }
-    let task1 = root.spawn() <| () => {
-        // after calling `pause`, current coroutine would be in `run_later`,
-        // and it will receive cancellation in this situation
-        @async.pause() catch {
-          err => {
-            log.write_string("`pause` cancelled with \{err}\n")
-            @async.protect_from_cancel() <| () => {
-              // Now, due to `protect_from_cancel`,
-              // we are allowed to suspend inside cancellation handler.
-              // However, since current coroutine is still in `run_later`,
-              // the scheduler will wakeup current coroutine immediately,
-              // before the timer expires.
-              @async.sleep(300)
-              log <+ "async cleanup finished\n"
-            }
-            raise err
+    let task1 = root.spawn(() => {
+      // after calling `pause`, current coroutine would be in `run_later`,
+      // and it will receive cancellation in this situation
+      @async.pause() catch {
+        err => {
+          log.write_string("`pause` cancelled with \{err}\n")
+          @async.protect_from_cancel() <| () => {
+            // Now, due to `protect_from_cancel`,
+            // we are allowed to suspend inside cancellation handler.
+            // However, since current coroutine is still in `run_later`,
+            // the scheduler will wakeup current coroutine immediately,
+            // before the timer expires.
+            @async.sleep(300)
+            log <+ "async cleanup finished\n"
           }
+          raise err
         }
       }
-    root.spawn_bg() <| () => { task1.cancel() }
+    })
+    root.spawn_bg(() => task1.cancel())
   }
   inspect(
     log.to_string(),
@@ -325,7 +325,7 @@ async test "error in async cancel" {
     }
     log.write_string(
       @debug.to_string(
-        try? (@async.with_task_group() <| group => {
+        try? @async.with_task_group(group => {
           group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
             @async.sleep(1000) catch {
               _ => {

--- a/src/retry_test.mbt
+++ b/src/retry_test.mbt
@@ -81,7 +81,7 @@ async test "retry exponential" {
 async test "retry cancelled1" {
   let log = StringBuilder::new()
   let mut i = 0
-  (@async.with_timeout(500) <| () => {
+  @async.with_timeout(500, () => {
     @async.retry(Immediate) <| () => {
       @async.sleep(200)
       log.write_string("loop \{i}\n")
@@ -106,7 +106,7 @@ async test "retry cancelled1" {
 async test "retry cancelled2" {
   let log = StringBuilder::new()
   let mut i = 0
-  (@async.with_timeout(500) <| () => {
+  @async.with_timeout(500, () => {
     @async.retry(FixedDelay(200)) <| () => {
       log.write_string("loop \{i}\n")
       i = i + 1
@@ -139,7 +139,7 @@ async test "retry fatal_error" {
     log.write_string("worker run #\{i}\n")
     i = i + 1
     if i < 3 {
-      @async.with_timeout(100) <| () => { @async.sleep(1000) }
+      @async.with_timeout(100, () => @async.sleep(1000))
     } else {
       raise Failure::Failure("fatal error")
     }

--- a/src/return_immediately_test.mbt
+++ b/src/return_immediately_test.mbt
@@ -17,7 +17,7 @@ async test "return_immediately basic" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(200)
           root.return_immediately(())
@@ -37,7 +37,7 @@ async test "return_immediately nested" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(300)
           log <+ "outer task finished\n"
@@ -63,7 +63,7 @@ async test "return_immediately error on cancel" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(200)
           root.return_immediately(())
@@ -97,7 +97,7 @@ async test "return_immediately recursive cancel" {
       @async.sleep(100)
       log.push("100ms tick")
     }
-    (@async.with_task_group() <| group => {
+    @async.with_task_group(group => {
       group.return_immediately(()) catch {
         _ => @async.sleep(200)
       }
@@ -117,9 +117,9 @@ async test "return_immediately called outside" {
       @async.sleep(100)
       log.push("100ms tick")
     }
-    @async.with_task_group() <| inner => {
-      outer.spawn_bg() <| () => { inner.return_immediately(()) }
-    }
+    @async.with_task_group(inner => {
+      outer.spawn_bg(() => inner.return_immediately(()))
+    })
     log.push("inner group finished")
   }
   json_inspect(log, content=["inner group finished", "100ms tick"])

--- a/src/semaphore/semaphore_test.mbt
+++ b/src/semaphore/semaphore_test.mbt
@@ -91,7 +91,7 @@ async test "semaphore cancellation" {
       semaphore.release()
     }
     debug_inspect(
-      try? (@async.with_timeout(250) <| () => { semaphore.acquire() }),
+      try? @async.with_timeout(250, () => semaphore.acquire()),
       content="Err(TimeoutError)",
     )
     @async.sleep(500)
@@ -105,10 +105,10 @@ async test "semaphore cancellation no_swallow" {
   @async.with_task_group() <| root => {
     let semaphore = @semaphore.Semaphore(1)
     semaphore.acquire()
-    let acquire_taskire_task = root.spawn() <| () => {
-        semaphore.acquire()
-        log <+ "acquire() succeed\n"
-      }
+    let acquire_taskire_task = root.spawn(() => {
+      semaphore.acquire()
+      log <+ "acquire() succeed\n"
+    })
     @async.sleep(100)
     semaphore.release()
     acquire_taskire_task.cancel()

--- a/src/signal/signal.mbt
+++ b/src/signal/signal.mbt
@@ -46,7 +46,5 @@ pub fn Signal::to_int(signal : Signal) -> Int {
 ///
 /// The default list is all supported signals.
 pub fn set_global_cancellation_signals(signals : ReadOnlyArray[Signal]) -> Unit {
-  @event_loop.set_global_cancellation_signals(
-    signals.map() <| sig => { sig.to_int() },
-  )
+  @event_loop.set_global_cancellation_signals(signals.map(sig => sig.to_int()))
 }

--- a/src/signal/signal_test.mbt
+++ b/src/signal/signal_test.mbt
@@ -38,13 +38,13 @@ async test "cancel with default signal" {
   let log = []
   @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
-    let task = group.spawn() <| () => {
-        defer log.push("process terminates")
-        @process.run(test_prog, stdout=w, [
-          "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
-          "before exit",
-        ])
-      }
+    let task = group.spawn(() => {
+      defer log.push("process terminates")
+      @process.run(test_prog, stdout=w, [
+        "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
+        "before exit",
+      ])
+    })
     group.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(data) {
@@ -69,17 +69,17 @@ async test "cancel with ctrl+c" {
   let log = []
   @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
-    let task = group.spawn() <| () => {
-        defer log.push("process terminates")
-        let cancel_handler = @process.graceful_cancel(
-          timeout=5000,
-          signal=@signal.SIGINT,
-        )
-        @process.run(test_prog, stdout=w, cancel_handler~, [
-          "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
-          "before exit",
-        ])
-      }
+    let task = group.spawn(() => {
+      defer log.push("process terminates")
+      let cancel_handler = @process.graceful_cancel(
+        timeout=5000,
+        signal=@signal.SIGINT,
+      )
+      @process.run(test_prog, stdout=w, cancel_handler~, [
+        "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
+        "before exit",
+      ])
+    })
     group.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(data) {
@@ -104,17 +104,17 @@ async test "cancel with SIGHUP" {
   let log = []
   @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
-    let task = group.spawn() <| () => {
-        defer log.push("process terminates")
-        let cancel_handler = @process.graceful_cancel(
-          timeout=5000,
-          signal=@signal.SIGHUP,
-        )
-        @process.run(test_prog, stdout=w, cancel_handler~, [
-          "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
-          "before exit",
-        ])
-      }
+    let task = group.spawn(() => {
+      defer log.push("process terminates")
+      let cancel_handler = @process.graceful_cancel(
+        timeout=5000,
+        signal=@signal.SIGHUP,
+      )
+      @process.run(test_prog, stdout=w, cancel_handler~, [
+        "10000", "-use-default-handler", "-print-after-sleep", "normal exit", "-print-finally",
+        "before exit",
+      ])
+    })
     group.spawn_bg() <| () => {
       defer r.close()
       while r.read_some() is Some(data) {

--- a/src/socket/connect_burst_test.mbt
+++ b/src/socket/connect_burst_test.mbt
@@ -46,14 +46,14 @@ async test "connection burst" {
   @async.with_task_group() <| root => {
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    root.spawn_bg() <| () => { result = server_main(server) }
+    root.spawn_bg(() => result = server_main(server))
     root.spawn_bg() <| () => {
       @async.with_task_group() <| fn(ctx) {
         for _ in 0..<6 {
-          ctx.spawn_bg() <| () => { client(b"ping", addr) }
+          ctx.spawn_bg(() => client(b"ping", addr))
         }
       }
-      root.spawn_bg() <| () => { client(b"exit", addr) }
+      root.spawn_bg(() => client(b"exit", addr))
     }
   }
   inspect(result, content="7")
@@ -68,14 +68,14 @@ async test "connection burst with ipv6" {
       dual_stack=false,
     )
     let addr = server.addr
-    root.spawn_bg() <| () => { result = server_main(server) }
+    root.spawn_bg(() => result = server_main(server))
     root.spawn_bg() <| () => {
       @async.with_task_group() <| fn(ctx) {
         for _ in 0..<6 {
-          ctx.spawn_bg() <| () => { client(b"ping", addr) }
+          ctx.spawn_bg(() => client(b"ping", addr))
         }
       }
-      root.spawn_bg() <| () => { client(b"exit", addr) }
+      root.spawn_bg(() => client(b"exit", addr))
     }
   }
   inspect(result, content="7")

--- a/src/socket/getsockname_test.mbt
+++ b/src/socket/getsockname_test.mbt
@@ -20,19 +20,19 @@ async test "getsockname TCP" {
     guard server_addr.to_string() is [.. "127.0.0.1:", ..] else {
       raise Failure::Failure("incorrect server address \{server_addr}")
     }
-    let client_addr_from_server = group.spawn() <| () => {
-        defer server.close()
-        let (conn, peer_addr) = server.accept()
-        assert_eq(conn.addr, server_addr)
-        inspect(conn.read_all().text(), content="abcd")
-        peer_addr
-      }
-    let client_addr = group.spawn() <| () => {
-        let client = @socket.Tcp::connect(server_addr)
-        defer client.close()
-        client.write("abcd")
-        client.addr
-      }
+    let client_addr_from_server = group.spawn(() => {
+      defer server.close()
+      let (conn, peer_addr) = server.accept()
+      assert_eq(conn.addr, server_addr)
+      inspect(conn.read_all().text(), content="abcd")
+      peer_addr
+    })
+    let client_addr = group.spawn(() => {
+      let client = @socket.Tcp::connect(server_addr)
+      defer client.close()
+      client.write("abcd")
+      client.addr
+    })
     assert_eq(client_addr_from_server.wait(), client_addr.wait())
   }
 }
@@ -45,20 +45,20 @@ async test "getsockname UDP" {
     guard server_addr.to_string() is [.. "127.0.0.1:", ..] else {
       raise Failure::Failure("incorrect server address \{server_addr}")
     }
-    let client_addr_from_server = group.spawn() <| () => {
-        defer server.close()
-        let buf = FixedArray::make(1024, b'\x00')
-        let (n, peer_addr) = server.recvfrom(buf)
-        let data = buf.unsafe_reinterpret_as_bytes()[:n]
-        inspect(@utf8.decode(data), content="abcd")
-        peer_addr
-      }
-    let client_addr = group.spawn() <| () => {
-        let client = @socket.UdpClient(server_addr)
-        defer client.close()
-        client.send(b"abcd")
-        client.addr
-      }
+    let client_addr_from_server = group.spawn(() => {
+      defer server.close()
+      let buf = FixedArray::make(1024, b'\x00')
+      let (n, peer_addr) = server.recvfrom(buf)
+      let data = buf.unsafe_reinterpret_as_bytes()[:n]
+      inspect(@utf8.decode(data), content="abcd")
+      peer_addr
+    })
+    let client_addr = group.spawn(() => {
+      let client = @socket.UdpClient(server_addr)
+      defer client.close()
+      client.send(b"abcd")
+      client.addr
+    })
     assert_eq(client_addr_from_server.wait(), client_addr.wait())
   }
 }

--- a/src/socket/resolve_host_test.mbt
+++ b/src/socket/resolve_host_test.mbt
@@ -25,10 +25,10 @@ async test "resolve cancel" {
   let log = StringBuilder::new()
   @async.with_task_group() <| root => {
     let lock = @async.Semaphore(1, initial_value=1)
-    let task = root.spawn() <| () => {
-        lock.release()
-        log.write_object(@socket.Addr::resolve("does.not.exist", port=443))
-      }
+    let task = root.spawn(() => {
+      lock.release()
+      log.write_object(@socket.Addr::resolve("does.not.exist", port=443))
+    })
     lock.acquire() // make sure the task already started
     task.cancel()
     log <+ "host resolution cancelled\n"

--- a/src/spawn_loop_test.mbt
+++ b/src/spawn_loop_test.mbt
@@ -17,7 +17,7 @@ async test "spawn_loop basic" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         let mut i = 0
         root.spawn_loop() <| () => {
           log.write_string("tick \{i}\n")
@@ -45,7 +45,7 @@ async test "spawn_loop basic-error" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         let mut i = 0
         root.spawn_loop() <| () => {
           log.write_string("tick \{i}\n")

--- a/src/spawn_test.mbt
+++ b/src/spawn_test.mbt
@@ -15,7 +15,7 @@
 ///|
 async test "spawn error1" {
   let buf = StringBuilder::new()
-  let result = try? (@async.with_task_group() <| root => {
+  let result = try? @async.with_task_group(root => {
     root.spawn_bg() <| () => {
       @async.sleep(1000)
       buf <+ "task 1 finished\n"
@@ -32,7 +32,7 @@ async test "spawn error1" {
 ///|
 async test "spawn error2" {
   let buf = StringBuilder::new()
-  let result = try? (@async.with_task_group() <| root => {
+  let result = try? @async.with_task_group(root => {
     root.spawn_bg() <| () => {
       @async.sleep(200)
       raise Err
@@ -49,7 +49,7 @@ async test "spawn error2" {
 ///|
 async test "spawn after cancelled" {
   let log = []
-  let _ : Result[Unit, _] = try? (@async.with_task_group() <| group => {
+  let _ : Result[Unit, _] = try? @async.with_task_group(group => {
     group.spawn_bg() <| () => {
       // emulate a non-cancellable job,
       // or a job that happens to be completed on cancellation,

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 ///|
-let cat : @async.Lazy[String] = @async.Lazy() <| () => {
-    // Note: the `cat` example program lies in another MoonBit module.
-    // Currently, dependencies of a module is built locally in that module,
-    // so there will be no build lock conflict between this test and the `cat` program.
-    let exit_code = @process.run("moon", [
-      "-C", "src/process/test_programs", "build", "--debug", "cat",
-    ])
-    guard exit_code is 0 else {
-      fail("failed to build `cat` program: \{exit_code}")
-    }
-    "./src/process/test_programs/_build/native/debug/build/cat/cat.exe"
+let cat : @async.Lazy[String] = @async.Lazy(() => {
+  // Note: the `cat` example program lies in another MoonBit module.
+  // Currently, dependencies of a module is built locally in that module,
+  // so there will be no build lock conflict between this test and the `cat` program.
+  let exit_code = @process.run("moon", [
+    "-C", "src/process/test_programs", "build", "--debug", "cat",
+  ])
+  guard exit_code is 0 else {
+    fail("failed to build `cat` program: \{exit_code}")
   }
+  "./src/process/test_programs/_build/native/debug/build/cat/cat.exe"
+})
 
 ///|
 async test "redirect_file" {

--- a/src/timer.mbt
+++ b/src/timer.mbt
@@ -18,7 +18,7 @@
 /// If current task is cancelled, `sleep` will return early with an error.
 pub async fn sleep(duration : Int) -> Unit {
   let coro = @coroutine.current_coroutine()
-  let timer = @event_loop.Timer::new(duration) <| () => { coro.wake() }
+  let timer = @event_loop.Timer::new(duration, () => coro.wake())
   defer timer.cancel()
   @coroutine.suspend()
 }
@@ -136,7 +136,7 @@ pub fn Timer::refresh(timer : Timer) -> Unit {
     timer.state = Detached
   } else {
     timer.state = Running(
-      @event_loop.Timer::new(timer.duration) <| () => { timer.wake(Terminated) },
+      @event_loop.Timer::new(timer.duration, () => timer.wake(Terminated)),
     )
   }
 }

--- a/src/timer_test.mbt
+++ b/src/timer_test.mbt
@@ -71,7 +71,7 @@ async test "Timer basic" {
         }
       }
     }
-    let result = @async.with_timeout_opt(0) <| () => { timer.wait() }
+    let result = @async.with_timeout_opt(0, () => timer.wait())
     log.push("wait again: \{@debug.to_string(result)}")
   }
   json_inspect(log, content=[
@@ -85,7 +85,7 @@ async test "Timer no waiter" {
   let timer = @async.Timer(200)
   @async.sleep(400)
   debug_inspect(
-    @async.with_timeout_opt(0) <| () => { timer.wait() },
+    @async.with_timeout_opt(0, () => timer.wait()),
     content=(
       #|Some(())
     ),
@@ -101,17 +101,17 @@ async test "Timer no one waiting" {
 ///|
 async test "Timer waiter cancelled 1" {
   let timer = @async.Timer(600)
-  assert_true((@async.with_timeout_opt(200) <| () => { timer.wait() }) is None)
+  assert_true(@async.with_timeout_opt(200, () => timer.wait()) is None)
   @async.sleep(200)
-  assert_false((@async.with_timeout_opt(300) <| () => { timer.wait() }) is None)
+  assert_false(@async.with_timeout_opt(300, () => timer.wait()) is None)
 }
 
 ///|
 async test "Timer waiter cancelled 2" {
   let timer = @async.Timer(300)
-  assert_true((@async.with_timeout_opt(200) <| () => { timer.wait() }) is None)
+  assert_true(@async.with_timeout_opt(200, () => timer.wait()) is None)
   @async.sleep(200)
-  assert_false((@async.with_timeout_opt(0) <| () => { timer.wait() }) is None)
+  assert_false(@async.with_timeout_opt(0, () => timer.wait()) is None)
 }
 
 ///|
@@ -219,7 +219,7 @@ async test "Timer::refresh already cancelled" {
   timer.cancel()
   timer.refresh()
   debug_inspect(
-    @async.with_timeout_opt(0) <| () => { try? timer.wait() },
+    @async.with_timeout_opt(0, () => try? timer.wait()),
     content=(
       #|Some(Err(TimerCancelled))
     ),

--- a/src/tls/certificate_test.mbt
+++ b/src/tls/certificate_test.mbt
@@ -26,7 +26,7 @@ async test "get_peer_certificate" {
       let server = test_server(server_read_from_client, server_write_to_client)
       defer server.close()
       debug_inspect(
-        server.get_peer_certificate().map() <| cert => { cert.length() },
+        server.get_peer_certificate().map(cert => cert.length()),
         content="None",
       )
     }
@@ -43,7 +43,7 @@ async test "get_peer_certificate" {
       )
       defer client.close()
       debug_inspect(
-        client.get_peer_certificate().map() <| cert => { cert.length() },
+        client.get_peer_certificate().map(cert => cert.length()),
         content=(
           #|Some(1447)
         ),

--- a/src/tls/channel_binding_test.mbt
+++ b/src/tls/channel_binding_test.mbt
@@ -18,39 +18,37 @@ async test "channel binding" {
     let (client_read_from_server, server_write_to_client) = @pipe.pipe()
     let (server_read_from_client, client_write_to_server) = @pipe.pipe()
     // server
-    let server_task = group.spawn() <| () => {
-        defer {
-          server_read_from_client.close()
-          server_write_to_client.close()
-        }
-        let server = test_server(
-          server_read_from_client, server_write_to_client,
-        )
-        defer server.close()
-        (
-          server.unique_channel_binding(),
-          server.server_endpoint_channel_binding(),
-        )
+    let server_task = group.spawn(() => {
+      defer {
+        server_read_from_client.close()
+        server_write_to_client.close()
       }
+      let server = test_server(server_read_from_client, server_write_to_client)
+      defer server.close()
+      (
+        server.unique_channel_binding(),
+        server.server_endpoint_channel_binding(),
+      )
+    })
     // client
-    let client_task = group.spawn() <| () => {
-        defer {
-          client_read_from_server.close()
-          client_write_to_server.close()
-        }
-        let client = @tls.Tls::client_from_pair(
-          client_read_from_server,
-          client_write_to_server,
-          trust=NoVerification,
-        )
-        defer client.close()
-        let binding = (
-          client.unique_channel_binding(),
-          client.server_endpoint_channel_binding(),
-        )
-        client.shutdown()
-        binding
+    let client_task = group.spawn(() => {
+      defer {
+        client_read_from_server.close()
+        client_write_to_server.close()
       }
+      let client = @tls.Tls::client_from_pair(
+        client_read_from_server,
+        client_write_to_server,
+        trust=NoVerification,
+      )
+      defer client.close()
+      let binding = (
+        client.unique_channel_binding(),
+        client.server_endpoint_channel_binding(),
+      )
+      client.shutdown()
+      binding
+    })
     let (unique_binding_for_server, endpoint_binding_for_server) = server_task.wait()
     let (unique_binding_for_client, endpoint_binding_for_client) = client_task.wait()
     assert_eq(unique_binding_for_client, unique_binding_for_server)

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -651,5 +651,5 @@ pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
 let _unused : Unit = {
   ignore(@os_error.check_errno)
   ignore(@os_string.encode)
-  ignore() <| ((_ : @fs.File) => ())
+  ignore((_ : @fs.File) => ())
 }

--- a/src/wait_test.mbt
+++ b/src/wait_test.mbt
@@ -17,17 +17,17 @@ async test "wait basic" {
   let buf = StringBuilder::new()
   buf.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(200)
           buf <+ "200ms tick\n"
           @async.sleep(200)
           buf <+ "400ms tick\n"
         }
-        let task = root.spawn(no_wait=true) <| () => {
-            @async.sleep(300)
-            buf <+ "task finished\n"
-          }
+        let task = root.spawn(no_wait=true, () => {
+          @async.sleep(300)
+          buf <+ "task finished\n"
+        })
         task.wait()
         buf <+ "main task exit\n"
       }),
@@ -48,11 +48,11 @@ async test "wait basic" {
 ///|
 async test "wait cancelled" {
   let buf = StringBuilder::new()
-  (@async.with_task_group() <| root => {
-    let task = root.spawn() <| () => {
-        @async.sleep(1000)
-        buf <+ "task finished\n"
-      }
+  @async.with_task_group(root => {
+    let task = root.spawn(() => {
+      @async.sleep(1000)
+      buf <+ "task finished\n"
+    })
     root.spawn_bg() <| () => {
       task.wait() catch {
         err => {
@@ -79,10 +79,10 @@ async test "wait cancelled" {
 async test "try_wait" {
   let log = StringBuilder::new()
   @async.with_task_group() <| root => {
-    let task = root.spawn(no_wait=true) <| () => {
-        @async.sleep(450)
-        42
-      }
+    let task = root.spawn(no_wait=true, () => {
+      @async.sleep(450)
+      42
+    })
     root.spawn_bg() <| () => {
       @async.sleep(300)
       log.write_string("300ms: \{@debug.to_string(task.try_wait())}\n")

--- a/src/websocket/control_test.mbt
+++ b/src/websocket/control_test.mbt
@@ -76,7 +76,7 @@ async test "ping auto-reply race-with-write" {
       defer ws.close()
       @async.with_task_group() <| group => {
         // currently, auto-reply is only triggered when the user is actually reading.
-        group.spawn_bg(no_wait=true) <| () => { ignore(ws.recv().read_all()) }
+        group.spawn_bg(no_wait=true, () => ignore(ws.recv().read_all()))
         ws.start_message(Text)
         ws.write("1234")
         @async.sleep(400)
@@ -216,8 +216,8 @@ async test "multiple ping" {
     @async.with_task_group() <| group => {
       group.spawn_bg() <| () => {
         @async.with_task_group() <| inner => {
-          inner.spawn_bg() <| () => { ws.ping() }
-          inner.spawn_bg() <| () => { ws.ping() }
+          inner.spawn_bg(() => ws.ping())
+          inner.spawn_bg(() => ws.ping())
         }
         ws.send_text("1234")
       }
@@ -249,7 +249,7 @@ async test "ping cancelled" {
         inspect(ws.recv().read_all().text(), content="abcd")
       }
       debug_inspect(
-        @async.with_timeout_opt(100) <| () => { ws.ping(msg=b"1") },
+        @async.with_timeout_opt(100, () => ws.ping(msg=b"1")),
         content="None",
       )
       ws.ping(msg=b"1")
@@ -279,7 +279,7 @@ async test "duplicated ping" {
     @async.with_task_group() <| group => {
       group.spawn_bg() <| () => {
         @async.with_task_group() <| inner => {
-          inner.spawn_bg() <| () => { ws.ping(msg=b"1") }
+          inner.spawn_bg(() => ws.ping(msg=b"1"))
           inner.spawn_bg() <| () => {
             debug_inspect(
               try? ws.ping(msg=b"1"),

--- a/src/websocket/websocket_test.mbt
+++ b/src/websocket/websocket_test.mbt
@@ -157,27 +157,27 @@ async test "large message" {
   @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     let addr = server.addr
-    let server_checksum = group.spawn() <| () => {
-        defer server.close()
-        let (conn, _) = server.accept()
-        defer conn.close()
-        let request = conn.read_request()
-        let ws = @websocket.from_http_server(request, conn)
-        defer ws.close()
-        let msg = ws.recv()
-        debug_inspect(msg.kind, content="Binary")
-        let mut checksum = 0
-        while msg.read_some() is Some(chunk) {
-          for byte in chunk {
-            checksum += byte.to_int()
-          }
+    let server_checksum = group.spawn(() => {
+      defer server.close()
+      let (conn, _) = server.accept()
+      defer conn.close()
+      let request = conn.read_request()
+      let ws = @websocket.from_http_server(request, conn)
+      defer ws.close()
+      let msg = ws.recv()
+      debug_inspect(msg.kind, content="Binary")
+      let mut checksum = 0
+      while msg.read_some() is Some(chunk) {
+        for byte in chunk {
+          checksum += byte.to_int()
         }
-        checksum
       }
+      checksum
+    })
     let client = @websocket.connect("ws://localhost:\{addr.port()}")
     defer client.close()
     client.start_message(Binary)
-    let chunk = Bytes::makei(1500) <| i => { (i % 0x100).to_byte() }
+    let chunk = Bytes::makei(1500, i => (i % 0x100).to_byte())
     let mut checksum = 0
     for _ in 0..<20 {
       for byte in chunk {

--- a/src/with_timeout_test.mbt
+++ b/src/with_timeout_test.mbt
@@ -15,7 +15,7 @@
 ///|
 async test "with_timeout normal exit" {
   let log = []
-  @async.with_task_group() <| root => {
+  @async.with_task_group(root => {
     root.spawn_bg() <| () => {
       @async.sleep(300)
       log.push("300ms tick")
@@ -25,7 +25,7 @@ async test "with_timeout normal exit" {
       log.push("task finished after 200ms")
     }
     log.push("main task finished")
-  }
+  })
   json_inspect(log, content=[
     "task finished after 200ms", "main task finished", "300ms tick",
   ])
@@ -34,12 +34,12 @@ async test "with_timeout normal exit" {
 ///|
 async test "with_timeout failure" {
   let log = StringBuilder::new()
-  (@async.with_task_group() <| root => {
+  @async.with_task_group(root => {
     root.spawn_bg() <| () => {
       @async.sleep(200)
       log <+ "200ms tick\n"
     }
-    (@async.with_timeout(300) <| () => {
+    @async.with_timeout(300, () => {
       @async.sleep(100)
       raise Err
     }) catch {
@@ -65,12 +65,12 @@ async test "with_timeout timeout" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(300)
           log <+ "300ms tick\n"
         }
-        (@async.with_timeout(200) <| () => {
+        @async.with_timeout(200, () => {
           @async.sleep(400) catch {
             err => {
               log <+ "task cancelled\n"
@@ -102,15 +102,15 @@ async test "with_timeout nested1" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(200)
           log <+ "200ms tick\n"
           @async.sleep(200)
           log <+ "400ms tick\n"
         }
-        (@async.with_timeout(300) <| () => {
-          (@async.with_timeout(500) <| () => {
+        @async.with_timeout(300, () => {
+          @async.with_timeout(500, () => {
             @async.sleep(2000) catch {
               err => {
                 log <+ "task cancelled\n"
@@ -147,15 +147,15 @@ async test "with_timeout nested2" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(300)
           log <+ "300ms tick\n"
           @async.sleep(300)
           log <+ "600ms tick\n"
         }
-        (@async.with_timeout(750) <| () => {
-          (@async.with_timeout(450) <| () => {
+        @async.with_timeout(750, () => {
+          @async.with_timeout(450, () => {
             @async.sleep(2000) catch {
               err => {
                 log <+ "task cancelled\n"
@@ -191,7 +191,7 @@ async test "with_timeout error_on_cancel" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(200)
           log <+ "200ms tick\n"
@@ -223,7 +223,7 @@ async test "with_timeout error-on-timeout" {
   let log = StringBuilder::new()
   log.write_string(
     @debug.to_string(
-      try? (@async.with_task_group() <| root => {
+      try? @async.with_task_group(root => {
         root.spawn_bg() <| () => {
           @async.sleep(200)
           log <+ "200ms tick\n"
@@ -254,18 +254,18 @@ async test "with_timeout error-on-timeout" {
 ///|
 async test "with_timeout_opt normal exit" {
   let log = []
-  @async.with_task_group() <| root => {
+  @async.with_task_group(root => {
     root.spawn_bg() <| () => {
       @async.sleep(200)
       log.push("200ms tick")
     }
-    let result = @async.with_timeout_opt(1000) <| () => {
-        @async.sleep(100)
-        log.push("task finished after 100ms")
-        42
-      }
+    let result = @async.with_timeout_opt(1000, () => {
+      @async.sleep(100)
+      log.push("task finished after 100ms")
+      42
+    })
     log.push(@debug.to_string(result))
-  }
+  })
   json_inspect(log, content=[
     "task finished after 100ms", "Some(42)", "200ms tick",
   ])
@@ -274,12 +274,12 @@ async test "with_timeout_opt normal exit" {
 ///|
 async test "with_timeout_opt failure" {
   let log = StringBuilder::new()
-  (@async.with_task_group() <| root => {
+  @async.with_task_group(root => {
     root.spawn_bg() <| () => {
       @async.sleep(200)
       log <+ "200ms tick\n"
     }
-    (@async.with_timeout(1000) <| () => {
+    @async.with_timeout(1000, () => {
       @async.sleep(100)
       raise Err
     }) catch {
@@ -308,19 +308,19 @@ async test "with_timeout_opt timeout" {
       @async.sleep(200)
       log.push("200ms tick")
     }
-    let result = @async.with_timeout_opt(100) <| () => {
-        try @async.sleep(2000) catch {
-          err => {
-            log.push("task cancelled")
-            raise err
-          }
-        } noraise {
-          _ => {
-            log.push("task finished after 2s")
-            42
-          }
+    let result = @async.with_timeout_opt(100, () => {
+      try @async.sleep(2000) catch {
+        err => {
+          log.push("task cancelled")
+          raise err
+        }
+      } noraise {
+        _ => {
+          log.push("task finished after 2s")
+          42
         }
       }
+    })
     log.push(@debug.to_string(result))
   }
   json_inspect(log, content=["task cancelled", "None", "200ms tick"])


### PR DESCRIPTION
Mainly three categories:

1. one liner with no braces around callback. In this case using reverse pipe is actually more noisy
2. places where using reverse pipe requires extra parenthesis, such as left hand side of `catch`
3. avoid the formatter bug in https://github.com/moonbitlang/async/pull/367#discussion_r3245386336