### PR TITLE
Preserve URI authority in HTTP Host headers

### DIFF
--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -63,8 +63,7 @@ priv struct OngoingRequest {
 
 ///|
 struct Client {
-  host : String
-  port : Int
+  authority : String
   protocol : Protocol
   headers : Map[String, String]
   mut request : OngoingRequest?
@@ -85,13 +84,16 @@ pub fn Client::close(self : Client) -> Unit {
 ///|
 fn Client::connect(
   host : String,
+  authority? : String = host,
   headers? : Map[String, String] = {},
   protocol? : Protocol = Https,
   port? : Int = protocol.default_port(),
   proxy? : Client,
 ) -> Client {
   ignore(proxy)
-  { host, headers, protocol, port, request: None, response_body: None }
+  ignore(host)
+  ignore(port)
+  { authority, headers, protocol, request: None, response_body: None }
 }
 
 ///|
@@ -123,9 +125,9 @@ pub async fn Client::Client(
 ) -> Client {
   ignore(proxy)
   ignore(verify)
-  let (protocol, port, host, path) = resolve_url(uri)
+  let (protocol, authority, host, port, path) = resolve_url(uri)
   guard path is "/" else { raise InvalidFormat }
-  Client::connect(host, protocol~, port~, headers~, proxy?)
+  Client::connect(host, authority~, protocol~, port~, headers~, proxy?)
 }
 
 ///|
@@ -226,12 +228,7 @@ pub async fn Client::request(
     Https => "https://"
   }
   let path = if path is ['/', ..] { path } else { "/\{path}" }
-  let port = if self.port == self.protocol.default_port() {
-    ""
-  } else {
-    ":\{self.port}"
-  }
-  let uri = "\{protocol}\{self.host}\{port}\{path}"
+  let uri = "\{protocol}\{self.authority}\{path}"
   let meth = match meth {
     Get => "GET"
     Head => "HEAD"

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -39,6 +39,7 @@ pub suberror ProxyError {
 ///|
 async fn Client::connect(
   host : String,
+  authority? : String = host,
   headers? : Map[String, String] = {},
   protocol? : Protocol = Https,
   port? : Int = protocol.default_port(),
@@ -61,7 +62,7 @@ async fn Client::connect(
   } else {
     Plain(@socket.Tcp::connect_to_host(host, port~))
   }
-  headers["Host"] = host
+  headers["Host"] = authority
   let (tls, reader, sender) = match (protocol, transport) {
     (Http, Plain(conn)) =>
       (None, Reader::new(conn), Sender::new(conn, headers~))
@@ -133,13 +134,13 @@ pub async fn Client::Client(
   verify? : Bool = true,
   trust? : @tls.TrustedRoot,
 ) -> Client {
-  let (protocol, port, host, path) = resolve_url(uri)
+  let (protocol, authority, host, port, path) = resolve_url(uri)
   guard path is "/" else { raise InvalidFormat }
   let trust = match trust {
     Some(trust) => trust
     None => if verify { SystemRoot } else { NoVerification }
   }
-  Client::connect(host, protocol~, port~, headers~, proxy?, trust~)
+  Client::connect(host, authority~, protocol~, port~, headers~, proxy?, trust~)
 }
 
 ///|

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -33,7 +33,7 @@ pub suberror URIParseError {
 } derive(Debug, ToJson)
 
 ///|
-fn resolve_url(uri : String) -> (Protocol, Int, String, String) raise {
+fn resolve_url(uri : String) -> (Protocol, String, String, Int, String) raise {
   guard uri.find("://") is Some(protocol_len) else { raise InvalidFormat }
   let protocol = match uri[:protocol_len] {
     "http" => Http
@@ -41,12 +41,12 @@ fn resolve_url(uri : String) -> (Protocol, Int, String, String) raise {
     protocol => raise UnsupportedProtocol(protocol.to_owned())
   }
   let uri = uri[protocol_len + 3:]
-  let (host, path) = if uri.find("/") is Some(i) {
+  let (authority, path) = if uri.find("/") is Some(i) {
     (uri[:i], uri[i:])
   } else {
     (uri, "/")
   }
-  let (host, port) = if host =~ (
+  let (host, port) = if authority =~ (
       re"^" +
       (re".*" as host) +
       re":" +
@@ -57,10 +57,10 @@ fn resolve_url(uri : String) -> (Protocol, Int, String, String) raise {
     guard port is (1..<65536) else { raise InvalidFormat }
     (host, port)
   } else {
-    (host, protocol.default_port())
+    (authority, protocol.default_port())
   }
   let path = if path == "" { "/" } else { path.to_owned() }
-  (protocol, port, host.to_owned(), path)
+  (protocol, authority.to_owned(), host.to_owned(), port, path)
 }
 
 ///|
@@ -71,8 +71,15 @@ async fn perform_request(
   body : &@io.Data,
   proxy? : Client,
 ) -> (Response, &@io.Data) {
-  let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
+  let (protocol, authority, host, port, path) = resolve_url(uri)
+  let client = Client::connect(
+    host,
+    authority~,
+    headers~,
+    protocol~,
+    port~,
+    proxy?,
+  )
   defer client.close()
   let response = client..request(meth, path)..write(body).end_request()
   (response, client.read_all())
@@ -135,8 +142,15 @@ pub async fn get_stream(
   body? : &@io.Data = b"",
   proxy? : Client,
 ) -> (Response, Client) {
-  let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
+  let (protocol, authority, host, port, path) = resolve_url(uri)
+  let client = Client::connect(
+    host,
+    authority~,
+    headers~,
+    protocol~,
+    port~,
+    proxy?,
+  )
   try {
     let response = client..request(Get, path)..write(body).end_request()
     (response, client)
@@ -166,8 +180,8 @@ pub async fn put_stream(
   headers? : Map[String, String] = {},
   proxy? : Client,
 ) -> Client {
-  let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, protocol~, port~, proxy?)
+  let (protocol, authority, host, port, path) = resolve_url(uri)
+  let client = Client::connect(host, authority~, protocol~, port~, proxy?)
   try client.request(Put, path, extra_headers=headers) catch {
     err => {
       client.close()
@@ -196,8 +210,8 @@ pub async fn post_stream(
   headers? : Map[String, String] = {},
   proxy? : Client,
 ) -> Client {
-  let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, protocol~, port~, proxy?)
+  let (protocol, authority, host, port, path) = resolve_url(uri)
+  let client = Client::connect(host, authority~, protocol~, port~, proxy?)
   try client.request(Post, path, extra_headers=headers) catch {
     err => {
       client.close()

--- a/src/http/resolve_url_wbtest.mbt
+++ b/src/http/resolve_url_wbtest.mbt
@@ -17,19 +17,27 @@ test "resolve_url" {
   debug_inspect(
     try? resolve_url("http://www.example.org"),
     content=(
-      #|Ok((Http, 80, "www.example.org", "/"))
+      #|Ok((Http, "www.example.org", "www.example.org", 80, "/"))
     ),
   )
   debug_inspect(
     try? resolve_url("http://www.example.org/path/to"),
     content=(
-      #|Ok((Http, 80, "www.example.org", "/path/to"))
+      #|Ok((Http, "www.example.org", "www.example.org", 80, "/path/to"))
     ),
   )
   debug_inspect(
     try? resolve_url("https://www.example.org/path/to?search=q"),
     content=(
-      #|Ok((Https, 443, "www.example.org", "/path/to?search=q"))
+      #|Ok(
+      #|  (
+      #|    Https,
+      #|    "www.example.org",
+      #|    "www.example.org",
+      #|    443,
+      #|    "/path/to?search=q",
+      #|  ),
+      #|)
     ),
   )
   debug_inspect(
@@ -41,13 +49,25 @@ test "resolve_url" {
   debug_inspect(
     try? resolve_url("http://www.example.org:10042"),
     content=(
-      #|Ok((Http, 10042, "www.example.org", "/"))
+      #|Ok((Http, "www.example.org:10042", "www.example.org", 10042, "/"))
     ),
   )
   debug_inspect(
     try? resolve_url("http://www.example.org:10042/path"),
     content=(
-      #|Ok((Http, 10042, "www.example.org", "/path"))
+      #|Ok((Http, "www.example.org:10042", "www.example.org", 10042, "/path"))
+    ),
+  )
+  debug_inspect(
+    try? resolve_url("http://www.example.org:80"),
+    content=(
+      #|Ok((Http, "www.example.org:80", "www.example.org", 80, "/"))
+    ),
+  )
+  debug_inspect(
+    try? resolve_url("https://www.example.org:443"),
+    content=(
+      #|Ok((Https, "www.example.org:443", "www.example.org", 443, "/"))
     ),
   )
   debug_inspect(


### PR DESCRIPTION
## Summary

This change preserves the parsed URI authority through HTTP request setup instead of reconstructing the Host header from host and port.

## What changed

- make resolve_url preserve the original authority
- use that authority directly for the HTTP Host header on native
- use the preserved authority when constructing request URIs on JS
- add coverage for explicit default ports such as 80 and 443

## Why

This change fixes a real request-construction bug that caused the emitted request authority to diverge from the URI that the caller provided.

In the observed failure mode, a request URI with an explicitly specified port could be turned into a request with a different Host value during setup. The implementation parsed the URI, split the authority into derived host and port values, discarded the original authority form, and later rebuilt Host from those derived pieces. That sequence was lossy.

Once the original authority was discarded, request construction could no longer preserve whether a port had been explicitly present in the URI. As a result, the final request metadata could differ from the caller-provided URI, including cases where an explicitly specified port was dropped from Host.

By preserving the original URI authority, the request stays aligned with the authority the caller actually , improving HTTP/1.1 correctness and interoperability.