### PR TITLE
forbid `Transfer-Encoding` instead of `Content-Encoding` in supplied HTTP headers

### DIFF
--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -35,7 +35,7 @@ priv struct Sender {
 
 ///|
 let forbidden_headers : Set[String] = Set::from_array([
-  "content-length", "content-encoding",
+  "content-length", "transfer-encoding",
 ])
 
 ///|

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -347,11 +347,11 @@ async test "send invalid header" {
     let (r, w) = @io.pipe()
     root.spawn_bg() <| () => {
       defer w.close()
-      let sender = Sender::new(w, headers={ "Content-Encoding": "chunked" })
+      let sender = Sender::new(w, headers={ "Transfer-Encoding": "chunked" })
       let _ = sender.send_request(Get, "/", extra_headers={
         "Host": "x.y.org",
         "User-Agent": "MoonBit",
-        "Content-Encoding": "chunked",
+        "Transfer-Encoding": "chunked",
       })
       sender.end_body()
     }


### PR DESCRIPTION
Some HTTP headers are automatically set by `moonbitlang/async/http`, so they should not be set manually by users. Previously, there was a typo in the code that wrongly forbid `Content-Encoding` instead of `Transfer-Encoding`. This PR fixes the issue.