### PR TITLE
add `RawFdStream` abstraction for stream based IO on raw fd

### DIFF
--- a/src/raw_fd/moon.pkg
+++ b/src/raw_fd/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/async/internal/fd_util",
   "moonbitlang/async/internal/event_loop",
+  "moonbitlang/async/io",
 }
 
 import {

--- a/src/raw_fd/pkg.generated.mbti
+++ b/src/raw_fd/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/async/raw_fd"
 
+import {
+  "moonbitlang/async/io",
+}
+
 // Values
 
 // Errors
@@ -15,6 +19,15 @@ pub async fn RawFd::RawFd(Int) -> Self
 pub fn RawFd::close(Self) -> Unit
 pub async fn RawFd::read(Self, FixedArray[Byte], offset? : Int, max_len? : Int) -> Int
 pub async fn RawFd::write(Self, Bytes, offset? : Int, len? : Int) -> Int
+
+pub struct RawFdStream {
+  fd : Int
+  // private fields
+}
+pub async fn RawFdStream::RawFdStream(Int) -> Self
+pub fn RawFdStream::close(Self) -> Unit
+pub impl @io.Reader for RawFdStream
+pub impl @io.Writer for RawFdStream
 
 // Type aliases
 

--- a/src/raw_fd/raw_fd.mbt
+++ b/src/raw_fd/raw_fd.mbt
@@ -86,3 +86,69 @@ pub async fn RawFd::write(
 ) -> Int {
   self.io.write(buf, offset~, len~, context="@raw_fd.RawFd::write()")
 }
+
+///|
+/// A wrapper around a raw file descriptor that can be used to
+/// perform asynchronous stream-based IO on the raw file descriptor
+/// via the `@io.Reader`/`@io.Writer` interface.
+/// This is useful for binding special file descriptors
+/// that are not natively supported by `moonbitlang/async`.
+pub struct RawFdStream {
+  fd : @fd_util.Fd
+  priv io : @event_loop.IoHandle
+  priv read_buf : @io.ReaderBuffer
+}
+
+///|
+/// Create a new `RawFdStream` object from the underlying file descriptor.
+/// The ownership of the file descriptor will be transferred to this function,
+/// so the file descriptor must not be used or closed directly later,
+/// even if creation of `RawFdStream` object failed.
+#cfg(not(platform="windows"))
+pub async fn RawFdStream::RawFdStream(fd : @fd_util.Fd) -> RawFdStream {
+  let context = "@raw_fd.RawFdStream()"
+  let kind = @event_loop.kind_of_fd(fd, context~)
+  let is_async = @fd_util.fd_is_nonblocking(fd, context~)
+  let read_buf = @io.ReaderBuffer::new()
+  { fd, io: @event_loop.IoHandle::from_fd(fd, kind~, is_async~), read_buf }
+}
+
+///|
+/// Create a new `RawFdStream` object from the underlying file descriptor.
+/// The ownership of the file descriptor will be transferred to this function,
+/// so the file descriptor must not be used or closed directly later,
+/// even if creation of `RawFdStream` object failed.
+///
+/// The file descriptor (`HANDLE`) MUST NOT be overlapped.
+#cfg(platform="windows")
+pub async fn RawFdStream::RawFdStream(fd : @fd_util.Fd) -> RawFdStream {
+  let context = "@raw_fd.RawFdStream()"
+  let kind = @event_loop.kind_of_fd(fd, context~)
+  let read_buf = @io.ReaderBuffer::new()
+  { fd, io: @event_loop.IoHandle::from_fd(fd, kind~, is_async=false), read_buf }
+}
+
+///|
+pub fn RawFdStream::close(self : RawFdStream) -> Unit {
+  self.io.close()
+}
+
+///|
+pub impl @io.Reader for RawFdStream with fn _get_internal_buffer(self) {
+  self.read_buf
+}
+
+///|
+pub impl @io.Reader for RawFdStream with fn _direct_read(
+  self,
+  buf,
+  offset~,
+  max_len~,
+) {
+  self.io.read(buf, offset~, len=max_len, context="@raw_fd.RawFdStream::read()")
+}
+
+///|
+pub impl @io.Writer for RawFdStream with fn write_once(self, buf, offset~, len~) {
+  self.io.write(buf, offset~, len~, context="@raw_fd.RawFdStream::write()")
+}

--- a/src/raw_fd/raw_fd_test.mbt
+++ b/src/raw_fd/raw_fd_test.mbt
@@ -55,6 +55,41 @@ async test "pipe as raw fd" {
 }
 
 ///|
+async test "pipe as raw fd stream" {
+  let log = []
+  let (r, w) = @fd_util.pipe(
+    read_end_is_async=false,
+    write_end_is_async=false,
+    context="pipe as raw fd",
+  )
+  assert_true(@event_loop.kind_of_fd(r, context="kind_of_fd") is Pipe)
+  assert_true(@event_loop.kind_of_fd(w, context="kind_of_fd") is Pipe)
+  @async.with_task_group <| group => {
+    group.spawn_bg() <| () => {
+      let r = @raw_fd.RawFdStream(r)
+      defer r.close()
+      while r.read_some() is Some(data) {
+        @async.sleep(50)
+        log.push("read() => \{@utf8.decode(data).escape()}")
+      }
+    }
+    group.spawn_bg() <| () => {
+      let w = @raw_fd.RawFdStream(w)
+      defer w.close()
+      for data in [b"abcd", b"1234", b"ABCD"] {
+        @async.sleep(200)
+        w.write(data)
+        log.push("write(\{@utf8.decode(data).escape()})")
+      }
+    }
+  }
+  json_inspect(log, content=[
+    "write(\"abcd\")", "read() => \"abcd\"", "write(\"1234\")", "read() => \"1234\"",
+    "write(\"ABCD\")", "read() => \"ABCD\"",
+  ])
+}
+
+///|
 async test "file as raw fd" {
   let truth = @fs.read_file("LICENSE").binary()
   let (io, _) = @event_loop.open(
@@ -81,6 +116,27 @@ async test "file as raw fd" {
   assert_eq(len, truth.length())
   let raw_fd_result = buf.unsafe_reinterpret_as_bytes()[:len]
   assert_eq(truth[:], raw_fd_result)
+}
+
+///|
+async test "file as raw fd stream" {
+  let truth = @fs.read_file("LICENSE").binary()
+  let (io, _) = @event_loop.open(
+    "LICENSE",
+    0,
+    create=0,
+    append=false,
+    sync=0,
+    mode=0,
+    context="file as raw fd test",
+  )
+  let fd = io.detach_from_event_loop()
+  let file = @raw_fd.RawFdStream(fd)
+  defer file.close()
+  assert_true(@event_loop.kind_of_fd(fd, context="kind_of_fd") is Regular)
+  let actual = file.read_all().binary()
+  assert_eq(actual.length(), truth.length())
+  assert_eq(truth, actual)
 }
 
 ///|


### PR DESCRIPTION
Previously, `@raw_fd.RawFd` was introduced so that arbitrary raw file descriptor not supported by `moonbitlang/async` natively can be integrated into the event loop. `@raw_fd.RawFd` has a single read/write syscall based API similar to UDP socket, because not all file descriptors are stream based. However, for those file descriptors that are indeed stream based, `@raw_fd.RawFd` cannot utilize the `@io.Reader`/`@io.Writer` system and various helpers attached to it.

This PR introduces `@raw_fd.RawFdStream`, which is a stream based wrapper for a raw file descriptor with `@io.Reader`/`@io.Writer` implementations.