### PR TITLE
add `Output::write_string`; rename `Writer::write` → `write_data`

### DIFF
--- a/examples/http_file_server/main.mbt
+++ b/examples/http_file_server/main.mbt
@@ -122,7 +122,7 @@ let page_for_404 : Bytes = b"<html><head></head><body>Page Not Found</body></htm
 async fn serve_404(conn : @http.ServerConnection) -> Unit {
   conn
   ..send_response(404, "NotFound", extra_headers={ "Content-Type": "text/html" })
-  ..write(page_for_404)
+  ..write_data(page_for_404)
   .end_response()
 }
 

--- a/examples/tcp_ping_pong/main.mbt
+++ b/examples/tcp_ping_pong/main.mbt
@@ -26,7 +26,7 @@ async fn server_main(server : @socket.TcpServer, println : Printer) -> Unit {
       @async.sleep(10)
       println("server received: \{@utf8.decode(msg)}")
       let reply = "pong"
-      conn.write(reply)
+      conn.write_data(reply)
       println("server sent: \{reply}")
       if msg == b"exit" {
         println("server initiate terminate")
@@ -58,7 +58,7 @@ async fn client(
   // with server side "received connection" message
   @async.sleep(10)
   println("client \{id}: connection established")
-  conn.write(msg)
+  conn.write_data(msg)
   println("client \{id} sent: \{msg}")
   if conn.read_some() is Some(msg) {
     @async.sleep(10)

--- a/examples/tcp_server_benchmark/main.mbt
+++ b/examples/tcp_server_benchmark/main.mbt
@@ -43,7 +43,7 @@ async fn client(
               if send_count == 0 {
                 before = @async.now()
               }
-              conn.write(data)
+              conn.write_data(data)
               send_count += data.length().to_int64()
             }
             conn_group.spawn_loop(no_wait=true) <| () => {

--- a/src/fs/README.mbt.md
+++ b/src/fs/README.mbt.md
@@ -46,7 +46,7 @@ async test "open file for writing" {
   let test_file = "_build/test_open_write.txt"
   let file = @fs.open(test_file, mode=WriteOnly, create_mode=CreateOrTruncate)
   defer file.close()
-  file.write(b"Hello, World!")
+  file.write_data(b"Hello, World!")
   @fs.remove(test_file)
 }
 
@@ -59,7 +59,7 @@ async test "open with append mode" {
 
   // Append to existing file
   let file = @fs.open(test_file, mode=WriteOnly, append=true)
-  file.write(b"Second line\n")
+  file.write_data(b"Second line\n")
   file.close()
   let content = @fs.read_file(test_file).text()
   @fs.remove(test_file)
@@ -75,7 +75,7 @@ The `create` function is a convenience wrapper for creating new files:
 async test "create new file" {
   let test_file = "_build/test_create.txt"
   let file = @fs.create(test_file)
-  file.write(b"New file content")
+  file.write_data(b"New file content")
   file.close()
   let exists = @fs.exists(test_file)
   @fs.remove(test_file)
@@ -173,8 +173,8 @@ async test "write with sync modes" {
 async test "write using File methods" {
   let test_file = "_build/test_file_write.txt"
   let file = @fs.create(test_file)
-  file.write(b"Line 1\n")
-  file.write(b"Line 2\n")
+  file.write_data(b"Line 1\n")
+  file.write_data(b"Line 2\n")
   file.close()
   let content = @fs.read_file(test_file).text()
   @fs.remove(test_file)
@@ -227,7 +227,7 @@ async test "write at specific position" {
   {
     let file = @fs.open(test_file, mode=WriteOnly, create_mode=CreateOrTruncate)
     defer file.close()
-    file.write("abcdef")
+    file.write_data("abcdef")
     file.write_at(b"CD", position=2)
   }
 

--- a/src/fs/create_test.mbt
+++ b/src/fs/create_test.mbt
@@ -18,7 +18,7 @@ async test "basic create" {
   {
     let w = @fs.create(path, sync=Full)
     defer w.close()
-    w.write(b"abcd\n")
+    w.write_data(b"abcd\n")
   }
   let result = {
     let r = @fs.open(path, mode=ReadOnly)
@@ -47,7 +47,7 @@ async test "create or append" {
       append=true,
     )
     defer w.close()
-    w.write(data)
+    w.write_data(data)
   }
 
   add_data(b"abcd")
@@ -81,7 +81,7 @@ async test "create_mode test" {
       let file = @fs.create(path, allow_existing=false)
       defer file.close()
       group.add_defer(() => @fs.remove(path))
-      file.write("abcd")
+      file.write_data("abcd")
     }
     inspect(@fs.read_file(path).text(), content="abcd")
     assert_true((try? @fs.create(path, allow_existing=false)) is Err(_))
@@ -91,25 +91,25 @@ async test "create_mode test" {
     {
       let file = @fs.open(path, mode=WriteOnly, create_mode=OpenExisting)
       defer file.close()
-      file.write("AB")
+      file.write_data("AB")
     }
     inspect(@fs.read_file(path).text(), content="ABcd")
     {
       let file = @fs.open(path, mode=WriteOnly, create_mode=OpenOrCreate)
       defer file.close()
-      file.write("XY")
+      file.write_data("XY")
     }
     inspect(@fs.read_file(path).text(), content="XYcd")
     {
       let file = @fs.open(path, mode=WriteOnly, create_mode=CreateOrTruncate)
       defer file.close()
-      file.write("12")
+      file.write_data("12")
     }
     inspect(@fs.read_file(path).text(), content="12")
     {
       let file = @fs.open(path, mode=WriteOnly, create_mode=TruncateExisting)
       defer file.close()
-      file.write("34")
+      file.write_data("34")
     }
     inspect(@fs.read_file(path).text(), content="34")
   }

--- a/src/fs/eof_test.mbt
+++ b/src/fs/eof_test.mbt
@@ -19,7 +19,7 @@ async test "read EOF" {
   {
     let w = @fs.create(path, permission=0o644, sync=Full)
     defer w.close()
-    w.write(b"abcd")
+    w.write_data(b"abcd")
   }
   let n = {
     let r = @fs.open(path, mode=ReadOnly)

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -490,5 +490,5 @@ pub async fn write_file(
     permission~,
   )
   defer file.close()
-  file.write(content.binary())
+  file.write_data(content.binary())
 }

--- a/src/fs/named_pipe_test.mbt
+++ b/src/fs/named_pipe_test.mbt
@@ -76,9 +76,9 @@ async test "named fifo" {
     group.spawn_bg() <| () => {
       let w = @fs.open(path, mode=WriteOnly)
       defer w.close()
-      w.write("abcd\n")
+      w.write_data("abcd\n")
       @async.sleep(500)
-      w.write("efgh")
+      w.write_data("efgh")
     }
   }
 }

--- a/src/fs/random_access_test.mbt
+++ b/src/fs/random_access_test.mbt
@@ -25,7 +25,7 @@ async test "write_at" {
     defer w.close()
     w.write_at(b"56", position=w.size() - 2)
     w.write_at(b"34", position=2)
-    w.write("12") // still write from the start
+    w.write_data("12") // still write from the start
   }
   // read content
   {

--- a/src/fs/rename_test.mbt
+++ b/src/fs/rename_test.mbt
@@ -23,7 +23,7 @@ async test "rename basic" {
     sync=Full,
   )
   defer file.close()
-  file.write("abcd")
+  file.write_data("abcd")
   inspect(@fs.read_file(old_path).text(), content="abcd")
   @fs.rename(old_path, new_path)
   inspect(@fs.read_file(new_path).text(), content="abcd")
@@ -47,7 +47,7 @@ async test "rename replace" {
   defer old_file.close()
   let new_file = @fs.open(new_path, mode=ReadOnly, create_mode=OpenExisting)
   defer new_file.close()
-  old_file.write("abcd")
+  old_file.write_data("abcd")
   inspect(@fs.read_file(old_path).text(), content="abcd")
   inspect(@fs.read_file(new_path).text(), content="xyzw")
   assert_true((try? @fs.rename(old_path, new_path, replace=false)) is Err(_))

--- a/src/gzip/gzip_test.mbt
+++ b/src/gzip/gzip_test.mbt
@@ -22,7 +22,7 @@ async fn node_gzip(mode : String, input : Bytes) -> Bytes {
     })
     group.spawn_bg() <| () => {
       defer we_write.close()
-      we_write.write(input)
+      we_write.write_data(input)
     }
     let (code, stdout, stderr) = runner.wait()
     assert_eq(code, 0)
@@ -38,7 +38,7 @@ async fn encode_with_moonbit(input : Bytes) -> Bytes {
   @async.with_task_group() <| group => {
     group.spawn_bg() <| () => {
       defer w.close()
-      @gzip.Encoder(w)..write(input).end()
+      @gzip.Encoder(w)..write_data(input).end()
     }
     defer r.close()
     r.read_all().binary()
@@ -52,7 +52,7 @@ async fn decode_with_moonbit(input : Bytes) -> Bytes {
   @async.with_task_group() <| group => {
     group.spawn_bg() <| () => {
       defer w.close()
-      w.write(input)
+      w.write_data(input)
     }
     defer r.close()
     @gzip.Decoder(r).read_all().binary()
@@ -82,7 +82,7 @@ async test "encode decode roundtrip" {
         operating_system=b'\x03',
       )
       for chunk in source_chunks {
-        encoder.write(chunk)
+        encoder.write_data(chunk)
         @async.sleep(10)
       }
       encoder.end()
@@ -102,7 +102,7 @@ async test "encoder uses valid blocks across large writes" {
     root.spawn_bg() <| () => {
       defer compressed_w.close()
       let encoder = @gzip.Encoder(compressed_w)
-      encoder.write(payload)
+      encoder.write_data(payload)
       encoder.end()
     }
 
@@ -123,11 +123,11 @@ async test "encoder emits output when flushed" {
       let encoder = @gzip.Encoder(w)
       log.push("encoder ready")
       log.push("write plain ab")
-      encoder.write("ab")
+      encoder.write_data("ab")
       encoder.flush()
       @async.sleep(60)
       log.push("write plain cd")
-      encoder.write("cd")
+      encoder.write_data("cd")
       encoder.flush()
       @async.sleep(60)
       log.push("end")
@@ -153,20 +153,20 @@ async test "decoder yields plain chunks lazily across delayed chunks" {
     let (compressed_r, compressed_w) = @io.pipe()
     root.spawn_bg() <| () => {
       defer compressed_w.close()
-      compressed_w.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff")
+      compressed_w.write_data(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff")
       @async.sleep(20)
       log.push("write plain ab")
-      compressed_w.write(b"\x00\x02\x00\xfd\xffab")
+      compressed_w.write_data(b"\x00\x02\x00\xfd\xffab")
       @async.sleep(200)
       log.push("write plain cd")
-      compressed_w.write(b"\x00\x02\x00\xfd\xffcd")
+      compressed_w.write_data(b"\x00\x02\x00\xfd\xffcd")
       @async.sleep(200)
       log.push("write plain ef")
-      compressed_w.write(b"\x00\x02\x00\xfd\xffef")
+      compressed_w.write_data(b"\x00\x02\x00\xfd\xffef")
       @async.sleep(200)
       log.push("finish")
-      compressed_w.write(b"\x01\x00\x00\xff\xff")
-      compressed_w.write(b"\xef\x39\x8e\x4b\x06\x00\x00\x00")
+      compressed_w.write_data(b"\x01\x00\x00\xff\xff")
+      compressed_w.write_data(b"\xef\x39\x8e\x4b\x06\x00\x00\x00")
     }
     let decoder = @gzip.Decoder(compressed_r)
     match decoder.read_some(max_len=2) {
@@ -195,12 +195,12 @@ async test "decoder supports reads smaller than writer chunks" {
     let (compressed_r, compressed_w) = @io.pipe()
     root.spawn_bg() <| () => {
       defer compressed_w.close()
-      compressed_w.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff")
-      compressed_w.write(b"\x00\x04\x00\xfb\xffabcd")
+      compressed_w.write_data(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff")
+      compressed_w.write_data(b"\x00\x04\x00\xfb\xffabcd")
       @async.sleep(200)
-      compressed_w.write(b"\x00\x04\x00\xfb\xffefgh")
-      compressed_w.write(b"\x01\x00\x00\xff\xff")
-      compressed_w.write(b"\x50\x2a\xef\xae\x08\x00\x00\x00")
+      compressed_w.write_data(b"\x00\x04\x00\xfb\xffefgh")
+      compressed_w.write_data(b"\x01\x00\x00\xff\xff")
+      compressed_w.write_data(b"\x50\x2a\xef\xae\x08\x00\x00\x00")
     }
     let decoder = @gzip.Decoder(compressed_r)
     debug_inspect(

--- a/src/http/README.mbt.md
+++ b/src/http/README.mbt.md
@@ -81,7 +81,7 @@ Here's an example server that returns 404 to every request:
 #cfg(target="native")
 pub async fn server(listen_addr : @socket.Addr) -> Unit {
   @http.Server(listen_addr).run_forever((request, _body, conn) => {
-    conn..send_response(404, "NotFound").write("`\{request.path}` not found")
+    conn..send_response(404, "NotFound").write_data("`\{request.path}` not found")
   })
 }
 ```

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -269,7 +269,7 @@ pub async fn Client::get(
 ) -> Response {
   self.request(Get, path, extra_headers~)
   if body is Some(body) {
-    self.write(body)
+    self.write_data(body)
   }
   self.end_request()
 }
@@ -282,7 +282,7 @@ pub async fn Client::put(
   body : &@io.Data,
   extra_headers? : Map[String, String] = {},
 ) -> Response {
-  self..request(Put, path, extra_headers~)..write(body).end_request()
+  self..request(Put, path, extra_headers~)..write_data(body).end_request()
 }
 
 ///|
@@ -293,7 +293,7 @@ pub async fn Client::post(
   body : &@io.Data,
   extra_headers? : Map[String, String] = {},
 ) -> Response {
-  self..request(Post, path, extra_headers~)..write(body).end_request()
+  self..request(Post, path, extra_headers~)..write_data(body).end_request()
 }
 
 ///|

--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -26,10 +26,10 @@ async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
       }
       conn.send_response(200, "OK")
       log.write_string("server: sending \{meth} response part 1\n")
-      conn..write("\{meth} response part 1\n").flush()
+      conn..write_data("\{meth} response part 1\n").flush()
       @async.sleep(100)
       log.write_string("server: sending \{meth} response part 2\n")
-      conn.write("\{meth} response part 2\n")
+      conn.write_data("\{meth} response part 2\n")
     })
   }
   server.addr.port()
@@ -114,10 +114,10 @@ async test "request streaming" {
       defer client.close()
       @async.sleep(100)
       log <+ "client: sending PUT data part 1\n"
-      client..write("PUT data part 1\n").flush()
+      client..write_data("PUT data part 1\n").flush()
       @async.sleep(100)
       log <+ "client: sending PUT data part 2\n"
-      client.write("PUT data part 2\n")
+      client.write_data("PUT data part 2\n")
       let response = client.end_request()
       inspect(response.code, content="200")
       fetch_response(client)
@@ -128,10 +128,10 @@ async test "request streaming" {
       defer client.close()
       @async.sleep(100)
       log <+ "client: sending POST data part 1\n"
-      client..write("POST data part 1\n").flush()
+      client..write_data("POST data part 1\n").flush()
       @async.sleep(100)
       log <+ "client: sending POST data part 2\n"
-      client.write("POST data part 2\n")
+      client.write_data("POST data part 2\n")
       let response = client.end_request()
       inspect(response.code, content="200")
       fetch_response(client)

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -39,9 +39,9 @@ async test "read_request basic" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("GET / HTTP/1.1\r\n")
-      ..write("Host: x.y.org\r\n")
-      .write("User-Agent: MoonBit\r\n\r\n")
+      ..write_data("GET / HTTP/1.1\r\n")
+      ..write_data("Host: x.y.org\r\n")
+      .write_data("User-Agent: MoonBit\r\n\r\n")
     }
     defer r.close()
     let input = Reader::new(r)
@@ -68,11 +68,11 @@ async test "read_request fixed body" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("GET / HTTP/1.1\r\n")
-      ..write("Host: x.y.org\r\n")
-      ..write("User-Agent: MoonBit\r\n")
-      ..write("Content-Length: 7\r\n\r\n")
-      .write("message")
+      ..write_data("GET / HTTP/1.1\r\n")
+      ..write_data("Host: x.y.org\r\n")
+      ..write_data("User-Agent: MoonBit\r\n")
+      ..write_data("Content-Length: 7\r\n\r\n")
+      .write_data("message")
     }
     defer r.close()
     let input = Reader::new(r)
@@ -100,15 +100,15 @@ async test "read_request chunked" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("GET / HTTP/1.1\r\n")
-      ..write("Host: x.y.org\r\n")
-      ..write("User-Agent: MoonBit\r\n")
-      ..write("Transfer-Encoding: chunked\r\n\r\n")
-      ..write("4\r\n")
-      ..write("abcd\r\n")
-      ..write("10\r\n")
-      ..write("abcdefghijklmnop\r\n")
-      .write("0\r\n\r\n")
+      ..write_data("GET / HTTP/1.1\r\n")
+      ..write_data("Host: x.y.org\r\n")
+      ..write_data("User-Agent: MoonBit\r\n")
+      ..write_data("Transfer-Encoding: chunked\r\n\r\n")
+      ..write_data("4\r\n")
+      ..write_data("abcd\r\n")
+      ..write_data("10\r\n")
+      ..write_data("abcdefghijklmnop\r\n")
+      .write_data("0\r\n\r\n")
     }
     defer r.close()
     let input = Reader::new(r)
@@ -136,20 +136,20 @@ async test "read_request stream" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("GET / HTTP/1.1\r\n")
-      ..write("Host: x.y.org\r\n")
-      ..write("User-Agent: MoonBit\r\n")
-      .write("Transfer-Encoding: chunked\r\n\r\n")
+      ..write_data("GET / HTTP/1.1\r\n")
+      ..write_data("Host: x.y.org\r\n")
+      ..write_data("User-Agent: MoonBit\r\n")
+      .write_data("Transfer-Encoding: chunked\r\n\r\n")
       @async.sleep(50)
       log <+ "writing data...\n"
-      w.write("4\r\nabcd\r\n")
+      w.write_data("4\r\nabcd\r\n")
       @async.sleep(50)
       log <+ "writing data...\n"
-      w.write("4\r\nefgh\r\n")
+      w.write_data("4\r\nefgh\r\n")
       @async.sleep(50)
       log <+ "writing data...\n"
-      w.write("4\r\nijkl\r\n")
-      w.write("0\r\n\r\n")
+      w.write_data("4\r\nijkl\r\n")
+      w.write_data("0\r\n\r\n")
     }
     defer r.close()
     let input = Reader::new(r)
@@ -186,27 +186,27 @@ async test "multiple request" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("GET / HTTP/1.1\r\n")
-      ..write("Host: x.y.org\r\n")
-      ..write("User-Agent: MoonBit\r\n")
-      .write("Transfer-Encoding: chunked\r\n\r\n")
+      ..write_data("GET / HTTP/1.1\r\n")
+      ..write_data("Host: x.y.org\r\n")
+      ..write_data("User-Agent: MoonBit\r\n")
+      .write_data("Transfer-Encoding: chunked\r\n\r\n")
       @async.sleep(50)
       log <+ "writing data...\n"
-      w.write("4\r\nabcd\r\n")
+      w.write_data("4\r\nabcd\r\n")
       @async.sleep(50)
       log <+ "writing data...\n"
-      w.write("4\r\nefgh\r\n")
+      w.write_data("4\r\nefgh\r\n")
       @async.sleep(50)
       log <+ "writing data...\n"
-      w.write("4\r\nijkl\r\n")
-      w.write("0\r\n\r\n")
+      w.write_data("4\r\nijkl\r\n")
+      w.write_data("0\r\n\r\n")
       @async.sleep(50)
       w
-      ..write("GET / HTTP/1.1\r\n")
-      ..write("Host: z.w.org\r\n")
-      ..write("User-Agent: MoonBit\r\n")
-      ..write("Content-Length: 8\r\n\r\n")
-      .write("message2")
+      ..write_data("GET / HTTP/1.1\r\n")
+      ..write_data("Host: z.w.org\r\n")
+      ..write_data("User-Agent: MoonBit\r\n")
+      ..write_data("Content-Length: 8\r\n\r\n")
+      .write_data("message2")
     }
     defer r.close()
     let input = Reader::new(r)
@@ -248,9 +248,9 @@ async test "read_response basic" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 200 OK\r\n")
-      ..write("Content-Length: 7\r\n\r\n")
-      .write("message")
+      ..write_data("HTTP/1.1 200 OK\r\n")
+      ..write_data("Content-Length: 7\r\n\r\n")
+      .write_data("message")
     }
     defer r.close()
     let input = Reader::new(r)
@@ -279,12 +279,12 @@ async test "read_response passthrough fallback (no length headers)" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 200 OK\r\n")
-      ..write("Connection: close\r\n")
-      ..write("Content-Type: text/plain\r\n\r\n")
+      ..write_data("HTTP/1.1 200 OK\r\n")
+      ..write_data("Connection: close\r\n")
+      ..write_data("Content-Type: text/plain\r\n\r\n")
       // No Content-Length or Transfer-Encoding
       // Body ends when connection closes
-      .write("Hello, World!")
+      .write_data("Hello, World!")
     }
     defer r.close()
     let input = Reader::new(r)
@@ -316,9 +316,9 @@ async test "read_response 204 No Content (no body)" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 204 No Content\r\n")
-      ..write("Connection: keep-alive\r\n")
-      .write("Date: Mon, 15 Feb 2026 00:00:00 GMT\r\n\r\n")
+      ..write_data("HTTP/1.1 204 No Content\r\n")
+      ..write_data("Connection: keep-alive\r\n")
+      .write_data("Date: Mon, 15 Feb 2026 00:00:00 GMT\r\n\r\n")
       // 204 responses MUST NOT contain a message body
       // Connection remains open for next request
     }
@@ -353,9 +353,9 @@ async test "read_response 205 Reset Content (no body)" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 205 Reset Content\r\n")
-      ..write("Connection: keep-alive\r\n")
-      .write("Date: Mon, 15 Feb 2026 00:00:00 GMT\r\n\r\n")
+      ..write_data("HTTP/1.1 205 Reset Content\r\n")
+      ..write_data("Connection: keep-alive\r\n")
+      .write_data("Date: Mon, 15 Feb 2026 00:00:00 GMT\r\n\r\n")
       // 205 responses MUST NOT contain a message body
       // Connection remains open for next request
     }
@@ -390,10 +390,10 @@ async test "read_response 304 Not Modified (no body)" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 304 Not Modified\r\n")
-      ..write("Connection: keep-alive\r\n")
-      ..write("ETag: \"abc123\"\r\n")
-      .write("Cache-Control: max-age=3600\r\n\r\n")
+      ..write_data("HTTP/1.1 304 Not Modified\r\n")
+      ..write_data("Connection: keep-alive\r\n")
+      ..write_data("ETag: \"abc123\"\r\n")
+      .write_data("Cache-Control: max-age=3600\r\n\r\n")
       // 304 responses MUST NOT contain a message body
     }
     defer r.close()
@@ -427,8 +427,8 @@ async test "read_response 100 Continue (no body)" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 100 Continue\r\n")
-      .write("\r\n")
+      ..write_data("HTTP/1.1 100 Continue\r\n")
+      .write_data("\r\n")
       // 1xx responses MUST NOT contain a message body
     }
     defer r.close()
@@ -459,8 +459,8 @@ async test "read_response CONNECT 200 (no body, tunnel mode)" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 200 Connection Established\r\n")
-      .write("\r\n")
+      ..write_data("HTTP/1.1 200 Connection Established\r\n")
+      .write_data("\r\n")
       // Successful CONNECT responses switch to tunnel mode
       // Connection remains open for tunneled traffic
     }
@@ -493,10 +493,10 @@ async test "read_response HEAD 200 (no body)" {
     root.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 200 OK\r\n")
-      ..write("Content-Length: 1234\r\n")
-      ..write("Content-Type: text/html\r\n")
-      .write("\r\n")
+      ..write_data("HTTP/1.1 200 OK\r\n")
+      ..write_data("Content-Length: 1234\r\n")
+      ..write_data("Content-Type: text/html\r\n")
+      .write_data("\r\n")
       // HEAD responses never have a body, even with Content-Length
       // Connection remains open for next request
     }
@@ -733,7 +733,7 @@ async test "gzip split between chunks" {
     let (r, w) = @io.pipe()
     group.spawn_bg() <| () => {
       defer w.close()
-      @gzip_stream.Encoder(w)..write("A simple message to compress").end()
+      @gzip_stream.Encoder(w)..write_data("A simple message to compress").end()
     }
     defer r.close()
     r.read_all().binary()
@@ -743,13 +743,13 @@ async test "gzip split between chunks" {
     group.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 200 OK\r\n")
-      ..write("Transfer-Encoding: Chunked\r\n")
-      .write("Content-Encoding: gzip\r\n\r\n")
+      ..write_data("HTTP/1.1 200 OK\r\n")
+      ..write_data("Transfer-Encoding: Chunked\r\n")
+      .write_data("Content-Encoding: gzip\r\n\r\n")
       for i in 0..<compressed.length() {
-        w..write("1\r\n")..write(compressed[i:i + 1]).write("\r\n")
+        w..write_data("1\r\n")..write_data(compressed[i:i + 1]).write_data("\r\n")
       }
-      w.write("0\r\n\r\n")
+      w.write_data("0\r\n\r\n")
     }
     defer r.close()
     let r = Reader::new(r)
@@ -774,16 +774,16 @@ async test "read_response parse cookie" {
     group.spawn_bg() <| () => {
       defer w.close()
       w
-      ..write("HTTP/1.1 200 OK\r\n")
-      ..write("Set-Cookie: Cookie1=value1\r\n")
-      ..write(
+      ..write_data("HTTP/1.1 200 OK\r\n")
+      ..write_data("Set-Cookie: Cookie1=value1\r\n")
+      ..write_data(
         "Set-Cookie: Cookie2=value2; Path=/path/to/xxx; Max-Age=420000; Secure\r\n",
       )
-      ..write(
+      ..write_data(
         "Set-Cookie: Cookie3=value3; Expires=Sun, 06 Nov 1994 08:49:37 GMT; Domain=example.moonbitlang.com; HttpOnly\r\n",
       )
-      ..write("Set-Cookie: Cookie4=value four; ExtNoArg; ExtWithArg=xxx\r\n")
-      .write("Content-Length: 0\r\n\r\n")
+      ..write_data("Set-Cookie: Cookie4=value four; ExtNoArg; ExtWithArg=xxx\r\n")
+      .write_data("Content-Length: 0\r\n\r\n")
     }
     defer r.close()
     let input = Reader::new(r)

--- a/src/http/proxy_test.mbt
+++ b/src/http/proxy_test.mbt
@@ -40,7 +40,7 @@ async test "passthrough mode" {
     client.enter_passthrough_mode()
     for packet in ["abcd", "efgh", "ijkl"] {
       log.push("client sending: \{packet}")
-      client.write(packet)
+      client.write_data(packet)
       @async.sleep(200)
     }
   }
@@ -70,7 +70,7 @@ async test "passthrough mode remaining data" {
       @socket.Addr::parse("127.0.0.1:\{server_addr.port()}"),
     )
     defer client.close()
-    client.write("GET / HTTP/1.1\r\n\r\nremaining data")
+    client.write_data("GET / HTTP/1.1\r\n\r\nremaining data")
   }
 }
 

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -82,7 +82,7 @@ async fn perform_request(
   let (protocol, host, path) = resolve_url(uri)
   let client = Client::connect(host, headers~, protocol~, proxy?)
   defer client.close()
-  let response = client..request(meth, path)..write(body).end_request()
+  let response = client..request(meth, path)..write_data(body).end_request()
   (response, client.read_all())
 }
 
@@ -146,7 +146,7 @@ pub async fn get_stream(
   let (protocol, host, path) = resolve_url(uri)
   let client = Client::connect(host, headers~, protocol~, proxy?)
   try {
-    let response = client..request(Get, path)..write(body).end_request()
+    let response = client..request(Get, path)..write_data(body).end_request()
     (response, client)
   } catch {
     err => {

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -231,7 +231,7 @@ async fn Sender::end_body(self : Sender) -> Unit {
     SendingFixed(_) => raise IncorrectBodyLength
     WaitingBody if self.should_have_empty_body => {
       self.mode = SendingHeader
-      self..write(b"\r\n").flush()
+      self..write_data(b"\r\n").flush()
     }
     WaitingBody =>
       if self.send_len + EMPTY_MESSAGE_HEADER_END.length() >
@@ -277,7 +277,7 @@ async fn Sender::send_headers(
     } else if forbidden_headers.contains(k_lower) {
       continue
     }
-    self..write(k)..write(b": ")..write(v).write(b"\r\n")
+    self..write_data(k)..write_data(b": ")..write_data(v).write_data(b"\r\n")
   }
   content_length
 }
@@ -293,29 +293,29 @@ async fn Sender::send_request(
   guard self.mode is SendingHeader
   self.should_have_empty_body = meth is (Get | Head | Delete | Trace)
   match meth {
-    Get => self.write(b"GET ")
-    Head => self.write(b"HEAD ")
-    Post => self.write(b"POST ")
-    Put => self.write(b"PUT ")
-    Delete => self.write(b"DELETE ")
-    Connect => self.write(b"CONNECT ")
-    Options => self.write(b"OPTIONS ")
-    Trace => self.write(b"TRACE ")
-    Patch => self.write(b"PATCH ")
+    Get => self.write_data(b"GET ")
+    Head => self.write_data(b"HEAD ")
+    Post => self.write_data(b"POST ")
+    Put => self.write_data(b"PUT ")
+    Delete => self.write_data(b"DELETE ")
+    Connect => self.write_data(b"CONNECT ")
+    Options => self.write_data(b"OPTIONS ")
+    Trace => self.write_data(b"TRACE ")
+    Patch => self.write_data(b"PATCH ")
   }
   let content_length = self
-    ..write(path)
-    ..write(b" HTTP/1.1\r\n")
-    ..write(self.headers)
+    ..write_data(path)
+    ..write_data(b" HTTP/1.1\r\n")
+    ..write_data(self.headers)
     .send_headers(extra_headers)
   let auto_decompress = !self.has_accept_encoding &&
     extra_headers.keys().find_first(k => k.to_lower() is "accept-encoding")
     is None
   if auto_decompress {
-    self.write(b"Accept-Encoding: gzip,identity\r\n")
+    self.write_data(b"Accept-Encoding: gzip,identity\r\n")
   }
   if content_length is Some(len) {
-    self.write(b"\r\n")
+    self.write_data(b"\r\n")
     self.mode = SendingFixed(remaining=len)
   } else {
     self.mode = WaitingBody
@@ -339,20 +339,20 @@ async fn Sender::send_response(
     _ => self.should_have_empty_body = code is (100..<200 | 204 | 205 | 304)
   }
   let content_length = self
-    ..write(b"HTTP/1.1 ")
-    ..write(encode_int(code, base=10))
-    ..write(b" ")
-    ..write(reason)
-    ..write(b"\r\n")
-    ..write(self.headers)
+    ..write_data(b"HTTP/1.1 ")
+    ..write_data(encode_int(code, base=10))
+    ..write_data(b" ")
+    ..write_data(reason)
+    ..write_data(b"\r\n")
+    ..write_data(self.headers)
     .send_headers(extra_headers)
   for cookie in cookies {
-    self.write(b"Set-Cookie: ")
+    self.write_data(b"Set-Cookie: ")
     cookie.write_to(self)
-    self.write(b"\r\n")
+    self.write_data(b"\r\n")
   }
   if content_length is Some(len) {
-    self.write(b"\r\n")
+    self.write_data(b"\r\n")
     self.mode = SendingFixed(remaining=len)
   } else {
     self.mode = WaitingBody

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -310,11 +310,11 @@ async test "send_request stream2" {
         "Host": "x.y.org",
         "User-Agent": "MoonBit",
       })
-      sender.write("abcd")
+      sender.write_data("abcd")
       @async.sleep(50)
-      sender.write("efgh")
+      sender.write_data("efgh")
       @async.sleep(50)
-      sender.write("ijkl")
+      sender.write_data("ijkl")
       sender.end_body()
     }
     defer r.close()
@@ -388,9 +388,9 @@ async test "send fixed length" {
         "Content-Length": total_size.to_string(),
       })
       sender
-      ..write(header)
+      ..write_data(header)
       ..write_reader(license_file)
-      ..write(trailer)
+      ..write_data(trailer)
       .end_body()
     }
     defer r.close()
@@ -627,9 +627,9 @@ async test "sender write incorrect length" {
       "Content-Length": "39",
     })
     let data = Bytes::make(20, b'\x00')
-    sender.write(data)
+    sender.write_data(data)
     debug_inspect(
-      try? sender.write(data),
+      try? sender.write_data(data),
       content=(
         #|Err(IncorrectBodyLength)
       ),
@@ -740,7 +740,7 @@ async test "send_request empty body" {
       defer w.close()
       let sender = Sender::new(w)
       let _ = sender.send_request(Get, "/", extra_headers={})
-      sender..write("").end_body()
+      sender..write_data("").end_body()
       let _ = sender.send_request(Head, "/", extra_headers={})
       sender.end_body()
       let _ = sender.send_request(Post, "/", extra_headers={})
@@ -776,11 +776,11 @@ async test "send_response empty body" {
       let _ = sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={})
       sender.end_body()
       let _ = sender.send_response(200, "OK", cookies=[], request_method=Head, extra_headers={})
-      sender..write("").end_body()
+      sender..write_data("").end_body()
       let _ = sender.send_response(102, "OK", cookies=[], request_method=Get, extra_headers={})
       sender.end_body()
       let _ = sender.send_response(204, "OK", cookies=[], request_method=Get, extra_headers={})
-      sender..write("").end_body()
+      sender..write_data("").end_body()
       let _ = sender.send_response(304, "OK", cookies=[], request_method=Get, extra_headers={})
       sender.end_body()
     }

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -123,7 +123,7 @@ pub async fn ServerConnection::write_string(
   self : ServerConnection,
   s : String,
 ) -> Unit {
-  @io.Writer::write(self, s)
+  @io.Writer::write_data(self, s)
 }
 
 ///|

--- a/src/internal/event_loop/missing_close_test.mbt
+++ b/src/internal/event_loop/missing_close_test.mbt
@@ -26,7 +26,7 @@ test "missing_close" {
       }
       root.spawn_bg() <| () => {
         let data = "abcd"
-        w.write(data)
+        w.write_data(data)
         log.write_string("written \{data}\n")
       }
     }

--- a/src/io/README.mbt.md
+++ b/src/io/README.mbt.md
@@ -32,11 +32,11 @@ async test "quick start pipeline" {
     // Spawn a background writer that sends a UTF-8 string in three chunks.
     root.spawn_bg(() => {
       defer writer.close()
-      writer.write(b"Hello, ")
+      writer.write_data(b"Hello, ")
       @async.sleep(10)
-      writer.write(b"MoonBit")
+      writer.write_data(b"MoonBit")
       @async.sleep(10)
-      writer.write(b"!\n")
+      writer.write_data(b"!\n")
     })
 
     // Read everything that arrives and print it as text.
@@ -69,7 +69,7 @@ async test "data as binary" {
     root.spawn_bg(() => {
       defer w.close()
       // Send raw binary bytes.
-      w.write(b"binary data")
+      w.write_data(b"binary data")
     })
     let data = r.read_all()
     let binary = data.binary()
@@ -85,7 +85,7 @@ async test "data as text" {
     root.spawn_bg(() => {
       defer w.close()
       // Send UTF-8 encoded string
-      w.write("Hello, MoonBit!")
+      w.write_data("Hello, MoonBit!")
     })
     let data = r.read_all()
     // Decoding happens lazily when `.text()` is invoked.
@@ -102,7 +102,7 @@ async test "data as json" {
       defer w.close()
       // send UTF-8 encoded JSON string
       let data : Json = { "name": "John", "age": 30 }
-      w.write(data)
+      w.write_data(data)
     })
     let data = r.read_all()
     let json = data.json()
@@ -134,7 +134,7 @@ async test "read from reader" {
     root.spawn_bg(() => {
       defer w.close()
       // Emit the payload in a single chunk.
-      w.write(b"Hello, World!")
+      w.write_data(b"Hello, World!")
     })
     let buf = FixedArray::make(13, b'0')
     // Read up to 13 bytes into the fixed buffer.
@@ -156,7 +156,7 @@ async test "read_exactly - read exact number of bytes" {
     root.spawn_bg(() => {
       defer w.close()
       // Produce a fixed-size frame.
-      w.write(b"0123456789")
+      w.write_data(b"0123456789")
     })
     // Blocks until exactly 5 bytes are received or ReaderClosed is raised.
     let data1 = r.read_exactly(5)
@@ -174,11 +174,11 @@ async test "read_some - read next chunk of data" {
     root.spawn_bg(() => {
       defer w.close()
       // the writer supplieds data in two chunks
-      w.write("abcd")
+      w.write_data("abcd")
       @async.sleep(200)
-      w.write("efgh")
+      w.write_data("efgh")
       @async.sleep(200)
-      w.write("ijkl")
+      w.write_data("ijkl")
     })
     debug_inspect(
       r.read_some(),
@@ -218,7 +218,7 @@ async test "read_all - read entire content" {
     defer r.close()
     root.spawn_bg(() => {
       defer w.close()
-      w.write(b"Complete content")
+      w.write_data(b"Complete content")
     })
     // `read_all` accumulates everything into a `&Data` handle.
     let data = r.read_all()
@@ -235,7 +235,7 @@ async test "read_all large data" {
     root.spawn_bg(() => {
       defer w.close()
       // Large payloads can be streamed without precomputing the size.
-      w.write(Bytes::make(4097, 0))
+      w.write_data(Bytes::make(4097, 0))
     })
     inspect(r.read_all().binary().length(), content="4097")
   })
@@ -248,7 +248,7 @@ async test "drop - advance stream by discarding data" {
     defer r.close()
     root.spawn_bg(() => {
       defer w.close()
-      w.write(b"0123456789")
+      w.write_data(b"0123456789")
     })
     // Advance the window by five bytes; subsequent reads start after this point.
     // The number of bytes actually dropped would be returned.
@@ -265,8 +265,8 @@ async test "read_until - read text from stream until a separator is found" {
     defer r.close()
     root.spawn_bg(() => {
       defer w.close()
-      w.write("abcd|")
-      w.write("defg")
+      w.write_data("abcd|")
+      w.write_data("defg")
     })
     // read until the separator "|" is met. The separator will be consumed as well
     debug_inspect(
@@ -321,9 +321,9 @@ async test "write to writer" {
     root.spawn_bg(() => {
       defer w.close()
       // Each call appends to the outgoing stream.
-      w.write(b"Hello")
-      w.write(b", ")
-      w.write(b"World!")
+      w.write_data(b"Hello")
+      w.write_data(b", ")
+      w.write_data(b"World!")
     })
     // `read_all` collapses everything for verification.
     let data = r.read_all()
@@ -356,7 +356,7 @@ async test "write large data" {
       defer w.close()
       let data = Bytes::make(1024 * 16, 0)
       // `write` handles chunking internally, avoiding manual loops.
-      w.write(data)
+      w.write_data(data)
     })
     root.spawn_bg(() => {
       defer r.close()
@@ -388,13 +388,13 @@ async test "write_reader - copy from reader to writer" {
       defer w2.close()
       // Simulate a producer that emits three frames with pauses in between.
       log <+ "sending 4 bytes\n"
-      w2.write(b"abcd")
+      w2.write_data(b"abcd")
       @async.sleep(300)
       log <+ "sending 4 bytes\n"
-      w2.write(b"efgh")
+      w2.write_data(b"efgh")
       @async.sleep(300)
       log <+ "sending 4 bytes\n"
-      w2.write(b"ijkl")
+      w2.write_data(b"ijkl")
     })
   })
   inspect(
@@ -419,7 +419,7 @@ async test "write string" {
     root.spawn_bg(() => {
       defer w.close()
       // Unicode data is transparently encoded via UTF-8.
-      w.write("abcd中文☺")
+      w.write_data("abcd中文☺")
     })
     inspect(r.read_all().text(), content="abcd中文☺")
   })
@@ -442,13 +442,13 @@ async test "BufferedWriter - basic buffering" {
       defer w.close()
       let w = @io.BufferedWriter::new(w, size=4)
       log <+ "2 bytes written\n"
-      w.write("ab")
+      w.write_data("ab")
       @async.sleep(20)
       log <+ "2 bytes written\n"
-      w.write("cd")
+      w.write_data("cd")
       @async.sleep(20)
       log <+ "2 bytes written\n"
-      w.write("ef")
+      w.write_data("ef")
       // Force the remaining bytes out of the buffer.
       w.flush()
     })
@@ -482,7 +482,7 @@ async test "BufferedWriter::new with custom size" {
       let w = @io.BufferedWriter::new(w, size=8)
       inspect(w.capacity(), content="8")
       // Writes remain buffered until an explicit flush.
-      w.write(b"test")
+      w.write_data(b"test")
       w.flush()
     })
     let data = r.read_all()
@@ -498,10 +498,10 @@ async test "BufferedWriter::flush - commit buffered data" {
     root.spawn_bg(() => {
       defer w.close()
       let w = @io.BufferedWriter::new(w, size=16)
-      w.write(b"buffer")
+      w.write_data(b"buffer")
       w.flush()
       // Data written after the flush remains buffered until the next flush.
-      w.write(b"more")
+      w.write_data(b"more")
       w.flush()
     })
     let data = r.read_all()
@@ -533,13 +533,13 @@ async test "BufferedWriter::write_reader - buffered copy" {
     root.spawn_bg(() => {
       defer w2.close()
       log <+ "sending 4 bytes\n"
-      w2.write(b"abcd")
+      w2.write_data(b"abcd")
       @async.sleep(100)
       log <+ "sending 4 bytes\n"
-      w2.write(b"efgh")
+      w2.write_data(b"efgh")
       @async.sleep(100)
       log <+ "sending 4 bytes\n"
-      w2.write(b"ijkl")
+      w2.write_data(b"ijkl")
     })
   })
   inspect(

--- a/src/io/buffered_writer_test.mbt
+++ b/src/io/buffered_writer_test.mbt
@@ -21,13 +21,13 @@ async test "BufferedWriter" {
       defer w.close()
       let w = @io.BufferedWriter::new(w, size=4)
       log <+ "2 bytes written\n"
-      w.write("ab")
+      w.write_data("ab")
       @async.sleep(20)
       log <+ "2 bytes written\n"
-      w.write("cd")
+      w.write_data("cd")
       @async.sleep(20)
       log <+ "2 bytes written\n"
-      w.write("ef")
+      w.write_data("ef")
       w.flush()
     }
     root.spawn_bg() <| () => {
@@ -73,13 +73,13 @@ async test "BufferedWriter::write_reader" {
     root.spawn_bg() <| () => {
       defer w2.close()
       log <+ "sending 4 bytes\n"
-      w2.write(b"abcd")
+      w2.write_data(b"abcd")
       @async.sleep(100)
       log <+ "sending 4 bytes\n"
-      w2.write(b"efgh")
+      w2.write_data(b"efgh")
       @async.sleep(100)
       log <+ "sending 4 bytes\n"
-      w2.write(b"ijkl")
+      w2.write_data(b"ijkl")
     }
   }
   inspect(

--- a/src/io/deprecated.mbt
+++ b/src/io/deprecated.mbt
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 ///|
+impl Writer with write(self, data) {
+  self.write_data(data)
+}
+
+///|
 #deprecated("`Show` implementation for this type is deprecated, use `Debug` related API, or use `@debug.to_string` instead.")
 pub impl Show for ReaderClosed
 

--- a/src/io/pkg.generated.mbti
+++ b/src/io/pkg.generated.mbti
@@ -53,19 +53,21 @@ pub fn &Data::json(Self) -> Json raise
 pub fn &Data::text(Self) -> String raise
 
 pub(open) trait Reader {
-  _get_internal_buffer(Self) -> ReaderBuffer
-  async _direct_read(Self, FixedArray[Byte], offset~ : Int, max_len~ : Int) -> Int
-  async read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int = _
-  async drop(Self, Int) -> Int = _
-  async read_exactly(Self, Int) -> Bytes = _
-  async read_some(Self, max_len? : Int) -> Bytes? = _
-  async read_all(Self) -> &Data = _
-  async read_until(Self, StringView) -> String? = _
+  fn _get_internal_buffer(Self) -> ReaderBuffer
+  async fn _direct_read(Self, FixedArray[Byte], offset~ : Int, max_len~ : Int) -> Int
+  async fn read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int = _
+  async fn drop(Self, Int) -> Int = _
+  async fn read_exactly(Self, Int) -> Bytes = _
+  async fn read_some(Self, max_len? : Int) -> Bytes? = _
+  async fn read_all(Self) -> &Data = _
+  async fn read_until(Self, StringView) -> String? = _
 }
 
 pub(open) trait Writer {
-  async write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int
-  async write(Self, &Data) -> Unit = _
-  async write_reader(Self, &Reader) -> Unit = _
+  async fn write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int
+  async fn write_data(Self, &Data) -> Unit = _
+  async fn write_reader(Self, &Reader) -> Unit = _
+  #deprecated
+  async fn write(Self, &Data) -> Unit = _
 }
 

--- a/src/io/read_all_test.mbt
+++ b/src/io/read_all_test.mbt
@@ -17,13 +17,13 @@ async fn writer(log : StringBuilder, w : @io.PipeWrite) -> Unit {
   defer w.close()
   @async.sleep(20)
   log <+ "writing 4 bytes of data\n"
-  w.write(b"abcd")
+  w.write_data(b"abcd")
   @async.sleep(20)
   log <+ "writing 4 bytes of data\n"
-  w.write(b"efgh")
+  w.write_data(b"efgh")
   @async.sleep(20)
   log <+ "writing 4 bytes of data\n"
-  w.write(b"ijkl")
+  w.write_data(b"ijkl")
 }
 
 ///|
@@ -44,7 +44,7 @@ async test "read_all large data" {
     defer r.close()
     root.spawn_bg() <| () => {
       defer w.close()
-      w.write(Bytes::make(4097, 0))
+      w.write_data(Bytes::make(4097, 0))
     }
     inspect(r.read_all().binary().length(), content="4097")
   }

--- a/src/io/read_some_test.mbt
+++ b/src/io/read_some_test.mbt
@@ -100,7 +100,7 @@ async test "read_some length limit 3" {
     defer r.close()
     root.spawn_bg() <| () => {
       defer w.close()
-      w.write("abcdefghijkl")
+      w.write_data("abcdefghijkl")
     }
     for max_len = 2; ; max_len = max_len * 2 {
       guard r.read_some(max_len~) is Some(chunk) else { break }

--- a/src/io/writer.mbt
+++ b/src/io/writer.mbt
@@ -20,12 +20,14 @@ pub(all) enum Encoding {
 ///|
 pub(open) trait Writer {
   async write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int
-  async write(Self, &Data) -> Unit = _
+  async write_data(Self, &Data) -> Unit = _
   async write_reader(Self, &Reader) -> Unit = _
+  #deprecated("use `write_data` instead; `write` is reserved for a future `Show`-based overload")
+  async write(Self, &Data) -> Unit = _
 }
 
 ///|
-impl Writer with write(self, data) {
+impl Writer with write_data(self, data) {
   let view = data.to_bytesview()
   let start = view.start_offset()
   let len = view.length()
@@ -46,7 +48,7 @@ impl Writer with write_reader(self, reader) {
   let buf = reader._get_internal_buffer()
   if buf.len > 0 {
     let buf_bytes = buf.buf.unsafe_reinterpret_as_bytes()
-    self.write(buf_bytes[buf.start:buf.start + buf.len])
+    self.write_data(buf_bytes[buf.start:buf.start + buf.len])
     buf.start = 0
     buf.len = 0
   }
@@ -54,6 +56,6 @@ impl Writer with write_reader(self, reader) {
   let max_len = buf.buf.length()
   while reader._direct_read(buf.buf, offset=0, max_len~) is n && n > 0 {
     let buf_bytes = buf.buf.unsafe_reinterpret_as_bytes()
-    self.write(buf_bytes[:n])
+    self.write_data(buf_bytes[:n])
   }
 }

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -19,7 +19,7 @@ async test "write large data" {
     root.spawn_bg() <| () => {
       defer w.close()
       let data = Bytes::make(1024 * 16, 0)
-      w.write(data)
+      w.write_data(data)
     }
     root.spawn_bg() <| () => {
       defer r.close()
@@ -49,13 +49,13 @@ async test "write reader" {
     root.spawn_bg() <| () => {
       defer w2.close()
       log <+ "sending 4 bytes\n"
-      w2.write(b"abcd")
+      w2.write_data(b"abcd")
       @async.sleep(300)
       log <+ "sending 4 bytes\n"
-      w2.write(b"efgh")
+      w2.write_data(b"efgh")
       @async.sleep(300)
       log <+ "sending 4 bytes\n"
-      w2.write(b"ijkl")
+      w2.write_data(b"ijkl")
     }
   }
   inspect(
@@ -91,7 +91,7 @@ impl @io.Writer for DummyWriter with write_once(self, buf, offset~, len~) {
 async test "write cancel" {
   let log = StringBuilder::new()
   let writer = { logger: log, base_timeout: 300 }
-  @async.with_timeout_opt(450, () => writer.write(b"abcd")) |> ignore
+  @async.with_timeout_opt(450, () => writer.write_data(b"abcd")) |> ignore
   // The `write` here is partial and corrupted,
   // but we have no choice because making `write` atomic may cause hang
   inspect(
@@ -110,7 +110,7 @@ async test "write_string" {
     defer r.close()
     root.spawn_bg() <| () => {
       defer w.close()
-      w.write("abcd中文☺")
+      w.write_data("abcd中文☺")
     }
     inspect(r.read_all().text(), content="abcd中文☺")
   }

--- a/src/pipe/read_exactly_test.mbt
+++ b/src/pipe/read_exactly_test.mbt
@@ -35,10 +35,10 @@ async test "read_exactly" {
     root.spawn_bg() <| () => {
       defer w.close()
       log("first message sent")
-      w.write("abcdef")
+      w.write_data("abcdef")
       @async.sleep(100)
       log("second message sent")
-      w.write("ghijkl")
+      w.write_data("ghijkl")
     }
   }
   inspect(
@@ -77,7 +77,7 @@ async test "read_exactly failure" {
     root.spawn_bg() <| () => {
       defer w.close()
       log("first message sent")
-      w.write("abcdef")
+      w.write_data("abcdef")
     }
   }) catch {
     err => log(err.to_string())

--- a/src/pipe/reader_closed_test.mbt
+++ b/src/pipe/reader_closed_test.mbt
@@ -18,5 +18,5 @@ async test "reader closed" {
   defer w.close()
   r.close()
   @async.sleep(100)
-  assert_true((try? w.write("abcd")) is Err(_))
+  assert_true((try? w.write_data("abcd")) is Err(_))
 }

--- a/src/process/README.mbt.md
+++ b/src/process/README.mbt.md
@@ -168,7 +168,7 @@ async test "write to process with pipe" {
     )
     group.spawn_bg(() => {
       defer we_write.close()
-      we_write.write(b"test input\n")
+      we_write.write_data(b"test input\n")
     })
     group.spawn_bg(() => {
       defer we_read.close()

--- a/src/process/basic_test.mbt
+++ b/src/process/basic_test.mbt
@@ -50,9 +50,9 @@ async test "basic_cat" {
     @process.spawn(group, cat, [], stdin=cat_read, stdout=cat_write) |> ignore
     group.spawn_bg() <| () => {
       defer we_write.close()
-      we_write.write(b"abcd")
+      we_write.write_data(b"abcd")
       @async.sleep(50)
-      we_write.write(b"efgh")
+      we_write.write_data(b"efgh")
     }
     group.spawn_bg() <| () => {
       defer we_read.close()

--- a/src/process/helper_test.mbt
+++ b/src/process/helper_test.mbt
@@ -63,7 +63,7 @@ async test "collect_output blocked" {
       defer we_write.close()
       let chunk = Bytes::make(1024, 0)
       for _ in 0..<1024 {
-        we_write.write(chunk)
+        we_write.write_data(chunk)
       }
     }
     let (code, stdout, stderr) = @process.collect_output(

--- a/src/socket/connect_burst_test.mbt
+++ b/src/socket/connect_burst_test.mbt
@@ -37,7 +37,7 @@ async fn server_main(server : @socket.TcpServer) -> Int {
 async fn client(msg : Bytes, addr : @socket.Addr) -> Unit {
   let conn = @socket.Tcp::connect(addr)
   defer conn.close()
-  conn.write(msg)
+  conn.write_data(msg)
 }
 
 ///|

--- a/src/socket/dual_stack_test.mbt
+++ b/src/socket/dual_stack_test.mbt
@@ -42,7 +42,7 @@ async test "Only_V4 server" {
         err => raise err
       }
       defer conn.close()
-      conn.write("message")
+      conn.write_data("message")
     }
 
     for protocol in all_protocol_preferences {
@@ -95,7 +95,7 @@ async test "Only_V6 server" {
         err => raise err
       }
       defer conn.close()
-      conn.write("message")
+      conn.write_data("message")
     }
 
     for protocol in all_protocol_preferences {
@@ -141,7 +141,7 @@ async test "dual stack server" {
     async fn client(protocol) {
       let conn = @socket.Tcp::connect_to_host("localhost", port~, protocol~)
       defer conn.close()
-      conn.write("message")
+      conn.write_data("message")
     }
 
     for protocol in all_protocol_preferences {

--- a/src/socket/getsockname_test.mbt
+++ b/src/socket/getsockname_test.mbt
@@ -32,7 +32,7 @@ async test "getsockname TCP" {
     let client_addr = group.spawn(() => {
       let client = @socket.Tcp::connect(server_addr)
       defer client.close()
-      client.write("abcd")
+      client.write_data("abcd")
       client.addr
     })
     assert_eq(client_addr_from_server.wait(), client_addr.wait())

--- a/src/socket/read_exactly_test.mbt
+++ b/src/socket/read_exactly_test.mbt
@@ -41,10 +41,10 @@ async test "read_exactly" {
     root.spawn_bg() <| () => {
       let conn = @socket.Tcp::connect(addr)
       defer conn.close()
-      conn.write("abcdef")
+      conn.write_data("abcdef")
       log("first message sent")
       @async.sleep(100)
-      conn.write("ghijkl")
+      conn.write_data("ghijkl")
       log("second message sent")
     }
   }
@@ -93,7 +93,7 @@ async test "read_exactly failure" {
     root.spawn_bg() <| () => {
       let conn = @socket.Tcp::connect(addr)
       defer conn.close()
-      conn.write("abcdef")
+      conn.write_data("abcdef")
       log("first message sent")
     }
   }) catch {

--- a/src/socket/reuse_addr_test.mbt
+++ b/src/socket/reuse_addr_test.mbt
@@ -26,7 +26,7 @@ async test "reuse addr" {
         port = server.addr.port()
         let (conn, _) = server.accept()
         defer conn.close()
-        conn.write("abcd")
+        conn.write_data("abcd")
       }
     }
     for _ in 0..<2 {

--- a/src/stdio/pkg.generated.mbti
+++ b/src/stdio/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub impl @io.Reader for Input
 
 type Output
 pub fn Output::fd(Self) -> Int
+pub async fn Output::write_string(Self, String) -> Unit
 pub impl @io.Writer for Output
 
 // Type aliases

--- a/src/stdio/stdio.mbt
+++ b/src/stdio/stdio.mbt
@@ -49,7 +49,7 @@ pub impl @io.Writer for Output with write_once(self, buf, offset~, len~) {
 ///|
 /// Introduced so that the sugar `writer <+ "hello \{world}"` can work on `Output`.
 pub async fn Output::write_string(self : Output, s : String) -> Unit {
-  @io.Writer::write(self, s)
+  @io.Writer::write_data(self, s)
 }
 
 ///|

--- a/src/stdio/stdio.mbt
+++ b/src/stdio/stdio.mbt
@@ -47,6 +47,12 @@ pub impl @io.Writer for Output with write_once(self, buf, offset~, len~) {
 }
 
 ///|
+/// Introduced so that the sugar `writer <+ "hello \{world}"` can work on `Output`.
+pub async fn Output::write_string(self : Output, s : String) -> Unit {
+  @io.Writer::write(self, s)
+}
+
+///|
 /// The standard input channel.
 /// Using this value will result in standard input being set to non-blocking mode.
 /// The standard input will be reset to its original state after the program exits.

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -55,9 +55,9 @@ async test "redirect pipe" {
     }
     root.spawn_bg() <| () => {
       defer we_write.close()
-      we_write.write(b"abcd\n")
+      we_write.write_data(b"abcd\n")
       @async.sleep(50)
-      we_write.write(b"defg\n")
+      we_write.write_data(b"defg\n")
     }
     defer we_read.close()
     inspect(
@@ -88,7 +88,7 @@ async test "stdio cancel" {
     }
     defer we_write.close()
     defer we_read.close()
-    we_write.write("abcd")
+    we_write.write_data("abcd")
     debug_inspect(
       we_read.read_some(),
       content=(

--- a/src/tls/shutdown_test.mbt
+++ b/src/tls/shutdown_test.mbt
@@ -24,7 +24,7 @@ async test "peer close connection" {
       defer conn.close()
       let server = test_server(conn, conn)
       defer server.close()
-      server.write("1234")
+      server.write_data("1234")
       inspect(server.read_all().text(), content="abcd")
     }
     // client
@@ -41,7 +41,7 @@ async test "peer close connection" {
     // due to pending data in the recv buffer.
     // Read something before closing the connection solves the problem.
     inspect(@utf8.decode(client.read_exactly(4)), content="1234")
-    client.write("abcd")
+    client.write_data("abcd")
     // close the underlying connection directly
   }
 }

--- a/src/tls/tls_test.mbt
+++ b/src/tls/tls_test.mbt
@@ -64,11 +64,11 @@ async test "one way" {
         trust=NoVerification,
       )
       defer client.close()
-      client.write(b"abcd")
+      client.write_data(b"abcd")
       @async.sleep(50)
-      client.write(b"efgh")
+      client.write_data(b"efgh")
       @async.sleep(50)
-      client.write(b"ijkl")
+      client.write_data(b"ijkl")
       client.shutdown()
       inspect(client.read_all().text(), content="")
     }
@@ -100,7 +100,7 @@ async test "echo" {
       defer server.close()
       while server.read_some() is Some(data) {
         log.write_string("server received: \{@utf8.decode(data)}\n")
-        server.write(data)
+        server.write_data(data)
       } nobreak {
         server.shutdown()
       }
@@ -118,7 +118,7 @@ async test "echo" {
       )
       defer client.close()
       for data in [b"abcd", b"efgh", b"ijkl"] {
-        client.write(data)
+        client.write_data(data)
         assert_eq(client.read_exactly(4), data)
         @async.sleep(50)
       }
@@ -271,7 +271,7 @@ async test "client custom root certificate" {
         trust=CustomPemFile("test_keys/valid_root_cert.pem"),
       )
       defer client.close()
-      client.write(b"ok")
+      client.write_data(b"ok")
       client.shutdown()
       inspect(client.read_all().text(), content="")
     }

--- a/src/websocket/bad_client_test.mbt
+++ b/src/websocket/bad_client_test.mbt
@@ -41,7 +41,7 @@ async test "bad client" {
       @async.with_task_group() <| group => {
         group.spawn_bg() <| () => {
           for frame in frames {
-            http_client.write(frame)
+            http_client.write_data(frame)
           }
         }
         try? ws_client.recv().read_all().text()

--- a/src/websocket/conn.mbt
+++ b/src/websocket/conn.mbt
@@ -684,14 +684,14 @@ pub impl @io.Writer for Conn with write_once(self, buf, offset~, len~) {
 /// Convenient helper for sending a single text message.
 /// To send large message lazily, see `start_message`.
 pub async fn Conn::send_text(self : Conn, text : StringView) -> Unit {
-  self..start_message(Text)..write(text).end_message()
+  self..start_message(Text)..write_data(text).end_message()
 }
 
 ///|
 /// Convenient helper for sending a single binary message.
 /// To send large message lazily, see `start_message`.
 pub async fn Conn::send_binary(self : Conn, data : BytesView) -> Unit {
-  self..start_message(Binary)..write(data).end_message()
+  self..start_message(Binary)..write_data(data).end_message()
 }
 
 ///|

--- a/src/websocket/control_test.mbt
+++ b/src/websocket/control_test.mbt
@@ -30,7 +30,7 @@ async test "ping auto-reply" {
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
     let ping_frame : Bytes = [0x89, 0x04, ..b"abcd"]
-    http_client.write(ping_frame)
+    http_client.write_data(ping_frame)
     json_inspect(http_client.read_exactly(2).to_array(), content=[0x8a, 0x04])
     inspect(@utf8.decode(http_client.read_exactly(4)), content="abcd")
     ws_client.send_text("1234")
@@ -56,7 +56,7 @@ async test "pong ignored" {
     let ws_client = @websocket.from_http_client(http_client, "/")
     defer ws_client.close()
     let ping_frame : Bytes = [0x89, 0x04, ..b"abcd"]
-    http_client.write(ping_frame)
+    http_client.write_data(ping_frame)
     ws_client.send_text("1234")
     inspect(ws_client.recv().read_all().text(), content="1234")
   }
@@ -78,7 +78,7 @@ async test "ping auto-reply race-with-write" {
         // currently, auto-reply is only triggered when the user is actually reading.
         group.spawn_bg(no_wait=true, () => ignore(ws.recv().read_all()))
         ws.start_message(Text)
-        ws.write("1234")
+        ws.write_data("1234")
         @async.sleep(400)
         ws.end_message()
       }
@@ -90,7 +90,7 @@ async test "ping auto-reply race-with-write" {
     let ping_frame : Bytes = [0x89, 0x04, ..b"abcd"]
     // the "1234" message from the server is already buffered at this stage.
     // However, the pong message will interrupt it.
-    http_client.write(ping_frame)
+    http_client.write_data(ping_frame)
     // The `PONG` reply should come first
     json_inspect(http_client.read_exactly(2).to_array(), content=[0x8a, 0x04])
     inspect(@utf8.decode(http_client.read_exactly(4)), content="abcd")
@@ -122,7 +122,7 @@ async test "close test" {
           )
         }
         ws.start_message(Text)
-        ws.write("1234")
+        ws.write_data("1234")
         @async.sleep(400)
         ws.end_message()
       }
@@ -188,7 +188,7 @@ async test "ping inside message" {
     defer ws.close()
     @async.with_task_group() <| group => {
       group.spawn_bg() <| () => {
-        ws..start_message(Text)..ping()..write("1234").end_message()
+        ws..start_message(Text)..ping()..write_data("1234").end_message()
       }
       inspect(ws.recv().read_all().text(), content="abcd")
     }

--- a/src/websocket/external_client_test.mbt
+++ b/src/websocket/external_client_test.mbt
@@ -27,7 +27,7 @@ async test "external client" {
           let msg = ws.recv()
           let data = msg.read_all().text()
           log.push("\{@debug.to_string(msg.kind)}: \{data}")
-          ws..start_message(msg.kind)..write(data).end_message()
+          ws..start_message(msg.kind)..write_data(data).end_message()
         }
       })
     }

--- a/src/websocket/server.mbt
+++ b/src/websocket/server.mbt
@@ -31,7 +31,7 @@ pub async fn Conn::from_http_server(
 ) -> Conn {
   try {
     async fn bad_request(msg : String) {
-      conn..send_response(400, "Bad Request")..write(msg).end_response()
+      conn..send_response(400, "Bad Request")..write_data(msg).end_response()
       raise InvalidHandshake(msg)
     }
 

--- a/src/websocket/utf8_validation_test.mbt
+++ b/src/websocket/utf8_validation_test.mbt
@@ -47,7 +47,7 @@ async test "UTF8 validation" {
     async fn send_bad_message(msg : Bytes) {
       let client = @websocket.connect("ws://localhost:\{addr.port()}")
       defer client.close()
-      client..start_message(Text)..write(msg).end_message()
+      client..start_message(Text)..write_data(msg).end_message()
       let result = try? client.recv().read_all().binary()
       log.push(
         "client: \{@debug.to_string(msg.to_array())} => \{@debug.to_string(result)}",
@@ -108,9 +108,9 @@ async test "UTF8 validation large message" {
       let chunk_bin = @utf8.encode(chunk_text)
       group.spawn_bg() <| () => {
         client.start_message(Text)
-        client.write("a")
+        client.write_data("a")
         for n = 0; n < 10240; n = n + chunk_bin.length() {
-          client.write(chunk_bin)
+          client.write_data(chunk_bin)
         }
         client.end_message()
       }

--- a/src/websocket/websocket_test.mbt
+++ b/src/websocket/websocket_test.mbt
@@ -28,12 +28,12 @@ async test "websocket basic" {
       let msg_content = msg.read_all().text()
       debug_inspect(msg.kind, content="Binary")
       inspect(msg_content, content="abcd")
-      ws..start_message(msg.kind)..write(msg_content).end_message()
+      ws..start_message(msg.kind)..write_data(msg_content).end_message()
       let msg = ws.recv()
       let msg_content = msg.read_all().text()
       debug_inspect(msg.kind, content="Text")
       inspect(msg_content, content="abcd")
-      ws..start_message(msg.kind)..write(msg_content).end_message()
+      ws..start_message(msg.kind)..write_data(msg_content).end_message()
       try ws.recv() catch {
         err => inspect(err, content="ConnectionClosed(Normal, None)")
       } noraise {
@@ -139,10 +139,10 @@ async test "write buffering" {
     }
     let client = @websocket.connect("ws://localhost:\{addr.port()}")
     defer client.close()
-    client..start_message(Text).write("ab")
+    client..start_message(Text).write_data("ab")
     @async.sleep(100)
     // due to buffering, this message will not be sent directly
-    client..write("cd").end_message()
+    client..write_data("cd").end_message()
 
     // close the channel
     client.send_close()
@@ -183,7 +183,7 @@ async test "large message" {
       for byte in chunk {
         checksum += byte.to_int()
       }
-      client.write(chunk)
+      client.write_data(chunk)
     }
     client.end_message()
     inspect(checksum, content="3745800")


### PR DESCRIPTION
## Summary
Two related changes (commits separated for review):

1. **`Output::write_string`** on `@stdio.Output` — mirror of the helper introduced for `ServerConnection` in ff28856, so `out <+ "hello \{x}"` resolves on stdio/stderr.
2. **Rename `Writer::write(&Data)` → `write_data(&Data)`** on the `@io.Writer` trait, with a `#deprecated` `write` alias kept for backwards compatibility. This frees up the `write` name for a future `fn[A: Show] write(Self, A)` overload, at which point `<+` can render any value (not just `&Data`-implementing types).

The internal call sites (~280) are migrated mechanically from `.write(...)` to `.write_data(...)`. `<+` macro expansions in `examples/http_file_server` still hit the deprecated `write` (7 warnings) and will be cleaned up when the Show-based overload lands in a follow-up.

## Test plan
- [x] `moon check` — 0 errors; 8 expected deprecation warnings (7 from `<+` in http_file_server, 1 from the deprecated `write` shim's own body in `src/io/deprecated.mbt`)
- [x] `moon test` — 490/490 pass
- [x] mbti regenerated for `io` and `stdio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)