### PR TITLE
include explicit port in `Host` header

### DIFF
--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -64,7 +64,6 @@ priv struct OngoingRequest {
 ///|
 struct Client {
   host : String
-  port : Int
   protocol : Protocol
   headers : Map[String, String]
   mut request : OngoingRequest?
@@ -87,11 +86,10 @@ fn Client::connect(
   host : String,
   headers? : Map[String, String] = {},
   protocol? : Protocol = Https,
-  port? : Int = protocol.default_port(),
   proxy? : Client,
 ) -> Client {
   ignore(proxy)
-  { host, headers, protocol, port, request: None, response_body: None }
+  { host, headers, protocol, request: None, response_body: None }
 }
 
 ///|
@@ -123,9 +121,9 @@ pub async fn Client::Client(
 ) -> Client {
   ignore(proxy)
   ignore(verify)
-  let (protocol, port, host, path) = resolve_url(uri)
+  let (protocol, host, path) = resolve_url(uri)
   guard path is "/" else { raise InvalidFormat }
-  Client::connect(host, protocol~, port~, headers~, proxy?)
+  Client::connect(host, protocol~, headers~, proxy?)
 }
 
 ///|
@@ -217,7 +215,7 @@ extern "js" fn Client::request_ffi(
 pub async fn Client::request(
   self : Client,
   meth : RequestMethod,
-  path : String,
+  path : StringView,
   extra_headers? : Map[String, String] = {},
 ) -> Unit {
   guard self.request is None
@@ -226,12 +224,7 @@ pub async fn Client::request(
     Https => "https://"
   }
   let path = if path is ['/', ..] { path } else { "/\{path}" }
-  let port = if self.port == self.protocol.default_port() {
-    ""
-  } else {
-    ":\{self.port}"
-  }
-  let uri = "\{protocol}\{self.host}\{port}\{path}"
+  let uri = "\{protocol}\{self.host}\{path}"
   let meth = match meth {
     Get => "GET"
     Head => "HEAD"

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -38,17 +38,18 @@ pub suberror ProxyError {
 
 ///|
 async fn Client::connect(
-  host : String,
+  host : StringView,
   headers? : Map[String, String] = {},
   protocol? : Protocol = Https,
-  port? : Int = protocol.default_port(),
   proxy? : Client,
   trust? : @tls.TrustedRoot = SystemRoot,
 ) -> Client {
+  let (hostname, port) = resolve_host(host, protocol~)
   let transport = if proxy is Some(proxy) {
-    let path = "\{host}:\{port}"
     try {
-      let response = proxy..request(Connect, path).end_request()
+      let response = proxy
+        ..request(Connect, "\{hostname}:\{port}")
+        .end_request()
       guard response.code is (200..<300) else { raise ProxyError(response) }
       proxy..skip_response_body().enter_passthrough_mode()
     } catch {
@@ -59,14 +60,14 @@ async fn Client::connect(
     }
     Proxy(proxy)
   } else {
-    Plain(@socket.Tcp::connect_to_host(host, port~))
+    Plain(@socket.Tcp::connect_to_host(hostname, port~))
   }
-  headers["Host"] = host
+  headers["Host"] = host.to_owned()
   let (tls, reader, sender) = match (protocol, transport) {
     (Http, Plain(conn)) =>
       (None, Reader::new(conn), Sender::new(conn, headers~))
     (Https, Plain(conn)) => {
-      let tls = @tls.Tls::client(conn, host~, trust~) catch {
+      let tls = @tls.Tls::client(conn, host=hostname.to_owned(), trust~) catch {
         err => {
           transport.close()
           raise err
@@ -77,7 +78,7 @@ async fn Client::connect(
     (Http, Proxy(proxy)) =>
       (None, Reader::new(proxy), Sender::new(proxy, headers~))
     (Https, Proxy(proxy)) => {
-      let tls = @tls.Tls::client(proxy, host~, trust~) catch {
+      let tls = @tls.Tls::client(proxy, host=hostname.to_owned(), trust~) catch {
         err => {
           transport.close()
           raise err
@@ -133,13 +134,13 @@ pub async fn Client::Client(
   verify? : Bool = true,
   trust? : @tls.TrustedRoot,
 ) -> Client {
-  let (protocol, port, host, path) = resolve_url(uri)
+  let (protocol, host, path) = resolve_url(uri)
   guard path is "/" else { raise InvalidFormat }
   let trust = match trust {
     Some(trust) => trust
     None => if verify { SystemRoot } else { NoVerification }
   }
-  Client::connect(host, protocol~, port~, headers~, proxy?, trust~)
+  Client::connect(host, protocol~, headers~, proxy?, trust~)
 }
 
 ///|

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -33,7 +33,7 @@ pub suberror URIParseError {
 } derive(Debug, ToJson)
 
 ///|
-fn resolve_url(uri : String) -> (Protocol, Int, String, String) raise {
+fn resolve_url(uri : String) -> (Protocol, String, StringView) raise {
   guard uri.find("://") is Some(protocol_len) else { raise InvalidFormat }
   let protocol = match uri[:protocol_len] {
     "http" => Http
@@ -46,7 +46,17 @@ fn resolve_url(uri : String) -> (Protocol, Int, String, String) raise {
   } else {
     (uri, "/")
   }
-  let (host, port) = if host =~ (
+  let path : StringView = if path == "" { "/" } else { path }
+  (protocol, host.to_owned(), path)
+}
+
+///|
+#cfg(target="native")
+fn resolve_host(
+  host : StringView,
+  protocol~ : Protocol,
+) -> (StringView, Int) raise {
+  if host =~ (
       re"^" +
       (re".*" as host) +
       re":" +
@@ -59,8 +69,6 @@ fn resolve_url(uri : String) -> (Protocol, Int, String, String) raise {
   } else {
     (host, protocol.default_port())
   }
-  let path = if path == "" { "/" } else { path.to_owned() }
-  (protocol, port, host.to_owned(), path)
 }
 
 ///|
@@ -71,8 +79,8 @@ async fn perform_request(
   body : &@io.Data,
   proxy? : Client,
 ) -> (Response, &@io.Data) {
-  let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
+  let (protocol, host, path) = resolve_url(uri)
+  let client = Client::connect(host, headers~, protocol~, proxy?)
   defer client.close()
   let response = client..request(meth, path)..write(body).end_request()
   (response, client.read_all())
@@ -135,8 +143,8 @@ pub async fn get_stream(
   body? : &@io.Data = b"",
   proxy? : Client,
 ) -> (Response, Client) {
-  let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, headers~, protocol~, port~, proxy?)
+  let (protocol, host, path) = resolve_url(uri)
+  let client = Client::connect(host, headers~, protocol~, proxy?)
   try {
     let response = client..request(Get, path)..write(body).end_request()
     (response, client)
@@ -166,8 +174,8 @@ pub async fn put_stream(
   headers? : Map[String, String] = {},
   proxy? : Client,
 ) -> Client {
-  let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, protocol~, port~, proxy?)
+  let (protocol, host, path) = resolve_url(uri)
+  let client = Client::connect(host, protocol~, proxy?)
   try client.request(Put, path, extra_headers=headers) catch {
     err => {
       client.close()
@@ -196,8 +204,8 @@ pub async fn post_stream(
   headers? : Map[String, String] = {},
   proxy? : Client,
 ) -> Client {
-  let (protocol, port, host, path) = resolve_url(uri)
-  let client = Client::connect(host, protocol~, port~, proxy?)
+  let (protocol, host, path) = resolve_url(uri)
+  let client = Client::connect(host, protocol~, proxy?)
   try client.request(Post, path, extra_headers=headers) catch {
     err => {
       client.close()

--- a/src/http/resolve_url_wbtest.mbt
+++ b/src/http/resolve_url_wbtest.mbt
@@ -14,48 +14,89 @@
 
 ///|
 test "resolve_url" {
+  fn to_owned(result : (_, _, StringView)) {
+    let (a, b, c) = result
+    (a, b, c.to_owned())
+  }
   debug_inspect(
-    try? resolve_url("http://www.example.org"),
+    try? to_owned(resolve_url("http://www.example.org")),
     content=(
-      #|Ok((Http, 80, "www.example.org", "/"))
+      #|Ok((Http, "www.example.org", "/"))
     ),
   )
   debug_inspect(
-    try? resolve_url("http://www.example.org/path/to"),
+    try? to_owned(resolve_url("http://www.example.org/path/to")),
     content=(
-      #|Ok((Http, 80, "www.example.org", "/path/to"))
+      #|Ok((Http, "www.example.org", "/path/to"))
     ),
   )
   debug_inspect(
-    try? resolve_url("https://www.example.org/path/to?search=q"),
+    try? to_owned(resolve_url("https://www.example.org/path/to?search=q")),
     content=(
-      #|Ok((Https, 443, "www.example.org", "/path/to?search=q"))
+      #|Ok((Https, "www.example.org", "/path/to?search=q"))
     ),
   )
   debug_inspect(
-    try? resolve_url("ftp://www.example.org"),
+    try? to_owned(resolve_url("ftp://www.example.org")),
     content=(
       #|Err(UnsupportedProtocol("ftp"))
     ),
   )
   debug_inspect(
-    try? resolve_url("http://www.example.org:10042"),
+    try? to_owned(resolve_url("http://www.example.org:10042")),
     content=(
-      #|Ok((Http, 10042, "www.example.org", "/"))
+      #|Ok((Http, "www.example.org:10042", "/"))
     ),
   )
   debug_inspect(
-    try? resolve_url("http://www.example.org:10042/path"),
+    try? to_owned(resolve_url("http://www.example.org:10042/path")),
     content=(
-      #|Ok((Http, 10042, "www.example.org", "/path"))
+      #|Ok((Http, "www.example.org:10042", "/path"))
+    ),
+  )
+}
+
+///|
+test "resolve_host" {
+  fn to_owned(result : (StringView, _)) {
+    let (a, b) = result
+    (a.to_owned(), b)
+  }
+
+  debug_inspect(
+    try? to_owned(resolve_host("www.example.org", protocol=Http)),
+    content=(
+      #|Ok(("www.example.org", 80))
     ),
   )
   debug_inspect(
-    try? resolve_url("http://www.example.org:0"),
-    content="Err(InvalidFormat)",
+    try? to_owned(resolve_host("www.example.org", protocol=Https)),
+    content=(
+      #|Ok(("www.example.org", 443))
+    ),
   )
   debug_inspect(
-    try? resolve_url("http://www.example.org:100042"),
-    content="Err(InvalidFormat)",
+    try? to_owned(resolve_host("www.example.org:42", protocol=Http)),
+    content=(
+      #|Ok(("www.example.org", 42))
+    ),
+  )
+  debug_inspect(
+    try? to_owned(resolve_host("www.example.org:42", protocol=Https)),
+    content=(
+      #|Ok(("www.example.org", 42))
+    ),
+  )
+  debug_inspect(
+    try? to_owned(resolve_host("www.example.org:0", protocol=Https)),
+    content=(
+      #|Err(InvalidFormat)
+    ),
+  )
+  debug_inspect(
+    try? to_owned(resolve_host("www.example.org:100042", protocol=Https)),
+    content=(
+      #|Err(InvalidFormat)
+    ),
   )
 }


### PR DESCRIPTION
#374

- for `Host`  header in the HTTP message, explicit port should be included
- for DNS resolution and TLS SNI, the port should not be included