### PR TITLE
attach #valtype to more types and expose Coroutine struct fields

### DIFF
--- a/src/cond_var/cond_var.mbt
+++ b/src/cond_var/cond_var.mbt
@@ -30,6 +30,7 @@ priv struct Waiter {
 
 ///|
 /// A condition variable that can be used for synchronization between tasks.
+#valtype
 struct Cond {
   waiters : @deque.Deque[Waiter]
 }

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-priv enum State {
+enum State {
   Done
   Fail(Error)
   Running
@@ -21,7 +21,7 @@ priv enum State {
 }
 
 ///|
-struct Coroutine {
+pub struct Coroutine {
   coro_id : Int
   mut state : State
   mut shielded : Bool

--- a/src/internal/coroutine/pkg.generated.mbti
+++ b/src/internal/coroutine/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/async/internal/coroutine"
 
 import {
   "moonbitlang/core/debug",
+  "moonbitlang/core/set",
 }
 
 // Values
@@ -32,7 +33,14 @@ pub(all) suberror Cancelled derive(@debug.Debug)
 pub impl Show for Cancelled
 
 // Types and methods
-type Coroutine
+pub struct Coroutine {
+  coro_id : Int
+  mut state : State
+  mut shielded : Bool
+  mut cancelled : Bool
+  mut ready : Bool
+  downstream : @set.Set[Coroutine]
+}
 pub fn Coroutine::cancel(Self) -> Unit
 pub fn Coroutine::check_error(Self) -> Unit raise
 pub fn Coroutine::unwrap(Self) -> Unit raise
@@ -40,6 +48,8 @@ pub async fn Coroutine::wait(Self) -> Unit
 pub fn Coroutine::wake(Self) -> Unit
 pub impl Eq for Coroutine
 pub impl Hash for Coroutine
+
+type State
 
 // Type aliases
 

--- a/src/task.mbt
+++ b/src/task.mbt
@@ -15,6 +15,7 @@
 ///|
 /// `Task[X]` represents a running task with result type `X`,
 /// it can be used to wait and retrieve the result value of the task.
+#valtype
 struct Task[X] {
   value : Ref[X?]
   coro : @coroutine.Coroutine


### PR DESCRIPTION
Note this is not plan to be merged.

I am thinking we need an attribute like

```
#allow_in_valtype
struct Coroutine {
   ...
}
```
cc @Yu-zh 

## Summary

This PR extends the use of `#valtype` to more types and exposes additional struct fields in the public API.

### Changes

- **`Task[X]`** — Added `#valtype`, enabling the struct to be passed as values (two reference fields: `value: Ref[X?]` and `coro: Coroutine`)
- **`Cond`** (cond_var) — Added `#valtype`; this struct has a single non-mutable field (`waiters: Deque`) so it qualifies
- **`Coroutine`** (internal/coroutine) — Changed from opaque `type Coroutine` to `pub struct Coroutine`, exposing its fields (`coro_id`, `state`, `shielded`, `cancelled`, `ready`, `downstream`) for downstream use and reflection
- **`State`** enum — Removed `priv` so it is accessible as part of the public `Coroutine` struct definition
- Regenerated `pkg.generated.mbti` for the coroutine package

### Why not more types?

Several candidates were evaluated but cannot be `#valtype` due to language constraints:
- **`Semaphore`**, **`Queue[X]`** — have `mut` fields; `#valtype` disallows mutable fields
- **`Tcp`, `TcpServer`, `UdpClient`, `UdpServer`, `RawFd`** — all hold a `@event_loop.IoHandle` field which is an abstract type; `#valtype` disallows abstract type fields

## Testing

`moon check` passes with no errors.