### PR TITLE
[codex] fix Buffer deprecations

### DIFF
--- a/examples/tcp_server_benchmark/main.mbt
+++ b/examples/tcp_server_benchmark/main.mbt
@@ -109,7 +109,7 @@ async fn main {
   let conn_duration = @string.parse_int(conn_duration_str)
   let addr = @socket.Addr::parse(addr_str)
   let rand = {
-    let seed = @buffer.new()
+    let seed = Buffer()
     let now = @env.now()
     seed
     ..write_uint64_le(now)

--- a/src/fs/tmpdir.mbt
+++ b/src/fs/tmpdir.mbt
@@ -14,7 +14,7 @@
 
 ///|
 let tmpdir_seed : @random.Rand = {
-  let seed = @buffer.new()
+  let seed = Buffer()
   let now = @async.now()
   for _ in 0..<4 {
     seed.write_int64_le(now)

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -43,7 +43,7 @@ fn[W : @io.Writer] Sender::new(
   w : W,
   headers? : Map[String, String] = {},
 ) -> Sender {
-  let header_text = @buffer.new()
+  let header_text = Buffer()
   let mut has_accept_encoding = false
   for k, v in headers {
     let k_lower = k.to_lower()


### PR DESCRIPTION
## Summary

Replace the deprecated `@buffer.new()` constructor with `Buffer()`.

This PR is intentionally scoped to Buffer deprecations only, split out from #392.

## Changed files

- `src/fs/tmpdir.mbt`
- `src/http/send.mbt`
- `examples/tcp_server_benchmark/main.mbt`

## Validation

- `moon check --deny-warn`
- `moon check --target js --deny-warn`
- `moon check examples/tcp_server_benchmark --deny-warn`
- `git diff --check`

## Known follow-up

- `moon test src/fs src/http` still hits the existing cold-build `src/fs/lock_test.mbt` race from #392; I left that out of this PR to keep this split focused on Buffer only.