### PR TITLE
perf(gzip): index BytesView directly in crc32_update

### DIFF
--- a/src/internal/gzip_internal/crc32.mbt
+++ b/src/internal/gzip_internal/crc32.mbt
@@ -23,10 +23,18 @@ let crc32_table : FixedArray[UInt] = FixedArray::makei(256, i => {
 
 ///|
 fn crc32_update(current : UInt, chunk : BytesView) -> UInt {
-  for byte in chunk; crc = current {
-    let index = ((crc ^ byte.to_uint()) & 0xffU).reinterpret_as_int()
-    continue crc32_table[index] ^ (crc >> 8)
-  } nobreak {
-    crc
+  // Pull out the backing Bytes + start offset once and index that
+  // directly. `for byte in chunk` desugars through BytesView::iter +
+  // Iter::next (15-16% in a gzip_roundtrip profile), and even
+  // `chunk[i]` (= BytesView::at) is a non-inlined function call
+  // (6.88% before this change). Indexing the raw Bytes is intrinsic.
+  let mut crc = current
+  let bytes = chunk.data()
+  let start = chunk.start_offset()
+  let len = chunk.length()
+  for i in 0..<len {
+    let index = ((crc ^ bytes[start + i].to_uint()) & 0xffU).reinterpret_as_int()
+    crc = crc32_table[index] ^ (crc >> 8)
   }
+  crc
 }


### PR DESCRIPTION
This proposal is superseded by [#475](https://github.com/moonbitlang/async/pull/475), merged on July 3, 2026. That change replaced the byte-at-a-time CRC32 loop with a slicing-by-eight implementation in [007b3ab](https://github.com/moonbitlang/async/commit/007b3ab7e54fabf09a3bd1dc195f582a5a0e14c4).

The original May proposal replaced iterator-based byte traversal with direct indexing. Current main already processes eight bytes per iteration and indexes the remaining tail directly, so porting the old loop would replace the newer algorithm. The original benchmark numbers no longer describe the implementation on main.

The current native release gzip and gzip-internal suites pass 39/39 with moonc `v0.10.12+1634b282e` (2026-09-07):

```sh
moon test src/internal/gzip_internal src/gzip --target native --release
```

Closing this obsolete proposal in favor of the implementation already merged in #475.
