### PR TITLE
fix `@async.Queue::close` wrongly swallow value

### DIFF
--- a/src/aqueue/aqueue.mbt
+++ b/src/aqueue/aqueue.mbt
@@ -237,10 +237,12 @@ pub async fn[X] Queue::get(self : Queue[X]) -> X {
       raise err
     }
   }
-  if self.closed is Some(err) {
+  if reader.value is Some(value) {
+    value
+  } else {
+    guard self.closed is Some(err)
     raise err
   }
-  reader.value.unwrap()
 }
 
 ///|

--- a/src/aqueue/close_test.mbt
+++ b/src/aqueue/close_test.mbt
@@ -111,7 +111,7 @@ async test "close with completed get" {
       debug_inspect(
         try? q.get(),
         content=(
-          #|Err(QueueAlreadyClosed)
+          #|Ok(42)
         ),
       )
     }

--- a/src/aqueue/close_test.mbt
+++ b/src/aqueue/close_test.mbt
@@ -102,3 +102,31 @@ async test "close with blocking get" {
     inspect(duration, content="1")
   }
 }
+
+///|
+async test "close with completed get" {
+  let q : @aqueue.Queue[Int] = @async.Queue(kind=Unbounded)
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
+      debug_inspect(
+        try? q.get(),
+        content=(
+          #|Err(QueueAlreadyClosed)
+        ),
+      )
+    }
+    // let the `get` fire first
+    @async.pause()
+    q.put(42)
+    // here the value we just put is already delivered to `get`
+    q.close()
+    // one of `get` above and `try_get` here should suceed,
+    // the value should not get swallowed.
+    debug_inspect(
+      try? q.try_get(),
+      content=(
+        #|Err(QueueAlreadyClosed)
+      ),
+    )
+  }
+}


### PR DESCRIPTION
https://github.com/moonbitlang/async/pull/377#issuecomment-4485100776

When `.close()` is called on a queue, if a previously `put` value is already handed to a blocked reader, but the reader itself has not yet woken, the value will be wrongly discarded by the logic of `get`. This PR fixes the issue.