### PR TITLE
avoid dependency on remote server behavior in test

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -254,6 +254,7 @@ jobs:
 
       - name: run test with address sanitizer
         run: |
+          export MOONBIT_ASYNC_TEST_SANITIZER_ENABLED=1
           moon test
 
   sanitizer-check-windows:
@@ -297,4 +298,5 @@ jobs:
       - name: run test with address sanitizer
         run: |
           $env:ASAN_OPTIONS='fast_unwind_on_malloc=0'
+          $env:MOONBIT_ASYNC_TEST_SANITIZER_ENABLED=1
           moon test

--- a/src/http/moon.pkg
+++ b/src/http/moon.pkg
@@ -13,6 +13,7 @@ import {
 import {
   "moonbitlang/core/debug",
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/env",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/gzip" @gzip_stream,

--- a/src/http/moon.pkg
+++ b/src/http/moon.pkg
@@ -14,6 +14,8 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/gzip" @gzip_stream,
 } for "test"
 
 import {

--- a/src/http/proxy_test.mbt
+++ b/src/http/proxy_test.mbt
@@ -120,12 +120,10 @@ async test "proxied https request" {
         handle_connect(log, req, body, conn)
       })
     }
-    let (_, result) = @async.with_timeout(10000, () => {
-      @http.get(
-        "https://www.moonbitlang.com",
-        proxy=@http.Client("http://localhost:\{port}"),
-      )
-    })
+    let (_, result) = @http.get(
+      "https://www.moonbitlang.com",
+      proxy=@http.Client("http://localhost:\{port}"),
+    )
     assert_true(result.text().has_prefix("<!doctype html>"))
   }
   json_inspect(log, content=[

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -39,9 +39,29 @@ async test "request cancel" {
 ///|
 #cfg(target="native")
 async test "manual Accept-Encoding" {
-  let (_, result1) = @http.get("https://www.moonbitlang.com")
-  let (_, result2) = @http.get("https://www.moonbitlang.com", headers={
-    "Accept-Encoding": "gzip",
-  })
-  assert_not_eq(result1.binary().length(), result2.binary().length())
+  let log = []
+  let test_server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
+  @async.with_task_group <| group => {
+    group.spawn_bg(no_wait=true) <| () => {
+      test_server.run_forever() <| ((req, _body, conn) => {
+        let accept_encoding = req.headers.get("accept-encoding")
+        log.push("server received: \{to_repr(accept_encoding)}")
+        let file = @fs.open("LICENSE", mode=ReadOnly)
+        defer file.close()
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Encoding": "gzip",
+        })
+        @gzip_stream.Encoder(conn)..write_reader(file).end()
+        conn.end_response()
+      })
+    }
+    let (_, result1) = @http.get("http://\{test_server.addr}")
+    let (_, result2) = @http.get("http://\{test_server.addr}", headers={
+      "Accept-Encoding": "gzip",
+    })
+    assert_not_eq(result1.binary().length(), result2.binary().length())
+    json_inspect(log, content=[
+      "server received: Some(\"gzip,identity\")", "server received: Some(\"gzip\")",
+    ])
+  }
 }

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -27,13 +27,16 @@ async test "http request" {
 ///|
 async test "request cancel" {
   let start = @async.now()
-  let _ = @async.with_timeout_opt(200, () => {
+  let result = @async.with_timeout_opt(200, () => {
     @http.get(
       "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz",
     )
   })
   let end = @async.now()
-  assert_true((end - start).to_int() < 250)
+  assert_true(result is None)
+  if @env.get_env_var("MOONBIT_ASYNC_TEST_SANITIZER_ENABLED") is None {
+    assert_true(end - start < 250)
+  }
 }
 
 ///|

--- a/src/http/unimplemented_test.mbt
+++ b/src/http/unimplemented_test.mbt
@@ -17,6 +17,7 @@
 let _ignore_unused_import : Unit = {
   ignore(@async.sleep)
   ignore(@utf8.encode(""))
+  ignore(@env.get_env_var)
   ignore((_ : @gzip_stream.Encoder[&@io.Writer]) => ())
   ignore(@fs.unimplemented)
 }

--- a/src/http/unimplemented_test.mbt
+++ b/src/http/unimplemented_test.mbt
@@ -17,4 +17,6 @@
 let _ignore_unused_import : Unit = {
   ignore(@async.sleep)
   ignore(@utf8.encode(""))
+  ignore((_ : @gzip_stream.Encoder[&@io.Writer]) => ())
+  ignore(@fs.unimplemented)
 }


### PR DESCRIPTION
https://github.com/moonbitlang/async/pull/377#issuecomment-4485123896

Get rid of dependency on a remote server in the test for HTTP auto gzip decompression. Use a custom local test server instead.