### PR TITLE
[codex] add fn syntax to trait implementations

### DIFF
--- a/examples/tcp_ping_pong/deprecated.mbt
+++ b/examples/tcp_ping_pong/deprecated.mbt
@@ -17,6 +17,6 @@
 impl Show for ServerTerminate
 
 ///|
-impl Show for ServerTerminate with output(_self, logger) {
+impl Show for ServerTerminate with fn output(_self, logger) {
   logger <+ "ServerTerminate"
 }

--- a/examples/udp_ping_pong/deprecated.mbt
+++ b/examples/udp_ping_pong/deprecated.mbt
@@ -17,6 +17,6 @@
 impl Show for ServerTerminate
 
 ///|
-impl Show for ServerTerminate with output(_self, logger) {
+impl Show for ServerTerminate with fn output(_self, logger) {
   logger <+ "ServerTerminate"
 }

--- a/src/aqueue/deprecated.mbt
+++ b/src/aqueue/deprecated.mbt
@@ -17,6 +17,6 @@
 pub impl Show for QueueAlreadyClosed
 
 ///|
-pub impl Show for QueueAlreadyClosed with output(_self, logger) {
+pub impl Show for QueueAlreadyClosed with fn output(_self, logger) {
   logger <+ "QueueAlreadyClosed"
 }

--- a/src/deprecated.mbt
+++ b/src/deprecated.mbt
@@ -17,7 +17,7 @@
 pub impl Show for TimeoutError
 
 ///|
-pub impl Show for TimeoutError with output(_self, logger) {
+pub impl Show for TimeoutError with fn output(_self, logger) {
   logger <+ "TimeoutError"
 }
 
@@ -26,6 +26,6 @@ pub impl Show for TimeoutError with output(_self, logger) {
 pub impl Show for TimerCancelled
 
 ///|
-pub impl Show for TimerCancelled with output(_self, logger) {
+pub impl Show for TimerCancelled with fn output(_self, logger) {
   logger <+ "TimerCancelled"
 }

--- a/src/fs/deprecated.mbt
+++ b/src/fs/deprecated.mbt
@@ -17,7 +17,7 @@
 pub impl Show for FileKind
 
 ///|
-pub impl Show for FileKind with output(self, logger) {
+pub impl Show for FileKind with fn output(self, logger) {
   match self {
     Unknown => logger <+ "Unknown"
     Regular => logger <+ "Regular"

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -189,12 +189,12 @@ pub async fn create(
 ///
 /// - EOF is reached before reading all requested data
 /// - the file is a named pipe, and not enough data is available
-pub impl @io.Reader for File with _direct_read(self, buf, offset~, max_len~) {
+pub impl @io.Reader for File with fn _direct_read(self, buf, offset~, max_len~) {
   self.io.read(buf, offset~, len=max_len, context="@fs.File::read()")
 }
 
 ///|
-pub impl @io.Reader for File with _get_internal_buffer(self) {
+pub impl @io.Reader for File with fn _get_internal_buffer(self) {
   self.read_buf
 }
 
@@ -241,7 +241,7 @@ pub async fn File::read_exactly_at(
 }
 
 ///|
-pub impl @io.Writer for File with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for File with fn write_once(self, buf, offset~, len~) {
   self.io.write(buf, offset~, len~, context="@fs.File::write()")
 }
 

--- a/src/gzip/decoder.mbt
+++ b/src/gzip/decoder.mbt
@@ -50,14 +50,14 @@ async fn[R : @io.Reader] Decoder::read_more_input(self : Decoder[R]) -> Unit {
 }
 
 ///|
-pub impl[R : @io.Reader] @io.Reader for Decoder[R] with _get_internal_buffer(
+pub impl[R : @io.Reader] @io.Reader for Decoder[R] with fn _get_internal_buffer(
   self,
 ) {
   self.read_buf
 }
 
 ///|
-pub impl[R : @io.Reader] @io.Reader for Decoder[R] with _direct_read(
+pub impl[R : @io.Reader] @io.Reader for Decoder[R] with fn _direct_read(
   self,
   dst,
   offset~,

--- a/src/gzip/encoder.mbt
+++ b/src/gzip/encoder.mbt
@@ -67,7 +67,7 @@ pub async fn[W : @io.Writer] Encoder::end(self : Encoder[W]) -> Unit {
 }
 
 ///|
-pub impl[W : @io.Writer] @io.Writer for Encoder[W] with write_once(
+pub impl[W : @io.Writer] @io.Writer for Encoder[W] with fn write_once(
   self,
   buf,
   offset~,

--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -127,7 +127,7 @@ pub async fn Client::Client(
 }
 
 ///|
-pub impl @io.Writer for Client with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for Client with fn write_once(self, buf, offset~, len~) {
   guard self.request is Some(request)
   request.body_writer.write_once(buf, offset~, len~)
 }
@@ -140,13 +140,13 @@ pub async fn Client::flush(_ : Client) -> Unit {
 }
 
 ///|
-pub impl @io.Reader for Client with _get_internal_buffer(self) {
+pub impl @io.Reader for Client with fn _get_internal_buffer(self) {
   guard self.response_body is Some(stream)
   stream._get_internal_buffer()
 }
 
 ///|
-pub impl @io.Reader for Client with _direct_read(self, buf, offset~, max_len~) {
+pub impl @io.Reader for Client with fn _direct_read(self, buf, offset~, max_len~) {
   guard self.response_body is Some(stream)
   stream._direct_read(buf, offset~, max_len~)
 }

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -164,12 +164,12 @@ pub fn Client::close(self : Client) -> Unit {
 }
 
 ///|
-pub impl @io.Reader for Client with _direct_read(self, buf, offset~, max_len~) {
+pub impl @io.Reader for Client with fn _direct_read(self, buf, offset~, max_len~) {
   self.reader._direct_read(buf, offset~, max_len~)
 }
 
 ///|
-pub impl @io.Reader for Client with _get_internal_buffer(self) {
+pub impl @io.Reader for Client with fn _get_internal_buffer(self) {
   self.reader._get_internal_buffer()
 }
 
@@ -180,13 +180,13 @@ pub impl @io.Reader for Client with _get_internal_buffer(self) {
 ///
 /// Writing to `@http.Client` MAY be buffered,
 /// call `flush` manually to ensure data is delivered to the remote peer.
-pub impl @io.Writer for Client with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for Client with fn write_once(self, buf, offset~, len~) {
   guard !(self.sender.mode is SendingHeader)
   self.sender.write_once(buf, offset~, len~)
 }
 
 ///|
-pub impl @io.Writer for Client with write_reader(self, reader) {
+pub impl @io.Writer for Client with fn write_reader(self, reader) {
   guard !(self.sender.mode is SendingHeader)
   self.sender.write_reader(reader)
 }

--- a/src/http/deprecated.mbt
+++ b/src/http/deprecated.mbt
@@ -71,7 +71,7 @@ fn Response::write_show(self : Response, logger : &Logger) -> Unit {
 pub impl Show for RequestMethod
 
 ///|
-pub impl Show for RequestMethod with output(self, logger) {
+pub impl Show for RequestMethod with fn output(self, logger) {
   self.write_show(logger)
 }
 
@@ -80,7 +80,7 @@ pub impl Show for RequestMethod with output(self, logger) {
 pub impl Show for Request
 
 ///|
-pub impl Show for Request with output(self, logger) {
+pub impl Show for Request with fn output(self, logger) {
   self.write_show(logger)
 }
 
@@ -89,7 +89,7 @@ pub impl Show for Request with output(self, logger) {
 pub impl Show for Response
 
 ///|
-pub impl Show for Response with output(self, logger) {
+pub impl Show for Response with fn output(self, logger) {
   self.write_show(logger)
 }
 
@@ -98,7 +98,7 @@ pub impl Show for Response with output(self, logger) {
 pub impl Show for Protocol
 
 ///|
-pub impl Show for Protocol with output(self, logger) {
+pub impl Show for Protocol with fn output(self, logger) {
   self.write_show(logger)
 }
 
@@ -107,7 +107,7 @@ pub impl Show for Protocol with output(self, logger) {
 pub impl Show for URIParseError
 
 ///|
-pub impl Show for URIParseError with output(self, logger) {
+pub impl Show for URIParseError with fn output(self, logger) {
   match self {
     InvalidFormat => logger <+ "InvalidFormat"
     UnsupportedProtocol(protocol) =>
@@ -122,7 +122,7 @@ pub impl Show for ProxyError
 
 ///|
 #cfg(target="native")
-pub impl Show for ProxyError with output(self, logger) {
+pub impl Show for ProxyError with fn output(self, logger) {
   match self {
     ProxyError(response) => {
       logger <+ "ProxyError("
@@ -139,7 +139,7 @@ pub impl Show for HttpProtocolError
 
 ///|
 #cfg(target="native")
-pub impl Show for HttpProtocolError with output(self, logger) {
+pub impl Show for HttpProtocolError with fn output(self, logger) {
   match self {
     BadRequest => logger <+ "BadRequest"
     HttpVersionNotSupported(version) =>

--- a/src/http/parser.mbt
+++ b/src/http/parser.mbt
@@ -129,7 +129,7 @@ async fn Reader::decode_chunk(
 /// All reader related API of `HttpReader` should be called
 /// after a successful call to `read_request` or `read_response`,
 /// otherwise reading always result in EOF.
-impl @io.Reader for Reader with _direct_read(self, buf, offset~, max_len~) {
+impl @io.Reader for Reader with fn _direct_read(self, buf, offset~, max_len~) {
   match self.body {
     Empty => 0
     Fixed(remaining) => {
@@ -214,7 +214,7 @@ impl @io.Reader for Reader with _direct_read(self, buf, offset~, max_len~) {
 }
 
 ///|
-impl @io.Reader for Reader with _get_internal_buffer(self) {
+impl @io.Reader for Reader with fn _get_internal_buffer(self) {
   if self.body is PassThrough || self.body is WaitConnectionClose {
     self.transport._get_internal_buffer()
   } else {

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -89,7 +89,7 @@ const EMPTY_MESSAGE_HEADER_END : Bytes = b"Content-Length: 0\r\n\r\n"
 pub suberror IncorrectBodyLength derive(Debug, ToJson)
 
 ///|
-impl @io.Writer for Sender with write_once(self, buf, offset~, len~) {
+impl @io.Writer for Sender with fn write_once(self, buf, offset~, len~) {
   match self.mode {
     SendingHeader => {
       if self.send_len >= self.send_buf.length() {
@@ -153,7 +153,7 @@ impl @io.Writer for Sender with write_once(self, buf, offset~, len~) {
 }
 
 ///|
-impl @io.Writer for Sender with write_reader(self, reader) {
+impl @io.Writer for Sender with fn write_reader(self, reader) {
   match self.mode {
     SendingHeader =>
       for ;; {

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -62,7 +62,7 @@ pub fn ServerConnection::client_addr(self : ServerConnection) -> @socket.Addr {
 }
 
 ///|
-pub impl @io.Reader for ServerConnection with _direct_read(
+pub impl @io.Reader for ServerConnection with fn _direct_read(
   self,
   buf,
   offset~,
@@ -72,7 +72,7 @@ pub impl @io.Reader for ServerConnection with _direct_read(
 }
 
 ///|
-pub impl @io.Reader for ServerConnection with _get_internal_buffer(self) {
+pub impl @io.Reader for ServerConnection with fn _get_internal_buffer(self) {
   self.reader._get_internal_buffer()
 }
 
@@ -106,7 +106,7 @@ pub async fn ServerConnection::skip_request_body(
 ///
 /// Writing to `@http.ServerConnection` MAY be buffered,
 /// call `flush` manually to ensure data is delivered to the remote peer.
-pub impl @io.Writer for ServerConnection with write_once(
+pub impl @io.Writer for ServerConnection with fn write_once(
   self,
   buf,
   offset~,
@@ -127,7 +127,7 @@ pub async fn ServerConnection::write_string(
 }
 
 ///|
-pub impl @io.Writer for ServerConnection with write_reader(self, reader) {
+pub impl @io.Writer for ServerConnection with fn write_reader(self, reader) {
   guard !(self.sender.mode is SendingHeader)
   self.sender.write_reader(reader)
 }

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -31,12 +31,12 @@ struct Coroutine {
 }
 
 ///|
-pub impl Eq for Coroutine with equal(c1, c2) {
+pub impl Eq for Coroutine with fn equal(c1, c2) {
   c1.coro_id == c2.coro_id
 }
 
 ///|
-pub impl Hash for Coroutine with hash_combine(self, hasher) {
+pub impl Hash for Coroutine with fn hash_combine(self, hasher) {
   self.coro_id.hash_combine(hasher)
 }
 

--- a/src/internal/coroutine/deprecated.mbt
+++ b/src/internal/coroutine/deprecated.mbt
@@ -17,6 +17,6 @@
 pub impl Show for Cancelled
 
 ///|
-pub impl Show for Cancelled with output(_self, logger) {
+pub impl Show for Cancelled with fn output(_self, logger) {
   logger <+ "Cancelled"
 }

--- a/src/internal/event_loop/timer.mbt
+++ b/src/internal/event_loop/timer.mbt
@@ -39,12 +39,12 @@ pub fn Timer::cancel(timer : Timer) -> Unit {
 }
 
 ///|
-impl Eq for Timer with equal(t1, t2) {
+impl Eq for Timer with fn equal(t1, t2) {
   t1.timer_id == t2.timer_id
 }
 
 ///|
-impl Compare for Timer with compare(t1, t2) {
+impl Compare for Timer with fn compare(t1, t2) {
   match t1.expire_time.compare(t2.expire_time) {
     0 => t1.timer_id.compare(t2.timer_id)
     o => o

--- a/src/internal/fd_util/deprecated.mbt
+++ b/src/internal/fd_util/deprecated.mbt
@@ -17,7 +17,7 @@
 pub impl Show for FileKind
 
 ///|
-pub impl Show for FileKind with output(self, logger) {
+pub impl Show for FileKind with fn output(self, logger) {
   match self {
     Unknown => logger <+ "Unknown"
     Regular => logger <+ "Regular"

--- a/src/internal/os_string/os_string.mbt
+++ b/src/internal/os_string/os_string.mbt
@@ -34,19 +34,19 @@ pub fn encode(str : StringView) -> OsString {
 }
 
 ///|
-pub impl Show for OsString with output(self, logger) {
+pub impl Show for OsString with fn output(self, logger) {
   self.to_string().output(logger)
 }
 
 ///|
 #cfg(not(platform="windows"))
-pub impl Show for OsString with to_string(self) {
+pub impl Show for OsString with fn to_string(self) {
   @utf8.decode_lossy(self.0)
 }
 
 ///|
 #cfg(platform="windows")
-pub impl Show for OsString with to_string(self) {
+pub impl Show for OsString with fn to_string(self) {
   self.0
 }
 

--- a/src/io/buffered_writer.mbt
+++ b/src/io/buffered_writer.mbt
@@ -55,7 +55,7 @@ pub async fn[W : Writer] BufferedWriter::flush(
 }
 
 ///|
-pub impl[W : Writer] Writer for BufferedWriter[W] with write_once(
+pub impl[W : Writer] Writer for BufferedWriter[W] with fn write_once(
   self,
   buf,
   offset~,
@@ -71,7 +71,7 @@ pub impl[W : Writer] Writer for BufferedWriter[W] with write_once(
 }
 
 ///|
-pub impl[W : Writer] Writer for BufferedWriter[W] with write_reader(
+pub impl[W : Writer] Writer for BufferedWriter[W] with fn write_reader(
   self,
   reader,
 ) {

--- a/src/io/data.mbt
+++ b/src/io/data.mbt
@@ -21,42 +21,42 @@
 /// - `String` and `StringView`, for string (UTF8 encoded)
 /// - `Json` for JSON string (UTF8 encoded)
 trait Data {
-  to_bytesview(Self) -> BytesView = _
-  to_bytes(Self) -> Bytes
+  fn to_bytesview(Self) -> BytesView = _
+  fn to_bytes(Self) -> Bytes
 }
 
 ///|
-impl Data with to_bytesview(self) {
+impl Data with fn to_bytesview(self) {
   self.to_bytes()[:]
 }
 
 ///|
-pub impl Data for Bytes with to_bytes(self) {
+pub impl Data for Bytes with fn to_bytes(self) {
   self
 }
 
 ///|
-pub impl Data for BytesView with to_bytes(self) {
+pub impl Data for BytesView with fn to_bytes(self) {
   self.to_owned()
 }
 
 ///|
-pub impl Data for BytesView with to_bytesview(self) {
+pub impl Data for BytesView with fn to_bytesview(self) {
   self
 }
 
 ///|
-pub impl Data for String with to_bytes(self) {
+pub impl Data for String with fn to_bytes(self) {
   @utf8.encode(self)
 }
 
 ///|
-pub impl Data for StringView with to_bytes(self) {
+pub impl Data for StringView with fn to_bytes(self) {
   @utf8.encode(self)
 }
 
 ///|
-pub impl Data for Json with to_bytes(self) {
+pub impl Data for Json with fn to_bytes(self) {
   @utf8.encode(self.stringify())
 }
 

--- a/src/io/deprecated.mbt
+++ b/src/io/deprecated.mbt
@@ -17,7 +17,7 @@
 pub impl Show for ReaderClosed
 
 ///|
-pub impl Show for ReaderClosed with output(_self, logger) {
+pub impl Show for ReaderClosed with fn output(_self, logger) {
   logger <+ "ReaderClosed"
 }
 
@@ -26,6 +26,6 @@ pub impl Show for ReaderClosed with output(_self, logger) {
 pub impl Show for PipeClosed
 
 ///|
-pub impl Show for PipeClosed with output(_self, logger) {
+pub impl Show for PipeClosed with fn output(_self, logger) {
   logger <+ "PipeClosed"
 }

--- a/src/io/pipe.mbt
+++ b/src/io/pipe.mbt
@@ -91,7 +91,7 @@ pub fn PipeWrite::close(self : PipeWrite) -> Unit {
 ///|
 /// Read data from a pipe. The data come from the write end of the pipe.
 /// Data transfer only happen when reader and writer are present at the same time.
-pub impl Reader for PipeRead with _direct_read(self, dst, offset~, max_len~) {
+pub impl Reader for PipeRead with fn _direct_read(self, dst, offset~, max_len~) {
   let PipeRead(self) = self
   guard self.reader is NoReader
   match self.writer {
@@ -117,7 +117,7 @@ pub impl Reader for PipeRead with _direct_read(self, dst, offset~, max_len~) {
 }
 
 ///|
-pub impl Reader for PipeRead with _get_internal_buffer(self) {
+pub impl Reader for PipeRead with fn _get_internal_buffer(self) {
   let PipeRead(self) = self
   self.read_buf
 }
@@ -130,7 +130,7 @@ pub suberror PipeClosed derive(Debug, ToJson)
 ///|
 /// Write data to a pipe. The data can be read from the read end of the pipe.
 /// Data transfer only happen when reader and writer are present at the same time.
-pub impl Writer for PipeWrite with write_once(self, buf, offset~, len~) {
+pub impl Writer for PipeWrite with fn write_once(self, buf, offset~, len~) {
   let PipeWrite(self) = self
   guard self.writer is NoWriter
   match self.reader {

--- a/src/io/pkg.generated.mbti
+++ b/src/io/pkg.generated.mbti
@@ -53,19 +53,19 @@ pub fn &Data::json(Self) -> Json raise
 pub fn &Data::text(Self) -> String raise
 
 pub(open) trait Reader {
-  _get_internal_buffer(Self) -> ReaderBuffer
-  async _direct_read(Self, FixedArray[Byte], offset~ : Int, max_len~ : Int) -> Int
-  async read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int = _
-  async drop(Self, Int) -> Int = _
-  async read_exactly(Self, Int) -> Bytes = _
-  async read_some(Self, max_len? : Int) -> Bytes? = _
-  async read_all(Self) -> &Data = _
-  async read_until(Self, StringView) -> String? = _
+  fn _get_internal_buffer(Self) -> ReaderBuffer
+  async fn _direct_read(Self, FixedArray[Byte], offset~ : Int, max_len~ : Int) -> Int
+  async fn read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int = _
+  async fn drop(Self, Int) -> Int = _
+  async fn read_exactly(Self, Int) -> Bytes = _
+  async fn read_some(Self, max_len? : Int) -> Bytes? = _
+  async fn read_all(Self) -> &Data = _
+  async fn read_until(Self, StringView) -> String? = _
 }
 
 pub(open) trait Writer {
-  async write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int
-  async write(Self, &Data) -> Unit = _
-  async write_reader(Self, &Reader) -> Unit = _
+  async fn write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int
+  async fn write(Self, &Data) -> Unit = _
+  async fn write_reader(Self, &Reader) -> Unit = _
 }
 

--- a/src/io/reader.mbt
+++ b/src/io/reader.mbt
@@ -15,16 +15,16 @@
 ///|
 pub(open) trait Reader {
   // API for internal implementation only, do not use
-  _get_internal_buffer(Self) -> ReaderBuffer
+  fn _get_internal_buffer(Self) -> ReaderBuffer
 
   // API for internal implementation only, do not use
-  async _direct_read(Self, FixedArray[Byte], offset~ : Int, max_len~ : Int) -> Int
-  async read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int = _
-  async drop(Self, Int) -> Int = _
-  async read_exactly(Self, len : Int) -> Bytes = _
-  async read_some(Self, max_len? : Int) -> Bytes? = _
-  async read_all(Self) -> &Data = _
-  async read_until(Self, StringView) -> String? = _
+  async fn _direct_read(Self, FixedArray[Byte], offset~ : Int, max_len~ : Int) -> Int
+  async fn read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int = _
+  async fn drop(Self, Int) -> Int = _
+  async fn read_exactly(Self, len : Int) -> Bytes = _
+  async fn read_some(Self, max_len? : Int) -> Bytes? = _
+  async fn read_all(Self) -> &Data = _
+  async fn read_until(Self, StringView) -> String? = _
 }
 
 ///|
@@ -37,7 +37,7 @@ pub(all) suberror ReaderClosed derive(Debug, ToJson)
 /// Note that the return value may be smaller than `max_len`
 /// if not enough data is *immediately* available.
 /// If EOF is reached and no more data is available, zero will be returned.
-impl Reader with read(self, dst, offset? = 0, max_len? = dst.length() - offset) {
+impl Reader with fn read(self, dst, offset? = 0, max_len? = dst.length() - offset) {
   let buf = self._get_internal_buffer()
   if buf.len > 0 {
     let n = @cmp.minimum(max_len, buf.len)
@@ -54,7 +54,7 @@ impl Reader with read(self, dst, offset? = 0, max_len? = dst.length() - offset) 
 /// The number of bytes actually dropped is returned.
 /// `drop` will wait until enough number of bytes is available,
 /// so the return value would be smaller than `len` only when EOF is reached.
-impl Reader with drop(self, len) {
+impl Reader with fn drop(self, len) {
   let buf = self._get_internal_buffer()
   if buf.len >= len {
     buf.0.drop(len)
@@ -81,7 +81,7 @@ impl Reader with drop(self, len) {
 /// `reader.read_exactly(len)` read exactly `len` number of bytes from the reader.
 /// It will wait until enough number of bytes is available.
 /// If EOF is reached before enough data is read, `ReaderClosed` is raised.
-impl Reader with read_exactly(self, len) {
+impl Reader with fn read_exactly(self, len) {
   let buf = FixedArray::make(len, b'0')
   for received = 0; received < len; {
     let new_received = self.read(buf, offset=received, max_len=len - received)
@@ -102,7 +102,7 @@ impl Reader with read_exactly(self, len) {
 /// Since `read_some` will return immediately when new data become available,
 /// the returned chunk may be smaller than `max_len`,
 /// even if there are still data available in the reader.
-impl Reader with read_some(self, max_len?) {
+impl Reader with fn read_some(self, max_len?) {
   let buf = self._get_internal_buffer()
   if buf.len > 0 {
     let buf_bytes = buf.buf.unsafe_reinterpret_as_bytes()
@@ -138,7 +138,7 @@ impl Reader with read_some(self, max_len?) {
 /// Read all remaining content from the reader.
 /// The return value is a `&io.Data` object, which can be converted to different formats
 /// using `.binary()`, `.text()` or `.json()`.
-impl Reader with read_all(self) {
+impl Reader with fn read_all(self) {
   let buffer_list = []
   let mut buffer = FixedArray::make(1024, b'0')
   let mut offset = 0
@@ -165,7 +165,7 @@ impl Reader with read_all(self) {
 /// until `sep` or EOF is reached.
 /// The segment of input from start of reader to start of `sep` or EOF is returned.
 /// `sep` will be conusmed from the input, but is not included in the return value.
-impl Reader with read_until(self, sep) {
+impl Reader with fn read_until(self, sep) {
   let sep = @utf8.encode(sep)
   let buf = self._get_internal_buffer()
   match buf.find_opt(sep, reader=self) {

--- a/src/io/writer.mbt
+++ b/src/io/writer.mbt
@@ -19,13 +19,13 @@ pub(all) enum Encoding {
 
 ///|
 pub(open) trait Writer {
-  async write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int
-  async write(Self, &Data) -> Unit = _
-  async write_reader(Self, &Reader) -> Unit = _
+  async fn write_once(Self, Bytes, offset~ : Int, len~ : Int) -> Int
+  async fn write(Self, &Data) -> Unit = _
+  async fn write_reader(Self, &Reader) -> Unit = _
 }
 
 ///|
-impl Writer with write(self, data) {
+impl Writer with fn write(self, data) {
   let view = data.to_bytesview()
   let start = view.start_offset()
   let len = view.length()
@@ -42,7 +42,7 @@ impl Writer with write(self, data) {
 }
 
 ///|
-impl Writer with write_reader(self, reader) {
+impl Writer with fn write_reader(self, reader) {
   let buf = reader._get_internal_buffer()
   if buf.len > 0 {
     let buf_bytes = buf.buf.unsafe_reinterpret_as_bytes()

--- a/src/io/writer_test.mbt
+++ b/src/io/writer_test.mbt
@@ -79,7 +79,7 @@ struct DummyWriter {
 }
 
 ///|
-impl @io.Writer for DummyWriter with write_once(self, buf, offset~, len~) {
+impl @io.Writer for DummyWriter with fn write_once(self, buf, offset~, len~) {
   guard offset + len <= buf.length()
   @async.sleep(self.base_timeout)
   let logger = self.logger

--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -46,7 +46,7 @@ suberror JsError {
 }
 
 ///|
-pub impl Show for JsError with output(self, logger) {
+pub impl Show for JsError with fn output(self, logger) {
   let JsError(value) = self
   logger <+ "\{value.to_string()}"
 }

--- a/src/js_async/readable_stream.mbt
+++ b/src/js_async/readable_stream.mbt
@@ -123,12 +123,12 @@ pub fn ReadableStream::close(self : ReadableStream) -> Unit {
 }
 
 ///|
-pub impl @io.Reader for ReadableStream with _get_internal_buffer(self) {
+pub impl @io.Reader for ReadableStream with fn _get_internal_buffer(self) {
   self.read_end._get_internal_buffer()
 }
 
 ///|
-pub impl @io.Reader for ReadableStream with _direct_read(
+pub impl @io.Reader for ReadableStream with fn _direct_read(
   self,
   buf,
   offset~,

--- a/src/js_async/unimplemented.mbt
+++ b/src/js_async/unimplemented.mbt
@@ -37,7 +37,7 @@ suberror JsError {
 ///|
 #internal(unimplemented, "unimplemented in native backend")
 #coverage.skip
-pub impl Show for JsError with output(self, _logger) {
+pub impl Show for JsError with fn output(self, _logger) {
   let JsError(x) = self
   let _ = JsError(x)
   abort("unimplemented in native backend")
@@ -199,13 +199,13 @@ pub fn ReadableStream::close(self : ReadableStream) -> Unit {
 
 ///|
 #coverage.skip
-pub impl @io.Reader for ReadableStream with _get_internal_buffer(_) {
+pub impl @io.Reader for ReadableStream with fn _get_internal_buffer(_) {
   abort("unimplemented in native backend")
 }
 
 ///|
 #coverage.skip
-pub impl @io.Reader for ReadableStream with _direct_read(
+pub impl @io.Reader for ReadableStream with fn _direct_read(
   _,
   _,
   offset~,

--- a/src/os_error/error.mbt
+++ b/src/os_error/error.mbt
@@ -58,7 +58,7 @@ pub(all) suberror OSError {
 } derive(ToJson)
 
 ///|
-pub impl Show for OSError with output(self, logger) -> Unit {
+pub impl Show for OSError with fn output(self, logger) -> Unit {
   let OSError(errno, context~) = self
   let msg = "\{context}: \{errno_to_string(errno)}"
   logger <+ "OSError(\{to_repr(msg)})"

--- a/src/pipe/pipe.mbt
+++ b/src/pipe/pipe.mbt
@@ -71,17 +71,17 @@ pub fn PipeWrite::close(self : PipeWrite) -> Unit {
 /// At most one task can read from a pipe at any time.
 /// To allow multiple reader,
 /// use a worker task for reading and use `@async.Queue` to distribute the data.
-pub impl @io.Reader for PipeRead with _direct_read(self, buf, offset~, max_len~) {
+pub impl @io.Reader for PipeRead with fn _direct_read(self, buf, offset~, max_len~) {
   self.io.read(buf, offset~, len=max_len, context="@pipe.PipeRead::read()")
 }
 
 ///|
-pub impl @io.Reader for PipeRead with _get_internal_buffer(self) {
+pub impl @io.Reader for PipeRead with fn _get_internal_buffer(self) {
   self.read_buf
 }
 
 ///|
-pub impl @io.Writer for PipeWrite with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for PipeWrite with fn write_once(self, buf, offset~, len~) {
   let PipeWrite(io) = self
   io.write(buf, offset~, len~, context="@pipe.PipeRead::write()")
 }

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -69,12 +69,12 @@ pub fn ReadFromProcess::close(self : ReadFromProcess) -> Unit {
 }
 
 ///|
-pub impl @io.Reader for ReadFromProcess with _get_internal_buffer(self) {
+pub impl @io.Reader for ReadFromProcess with fn _get_internal_buffer(self) {
   self.read_buf
 }
 
 ///|
-pub impl @io.Reader for ReadFromProcess with _direct_read(
+pub impl @io.Reader for ReadFromProcess with fn _direct_read(
   self,
   buf,
   offset~,
@@ -95,7 +95,7 @@ pub fn WriteToProcess::close(self : WriteToProcess) -> Unit {
 }
 
 ///|
-pub impl @io.Writer for WriteToProcess with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for WriteToProcess with fn write_once(self, buf, offset~, len~) {
   let WriteToProcess(io) = self
   io.write(buf, offset~, len~, context="@process.WriteToProcess::write()")
 }
@@ -162,44 +162,44 @@ pub async fn redirect_from_file(path : String) -> &ProcessInput {
 ///|
 /// An entity that can be used to redirect stdin of a process
 trait ProcessInput {
-  fd(Self) -> @fd_util.Fd
-  after_spawn(Self) -> Unit = _
+  fn fd(Self) -> @fd_util.Fd
+  fn after_spawn(Self) -> Unit = _
 }
 
 ///|
-impl ProcessInput with after_spawn(_) {
+impl ProcessInput with fn after_spawn(_) {
   ()
 }
 
 ///|
-pub impl ProcessInput for @pipe.PipeRead with fd(self) {
+pub impl ProcessInput for @pipe.PipeRead with fn fd(self) {
   self.fd()
 }
 
 ///|
-pub impl ProcessInput for @stdio.Input with fd(self) {
+pub impl ProcessInput for @stdio.Input with fn fd(self) {
   self.fd()
 }
 
 ///|
 /// An entity that can be used to redirect stdout/stderr of a process
 trait ProcessOutput {
-  fd(Self) -> @fd_util.Fd
-  after_spawn(Self) -> Unit = _
+  fn fd(Self) -> @fd_util.Fd
+  fn after_spawn(Self) -> Unit = _
 }
 
 ///|
-impl ProcessOutput with after_spawn(_) {
+impl ProcessOutput with fn after_spawn(_) {
   ()
 }
 
 ///|
-pub impl ProcessOutput for @pipe.PipeWrite with fd(self) {
+pub impl ProcessOutput for @pipe.PipeWrite with fn fd(self) {
   self.fd()
 }
 
 ///|
-pub impl ProcessOutput for @stdio.Output with fd(self) {
+pub impl ProcessOutput for @stdio.Output with fn fd(self) {
   self.fd()
 }
 
@@ -216,12 +216,12 @@ priv struct TempPipeWrite {
 }
 
 ///|
-impl ProcessOutput for TempPipeWrite with fd(self) {
+impl ProcessOutput for TempPipeWrite with fn fd(self) {
   self.pipe.fd()
 }
 
 ///|
-impl ProcessOutput for TempPipeWrite with after_spawn(self) {
+impl ProcessOutput for TempPipeWrite with fn after_spawn(self) {
   if !self.closed {
     self.closed = true
     self.pipe.close()
@@ -229,12 +229,12 @@ impl ProcessOutput for TempPipeWrite with after_spawn(self) {
 }
 
 ///|
-impl ProcessInput for TempPipeRead with fd(self) {
+impl ProcessInput for TempPipeRead with fn fd(self) {
   self.pipe.fd()
 }
 
 ///|
-impl ProcessInput for TempPipeRead with after_spawn(self) {
+impl ProcessInput for TempPipeRead with fn after_spawn(self) {
   if !self.closed {
     self.closed = true
     self.pipe.close()
@@ -245,21 +245,21 @@ impl ProcessInput for TempPipeRead with after_spawn(self) {
 priv struct RedirectToFile(@event_loop.IoHandle)
 
 ///|
-impl ProcessOutput for RedirectToFile with fd(self) {
+impl ProcessOutput for RedirectToFile with fn fd(self) {
   self.0.fd()
 }
 
 ///|
-impl ProcessOutput for RedirectToFile with after_spawn(self) {
+impl ProcessOutput for RedirectToFile with fn after_spawn(self) {
   self.0.close()
 }
 
 ///|
-impl ProcessInput for RedirectToFile with fd(self) {
+impl ProcessInput for RedirectToFile with fn fd(self) {
   self.0.fd()
 }
 
 ///|
-impl ProcessInput for RedirectToFile with after_spawn(self) {
+impl ProcessInput for RedirectToFile with fn after_spawn(self) {
   self.0.close()
 }

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -81,7 +81,7 @@ extern "C" fn Addr::scope_id(addr : Addr) -> UInt = "moonbitlang_async_addr_get_
 extern "C" fn Addr::is_ipv6_wildcard(addr : Addr) -> Bool = "moonbitlang_async_addr_is_ipv6_wildcard"
 
 ///|
-pub impl Show for Addr with output(self, logger) {
+pub impl Show for Addr with fn output(self, logger) {
   if self.is_ipv6() {
     // IPv6 address format
     logger <+ "["

--- a/src/socket/deprecated.mbt
+++ b/src/socket/deprecated.mbt
@@ -17,7 +17,7 @@
 pub impl Show for InvalidAddr
 
 ///|
-pub impl Show for InvalidAddr with output(_self, logger) {
+pub impl Show for InvalidAddr with fn output(_self, logger) {
   logger <+ "InvalidAddr"
 }
 
@@ -26,7 +26,7 @@ pub impl Show for InvalidAddr with output(_self, logger) {
 pub impl Show for ResolveHostnameError
 
 ///|
-pub impl Show for ResolveHostnameError with output(self, logger) {
+pub impl Show for ResolveHostnameError with fn output(self, logger) {
   match self {
     ResolveHostnameError(msg) =>
       logger <+ "ResolveHostnameError(\{to_repr(msg)})"
@@ -38,7 +38,7 @@ pub impl Show for ResolveHostnameError with output(self, logger) {
 pub impl Show for IpProtocolPreference
 
 ///|
-pub impl Show for IpProtocolPreference with output(self, logger) {
+pub impl Show for IpProtocolPreference with fn output(self, logger) {
   match self {
     OnlyV4 => logger <+ "OnlyV4"
     OnlyV6 => logger <+ "OnlyV6"

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -282,16 +282,16 @@ pub fn Tcp::addr(sock : Tcp) -> Addr {
 /// At most one task can read from a TCP socket at any time.
 /// To allow multiple reader,
 /// use a worker task for reading and use `@async.Queue` to distribute the data.
-pub impl @io.Reader for Tcp with _direct_read(self, buf, offset~, max_len~) {
+pub impl @io.Reader for Tcp with fn _direct_read(self, buf, offset~, max_len~) {
   self.io.read(buf, offset~, len=max_len, context="@socket.Tcp::read()")
 }
 
 ///|
-pub impl @io.Reader for Tcp with _get_internal_buffer(self) {
+pub impl @io.Reader for Tcp with fn _get_internal_buffer(self) {
   self.read_buf
 }
 
 ///|
-pub impl @io.Writer for Tcp with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for Tcp with fn write_once(self, buf, offset~, len~) {
   self.io.write(buf, offset~, len~, context="@socket.Tcp::write()")
 }

--- a/src/stdio/stdio.mbt
+++ b/src/stdio/stdio.mbt
@@ -24,12 +24,12 @@ pub fn Input::fd(self : Input) -> @fd_util.Fd {
 }
 
 ///|
-pub impl @io.Reader for Input with _direct_read(self, buf, offset~, max_len~) {
+pub impl @io.Reader for Input with fn _direct_read(self, buf, offset~, max_len~) {
   self.io.read(buf, offset~, len=max_len, context="@stdio.Input::read()")
 }
 
 ///|
-pub impl @io.Reader for Input with _get_internal_buffer(self) {
+pub impl @io.Reader for Input with fn _get_internal_buffer(self) {
   self.read_buf
 }
 
@@ -42,7 +42,7 @@ pub fn Output::fd(self : Output) -> @fd_util.Fd {
 }
 
 ///|
-pub impl @io.Writer for Output with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for Output with fn write_once(self, buf, offset~, len~) {
   self.0.write(buf, offset~, len~, context="@fs.File::write()")
 }
 

--- a/src/tls/deprecated.mbt
+++ b/src/tls/deprecated.mbt
@@ -17,7 +17,7 @@
 pub impl Show for TlsError
 
 ///|
-pub impl Show for TlsError with output(self, logger) {
+pub impl Show for TlsError with fn output(self, logger) {
   match self {
     TlsError(msg) => logger <+ "TlsError(\{to_repr(msg)})"
   }
@@ -28,6 +28,6 @@ pub impl Show for TlsError with output(self, logger) {
 pub impl Show for ConnectionClosed
 
 ///|
-pub impl Show for ConnectionClosed with output(_self, logger) {
+pub impl Show for ConnectionClosed with fn output(_self, logger) {
   logger <+ "ConnectionClosed"
 }

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -490,7 +490,7 @@ pub async fn[Inner : @io.Reader + @io.Writer] Tls::server(
 
 ///|
 #cfg(not(platform="windows"))
-pub impl @io.Reader for Tls with _direct_read(self, buf, offset~, max_len~) {
+pub impl @io.Reader for Tls with fn _direct_read(self, buf, offset~, max_len~) {
   let n = while self.ssl.read(buf, offset, max_len) is ret {
     if ret > 0 {
       break ret
@@ -520,13 +520,13 @@ pub impl @io.Reader for Tls with _direct_read(self, buf, offset~, max_len~) {
 
 ///|
 #cfg(not(platform="windows"))
-pub impl @io.Reader for Tls with _get_internal_buffer(self) {
+pub impl @io.Reader for Tls with fn _get_internal_buffer(self) {
   self.read_buf
 }
 
 ///|
 #cfg(not(platform="windows"))
-pub impl @io.Writer for Tls with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for Tls with fn write_once(self, buf, offset~, len~) {
   let n = while self.ssl.write(buf, offset, len) is ret {
     if ret > 0 {
       break ret

--- a/src/tls/schannel.mbt
+++ b/src/tls/schannel.mbt
@@ -321,7 +321,7 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::server_from_pair(
 
 ///|
 #cfg(platform="windows")
-pub impl @io.Reader for Tls with _get_internal_buffer(self) {
+pub impl @io.Reader for Tls with fn _get_internal_buffer(self) {
   self.read_buf
 }
 
@@ -341,7 +341,7 @@ extern "C" fn Schannel::msg_trailer(ch : Schannel) -> Int = "moonbitlang_async_s
 
 ///|
 #cfg(platform="windows")
-pub impl @io.Reader for Tls with _direct_read(self, buf, offset~, max_len~) {
+pub impl @io.Reader for Tls with fn _direct_read(self, buf, offset~, max_len~) {
   if self.closed {
     return 0
   }
@@ -406,7 +406,7 @@ extern "C" fn Schannel::write(
 
 ///|
 #cfg(platform="windows")
-pub impl @io.Writer for Tls with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for Tls with fn write_once(self, buf, offset~, len~) {
   let write_buf = self.transport.write_buf
   guard write_buf.len == 0
   let max_len = write_buf.buf.length() -

--- a/src/types/types.mbt
+++ b/src/types/types.mbt
@@ -21,7 +21,7 @@ pub type Fd
 
 ///|
 #cfg(platform="windows")
-pub impl Eq for Fd with equal(x, y) = "%refeq"
+pub impl Eq for Fd with fn equal(x, y) = "%refeq"
 
 ///|
 #cfg(platform="windows")
@@ -29,7 +29,7 @@ extern "C" fn Fd::to_uint64(fd : Fd) -> UInt64 = "moonbitlang_async_fd_as_uint64
 
 ///|
 #cfg(platform="windows")
-pub impl Hash for Fd with hash_combine(self, hasher) {
+pub impl Hash for Fd with fn hash_combine(self, hasher) {
   hasher.combine_uint64(self.to_uint64())
 }
 

--- a/src/websocket/conn.mbt
+++ b/src/websocket/conn.mbt
@@ -21,16 +21,16 @@ const MASK_SIZE : Int = 4
 
 ///|
 priv trait Transport: @io.Reader + @io.Writer {
-  close(Self) -> Unit
+  fn close(Self) -> Unit
 }
 
 ///|
-impl Transport for @http.Client with close(self) {
+impl Transport for @http.Client with fn close(self) {
   self.close()
 }
 
 ///|
-impl Transport for @http.ServerConnection with close(self) {
+impl Transport for @http.ServerConnection with fn close(self) {
   self.close()
 }
 
@@ -516,12 +516,12 @@ pub async fn Conn::recv(self : Conn) -> Message {
 }
 
 ///|
-pub impl @io.Reader for Message with _get_internal_buffer(self) {
+pub impl @io.Reader for Message with fn _get_internal_buffer(self) {
   self.conn.read_buf
 }
 
 ///|
-pub impl @io.Reader for Message with _direct_read(self, buf, offset~, max_len~) {
+pub impl @io.Reader for Message with fn _direct_read(self, buf, offset~, max_len~) {
   match self.state {
     Active => ()
     Closed => return 0
@@ -667,7 +667,7 @@ async fn Conn::flush(self : Conn) -> Unit {
 /// The message may be fragmented into multiple WebSocket frames automatically.
 /// Writing message content is buffered.
 /// To ensure immediate delivery of data, call `flush` manually.
-pub impl @io.Writer for Conn with write_once(self, buf, offset~, len~) {
+pub impl @io.Writer for Conn with fn write_once(self, buf, offset~, len~) {
   if self.payload_start + self.write_len >= self.write_buf.length() {
     self.flush()
   }

--- a/src/websocket/deprecated.mbt
+++ b/src/websocket/deprecated.mbt
@@ -34,7 +34,7 @@ fn CloseCode::write_show(self : CloseCode, logger : &Logger) -> Unit {
 pub impl Show for MessageKind
 
 ///|
-pub impl Show for MessageKind with output(self, logger) {
+pub impl Show for MessageKind with fn output(self, logger) {
   match self {
     Binary => logger <+ "Binary"
     Text => logger <+ "Text"
@@ -46,7 +46,7 @@ pub impl Show for MessageKind with output(self, logger) {
 pub impl Show for CloseCode
 
 ///|
-pub impl Show for CloseCode with output(self, logger) {
+pub impl Show for CloseCode with fn output(self, logger) {
   self.write_show(logger)
 }
 
@@ -56,7 +56,7 @@ pub impl Show for WebSocketError
 
 ///|
 #warnings("-deprecated")
-pub impl Show for WebSocketError with output(self, logger) {
+pub impl Show for WebSocketError with fn output(self, logger) {
   match self {
     ConnectionClosed(close_code, msg) =>
       logger <+ "ConnectionClosed(\{close_code}, \{msg})"


### PR DESCRIPTION
## Summary

Split out the safe `fn` syntax portion from the broader formatter/info PR.

- add `fn` to trait member declarations where needed
- update `impl ... with` declarations to `impl ... with fn`
- regenerate `src/io/pkg.generated.mbti` with the matching public trait syntax

This intentionally does not include the `moon fmt` manifest migration or the broader formatter/test-helper changes from #394.

## Validation

- `moon check --deny-warn`
- `moon check --target js --deny-warn`
- `moon info`
- `git diff --check`

`moon test --deny-warn` was also run locally, but this environment reported existing-looking fs/process timing and file-lock failures unrelated to this syntax-only change: `fs/lock_test.mbt` and `process/spawn_in_group_test.mbt` / `process/cancel_test.mbt`.