### PR TITLE
add optional fd leak check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  MOONBIT_ASYNC_CHECK_FD_LEAK: 1
+
 jobs:
   stable-build:
     strategy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  MOONBIT_ASYNC_CHECK_FD_LEAK: 1
+
 jobs:
   coverage-windows:
     runs-on: 'windows-latest'

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -87,7 +87,7 @@ priv enum DirectoryState {
 ///|
 /// A directory in file system
 struct Directory {
-  fd : @fd_util.Fd
+  io : @event_loop.IoHandle
   buf : FixedArray[Byte]
   // The offset of the next entry in the buffer
   mut offset : Int
@@ -103,9 +103,7 @@ struct Directory {
 
 ///|
 pub fn Directory::close(self : Directory) -> Unit {
-  @fd_util.close(self.fd, kind=Directory, context="") catch {
-    _ => ()
-  }
+  self.io.close()
 }
 
 ///|
@@ -120,7 +118,7 @@ pub async fn opendir(path : StringView) -> Directory {
 
 ///|
 async fn opendir_aux(path : StringView, context~ : String) -> Directory {
-  let open_result = @event_loop.open_detached(
+  let (io, _) = @event_loop.open(
     path,
     0,
     create=0,
@@ -129,22 +127,20 @@ async fn opendir_aux(path : StringView, context~ : String) -> Directory {
     mode=0,
     context~,
   )
-  let fd = open_result.fd()
-  let kind = open_result.kind()
-  if !(kind is Directory) {
-    @fd_util.close(fd, kind~, context~)
+  if !(io.kind() is Directory) {
+    io.close()
     raise @os_error.OSError(
       @os_error.errno_ENOTDIR,
       context="\{context}: \{path.escape()}",
     )
   }
-  Directory::from_fd(fd)
+  Directory::from_io_handle(io)
 }
 
 ///|
-fn Directory::from_fd(fd : @fd_util.Fd) -> Directory {
+fn Directory::from_io_handle(io : @event_loop.IoHandle) -> Directory {
   {
-    fd,
+    io,
     buf: FixedArray::make(
       @cmp.maximum(Directory::min_buffer_size(), 1024),
       b'\x00',
@@ -238,12 +234,7 @@ async fn Directory::next_aux(
     NeedMoreEntry => {
       dir.offset = 0
       dir.count = 0
-      dir.job_ret = @event_loop.readdir(
-        dir.fd,
-        dir.buf,
-        dir.buf.length(),
-        context~,
-      )
+      dir.job_ret = dir.io.readdir(dir.buf, dir.buf.length(), context~)
       if dir.job_ret is 0 {
         dir.state = NoMoreEntry
         return None
@@ -280,7 +271,7 @@ async fn Directory::next_aux(
     _..<0 => {
       let kind = @event_loop.file_kind_by_path(
         name,
-        parent=dir.fd,
+        parent=dir.io.fd(),
         follow_symlink=false,
         context~,
       )

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -375,6 +375,7 @@ pub async fn walk(
         sem.acquire()
         defer sem.release()
         let dir = opendir_aux(path, context~)
+        defer dir.close()
         let files = []
         while dir.next_aux(include_hidden=true, include_special=false, context~)
               is Some(ent) {

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -140,7 +140,7 @@ pub async fn open(
     Data => 1
     Full => 2
   }
-  let io = @event_loop.open(
+  let (io, _) = @event_loop.open(
     filename,
     access,
     create=create_mode.to_int(),
@@ -392,7 +392,7 @@ pub fn File::as_dir(self : File) -> Directory raise {
       context="@fs.File::as_dir()",
     )
   }
-  Directory::from_fd(self.io.detach_from_event_loop())
+  Directory::from_io_handle(self.io)
 }
 
 ///|

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -325,6 +325,21 @@ fn EventLoop::poll(self : Self) -> Unit raise {
 }
 
 ///|
+pub let check_fd_leak : Ref[Bool] = Ref(
+  @env.get_env_var("MOONBIT_ASYNC_CHECK_FD_LEAK") is Some(_),
+)
+
+///|
+fn EventLoop::check_fd_leak(self : Self) -> Unit {
+  if check_fd_leak.val && !self.fds.is_empty() {
+    let leaked_handles = [
+      for handle in self.fds.values() => @debug.to_string(handle.kind)
+    ].join(", ")
+    abort("file descriptor leak detected: \{leaked_handles}")
+  }
+}
+
+///|
 #cfg(not(platform="windows"))
 fn EventLoop::cleanup(self : Self) -> Unit raise {
   for hook in hooks {
@@ -351,6 +366,7 @@ fn EventLoop::cleanup(self : Self) -> Unit raise {
       context="runtime internal: close leaking fd",
     )
   }
+  self.check_fd_leak()
   self.fds.clear()
   for _, coro in self.jobs {
     coro.cancel()
@@ -380,6 +396,7 @@ fn EventLoop::cleanup(self : Self) -> Unit raise {
       context="runtime internal: close leaking fd",
     )
   }
+  self.check_fd_leak()
   self.fds.clear()
   for _, coro in self.jobs {
     coro.cancel()
@@ -402,7 +419,7 @@ fn EventLoop::run_forever(self : Self) -> Unit raise {
     }
   } catch {
     err => {
-      self.cleanup()
+      Ref::protect(check_fd_leak, false, () => self.cleanup())
       // In case the event loop has encountered some fatal error,
       // propagate the error to relevant coroutines.
       while !@coroutine.no_more_work() {
@@ -410,6 +427,8 @@ fn EventLoop::run_forever(self : Self) -> Unit raise {
       }
       raise err
     }
+  } noraise {
+    _ => self.cleanup()
   }
 }
 

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -13,36 +13,6 @@
 // limitations under the License.
 
 ///|
-pub async fn open_detached(
-  path : StringView,
-  // 0 => read only, 1 => write only, 2 => read write
-  access : Int,
-  // See `@fs.CreateMode` for more details
-  create~ : Int,
-  append~ : Bool,
-  // 0 => no sync, 1 => data sync, 2 => full sync
-  sync~ : Int,
-  // permission for file when new file is created
-  mode~ : Int,
-  context~ : String,
-) -> OpenResult {
-  let path_bytes = @os_string.encode(path)
-  let result = Job::open(path_bytes, access, create~, append~, sync~, mode~)
-  fn cancel(job_id) raise {
-    guard curr_loop.val is Some(evloop)
-    evloop.cancel_job_in_worker(job_id, context~)
-  }
-
-  try perform_job_in_worker(result.0, context~, cancel~) catch {
-    @os_error.OSError(errno, context~) =>
-      raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
-    err => raise err
-  } noraise {
-    _ => result
-  }
-}
-
-///|
 pub async fn open(
   path : StringView,
   // 0 => read only, 1 => write only, 2 => read write
@@ -55,25 +25,30 @@ pub async fn open(
   // permission for file when new file is created
   mode~ : Int,
   context~ : String,
-) -> IoHandle {
-  let result = open_detached(
-    path,
-    access,
-    create~,
-    append~,
-    sync~,
-    mode~,
-    context~,
-  )
-  let fd = result.fd()
-  let kind = result.kind()
-  // On Windows, due to a lot of complexity,
-  // we use synchronous IO + thread pool unconditionally for regular files.
-  // However, on Windows, overlapped IO must be enabled on file creation time,
-  // but we cannot know the kind of a file before opening it.
-  // So, we use synchronous IO unconditionally for everything opened by path,
-  // including named pipes.
-  IoHandle::from_fd(fd, kind~, is_async=!IS_WINDOWS && kind.can_poll())
+) -> (IoHandle, OpenResult) {
+  let path_bytes = @os_string.encode(path)
+  let result = Job::open(path_bytes, access, create~, append~, sync~, mode~)
+  fn cancel(job_id) raise {
+    guard curr_loop.val is Some(evloop)
+    evloop.cancel_job_in_worker(job_id, context~)
+  }
+
+  try perform_job_in_worker(result.0, context~, cancel~) catch {
+    @os_error.OSError(errno, context~) =>
+      raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
+    err => raise err
+  } noraise {
+    _ => {
+      let fd = result.fd()
+      let kind = result.kind()
+      let io = IoHandle::from_fd(
+        fd,
+        kind~,
+        is_async=!IS_WINDOWS && kind.can_poll(),
+      )
+      (io, result)
+    }
+  }
 }
 
 ///|
@@ -275,13 +250,13 @@ pub async fn rmdir(path : StringView, context~ : String) -> Unit {
 }
 
 ///|
-pub async fn readdir(
-  dir : @fd_util.Fd,
+pub async fn IoHandle::readdir(
+  dir : IoHandle,
   buf : FixedArray[Byte],
   len : Int,
   context~ : String,
 ) -> Int {
-  let job = Job::readdir(dir, buf, len)
+  let job = Job::readdir(dir.fd, buf, len)
   perform_job_in_worker(job, context~)
 }
 

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -24,16 +24,25 @@ struct IoHandle {
 }
 
 ///|
+/// Create a IO handle from a raw file descriptor.
+/// The ownership of the file descriptor would be transferred to this function,
+/// so the caller must not close the file descriptor manually in any circumstances.
 #cfg(not(platform="windows"))
 pub fn IoHandle::from_fd(
   fd : @fd_util.Fd,
   kind~ : @fd_util.FileKind,
   is_async? : Bool = true,
 ) -> IoHandle raise {
+  let context = "@event_loop.IoHandle::from_fd()"
   guard curr_loop.val is Some(evloop)
   guard evloop.fds.get(fd) is None
   if is_async {
-    @fd_util.set_nonblocking(fd, context="@event_loop.IoHandle::from_fd()")
+    @fd_util.set_nonblocking(fd, context~) catch {
+      err => {
+        @fd_util.close(fd, kind~, context~)
+        raise err
+      }
+    }
   }
   let handle = { fd, kind, is_async, read: None, write: None, events: NoEvent }
   evloop.fds[fd] = handle

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -131,16 +131,25 @@ struct IoHandle {
 }
 
 ///|
+/// Create a IO handle from a raw file descriptor.
+/// The ownership of the file descriptor would be transferred to this function,
+/// so the caller must not close the file descriptor manually in any circumstances.
 #cfg(platform="windows")
 pub fn IoHandle::from_fd(
   fd : @fd_util.Fd,
   kind~ : @fd_util.FileKind,
   is_async? : Bool = true,
 ) -> IoHandle raise {
+  let context = "@event_loop.IoHandle::from_fd()"
   guard curr_loop.val is Some(evloop)
   guard evloop.fds.get(fd) is None
   if is_async {
-    evloop.poll.register(fd)
+    evloop.poll.register(fd) catch {
+      err => {
+        @fd_util.close(fd, kind~, context~)
+        raise err
+      }
+    }
   }
   let handle = {
     fd,

--- a/src/internal/event_loop/missing_close_test.mbt
+++ b/src/internal/event_loop/missing_close_test.mbt
@@ -15,6 +15,7 @@
 ///|
 test "missing_close" {
   let log = StringBuilder::new()
+  @event_loop.check_fd_leak.val = false
   @event_loop.with_event_loop() <| () => {
     @async.with_task_group() <| root => {
       let (r, w) = @pipe.pipe()

--- a/src/internal/event_loop/moon.pkg
+++ b/src/internal/event_loop/moon.pkg
@@ -2,6 +2,8 @@ import {
   "moonbitlang/core/deque",
   "moonbitlang/core/sorted_set",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/env",
+  "moonbitlang/core/debug",
   "moonbitlang/async/os_error",
   "moonbitlang/async/internal/coroutine",
   "moonbitlang/async/internal/fd_util",

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -38,13 +38,9 @@ pub async fn kind_of_fd(Int, context~ : String) -> @fd_util.FileKind
 
 pub async fn mkdir(StringView, mode~ : Int, context~ : String) -> Unit
 
-pub async fn open(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> IoHandle
-
-pub async fn open_detached(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> OpenResult
+pub async fn open(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> (IoHandle, OpenResult)
 
 pub let platform : Platform
-
-pub async fn readdir(Int, FixedArray[Byte], Int, context~ : String) -> Int
 
 pub async fn realpath(StringView, context~ : String) -> String
 
@@ -99,6 +95,7 @@ pub fn IoHandle::kind(Self) -> @fd_util.FileKind
 pub async fn IoHandle::lock(Self, exclusive~ : Bool, context~ : String) -> Unit
 pub async fn IoHandle::read(Self, FixedArray[Byte], offset~ : Int, len~ : Int, context~ : String) -> Int
 pub async fn IoHandle::read_at(Self, FixedArray[Byte], offset~ : Int, len~ : Int, position~ : Int64, context~ : String) -> Int
+pub async fn IoHandle::readdir(Self, FixedArray[Byte], Int, context~ : String) -> Int
 pub async fn IoHandle::recvfrom(Self, FixedArray[Byte], offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 pub async fn IoHandle::sendto(Self, Bytes, offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 pub async fn IoHandle::write(Self, Bytes, offset~ : Int, len~ : Int, context~ : String) -> Int

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "moonbitlang/async/internal/event_loop"
 import {
   "moonbitlang/async/internal/fd_util",
   "moonbitlang/async/internal/os_string",
+  "moonbitlang/core/ref",
 }
 
 // Values
@@ -18,6 +19,8 @@ pub let _SIGINT : Int
 pub let _SIGTERM : Int
 
 pub async fn access(StringView, Access, context~ : String) -> Int
+
+pub let check_fd_leak : @ref.Ref[Bool]
 
 pub async fn chmod(StringView, Int, context~ : String) -> Unit
 

--- a/src/pipe/pipe.mbt
+++ b/src/pipe/pipe.mbt
@@ -44,19 +44,11 @@ pub fn pipe() -> (PipeRead, PipeWrite) raise {
     write_end_is_async=true,
     context~,
   )
-  try {
-    let r = {
-      io: @event_loop.IoHandle::from_fd(r, kind=Pipe),
-      read_buf: @io.ReaderBuffer::new(),
-    }
-    (r, PipeWrite(@event_loop.IoHandle::from_fd(w, kind=Pipe)))
-  } catch {
-    err => {
-      @fd_util.close(r, kind=Pipe, context~)
-      @fd_util.close(w, kind=Pipe, context~)
-      raise err
-    }
+  let r = {
+    io: @event_loop.IoHandle::from_fd(r, kind=Pipe),
+    read_buf: @io.ReaderBuffer::new(),
   }
+  (r, PipeWrite(@event_loop.IoHandle::from_fd(w, kind=Pipe)))
 }
 
 ///|

--- a/src/pipe/reader_closed_test.mbt
+++ b/src/pipe/reader_closed_test.mbt
@@ -15,6 +15,7 @@
 ///|
 async test "reader closed" {
   let (r, w) = @pipe.pipe()
+  defer w.close()
   r.close()
   @async.sleep(100)
   assert_true((try? w.write("abcd")) is Err(_))

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -38,19 +38,12 @@ pub fn read_from_process() -> (ReadFromProcess, &ProcessOutput) raise {
     write_end_is_async=false,
     context~,
   )
-  try {
-    let io = @event_loop.IoHandle::from_fd(r, kind=Pipe)
-    (
-      { io, read_buf: @io.ReaderBuffer::new() },
-      TempPipeWrite::{ pipe: w, closed: false },
-    )
-  } catch {
-    err => {
-      @fd_util.close(r, kind=Pipe, context~)
-      @fd_util.close(w, kind=Pipe, context~)
-      raise err
-    }
-  }
+  let r = @event_loop.IoHandle::from_fd(r, kind=Pipe)
+  let w = @event_loop.IoHandle::from_fd(w, kind=Pipe, is_async=false)
+  (
+    { io: r, read_buf: @io.ReaderBuffer::new() },
+    TempPipeWrite::{ pipe: w, closed: false },
+  )
 }
 
 ///|
@@ -65,16 +58,9 @@ pub fn write_to_process() -> (&ProcessInput, WriteToProcess) raise {
     write_end_is_async=true,
     context~,
   )
-  try {
-    let io = @event_loop.IoHandle::from_fd(w, kind=Pipe)
-    (TempPipeRead::{ pipe: r, closed: false }, io)
-  } catch {
-    err => {
-      @fd_util.close(r, kind=Pipe, context~)
-      @fd_util.close(w, kind=Pipe, context~)
-      raise err
-    }
-  }
+  let r = @event_loop.IoHandle::from_fd(r, kind=Pipe, is_async=false)
+  let w = @event_loop.IoHandle::from_fd(w, kind=Pipe)
+  (TempPipeRead::{ pipe: r, closed: false }, w)
 }
 
 ///|
@@ -146,7 +132,7 @@ pub async fn redirect_to_file(
     None if create is Some(perm) => perm
     None => 0o644
   }
-  let file = @event_loop.open_detached(
+  let (file, _) = @event_loop.open(
     path,
     1, // write only
     create=create_mode.to_int(),
@@ -155,13 +141,13 @@ pub async fn redirect_to_file(
     mode=permission,
     context="@process.redirect_to_file()",
   )
-  RedirectToFile(file.fd(), file.kind())
+  RedirectToFile(file)
 }
 
 ///|
 /// Redirect the content of a file at `path` to the stdin of a process.
 pub async fn redirect_from_file(path : String) -> &ProcessInput {
-  let file = @event_loop.open_detached(
+  let (file, _) = @event_loop.open(
     path,
     0, // read only
     create=0, // `OpenExisting`
@@ -170,7 +156,7 @@ pub async fn redirect_from_file(path : String) -> &ProcessInput {
     mode=0,
     context="@process.redirect_to_file()",
   )
-  RedirectToFile(file.fd(), file.kind())
+  RedirectToFile(file)
 }
 
 ///|
@@ -219,69 +205,61 @@ pub impl ProcessOutput for @stdio.Output with fd(self) {
 
 ///|
 priv struct TempPipeRead {
-  pipe : @fd_util.Fd
+  pipe : @event_loop.IoHandle
   mut closed : Bool
 }
 
 ///|
 priv struct TempPipeWrite {
-  pipe : @fd_util.Fd
+  pipe : @event_loop.IoHandle
   mut closed : Bool
 }
 
 ///|
 impl ProcessOutput for TempPipeWrite with fd(self) {
-  self.pipe
+  self.pipe.fd()
 }
 
 ///|
 impl ProcessOutput for TempPipeWrite with after_spawn(self) {
   if !self.closed {
     self.closed = true
-    @fd_util.close(self.pipe, kind=Pipe, context="") catch {
-      _ => ()
-    }
+    self.pipe.close()
   }
 }
 
 ///|
 impl ProcessInput for TempPipeRead with fd(self) {
-  self.pipe
+  self.pipe.fd()
 }
 
 ///|
 impl ProcessInput for TempPipeRead with after_spawn(self) {
   if !self.closed {
     self.closed = true
-    @fd_util.close(self.pipe, kind=Pipe, context="") catch {
-      _ => ()
-    }
+    self.pipe.close()
   }
 }
 
 ///|
-priv struct RedirectToFile(@fd_util.Fd, @fd_util.FileKind)
+priv struct RedirectToFile(@event_loop.IoHandle)
 
 ///|
 impl ProcessOutput for RedirectToFile with fd(self) {
-  self.0
+  self.0.fd()
 }
 
 ///|
 impl ProcessOutput for RedirectToFile with after_spawn(self) {
-  @fd_util.close(self.0, kind=self.1, context="") catch {
-    _ => ()
-  }
+  self.0.close()
 }
 
 ///|
 impl ProcessInput for RedirectToFile with fd(self) {
-  self.0
+  self.0.fd()
 }
 
 ///|
 impl ProcessInput for RedirectToFile with after_spawn(self) {
-  @fd_util.close(self.0, kind=self.1, context="") catch {
-    _ => ()
-  }
+  self.0.close()
 }

--- a/src/raw_fd/raw_fd.mbt
+++ b/src/raw_fd/raw_fd.mbt
@@ -32,15 +32,8 @@ pub struct RawFd {
 pub async fn RawFd::RawFd(fd : @fd_util.Fd) -> RawFd {
   let context = "@raw_fd.RawFd::new()"
   let kind = @event_loop.kind_of_fd(fd, context~)
-  try {
-    let is_async = @fd_util.fd_is_nonblocking(fd, context~)
-    { fd, io: @event_loop.IoHandle::from_fd(fd, kind~, is_async~) }
-  } catch {
-    err => {
-      @fd_util.close(fd, kind~, context~)
-      raise err
-    }
-  }
+  let is_async = @fd_util.fd_is_nonblocking(fd, context~)
+  { fd, io: @event_loop.IoHandle::from_fd(fd, kind~, is_async~) }
 }
 
 ///|
@@ -55,12 +48,7 @@ pub async fn RawFd::RawFd(fd : @fd_util.Fd) -> RawFd {
 pub async fn RawFd::RawFd(fd : @fd_util.Fd) -> RawFd {
   let context = "@raw_fd.RawFd::new()"
   let kind = @event_loop.kind_of_fd(fd, context~)
-  { fd, io: @event_loop.IoHandle::from_fd(fd, kind~, is_async=false) } catch {
-    err => {
-      @fd_util.close(fd, kind~, context~)
-      raise err
-    }
-  }
+  { fd, io: @event_loop.IoHandle::from_fd(fd, kind~, is_async=false) }
 }
 
 ///|

--- a/src/raw_fd/raw_fd_test.mbt
+++ b/src/raw_fd/raw_fd_test.mbt
@@ -68,6 +68,7 @@ async test "file as raw fd" {
   )
   let fd = io.detach_from_event_loop()
   let file = @raw_fd.RawFd(fd)
+  defer file.close()
   assert_true(@event_loop.kind_of_fd(fd, context="kind_of_fd") is Regular)
   let buf = FixedArray::make(truth.length() + 1, b'\x00')
   let len = for n = 0; n < buf.length(); {
@@ -112,8 +113,8 @@ async test "socket as raw fd" {
       @os_error.check_errno("make_udp_socket()")
     }
     let client = @raw_fd.RawFd(sock)
-    assert_true(@event_loop.kind_of_fd(sock, context="kind_of_fd") is Socket)
     defer client.close()
+    assert_true(@event_loop.kind_of_fd(sock, context="kind_of_fd") is Socket)
     let server_addr = @socket.Addr::parse("127.0.0.1:\{port}")
     if connect(sock, server_addr) < 0 {
       @os_error.check_errno("connect()")

--- a/src/raw_fd/raw_fd_test.mbt
+++ b/src/raw_fd/raw_fd_test.mbt
@@ -57,7 +57,7 @@ async test "pipe as raw fd" {
 ///|
 async test "file as raw fd" {
   let truth = @fs.read_file("LICENSE").binary()
-  let fd = @event_loop.open_detached(
+  let (io, _) = @event_loop.open(
     "LICENSE",
     0,
     create=0,
@@ -65,7 +65,8 @@ async test "file as raw fd" {
     sync=0,
     mode=0,
     context="file as raw fd test",
-  ).fd()
+  )
+  let fd = io.detach_from_event_loop()
   let file = @raw_fd.RawFd(fd)
   assert_true(@event_loop.kind_of_fd(fd, context="kind_of_fd") is Regular)
   let buf = FixedArray::make(truth.length() + 1, b'\x00')

--- a/src/socket/getsockname_test.mbt
+++ b/src/socket/getsockname_test.mbt
@@ -18,11 +18,13 @@ async test "getsockname TCP" {
     let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
     let server_addr = server.addr
     guard server_addr.to_string() is [.. "127.0.0.1:", ..] else {
+      server.close()
       raise Failure::Failure("incorrect server address \{server_addr}")
     }
     let client_addr_from_server = group.spawn(() => {
       defer server.close()
       let (conn, peer_addr) = server.accept()
+      defer conn.close()
       assert_eq(conn.addr, server_addr)
       inspect(conn.read_all().text(), content="abcd")
       peer_addr
@@ -43,6 +45,7 @@ async test "getsockname UDP" {
     let server = @socket.UdpServer(@socket.Addr::parse("127.0.0.1:0"))
     let server_addr = server.addr
     guard server_addr.to_string() is [.. "127.0.0.1:", ..] else {
+      server.close()
       raise Failure::Failure("incorrect server address \{server_addr}")
     }
     let client_addr_from_server = group.spawn(() => {

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -247,14 +247,14 @@ pub async fn Tcp::connect(addr : Addr) -> Tcp {
       @os_error.check_errno("@socket.Tcp::connect(): set TCP_NODELAY")
     }
     conn.connect(addr.0, context~)
+    let addr = getsockname(sock, family, context~)
+    { io: conn, addr, read_buf: @io.ReaderBuffer::new() }
   } catch {
     err => {
       conn.close()
       raise err
     }
   }
-  let addr = getsockname(sock, family, context~)
-  { io: conn, addr, read_buf: @io.ReaderBuffer::new() }
 }
 
 ///|

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -199,13 +199,19 @@ pub async fn TcpServer::accept(self : TcpServer) -> (Tcp, Addr) {
   let family = self.addr.family()
   let conn_sock = make_tcp_socket(family, context~)
   let conn = self.io.accept(conn_sock, context~)
-  if disable_nagle(conn_sock) < 0 {
-    @fd_util.close(conn_sock, kind=Socket, context~)
-    @os_error.check_errno("@socket.TcpServer::accept(): set TCP_NODELAY")
+  try {
+    if disable_nagle(conn_sock) < 0 {
+      @os_error.check_errno("@socket.TcpServer::accept(): set TCP_NODELAY")
+    }
+    let addr = getpeername(conn_sock, self.addr.family(), context~)
+    // The local address of a server connection is the same as the listen address
+    ({ io: conn, addr: self.addr, read_buf: @io.ReaderBuffer::new() }, addr)
+  } catch {
+    err => {
+      conn.close()
+      raise err
+    }
   }
-  let addr = getpeername(conn_sock, self.addr.family(), context~)
-  // The local address of a server connection is the same as the listen address
-  ({ io: conn, addr: self.addr, read_buf: @io.ReaderBuffer::new() }, addr)
 }
 
 ///|


### PR DESCRIPTION
This PR introduces an optional fd leak check, which can be enabled by setting the `MOONBIT_ASYNC_CHECK_FD_LEAK`. When enabled, the `moonbitlang/async` event loop will abort if there are unclosed file descriptor managed by the event loop on exit. Currently not much information can be reported on the exact source of the leaked fd, merely the presence of such leak can be known.

To make the scope of the leak check wilder, some internal refactor is performed. Most raw fd usage outside `moonbitlang/async/internal/event_loop` are eliminated in favor of using `@event_loop.IoHandle`. `is_async=false` can be used to disable event loop integration of the fd, but still allowing it to get managed by the library, and hence leak-checked. The semantic of `@event_loop.IoHandle::from_fd` is also refined a bit. It now automatically closes the input fd on failure, this allows eliminating some error handling boilerplate around the codebase when constructing IO handle.

Several leaks in the existing codebase are detected by the leak check. They are also fixed in this PR.