### PR TITLE
preliminary file system watching support with `wait_any`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To use these packages, add them to the `import` field of `moon.pkg.json`.
 - [X] signal handling
     - [X] graceful cancellation on receiving `SIGINT` etc.
     - [ ] custom signal handling logic
-- [ ] file system watching
+- [X] file system watching
 - [X] structured concurrency
 - [X] cooperative multi tasking
 - [X] IO worker thread

--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -27,11 +27,12 @@ typedef FILE_ID_BOTH_DIR_INFO sys_dirent;
 #include <sys/vnode.h>
 
 // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getattrlist.2.html
-typedef struct {
+typedef struct __attribute__((packed, aligned(4))) {
    u_int32_t       d_reclen; /* length of the whole record */
    attribute_set_t d_attrs;  /* list of supported attributes */
    attrreference_t d_name;   /* the name of the file */
    fsobj_type_t    d_type;   /* the type of the file */
+   uint64_t        d_fileid;  /* the id of the file on its volume */
 } sys_dirent;
 
 #elif defined(__linux__)
@@ -188,6 +189,24 @@ int32_t moonbitlang_async_dir_entry_is_hidden(char *buf, int32_t offset) {
 
   return ent->d_name[0] == '.';
 
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+uint64_t moonbitlang_async_dir_entry_get_file_id(char *buf, int32_t offset) {
+  sys_dirent *ent = (sys_dirent *)(buf + offset);
+
+#ifdef _WIN32
+
+  return ent->FileId.QuadPart;
+
+#elif defined(__MACH__)
+
+  return ent->d_fileid;
+
+#elif defined(__linux__)
+
+  return ent->d_ino;
 
 #endif
 }

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -188,12 +188,20 @@ extern "C" fn Directory::entry_is_hidden(
 ) -> Bool = "moonbitlang_async_dir_entry_is_hidden"
 
 ///|
+#borrow(buf)
+extern "C" fn Directory::entry_file_id(
+  buf : FixedArray[Byte],
+  offset : Int,
+) -> UInt64 = "moonbitlang_async_dir_entry_get_file_id"
+
+///|
 #valtype
 pub struct DirectoryEntry {
   name : String
   /// Indicate whether the directory entry is another directory.
   /// Symbolic links are not treated as directories here.
   is_dir : Bool
+  priv file_id : UInt64
 }
 
 ///|
@@ -226,6 +234,7 @@ async fn Directory::next_aux(
   dir : Directory,
   include_hidden~ : Bool,
   include_special~ : Bool,
+  restart? : Bool = false,
   context~ : String,
 ) -> DirectoryEntry? {
   match dir.state {
@@ -234,7 +243,12 @@ async fn Directory::next_aux(
     NeedMoreEntry => {
       dir.offset = 0
       dir.count = 0
-      dir.job_ret = dir.io.readdir(dir.buf, dir.buf.length(), context~)
+      dir.job_ret = dir.io.readdir(
+        dir.buf,
+        dir.buf.length(),
+        restart~,
+        context~,
+      )
       if dir.job_ret is 0 {
         dir.state = NoMoreEntry
         return None
@@ -278,7 +292,8 @@ async fn Directory::next_aux(
       kind is Directory
     }
   }
-  Some({ name, is_dir })
+  let file_id = Directory::entry_file_id(dir.buf, offset)
+  Some({ name, is_dir, file_id })
 }
 
 ///|

--- a/src/fs/dir_test.mbt
+++ b/src/fs/dir_test.mbt
@@ -22,11 +22,13 @@ async test "read_all" {
   list.sort()
   json_inspect(list, content=[
     "dir.c", "stub.c", "dir.mbt", "file.mbt", "moon.pkg", "README.md", "utils.mbt",
-    "tmpdir.mbt", "dir_test.mbt", "eof_test.mbt", "README.mbt.md", "constants.mbt",
+    "watch.mbt", "tmpdir.mbt", "dir_test.mbt", "eof_test.mbt", "README.mbt.md", "constants.mbt",
     "lock_test.mbt", "stat_test.mbt", "walk_test.mbt", "deprecated.mbt", "mkdir_test.mbt",
-    "access_test.mbt", "create_test.mbt", "rename_test.mbt", "tmpdir_test.mbt", "read_all_test.mbt",
-    "realpath_test.mbt", "unimplemented.mbt", "pkg.generated.mbti", "text_file_test.mbt",
-    "timestamp_test.mbt", "named_pipe_test.mbt", "random_access_test.mbt", "unimplemented_test.mbt",
+    "watch_kqueue.c", "watch_test.mbt", "watch_unix.mbt", "access_test.mbt", "create_test.mbt",
+    "rename_test.mbt", "tmpdir_test.mbt", "watch_inotify.c", "watch_windows.c", "watch_kqueue.mbt",
+    "read_all_test.mbt", "realpath_test.mbt", "unimplemented.mbt", "watch_inotify.mbt",
+    "watch_windows.mbt", "pkg.generated.mbti", "text_file_test.mbt", "timestamp_test.mbt",
+    "named_pipe_test.mbt", "random_access_test.mbt", "unimplemented_test.mbt",
   ])
 }
 
@@ -39,11 +41,13 @@ async test "as_dir" {
   let list = dir.read_all()..sort()
   json_inspect(list, content=[
     "dir.c", "stub.c", "dir.mbt", "file.mbt", "moon.pkg", "README.md", "utils.mbt",
-    "tmpdir.mbt", "dir_test.mbt", "eof_test.mbt", "README.mbt.md", "constants.mbt",
+    "watch.mbt", "tmpdir.mbt", "dir_test.mbt", "eof_test.mbt", "README.mbt.md", "constants.mbt",
     "lock_test.mbt", "stat_test.mbt", "walk_test.mbt", "deprecated.mbt", "mkdir_test.mbt",
-    "access_test.mbt", "create_test.mbt", "rename_test.mbt", "tmpdir_test.mbt", "read_all_test.mbt",
-    "realpath_test.mbt", "unimplemented.mbt", "pkg.generated.mbti", "text_file_test.mbt",
-    "timestamp_test.mbt", "named_pipe_test.mbt", "random_access_test.mbt", "unimplemented_test.mbt",
+    "watch_kqueue.c", "watch_test.mbt", "watch_unix.mbt", "access_test.mbt", "create_test.mbt",
+    "rename_test.mbt", "tmpdir_test.mbt", "watch_inotify.c", "watch_windows.c", "watch_kqueue.mbt",
+    "read_all_test.mbt", "realpath_test.mbt", "unimplemented.mbt", "watch_inotify.mbt",
+    "watch_windows.mbt", "pkg.generated.mbti", "text_file_test.mbt", "timestamp_test.mbt",
+    "named_pipe_test.mbt", "random_access_test.mbt", "unimplemented_test.mbt",
   ])
 }
 
@@ -62,7 +66,7 @@ test "readdir clear errno" {
     inspect(
       list.length(),
       content=(
-        #|30
+        #|39
       ),
     )
   }

--- a/src/fs/moon.pkg
+++ b/src/fs/moon.pkg
@@ -3,6 +3,8 @@ import {
   "moonbitlang/core/buffer",
   "moonbitlang/core/int",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/deque",
+  "moonbitlang/core/sorted_set",
   "moonbitlang/async/os_error",
   "moonbitlang/async/io",
   "moonbitlang/async/internal/event_loop",
@@ -11,6 +13,8 @@ import {
   "moonbitlang/async/internal/env_util",
   "moonbitlang/async/internal/c_buffer",
   "moonbitlang/async",
+  "moonbitlang/async/internal/coroutine",
+  "moonbitlang/async/internal/c_buffer",
 }
 
 import {
@@ -22,7 +26,13 @@ import {
 
 options(
   "max-concurrent-tests": 5,
-  "native-stub": [ "stub.c", "dir.c" ],
+  "native-stub": [
+    "stub.c",
+    "dir.c",
+    "watch_inotify.c",
+    "watch_kqueue.c",
+    "watch_windows.c",
+  ],
   targets: {
     "README.mbt.md": [ "native" ],
     "access_test.mbt": [ "native" ],
@@ -48,5 +58,11 @@ options(
     "tmpdir_test.mbt": [ "native" ],
     "utils.mbt": [ "native" ],
     "walk_test.mbt": [ "native" ],
+    "watch.mbt": [ "native" ],
+    "watch_inotify.mbt": [ "native" ],
+    "watch_kqueue.mbt": [ "native" ],
+    "watch_test.mbt": [ "native" ],
+    "watch_unix.mbt": [ "native" ],
+    "watch_windows.mbt": [ "native" ],
   },
 )

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -131,7 +131,7 @@ pub(all) enum SyncMode {
 pub struct Watcher {
   // private fields
 }
-pub async fn Watcher::Watcher(String) -> Self
+pub async fn Watcher::Watcher(String, debounce_timeout? : Int, max_debounce_delay? : Int) -> Self
 pub fn Watcher::close(Self) -> Unit
 pub async fn Watcher::wait_any(Self) -> Unit
 

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -76,6 +76,7 @@ pub async fn Directory::read_all(Self, include_hidden? : Bool, include_special? 
 pub struct DirectoryEntry {
   name : String
   is_dir : Bool
+  // private fields
 }
 
 type File
@@ -126,6 +127,13 @@ pub(all) enum SyncMode {
   Data
   Full
 }
+
+pub struct Watcher {
+  // private fields
+}
+pub async fn Watcher::Watcher(String) -> Self
+pub fn Watcher::close(Self) -> Unit
+pub async fn Watcher::wait_any(Self) -> Unit
 
 // Type aliases
 

--- a/src/fs/watch.mbt
+++ b/src/fs/watch.mbt
@@ -68,10 +68,12 @@ fn Watcher::new_backend(
   self : Watcher,
   root : @event_loop.IoHandle,
   root_id~ : FileIdentity,
+  debounce_timeout~ : Int,
+  max_debounce_delay~ : Int,
   context~ : String,
 ) -> &WatcherBackend {
   ignore(context)
-  WindowsWatcher(self, root, root_id~)
+  WindowsWatcher(self, root, root_id~, debounce_timeout~, max_debounce_delay~)
 }
 
 ///|
@@ -80,13 +82,19 @@ fn Watcher::new_backend(
   self : Watcher,
   root : @event_loop.IoHandle,
   root_id~ : FileIdentity,
+  debounce_timeout~ : Int,
+  max_debounce_delay~ : Int,
   context~ : String,
 ) -> &WatcherBackend raise {
   ignore(root_id)
   root.close()
   match @event_loop.platform {
-    Linux => InotifyWatcher(self, context~) as &WatcherBackend
-    MacOS => KqueueWatcher(self, context~) as &WatcherBackend
+    Linux =>
+      InotifyWatcher(self, debounce_timeout~, max_debounce_delay~, context~)
+      as &WatcherBackend
+    MacOS =>
+      KqueueWatcher(self, debounce_timeout~, max_debounce_delay~, context~)
+      as &WatcherBackend
     Windows => panic()
   }
 }
@@ -99,8 +107,20 @@ fn Watcher::new_backend(
 /// the watcher will get notified and report events for the change.
 /// New files will be watched automatically, and removed files will be unwatched automatically.
 ///
+/// File system events often come in batch.
+/// For example, removing a directory recursively will result in several removal event in a row.
+/// By default `Watcher` will perform debouncing internally:
+/// when many events are happening in sequence, instead of immediately return on the first event,
+/// `Watcher::wait_any` will wait until no event is happening
+/// within the last `debounce_timeout` ms (defaults to 20ms),
+/// or if `max_debounce_delay` ms (defaults to 200ms) has elapsed since the first event.
+///
 /// Currently, the behavior when `path` itself is renamed or removed is undefined.
-pub async fn Watcher::Watcher(path : String) -> Watcher {
+pub async fn Watcher::Watcher(
+  path : String,
+  debounce_timeout? : Int = 20,
+  max_debounce_delay? : Int = 200,
+) -> Watcher {
   let context = "@fs.Watcher()"
   let path = path.trim_end(chars="/")
   let path = if path is "" { "/" } else { path.to_owned() }
@@ -133,7 +153,13 @@ pub async fn Watcher::Watcher(path : String) -> Watcher {
     pending_remove: Set([]),
   }
   try {
-    let backend = self.new_backend(root_file, root_id~, context~)
+    let backend = self.new_backend(
+      root_file,
+      root_id~,
+      debounce_timeout~,
+      max_debounce_delay~,
+      context~,
+    )
     self.backend = Some(backend)
     let root_wd = backend.add_file(path, is_dir=true, file_id=root_id, context~)
     let root = {

--- a/src/fs/watch.mbt
+++ b/src/fs/watch.mbt
@@ -389,3 +389,15 @@ fn Watcher::add_dirty_child(
     }
   }
 }
+
+///|
+fn Watcher::overflow(self : Watcher) -> Unit {
+  for file in self.watched.values() {
+    file.modified = true
+    if file.is_dir {
+      for name, id in file.children {
+        file.dirty_children[name] = id
+      }
+    }
+  }
+}

--- a/src/fs/watch.mbt
+++ b/src/fs/watch.mbt
@@ -45,6 +45,7 @@ priv trait WatcherBackend {
 }
 
 ///|
+/// A file system watcher for watching changes in a directory.
 struct Watcher {
   mut backend : &WatcherBackend?
   root_id : FileIdentity
@@ -91,6 +92,14 @@ fn Watcher::new_backend(
 }
 
 ///|
+/// Create a new file system watcher that watches the directory `path` recursively.
+/// Currently only recursive directory watching is supported.
+///
+/// When files are created, removed, modified or renamed inside `path`,
+/// the watcher will get notified and report events for the change.
+/// New files will be watched automatically, and removed files will be unwatched automatically.
+///
+/// Currently, the behavior when `path` itself is renamed or removed is undefined.
 pub async fn Watcher::Watcher(path : String) -> Watcher {
   let context = "@fs.Watcher()"
   let path = path.trim_end(chars="/")
@@ -157,6 +166,8 @@ fn rel_path(parent : String, name : String) -> String {
 }
 
 ///|
+/// Wait for any change in the watched tree
+/// since the last `wait_any` call or watcher creation.
 pub async fn Watcher::wait_any(self : Watcher) -> Unit {
   let context = "@fs.Watcher::wait()"
   guard self.backend is Some(backend)

--- a/src/fs/watch.mbt
+++ b/src/fs/watch.mbt
@@ -1,0 +1,354 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#valtype
+priv struct FileIdentity {
+  dev_id : UInt64
+  file_id : UInt64
+} derive(Eq, Hash)
+
+///|
+priv struct WatchedFile {
+  wd : @fd_util.Fd
+  file_id : FileIdentity
+  paths : Set[(FileIdentity, String)]
+  is_dir : Bool
+  children : Map[String, FileIdentity]
+  mut modified : Bool
+  dirty_children : Map[String, FileIdentity]
+}
+
+///|
+priv trait WatcherBackend {
+  fn close(Self) -> Unit
+  async fn wait(Self) -> Unit
+  async fn add_file(
+    Self,
+    StringView,
+    is_dir~ : Bool,
+    file_id~ : FileIdentity,
+    context~ : String,
+  ) -> @fd_util.Fd
+  fn remove_file(Self, @fd_util.Fd, context~ : String) -> Unit raise
+}
+
+///|
+struct Watcher {
+  mut backend : &WatcherBackend?
+  root_id : FileIdentity
+  base_path : String
+  watched : Map[FileIdentity, WatchedFile]
+  pending_remove : Set[FileIdentity]
+}
+
+///|
+pub fn Watcher::close(self : Watcher) -> Unit {
+  if self.backend is Some(backend) {
+    self.backend = None
+    backend.close()
+  }
+}
+
+///|
+#cfg(platform="windows")
+fn Watcher::new_backend(
+  self : Watcher,
+  root : @event_loop.IoHandle,
+  root_id~ : FileIdentity,
+  context~ : String,
+) -> &WatcherBackend {
+  ignore(context)
+  WindowsWatcher(self, root, root_id~)
+}
+
+///|
+#cfg(not(platform="windows"))
+fn Watcher::new_backend(
+  self : Watcher,
+  root : @event_loop.IoHandle,
+  root_id~ : FileIdentity,
+  context~ : String,
+) -> &WatcherBackend raise {
+  ignore(root_id)
+  root.close()
+  match @event_loop.platform {
+    Linux => InotifyWatcher(self, context~) as &WatcherBackend
+    MacOS => KqueueWatcher(self, context~) as &WatcherBackend
+    Windows => panic()
+  }
+}
+
+///|
+pub async fn Watcher::Watcher(path : String) -> Watcher {
+  let context = "@fs.Watcher()"
+  let path = path.trim_end(chars="/")
+  let path = if path is "" { "/" } else { path.to_owned() }
+  let (root_file, root_file_info) = @event_loop.open(
+    path,
+    if @event_loop.IS_WINDOWS {
+      3
+    } else {
+      0
+    },
+    create=0,
+    append=false,
+    sync=0,
+    mode=0,
+    context~,
+  )
+  guard root_file.kind() is Directory else {
+    root_file.close()
+    raise @os_error.OSError(@os_error.errno_ENOTDIR, context~)
+  }
+  let root_id = {
+    dev_id: root_file_info.dev_id(),
+    file_id: root_file_info.file_id(),
+  }
+  let self = {
+    backend: None,
+    root_id,
+    base_path: path,
+    watched: {},
+    pending_remove: Set([]),
+  }
+  try {
+    let backend = self.new_backend(root_file, root_id~, context~)
+    self.backend = Some(backend)
+    let root_wd = backend.add_file(path, is_dir=true, file_id=root_id, context~)
+    let root = {
+      wd: root_wd,
+      file_id: root_id,
+      paths: Set([]),
+      is_dir: true,
+      children: {},
+      modified: true,
+      dirty_children: {},
+    }
+    self.watched[root_id] = root
+    self.synchronize_tree(context~)
+    self
+  } catch {
+    err => {
+      self.close()
+      raise err
+    }
+  }
+}
+
+///|
+fn rel_path(parent : String, name : String) -> String {
+  if parent is "" {
+    name
+  } else {
+    "\{parent}/\{name}"
+  }
+}
+
+///|
+pub async fn Watcher::wait_any(self : Watcher) -> Unit {
+  let context = "@fs.Watcher::wait()"
+  guard self.backend is Some(backend)
+  backend.wait()
+  self.synchronize_tree(context~)
+  while self.pending_remove.iter().next() is Some(file_id) {
+    self.pending_remove.remove(file_id)
+    let file = self.watched[file_id]
+    guard file.paths.is_empty() else { continue }
+    if file.is_dir {
+      for child in file.children.keys() {
+        self.remove_file_at(file, child)
+      }
+    }
+    self.watched.remove(file_id)
+    backend.remove_file(file.wd, context~)
+  }
+}
+
+///|
+fn WatchedFile::is_clean(file : WatchedFile) -> Bool {
+  !file.modified && file.dirty_children.is_empty()
+}
+
+///|
+async fn Watcher::get_file_at(
+  self : Watcher,
+  file_id~ : FileIdentity,
+  is_dir~ : Bool,
+  path~ : String,
+  context~ : String,
+) -> WatchedFile {
+  if self.watched.get(file_id) is Some(existing) {
+    return existing
+  }
+
+  let full_path = "\{self.base_path}/\{path}"
+
+  guard self.backend is Some(backend)
+  let wd = backend.add_file(full_path, is_dir~, file_id~, context~)
+  let new_file = {
+    wd,
+    file_id,
+    paths: Set([]),
+    is_dir,
+    children: {},
+    modified: is_dir, // new directory need rescan
+    dirty_children: {},
+  }
+  self.watched[file_id] = new_file
+  new_file
+}
+
+///|
+async fn Watcher::add_file_at(
+  self : Watcher,
+  dir : WatchedFile,
+  name : String,
+  is_dir~ : Bool,
+  file_id~ : FileIdentity,
+  path~ : String,
+  context~ : String,
+) -> Unit {
+  if dir.children.get(name) is Some(curr_id) {
+    if curr_id == file_id {
+      return
+    } else {
+      self.remove_file_at(dir, name)
+    }
+  }
+  let location = (dir.file_id, name)
+  let file = self.get_file_at(path~, is_dir~, file_id~, context~)
+  dir.children[name] = file.file_id
+  file.paths.add(location)
+  if !file.is_clean() {
+    dir.dirty_children[name] = file.file_id
+  }
+}
+
+///|
+fn Watcher::remove_file_at(
+  self : Watcher,
+  dir : WatchedFile,
+  name : String,
+) -> Unit {
+  let curr_id = dir.children.get(name)
+  guard curr_id is Some(curr_id) else { return }
+  let path = (dir.file_id, name)
+  dir.children.remove(name)
+  dir.dirty_children.remove(name)
+  let curr = self.watched[curr_id]
+  curr.paths.remove(path)
+  if curr.paths.is_empty() {
+    self.pending_remove.add(curr_id)
+  }
+}
+
+///|
+async fn Watcher::scan_dir(
+  self : Watcher,
+  dir : WatchedFile,
+  path~ : String,
+  context~ : String,
+) -> Unit {
+  let removed_children = dir.children.copy()
+  let dir_obj = opendir_aux("\{self.base_path}/\{path}", context~)
+  defer dir_obj.close()
+  while dir_obj.next_aux(include_special=false, include_hidden=true, context~)
+        is Some(ent) {
+    let new_file_id = { ..dir.file_id, file_id: ent.file_id }
+    self.add_file_at(
+      dir,
+      ent.name,
+      is_dir=ent.is_dir,
+      file_id=new_file_id,
+      path=rel_path(path, ent.name),
+      context~,
+    ) catch {
+      @os_error.OSError(_) as err if err.is_ENOENT() => continue
+      err => raise err
+    }
+    removed_children.remove(ent.name)
+  }
+  for name in removed_children.keys() {
+    self.remove_file_at(dir, name)
+  }
+}
+
+///|
+async fn Watcher::synchronize_tree(self : Watcher, context~ : String) -> Unit {
+  let root = self.watched[self.root_id]
+  while !root.is_clean() {
+    self.synchronize_file(root, path="", context~)
+  }
+}
+
+///|
+async fn Watcher::synchronize_file(
+  self : Watcher,
+  file : WatchedFile,
+  path~ : String,
+  context~ : String,
+) -> Unit {
+  if file.modified {
+    file.modified = false
+    if file.is_dir {
+      self.scan_dir(file, path~, context~)
+    }
+  } else if file.dirty_children.iter().next() is Some((name, child_id)) {
+    let child = self.watched[child_id]
+    try
+      self.synchronize_file(child, path=rel_path(path, name), context~)
+    catch {
+      @os_error.OSError(_) as err if err.is_ENOENT() =>
+        self.mark_as_modified(file.file_id)
+      err => raise err
+    } noraise {
+      _ => if child.is_clean() { file.dirty_children.remove(name) }
+    }
+  }
+}
+
+///|
+fn Watcher::mark_as_modified(self : Watcher, id : FileIdentity) -> Unit {
+  let file = self.watched[id]
+  if file.modified {
+    return
+  }
+  file.modified = true
+  if !file.dirty_children.is_empty() || id == self.root_id {
+    return
+  }
+  for path in file.paths {
+    let (dir, name) = path
+    self.add_dirty_child(dir, name, id)
+  }
+}
+
+///|
+fn Watcher::add_dirty_child(
+  self : Watcher,
+  dir_id : FileIdentity,
+  name : String,
+  child_id : FileIdentity,
+) -> Unit {
+  let dir = self.watched[dir_id]
+  let was_clean = dir.is_clean()
+  dir.dirty_children[name] = child_id
+  if was_clean && dir_id != self.root_id {
+    for path in dir.paths {
+      let (parent, name) = path
+      self.add_dirty_child(parent, name, dir_id)
+    }
+  }
+}

--- a/src/fs/watch_inotify.c
+++ b/src/fs/watch_inotify.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef __linux__
+
+#include <sys/inotify.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <errno.h>
+
+#endif
+
+#ifndef _WIN32
+
+#include "moonbit.h"
+_Noreturn void moonbit_panic();
+
+#ifndef __linux__
+struct inotify_event;
+#endif
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_inotify_create() {
+#ifdef __linux__
+  return inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_inotify_add_file(int inotify, const char *path, int32_t is_dir) {
+#ifdef __linux__
+  uint32_t flags = is_dir
+    ? IN_CREATE | IN_MOVED_FROM | IN_MOVED_TO | IN_DELETE
+    : IN_MODIFY;
+  return inotify_add_watch(inotify, path, flags);
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_inotify_remove_file(int inotify, int wd) {
+#ifdef __linux__
+  return inotify_rm_watch(inotify, wd);
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_inotify_event_buffer_size() {
+#ifdef __linux__
+  static const int min_size = sizeof(struct inotify_event) + NAME_MAX + 1;
+  return 4096 < min_size ? min_size : 4096;
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+struct inotify_event *moonbitlang_async_inotify_get_event(const char *buf, int32_t offset) {
+#ifdef __linux__
+  return (struct inotify_event*)(buf + offset);
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_inotify_fetch_event(int inotify, void *buf) {
+#ifdef __linux__
+  int ret = read(inotify, buf, Moonbit_array_length(buf));
+  if (ret > 0) {
+    return ret;
+  } else if (errno == EAGAIN) {
+    return 0;
+  } else {
+    return -1;
+  }
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_inotify_event_get_size(struct inotify_event *event) {
+#ifdef __linux__
+  return sizeof(struct inotify_event) + event->len;
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_inotify_event_get_wd(struct inotify_event *event) {
+#ifdef __linux__
+  return event->wd;
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_inotify_event_has_relevant_event(struct inotify_event *event) {
+#ifdef __linux__
+  return (event->mask & (IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO)) != 0;
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_inotify_event_has_overflow(struct inotify_event *event) {
+#ifdef __linux__
+  return (event->mask & IN_Q_OVERFLOW) != 0;
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_inotify_event_has_ignore(struct inotify_event *event) {
+#ifdef __linux__
+  return (event->mask & IN_IGNORED) != 0;
+#else
+  moonbit_panic();
+#endif
+}
+
+#endif // #ifndef _WIN32

--- a/src/fs/watch_inotify.c
+++ b/src/fs/watch_inotify.c
@@ -43,18 +43,6 @@ int moonbitlang_async_inotify_create() {
 }
 
 MOONBIT_FFI_EXPORT
-int moonbitlang_async_inotify_add_file(int inotify, const char *path, int32_t is_dir) {
-#ifdef __linux__
-  uint32_t flags = is_dir
-    ? IN_CREATE | IN_MOVED_FROM | IN_MOVED_TO | IN_DELETE
-    : IN_MODIFY;
-  return inotify_add_watch(inotify, path, flags);
-#else
-  moonbit_panic();
-#endif
-}
-
-MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_inotify_remove_file(int inotify, int wd) {
 #ifdef __linux__
   return inotify_rm_watch(inotify, wd);

--- a/src/fs/watch_inotify.mbt
+++ b/src/fs/watch_inotify.mbt
@@ -228,11 +228,7 @@ async fn InotifyWatcher::process_events(self : InotifyWatcher) -> Unit {
       }
 
       if event.has_overflow() {
-        for file_id, file in self.watcher.watched {
-          if file.is_dir {
-            self.watcher.mark_as_modified(file_id)
-          }
-        }
+        self.watcher.overflow()
         continue
       }
 

--- a/src/fs/watch_inotify.mbt
+++ b/src/fs/watch_inotify.mbt
@@ -107,27 +107,19 @@ impl WatcherBackend for InotifyWatcher with fn wait(self) {
 
 ///|
 #cfg(not(platform="windows"))
-#borrow(path)
-extern "C" fn InotifyWatcher::add_file_ffi(
-  inotify_fd : @fd_util.Fd,
-  path : @os_string.OsString,
-  is_dir~ : Bool,
-) -> @fd_util.Fd = "moonbitlang_async_inotify_add_file"
-
-///|
-#cfg(not(platform="windows"))
 impl WatcherBackend for InotifyWatcher with fn add_file(
   self,
-  path_str,
+  path,
   is_dir~,
   file_id~,
   context~,
 ) {
-  let path = @os_string.encode(path_str)
-  let wd = InotifyWatcher::add_file_ffi(self.inotify.fd(), path, is_dir~)
-  if !@fd_util.fd_is_valid(wd) {
-    @os_error.check_errno("\{context}: \{path_str.escape()}")
-  }
+  let wd = @event_loop.inotify_add_watch(
+    self.inotify.fd(),
+    path,
+    is_dir~,
+    context~,
+  )
   self.watched[wd] = file_id
   wd
 }

--- a/src/fs/watch_inotify.mbt
+++ b/src/fs/watch_inotify.mbt
@@ -1,0 +1,249 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(not(platform="windows"))
+priv struct InotifyWatcher {
+  inotify : @event_loop.IoHandle
+  watched : Map[@fd_util.Fd, FileIdentity]
+  watcher : Watcher
+  mut event_processor : @coroutine.Coroutine?
+  mut err : Error?
+  mut waiter : @coroutine.Coroutine?
+  debounce_timer : @async.Timer
+}
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn InotifyWatcher::new_ffi() -> @fd_util.Fd = "moonbitlang_async_inotify_create"
+
+///|
+#cfg(not(platform="windows"))
+fn InotifyWatcher::InotifyWatcher(
+  watcher : Watcher,
+  context~ : String,
+) -> InotifyWatcher raise {
+  let inotify_fd = InotifyWatcher::new_ffi()
+  if !@fd_util.fd_is_valid(inotify_fd) {
+    @os_error.check_errno(context)
+  }
+  let self = {
+    inotify: @event_loop.IoHandle::from_fd(
+      inotify_fd,
+      kind=Unknown,
+      is_async=true,
+    ),
+    watched: {},
+    watcher,
+    event_processor: None,
+    waiter: None,
+    err: None,
+    debounce_timer: @async.Timer(20),
+  }
+  self.event_processor = Some(
+    @coroutine.spawn(() => {
+      self.process_events() catch {
+        err => {
+          self.err = Some(err)
+          if self.waiter is Some(coro) {
+            coro.wake()
+          }
+          raise err
+        }
+      }
+    }),
+  )
+  self
+}
+
+///|
+#cfg(not(platform="windows"))
+impl WatcherBackend for InotifyWatcher with fn close(self) {
+  self.inotify.close()
+  if self.event_processor is Some(coro) {
+    coro.cancel()
+    self.event_processor = None
+  }
+  if self.waiter is Some(coro) {
+    coro.wake()
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+impl WatcherBackend for InotifyWatcher with fn wait(self) {
+  if self.err is Some(err) {
+    raise err
+  }
+  guard self.event_processor is Some(_)
+  guard self.waiter is None
+  let root = self.watcher.watched[self.watcher.root_id]
+  while root.is_clean() {
+    self.waiter = Some(@coroutine.current_coroutine())
+    defer {
+      self.waiter = None
+    }
+    @coroutine.suspend()
+    if self.err is Some(err) {
+      raise err
+    }
+  }
+  @async.with_timeout(200, () => self.debounce_timer.wait()) catch {
+    @async.TimeoutError => ()
+    err => raise err
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+#borrow(path)
+extern "C" fn InotifyWatcher::add_file_ffi(
+  inotify_fd : @fd_util.Fd,
+  path : @os_string.OsString,
+  is_dir~ : Bool,
+) -> @fd_util.Fd = "moonbitlang_async_inotify_add_file"
+
+///|
+#cfg(not(platform="windows"))
+impl WatcherBackend for InotifyWatcher with fn add_file(
+  self,
+  path_str,
+  is_dir~,
+  file_id~,
+  context~,
+) {
+  let path = @os_string.encode(path_str)
+  let wd = InotifyWatcher::add_file_ffi(self.inotify.fd(), path, is_dir~)
+  if !@fd_util.fd_is_valid(wd) {
+    @os_error.check_errno("\{context}: \{path_str.escape()}")
+  }
+  self.watched[wd] = file_id
+  wd
+}
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn InotifyWatcher::remove_file_ffi(
+  watcher : @fd_util.Fd,
+  wd : @fd_util.Fd,
+) -> Int = "moonbitlang_async_inotify_remove_file"
+
+///|
+#cfg(not(platform="windows"))
+impl WatcherBackend for InotifyWatcher with fn remove_file(self, wd, context~) {
+  guard self.watched.contains(wd) else {
+    // `inotify` sometimes perform auto removal when file is deleted
+    return
+  }
+  self.watched.remove(wd)
+  let ret = InotifyWatcher::remove_file_ffi(self.inotify.fd(), wd)
+  if ret < 0 {
+    @os_error.check_errno(context)
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn InotifyWatcher::event_buffer_size() -> Int = "moonbitlang_async_inotify_event_buffer_size"
+
+///|
+#cfg(not(platform="windows"))
+#external
+priv type InotifyEvent
+
+///|
+#cfg(not(platform="windows"))
+#borrow(buf)
+extern "C" fn InotifyWatcher::get_os_event(
+  buf : FixedArray[Byte],
+  offset : Int,
+) -> InotifyEvent = "moonbitlang_async_inotify_get_event"
+
+///|
+/// Return value:
+/// - positive => number of bytes written
+/// - zero => no more event available currently
+/// - negative => error
+#cfg(not(platform="windows"))
+#borrow(buf)
+extern "C" fn InotifyWatcher::fetch_os_event(
+  watcher : @fd_util.Fd,
+  buf : FixedArray[Byte],
+) -> Int = "moonbitlang_async_inotify_fetch_event"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn InotifyEvent::get_size(event : InotifyEvent) -> Int = "moonbitlang_async_inotify_event_get_size"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn InotifyEvent::get_wd(event : InotifyEvent) -> @fd_util.Fd = "moonbitlang_async_inotify_event_get_wd"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn InotifyEvent::has_relevant_evnet(event : InotifyEvent) -> Bool = "moonbitlang_async_inotify_event_has_relevant_event"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn InotifyEvent::has_overflow(event : InotifyEvent) -> Bool = "moonbitlang_async_inotify_event_has_overflow"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn InotifyEvent::has_ignore(event : InotifyEvent) -> Bool = "moonbitlang_async_inotify_event_has_ignore"
+
+///|
+#cfg(not(platform="windows"))
+async fn InotifyWatcher::process_events(self : InotifyWatcher) -> Unit {
+  let context = "@fs.Watcher::wait()"
+  let buf = FixedArray::make(InotifyWatcher::event_buffer_size(), b'\x00')
+  self.inotify.prepare_read()
+  for ;; {
+    let n = InotifyWatcher::fetch_os_event(self.inotify.fd(), buf)
+    if n < 0 {
+      @os_error.check_errno(context)
+    }
+    if n is 0 {
+      if self.waiter is Some(coro) {
+        coro.wake()
+      }
+      self.inotify.wait_read()
+      continue
+    }
+    self.debounce_timer.refresh()
+    let mut offset = 0
+    while offset < n {
+      let event = InotifyWatcher::get_os_event(buf, offset)
+      offset += event.get_size()
+      let wd = event.get_wd()
+      if event.has_ignore() {
+        self.watched.remove(wd)
+        continue
+      }
+
+      if event.has_overflow() {
+        for file_id, file in self.watcher.watched {
+          if file.is_dir {
+            self.watcher.mark_as_modified(file_id)
+          }
+        }
+        continue
+      }
+
+      if event.has_relevant_evnet() {
+        let id = self.watched[wd]
+        self.watcher.mark_as_modified(id)
+      }
+    }
+  }
+}

--- a/src/fs/watch_inotify.mbt
+++ b/src/fs/watch_inotify.mbt
@@ -22,6 +22,7 @@ priv struct InotifyWatcher {
   mut err : Error?
   mut waiter : @coroutine.Coroutine?
   debounce_timer : @async.Timer
+  max_debounce_delay : Int
 }
 
 ///|
@@ -32,6 +33,8 @@ extern "C" fn InotifyWatcher::new_ffi() -> @fd_util.Fd = "moonbitlang_async_inot
 #cfg(not(platform="windows"))
 fn InotifyWatcher::InotifyWatcher(
   watcher : Watcher,
+  debounce_timeout~ : Int,
+  max_debounce_delay~ : Int,
   context~ : String,
 ) -> InotifyWatcher raise {
   let inotify_fd = InotifyWatcher::new_ffi()
@@ -49,7 +52,8 @@ fn InotifyWatcher::InotifyWatcher(
     event_processor: None,
     waiter: None,
     err: None,
-    debounce_timer: @async.Timer(20),
+    debounce_timer: @async.Timer(debounce_timeout),
+    max_debounce_delay,
   }
   self.event_processor = Some(
     @coroutine.spawn(() => {
@@ -99,7 +103,7 @@ impl WatcherBackend for InotifyWatcher with fn wait(self) {
       raise err
     }
   }
-  @async.with_timeout(200, () => self.debounce_timer.wait()) catch {
+  @async.with_timeout(self.max_debounce_delay, () => self.debounce_timer.wait()) catch {
     @async.TimeoutError => ()
     err => raise err
   }

--- a/src/fs/watch_kqueue.c
+++ b/src/fs/watch_kqueue.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _WIN32
+
+#ifdef __MACH__
+#include <time.h>
+#include <sys/event.h>
+#endif
+
+#include "moonbit.h"
+_Noreturn void moonbit_panic();
+
+#ifndef __MACH__
+struct kevent;
+#endif
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_kqueue_watcher_create() {
+#ifdef __MACH__
+  return kqueue();
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_kqueue_watcher_buffer_size() {
+#ifdef __MACH__
+  return 1024 * sizeof(struct kevent);
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_kqueue_watcher_add_file(int kq, int fd, int32_t is_dir) {
+#ifdef __MACH__
+  struct kevent event;
+  int events_to_watch = NOTE_WRITE;
+  if (!is_dir) {
+    events_to_watch |= NOTE_EXTEND;
+  }
+  EV_SET(
+    &event,
+    fd,
+    EVFILT_VNODE,
+    EV_ADD | EV_CLEAR,
+    events_to_watch,
+    0,
+    0
+  );
+
+  return kevent(kq, &event, 1, 0, 0, 0);
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_kqueue_watcher_remove_file(int kq, int fd) {
+#ifdef __MACH__
+  struct kevent event;
+  EV_SET(&event, fd, EVFILT_VNODE, EV_DELETE, 0, 0, 0);
+  return kevent(kq, &event, 1, 0, 0, 0);
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_kqueue_watcher_event_size() {
+#ifdef __MACH__
+  return sizeof(struct kevent);
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+struct kevent *moonbitlang_async_kqueue_watcher_get_event(struct kevent *buf, int32_t index) {
+#ifdef __MACH__
+  return buf + index;
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_kqueue_watcher_fetch_event(int kq, void *buf) {
+#ifdef __MACH__
+  int buffer_size = Moonbit_array_length(buf) / sizeof(struct kevent);
+  struct timespec timeout = { 0, 0 };
+  return kevent(kq, 0, 0, buf, buffer_size, &timeout);
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_kqueue_watcher_event_get_fd(struct kevent *event) {
+#ifdef __MACH__
+  return event->ident;
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_kqueue_watcher_event_has_modify(struct kevent *event) {
+#ifdef __MACH__
+  return (event->filter & (NOTE_WRITE | NOTE_EXTEND)) != 0;
+#else
+  moonbit_panic();
+#endif
+}
+
+#endif

--- a/src/fs/watch_kqueue.c
+++ b/src/fs/watch_kqueue.c
@@ -122,7 +122,7 @@ int moonbitlang_async_kqueue_watcher_event_get_fd(struct kevent *event) {
 MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_kqueue_watcher_event_has_modify(struct kevent *event) {
 #ifdef __MACH__
-  return (event->filter & (NOTE_WRITE | NOTE_EXTEND)) != 0;
+  return (event->fflags & (NOTE_WRITE | NOTE_EXTEND)) != 0;
 #else
   moonbit_panic();
 #endif

--- a/src/fs/watch_kqueue.mbt
+++ b/src/fs/watch_kqueue.mbt
@@ -1,0 +1,190 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(not(platform="windows"))
+priv struct KqueueWatchedFile {
+  file_id : FileIdentity
+  io : @event_loop.IoHandle
+}
+
+///|
+#cfg(not(platform="windows"))
+priv struct KqueueWatcher {
+  kqueue : @event_loop.IoHandle
+  watched : Map[@fd_util.Fd, KqueueWatchedFile]
+  watcher : Watcher
+  event_buffer : FixedArray[Byte]
+}
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn KqueueWatcher::new_ffi() -> @fd_util.Fd = "moonbitlang_async_kqueue_watcher_create"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn KqueueWatcher::event_buffer_size() -> Int = "moonbitlang_async_kqueue_watcher_buffer_size"
+
+///|
+#cfg(not(platform="windows"))
+fn KqueueWatcher::KqueueWatcher(
+  watcher : Watcher,
+  context~ : String,
+) -> KqueueWatcher raise {
+  let kqueue = KqueueWatcher::new_ffi()
+  if !@fd_util.fd_is_valid(kqueue) {
+    @os_error.check_errno(context)
+  }
+  {
+    kqueue: @event_loop.IoHandle::from_fd(kqueue, kind=Unknown, is_async=true),
+    watched: {},
+    watcher,
+    event_buffer: FixedArray::make(KqueueWatcher::event_buffer_size(), 0),
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+impl WatcherBackend for KqueueWatcher with fn close(self) {
+  self.kqueue.close()
+  for file in self.watched.values() {
+    file.io.close()
+  }
+  self.watched.clear()
+}
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn KqueueWatcher::add_file_ffi(
+  kqueue : @fd_util.Fd,
+  fd : @fd_util.Fd,
+  is_dir~ : Bool,
+) -> Int = "moonbitlang_async_kqueue_watcher_add_file"
+
+///|
+#cfg(not(platform="windows"))
+impl WatcherBackend for KqueueWatcher with fn add_file(
+  self,
+  path,
+  is_dir~,
+  file_id~,
+  context~,
+) {
+  let (file, _) = @event_loop.open(
+    path,
+    0,
+    create=0,
+    append=false,
+    sync=0,
+    mode=0,
+    context~,
+  )
+  let fd = file.fd()
+  if KqueueWatcher::add_file_ffi(self.kqueue.fd(), fd, is_dir~) < 0 {
+    file.close()
+    @os_error.check_errno("\{context}: \{path.escape()}")
+  }
+  self.watched[fd] = { file_id, io: file }
+  fd
+}
+
+///|
+#cfg(not(platform="windows"))
+impl WatcherBackend for KqueueWatcher with fn remove_file(self, fd, context~) {
+  // closing the fd (which must be the last fd pointing to the file description)
+  // automatically unregister the event for kqueue
+  ignore(context)
+  let file = self.watched[fd]
+  file.io.close()
+}
+
+///|
+#cfg(not(platform="windows"))
+#external
+priv type KqueueEvent
+
+///|
+#cfg(not(platform="windows"))
+#borrow(buf)
+extern "C" fn KqueueWatcher::get_os_event(
+  buf : FixedArray[Byte],
+  index : Int,
+) -> KqueueEvent = "moonbitlang_async_kqueue_watcher_get_event"
+
+///|
+/// Return value:
+/// - positive => number of bytes written
+/// - zero => no more event available currently
+/// - negative => error
+#cfg(not(platform="windows"))
+#borrow(buf)
+extern "C" fn KqueueWatcher::fetch_os_event(
+  watcher : @fd_util.Fd,
+  buf : FixedArray[Byte],
+) -> Int = "moonbitlang_async_kqueue_watcher_fetch_event"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn KqueueEvent::fd(event : KqueueEvent) -> @fd_util.Fd = "moonbitlang_async_kqueue_watcher_event_get_fd"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn KqueueEvent::has_modify(event : KqueueEvent) -> Bool = "moonbitlang_async_kqueue_watcher_event_has_modify"
+
+///|
+#cfg(not(platform="windows"))
+impl WatcherBackend for KqueueWatcher with fn wait(self) {
+  let context = "@fs.Watcher::wait()"
+  self.kqueue.prepare_read()
+  let root = self.watcher.watched[self.watcher.root_id]
+  while root.is_clean() {
+    self.process_events(timeout=None, context~)
+  }
+  let debounce_deadline = @async.now() + 200
+  for ;; {
+    let t = @cmp.minimum(debounce_deadline - @async.now(), 20)
+    guard t > 0 else { break }
+    self.process_events(timeout=Some(t.to_int()), context~) catch {
+      @async.TimeoutError => break
+      err => raise err
+    }
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+async fn KqueueWatcher::process_events(
+  self : KqueueWatcher,
+  timeout~ : Int?,
+  context~ : String,
+) -> Unit {
+  let n = KqueueWatcher::fetch_os_event(self.kqueue.fd(), self.event_buffer)
+  if n < 0 {
+    @os_error.check_errno(context)
+  }
+  if n is 0 {
+    match timeout {
+      None => self.kqueue.wait_read()
+      Some(t) => @async.with_timeout(t, () => self.kqueue.wait_read())
+    }
+  }
+  for i in 0..<n {
+    let event = KqueueWatcher::get_os_event(self.event_buffer, i)
+    let fd = event.fd()
+    if event.has_modify() {
+      let { file_id, .. } = self.watched[fd]
+      self.watcher.mark_as_modified(file_id)
+    }
+  }
+}

--- a/src/fs/watch_kqueue.mbt
+++ b/src/fs/watch_kqueue.mbt
@@ -26,6 +26,8 @@ priv struct KqueueWatcher {
   watched : Map[@fd_util.Fd, KqueueWatchedFile]
   watcher : Watcher
   event_buffer : FixedArray[Byte]
+  debounce_timeout : Int
+  max_debounce_delay : Int
 }
 
 ///|
@@ -40,6 +42,8 @@ extern "C" fn KqueueWatcher::event_buffer_size() -> Int = "moonbitlang_async_kqu
 #cfg(not(platform="windows"))
 fn KqueueWatcher::KqueueWatcher(
   watcher : Watcher,
+  debounce_timeout~ : Int,
+  max_debounce_delay~ : Int,
   context~ : String,
 ) -> KqueueWatcher raise {
   let kqueue = KqueueWatcher::new_ffi()
@@ -51,6 +55,8 @@ fn KqueueWatcher::KqueueWatcher(
     watched: {},
     watcher,
     event_buffer: FixedArray::make(KqueueWatcher::event_buffer_size(), 0),
+    debounce_timeout,
+    max_debounce_delay,
   }
 }
 
@@ -151,11 +157,14 @@ impl WatcherBackend for KqueueWatcher with fn wait(self) {
   while root.is_clean() {
     self.process_events(timeout=None, context~)
   }
-  let debounce_deadline = @async.now() + 200
+  let debounce_deadline = @async.now() + self.max_debounce_delay.to_int64()
   for ;; {
-    let t = @cmp.minimum(debounce_deadline - @async.now(), 20)
+    let t = @cmp.minimum(
+      (debounce_deadline - @async.now()).to_int(),
+      self.debounce_timeout,
+    )
     guard t > 0 else { break }
-    self.process_events(timeout=Some(t.to_int()), context~) catch {
+    self.process_events(timeout=Some(t), context~) catch {
       @async.TimeoutError => break
       err => raise err
     }

--- a/src/fs/watch_kqueue.mbt
+++ b/src/fs/watch_kqueue.mbt
@@ -113,6 +113,7 @@ impl WatcherBackend for KqueueWatcher with fn remove_file(self, fd, context~) {
   ignore(context)
   let file = self.watched[fd]
   file.io.close()
+  self.watched.remove(fd)
 }
 
 ///|

--- a/src/fs/watch_test.mbt
+++ b/src/fs/watch_test.mbt
@@ -1,0 +1,444 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+enum TestFile {
+  File(String) // content of file
+  Dir(Map[String, TestFile])
+}
+
+///|
+async fn TestFile::instantiate(self : TestFile, path : String) -> Unit {
+  match self {
+    File(content) => @fs.write_file(path, content, create_mode=CreateOrTruncate)
+    Dir(files) => {
+      @fs.mkdir(path)
+      for name, file in files {
+        file.instantiate("\{path}/\{name}")
+      }
+    }
+  }
+}
+
+///|
+async test "watch basic" {
+  let log = []
+  @async.with_task_group(group => {
+    let path = "_build/watch_basic_test"
+    let test_dir = Dir({
+      "root_file": File("abcd"),
+      "inner_dir": Dir({ "inner_file": File("efgh") }),
+    })
+    test_dir.instantiate(path)
+    group.add_defer(() => {
+      @async.protect_from_cancel(() => @fs.rmdir(path, recursive=true))
+    })
+
+    let watcher = @fs.Watcher(path)
+    group.spawn_bg(no_wait=true, () => {
+      defer watcher.close()
+      for ;; {
+        watcher.wait_any()
+        log.push("watcher received change")
+      }
+    })
+    // 1. modify content of existing file at root
+    log.push("writing to root file")
+    @fs.write_file("\{path}/root_file", "ABCD", create_mode=OpenExisting)
+    @async.sleep(150)
+
+    // 2. modify content of existing file at inner directory
+    log.push("writing to inner file")
+    @fs.write_file(
+      "\{path}/inner_dir/inner_file",
+      "EFGH",
+      create_mode=OpenExisting,
+    )
+    @async.sleep(150)
+
+    // 3. create file in root directory
+    {
+      log.push("creating new file in root directory")
+      let file = @fs.create("\{path}/root_file2")
+      defer file.close()
+      @async.sleep(150)
+
+      // 4. modify content of newly created file at root directory
+      log.push("writing to newly created root file")
+      file.write("ABCD")
+    }
+    @async.sleep(150)
+
+    // 5. create file in inner directory
+    {
+      log.push("creating new file in inner directory")
+      let file = @fs.create("\{path}/inner_dir/inner_file2")
+      defer file.close()
+      @async.sleep(150)
+
+      // 6. modify content of newly created file at inner directory
+      log.push("writing to newly created inner file")
+      file.write("EFGH")
+    }
+    @async.sleep(150)
+
+    // 7. remove a file in root directory
+    log.push("removing file in root directory")
+    @fs.remove("\{path}/root_file")
+    @async.sleep(150)
+
+    // 8. remove a file in inner directory
+    log.push("removing file in inner directory")
+    @fs.remove("\{path}/inner_dir/inner_file2")
+    @async.sleep(150)
+
+    // 9. remove inner directory recursively
+    log.push("removing inner directory")
+    @fs.rmdir("\{path}/inner_dir", recursive=true)
+    @async.sleep(150)
+
+    // 10. create new inner directory
+    log.push("creating new directory in root directory")
+    @fs.mkdir("\{path}/inner_dir")
+    @async.sleep(150)
+
+    // 11. create new file in newly created inner directory
+    {
+      log.push("creating new file in inner directory")
+      let file = @fs.create("\{path}/inner_dir/inner_file")
+      defer file.close()
+      @async.sleep(150)
+
+      // 12. modify content of newly created file at newly created inner directory
+      log.push("writing to newly created inner file")
+      file.write("EFGH")
+    }
+    @async.sleep(150)
+  })
+  inspect(
+    log.join("\n"),
+    content=(
+      #|writing to root file
+      #|watcher received change
+      #|writing to inner file
+      #|watcher received change
+      #|creating new file in root directory
+      #|watcher received change
+      #|writing to newly created root file
+      #|watcher received change
+      #|creating new file in inner directory
+      #|watcher received change
+      #|writing to newly created inner file
+      #|watcher received change
+      #|removing file in root directory
+      #|watcher received change
+      #|removing file in inner directory
+      #|watcher received change
+      #|removing inner directory
+      #|watcher received change
+      #|creating new directory in root directory
+      #|watcher received change
+      #|creating new file in inner directory
+      #|watcher received change
+      #|writing to newly created inner file
+      #|watcher received change
+    ),
+  )
+}
+
+///|
+async test "watch rename within" {
+  let log = []
+  @async.with_task_group(group => {
+    let path = "_build/watch_rename_within_test"
+    let test_dir = Dir({
+      "root_file": File("abcd"),
+      "inner_dir": Dir({ "inner_file": File("efgh") }),
+    })
+    test_dir.instantiate(path)
+    group.add_defer(() => {
+      @async.protect_from_cancel(() => @fs.rmdir(path, recursive=true))
+    })
+
+    let watcher = @fs.Watcher(path)
+    group.spawn_bg(no_wait=true, () => {
+      defer watcher.close()
+      for ;; {
+        watcher.wait_any()
+        log.push("watcher received change")
+      }
+    })
+    // 1. rename within the same directory
+    log.push("rename: inner_dir/inner_file => inner_dir/inner_file2")
+    @fs.rename("\{path}/inner_dir/inner_file", "\{path}/inner_dir/inner_file2")
+    @async.sleep(150)
+
+    // 2. modify file renamed within the same directory
+    log.push("writing to inner_dir/inner_file2")
+    @fs.write_file(
+      "\{path}/inner_dir/inner_file2",
+      "efgh",
+      create_mode=OpenExisting,
+    )
+    @async.sleep(150)
+
+    // 3. rename directory
+    log.push("rename: inner_dir => inner_dir2")
+    @fs.rename("\{path}/inner_dir", "\{path}/inner_dir2")
+    @async.sleep(150)
+
+    // 4. modify file within renamed directory
+    log.push("writing to inner_dir2/inner_file2")
+    @fs.write_file(
+      "\{path}/inner_dir2/inner_file2",
+      "EFGH",
+      create_mode=OpenExisting,
+    )
+    @async.sleep(150)
+
+    // 5. rename across directory, but within watched tree
+    log.push("rename: inner_dir2/inner_file2 => root_file2")
+    @fs.rename("\{path}/inner_dir2/inner_file2", "\{path}/root_file2")
+    @async.sleep(150)
+
+    // 6. modify file moved across directory but still within watched tree
+    log.push("writing to root_file2")
+    @fs.write_file("\{path}/root_file2", "EFGH", create_mode=OpenExisting)
+    @async.sleep(150)
+
+    // 7. rename file replaces existing file
+    log.push("rename root_file2 to replace root_file")
+    @fs.rename("\{path}/root_file2", "\{path}/root_file")
+    @async.sleep(150)
+  })
+  inspect(
+    log.join("\n"),
+    content=(
+      #|rename: inner_dir/inner_file => inner_dir/inner_file2
+      #|watcher received change
+      #|writing to inner_dir/inner_file2
+      #|watcher received change
+      #|rename: inner_dir => inner_dir2
+      #|watcher received change
+      #|writing to inner_dir2/inner_file2
+      #|watcher received change
+      #|rename: inner_dir2/inner_file2 => root_file2
+      #|watcher received change
+      #|writing to root_file2
+      #|watcher received change
+      #|rename root_file2 to replace root_file
+      #|watcher received change
+    ),
+  )
+}
+
+///|
+async test "watch rename inout test" {
+  let log = []
+  @async.with_task_group(group => {
+    let base_path = "_build/watch_rename_inout_test"
+    let test_dir = Dir({
+      "watched": Dir({
+        "root_file": File("abcd"),
+        "inner_dir": Dir({ "inner_file": File("efgh") }),
+      }),
+    })
+    test_dir.instantiate(base_path)
+    group.add_defer(() => {
+      @async.protect_from_cancel(() => @fs.rmdir(base_path, recursive=true))
+    })
+    let watched_path = "\{base_path}/watched"
+
+    let watcher = @fs.Watcher(watched_path)
+    group.spawn_bg(no_wait=true, () => {
+      defer watcher.close()
+      for ;; {
+        watcher.wait_any()
+        log.push("watcher received change")
+      }
+    })
+    // 1. move foreign file inside watched tree
+    @fs.write_file("\{base_path}/foreign_file", "1234", create_mode=CreateNew)
+    log.push("moving foreign file inside watched tree")
+    @fs.rename("\{base_path}/foreign_file", "\{watched_path}/moved_in_file")
+    @async.sleep(150)
+
+    // 2. modify moved in file
+    log.push("writing to moved_in_file")
+    @fs.write_file(
+      "\{watched_path}/moved_in_file",
+      "5678",
+      create_mode=OpenExisting,
+    )
+    @async.sleep(150)
+
+    // 3. move foreign directory inside watched tree
+    let foreign_dir = Dir({ "foreign_file": File("xyzw") })
+    foreign_dir.instantiate("\{base_path}/foreign_dir")
+    log.push("moving foreign directory inside watched tree")
+    @fs.rename("\{base_path}/foreign_dir", "\{watched_path}/moved_in_dir")
+    @async.sleep(150)
+
+    // 4. modify file within moved in directory
+    log.push("writing to moved_in_dir/foreign_file")
+    @fs.write_file(
+      "\{watched_path}/moved_in_dir/foreign_file",
+      "XYZW",
+      create_mode=OpenExisting,
+    )
+    @async.sleep(150)
+
+    // 5. move file outside watched tree
+    log.push("moving file outside watched tree")
+    @fs.rename("\{watched_path}/moved_in_file", "\{base_path}/moved_out_file")
+    @async.sleep(150)
+
+    // 6. modify moved out file
+    log.push("writing to moved_out_file")
+    @fs.write_file(
+      "\{base_path}/moved_out_file",
+      "1234",
+      create_mode=OpenExisting,
+    )
+    @async.sleep(150)
+
+    // 7. remove moved out file
+    log.push("removing moved out file")
+    @fs.remove("\{base_path}/moved_out_file")
+    @async.sleep(150)
+
+    // 8. move directory outside watched tree
+    log.push("moving directory outside watched tree")
+    @fs.rename("\{watched_path}/moved_in_dir", "\{base_path}/moved_out_dir")
+    @async.sleep(150)
+
+    // 9. modify file inside moved out directoy
+    log.push("writing to moved_out_dir/foreign_file")
+    @fs.write_file(
+      "\{base_path}/moved_out_dir/foreign_file",
+      "xyzw",
+      create_mode=OpenExisting,
+    )
+    @async.sleep(150)
+
+    // 10. remove moved out file
+    log.push("removing moved out directory")
+    @fs.rmdir("\{base_path}/moved_out_dir", recursive=true)
+    @async.sleep(150)
+
+    // 11. moved in file overwrites existing file
+    log.push("renaming foreign file to replace root_file")
+    @fs.write_file("\{base_path}/foreign_file", "1234", create_mode=CreateNew)
+    @fs.rename("\{base_path}/foreign_file", "\{watched_path}/root_file")
+    @async.sleep(150)
+
+    // 12. moved in directory cannot replace existing directory: forbidden by OS
+  })
+  inspect(
+    log.join("\n"),
+    content=(
+      #|moving foreign file inside watched tree
+      #|watcher received change
+      #|writing to moved_in_file
+      #|watcher received change
+      #|moving foreign directory inside watched tree
+      #|watcher received change
+      #|writing to moved_in_dir/foreign_file
+      #|watcher received change
+      #|moving file outside watched tree
+      #|watcher received change
+      #|writing to moved_out_file
+      #|removing moved out file
+      #|moving directory outside watched tree
+      #|watcher received change
+      #|writing to moved_out_dir/foreign_file
+      #|removing moved out directory
+      #|renaming foreign file to replace root_file
+      #|watcher received change
+    ),
+  )
+}
+
+///|
+async test "watch horizontal swap" {
+  let log = []
+  @async.with_task_group(group => {
+    let path = "_build/watch_swap_test"
+    let test_dir = Dir({ "file1": File("abcd"), "file2": File("efgh") })
+    test_dir.instantiate(path)
+    group.add_defer(() => {
+      @async.protect_from_cancel(() => @fs.rmdir(path, recursive=true))
+    })
+    let watcher = @fs.Watcher(path)
+    defer watcher.close()
+    @fs.rename("\{path}/file1", "\{path}/tmp")
+    @fs.rename("\{path}/file2", "\{path}/file1")
+    @fs.rename("\{path}/tmp", "\{path}/file2")
+    @async.sleep(10)
+    watcher.wait_any()
+    log.push("watcher received change")
+  })
+  inspect(
+    log.join("\n"),
+    content=(
+      #|watcher received change
+    ),
+  )
+}
+
+///|
+async test "watch vertical swap" {
+  let log = []
+  @async.with_task_group(group => {
+    let path = "_build/watch_vertical_swap_test"
+    let test_dir = Dir({
+      "outer": Dir({
+        "file": File("abcd"),
+        "inner": Dir({ "file": File("efgh") }),
+      }),
+    })
+    test_dir.instantiate(path)
+    group.add_defer(() => {
+      @async.protect_from_cancel(() => @fs.rmdir(path, recursive=true))
+    })
+    let watcher = @fs.Watcher(path)
+    defer watcher.close()
+    log.push("performing vertical swapping")
+    @fs.rename("\{path}/outer/inner", "\{path}/tmp")
+    @fs.rename("\{path}/outer", "\{path}/tmp/inner")
+    @fs.rename("\{path}/tmp", "\{path}/outer")
+    @async.sleep(10)
+    watcher.wait_any()
+    log.push("watcher received change")
+    log.push("modifying previous outer file")
+    @fs.write_file("\{path}/outer/inner/file", "ABCD")
+    watcher.wait_any()
+    log.push("watcher received change")
+    log.push("modifying previous inner file")
+    @fs.write_file("\{path}/outer/file", "EFGH")
+    watcher.wait_any()
+    log.push("watcher received change")
+  })
+  inspect(
+    log.join("\n"),
+    content=(
+      #|performing vertical swapping
+      #|watcher received change
+      #|modifying previous outer file
+      #|watcher received change
+      #|modifying previous inner file
+      #|watcher received change
+    ),
+  )
+}

--- a/src/fs/watch_unix.mbt
+++ b/src/fs/watch_unix.mbt
@@ -11,19 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-///|
-/// This package currently does not support JavaScript backend
-#cfg(not(target="native"))
-#coverage.skip
-pub let unimplemented : Unit = {
-  ignore(@io.pipe)
-  ignore(@async.sleep)
-  ignore(@event_loop.Timer::new)
-  ignore(@os_error.unimplemented)
-  ignore(@fd_util.unimplemented)
-  ignore(@os_string.unimplemented)
-  ignore(@env_util.unimplemented)
-  ignore(@c_buffer.unimplemented)
-  ignore(@coroutine.pause)
-}

--- a/src/fs/watch_windows.c
+++ b/src/fs/watch_windows.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <stdio.h>
+#include "moonbit.h"
+
+#if _WIN32_WINNT >= 0x0A00
+#define HAS_ReadDirectoryChangesExW
+#endif
+
+#ifdef HAS_ReadDirectoryChangesExW
+typedef FILE_NOTIFY_EXTENDED_INFORMATION fs_event_t;
+#else
+typedef FILE_NOTIFY_INFORMATION fs_event_t;
+#endif
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_has_ReadDirectoryChangesExW() {
+#ifdef HAS_ReadDirectoryChangesExW
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_watcher_event_buffer_size() {
+  return sizeof(fs_event_t) * 16384;
+}
+
+MOONBIT_FFI_EXPORT
+fs_event_t *moonbitlang_async_watcher_get_event(char *buf, int32_t offset) {
+  return (fs_event_t*)(buf + offset);
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_watcher_event_get_size(fs_event_t *event) {
+  return event->NextEntryOffset;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_watcher_event_is_modify_event(fs_event_t *event) {
+  return event->Action == FILE_ACTION_MODIFIED;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_watcher_event_get_path_len(fs_event_t *event) {
+  return event->FileNameLength;
+}
+
+MOONBIT_FFI_EXPORT
+WCHAR *moonbitlang_async_watcher_event_get_path(fs_event_t *event) {
+  return event->FileName;
+}
+
+MOONBIT_FFI_EXPORT
+uint64_t moonbitlang_async_watcher_event_get_file_id(fs_event_t *event) {
+#ifdef HAS_ReadDirectoryChangesExW
+  return event->FileId.QuadPart;
+#else
+  moonbit_panic();
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+uint64_t moonbitlang_async_watcher_event_get_parent_file_id(fs_event_t *event) {
+#ifdef HAS_ReadDirectoryChangesExW
+  return event->ParentFileId.QuadPart;
+#else
+  moonbit_panic();
+#endif
+}
+
+#endif

--- a/src/fs/watch_windows.mbt
+++ b/src/fs/watch_windows.mbt
@@ -202,9 +202,10 @@ async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
               break path[:i]
             }
           } nobreak {
-            path
+            ""
           }
         }
+        // file change in the root directory
         let (file, file_info) = @event_loop.open(
           "\{self.watcher.base_path}\\\{path}",
           0,

--- a/src/fs/watch_windows.mbt
+++ b/src/fs/watch_windows.mbt
@@ -170,11 +170,7 @@ async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
     self.debounce_timer.refresh()
     if n is 0 {
       // overflow
-      for file_id, file in self.watcher.watched {
-        if file.is_dir {
-          self.watcher.mark_as_modified(file_id)
-        }
-      }
+      self.watcher.overflow()
       continue
     }
     let mut offset = 0

--- a/src/fs/watch_windows.mbt
+++ b/src/fs/watch_windows.mbt
@@ -22,6 +22,7 @@ priv struct WindowsWatcher {
   mut err : Error?
   mut waiter : @coroutine.Coroutine?
   debounce_timer : @async.Timer
+  max_debounce_delay : Int
 }
 
 ///|
@@ -30,6 +31,8 @@ fn WindowsWatcher::WindowsWatcher(
   watcher : Watcher,
   root : @event_loop.IoHandle,
   root_id~ : FileIdentity,
+  debounce_timeout~ : Int,
+  max_debounce_delay~ : Int,
 ) -> WindowsWatcher {
   let self = {
     root,
@@ -38,7 +41,8 @@ fn WindowsWatcher::WindowsWatcher(
     err: None,
     waiter: None,
     event_processor: None,
-    debounce_timer: @async.Timer(20),
+    debounce_timer: @async.Timer(debounce_timeout),
+    max_debounce_delay,
   }
   self.event_processor = Some(
     @coroutine.spawn(() => {
@@ -104,7 +108,7 @@ impl WatcherBackend for WindowsWatcher with fn wait(self) {
       raise err
     }
   }
-  @async.with_timeout(200, () => self.debounce_timer.wait()) catch {
+  @async.with_timeout(self.max_debounce_delay, () => self.debounce_timer.wait()) catch {
     @async.TimeoutError => ()
     err => raise err
   }

--- a/src/fs/watch_windows.mbt
+++ b/src/fs/watch_windows.mbt
@@ -1,0 +1,227 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(platform="windows")
+priv struct WindowsWatcher {
+  root : @event_loop.IoHandle
+  dev_id : UInt64
+  watcher : Watcher
+  mut event_processor : @coroutine.Coroutine?
+  mut err : Error?
+  mut waiter : @coroutine.Coroutine?
+  debounce_timer : @async.Timer
+}
+
+///|
+#cfg(platform="windows")
+fn WindowsWatcher::WindowsWatcher(
+  watcher : Watcher,
+  root : @event_loop.IoHandle,
+  root_id~ : FileIdentity,
+) -> WindowsWatcher {
+  let self = {
+    root,
+    dev_id: root_id.dev_id,
+    watcher,
+    err: None,
+    waiter: None,
+    event_processor: None,
+    debounce_timer: @async.Timer(20),
+  }
+  self.event_processor = Some(
+    @coroutine.spawn(() => {
+      self.event_handler() catch {
+        err => {
+          self.err = Some(err)
+          if self.waiter is Some(coro) {
+            coro.wake()
+          }
+          raise err
+        }
+      }
+    }),
+  )
+  self
+}
+
+///|
+#cfg(platform="windows")
+impl WatcherBackend for WindowsWatcher with fn close(self) {
+  if self.event_processor is Some(coro) {
+    coro.cancel()
+  }
+}
+
+///|
+#cfg(platform="windows")
+impl WatcherBackend for WindowsWatcher with fn add_file(
+  _self,
+  _path,
+  is_dir~,
+  file_id~,
+  context~,
+) {
+  ignore(is_dir)
+  ignore(file_id)
+  ignore(context)
+  @fd_util.invalid_fd
+}
+
+///|
+#cfg(platform="windows")
+impl WatcherBackend for WindowsWatcher with fn remove_file(_self, _fd, context~) {
+  ignore(context)
+}
+
+///|
+#cfg(platform="windows")
+impl WatcherBackend for WindowsWatcher with fn wait(self) {
+  if self.err is Some(err) {
+    raise err
+  }
+  guard self.event_processor is Some(_)
+  guard self.waiter is None
+  let root = self.watcher.watched[self.watcher.root_id]
+  while root.is_clean() {
+    self.waiter = Some(@coroutine.current_coroutine())
+    defer {
+      self.waiter = None
+    }
+    @coroutine.suspend()
+    if self.err is Some(err) {
+      raise err
+    }
+  }
+  @async.with_timeout(200, () => self.debounce_timer.wait()) catch {
+    @async.TimeoutError => ()
+    err => raise err
+  }
+}
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcher::has_ReadDirectoryChangesExW() -> Bool = "moonbitlang_async_has_ReadDirectoryChangesExW"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcher::event_buffer_size() -> Int = "moonbitlang_async_watcher_event_buffer_size"
+
+///|
+#cfg(platform="windows")
+#external
+priv type WindowsWatcherEvent
+
+///|
+#cfg(platform="windows")
+#borrow(buf)
+extern "C" fn WindowsWatcher::get_os_event(
+  buf : FixedArray[Byte],
+  offset : Int,
+) -> WindowsWatcherEvent = "moonbitlang_async_watcher_get_event"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherEvent::get_size(event : Self) -> Int = "moonbitlang_async_watcher_event_get_size"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherEvent::is_modify(event : Self) -> Bool = "moonbitlang_async_watcher_event_is_modify_event"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherEvent::get_path_len(event : Self) -> Int = "moonbitlang_async_watcher_event_get_path_len"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherEvent::get_path(event : Self) -> @c_buffer.Buffer = "moonbitlang_async_watcher_event_get_path"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherEvent::get_file_id(event : Self) -> UInt64 = "moonbitlang_async_watcher_event_get_file_id"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherEvent::get_parent_file_id(event : Self) -> UInt64 = "moonbitlang_async_watcher_event_get_parent_file_id"
+
+///|
+#cfg(platform="windows")
+async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
+  defer self.root.close()
+  let context = "@fs.Watcher::wait()"
+  let buf = FixedArray::make(WindowsWatcher::event_buffer_size(), b'\x00')
+  for ;; {
+    let n = self.root.read_dir_changes(buf, context~)
+    self.debounce_timer.refresh()
+    if n is 0 {
+      // overflow
+      for file_id, file in self.watcher.watched {
+        if file.is_dir {
+          self.watcher.mark_as_modified(file_id)
+        }
+      }
+      continue
+    }
+    let mut offset = 0
+    while offset < n {
+      let event = WindowsWatcher::get_os_event(buf, offset)
+      let size = event.get_size()
+      if size is 0 {
+        offset = n
+      } else {
+        offset += size
+      }
+      let file_id = if WindowsWatcher::has_ReadDirectoryChangesExW() {
+        if event.is_modify() {
+          event.get_file_id()
+        } else {
+          event.get_parent_file_id()
+        }
+      } else {
+        let path = @os_string.decode(event.get_path(), len=event.get_path_len())
+        let path = if event.is_modify() {
+          path[:]
+        } else {
+          for i in path.length()>..0 {
+            if path[i] is ('/' | '\\') {
+              break path[:i]
+            }
+          } nobreak {
+            path
+          }
+        }
+        let (file, file_info) = @event_loop.open(
+          "\{self.watcher.base_path}\\\{path}",
+          0,
+          create=0,
+          append=false,
+          sync=0,
+          mode=0,
+          context~,
+        )
+        file.close()
+        file_info.file_id()
+      }
+      let file_id = { dev_id: self.dev_id, file_id }
+      if self.watcher.watched.get(file_id) is Some(file) {
+        if !(event.is_modify() && file.is_dir) {
+          self.watcher.mark_as_modified(file_id)
+        }
+      }
+    }
+    if self.waiter is Some(coro) {
+      coro.wake()
+    }
+  }
+}

--- a/src/internal/event_loop/detect_file_kind.c
+++ b/src/internal/event_loop/detect_file_kind.c
@@ -50,6 +50,16 @@ BOOL handle_is_socket(HANDLE handle) {
 }
 
 MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_kind_from_attr(DWORD attrs) {
+  if (attrs & FILE_ATTRIBUTE_REPARSE_POINT)
+    return SymLink;
+  else if (attrs & FILE_ATTRIBUTE_DIRECTORY)
+    return Directory;
+  else
+    return Regular;
+}
+
+MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_kind_of_fd(HANDLE handle) {
   SetLastError(0);
   DWORD kind = GetFileType(handle);
@@ -66,12 +76,7 @@ int32_t moonbitlang_async_kind_of_fd(HANDLE handle) {
       ) {
         return -1;
       }
-      if (info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-        return Directory;
-      else if (info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
-        return SymLink;
-      else
-        return Regular;
+      return moonbitlang_async_kind_from_attr(info.FileAttributes);
     }
     case FILE_TYPE_CHAR:    return CharDevice;
     case FILE_TYPE_PIPE:    return handle_is_socket(handle) > 0 ? Socket : Pipe;

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -290,6 +290,23 @@ pub async fn realpath(path : StringView, context~ : String) -> String {
 }
 
 ///|
+#cfg(not(platform="windows"))
+pub async fn inotify_add_watch(
+  inotify : @fd_util.Fd,
+  path : StringView,
+  is_dir~ : Bool,
+  context~ : String,
+) -> @fd_util.Fd {
+  let path_bytes = @os_string.encode(path)
+  let job = Job::inotify_add_watch(inotify, path_bytes, is_dir)
+  perform_job_in_worker(job, context~) catch {
+    @os_error.OSError(errno, context~) =>
+      raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
+    err => raise err
+  }
+}
+
+///|
 #cfg(platform="windows")
 extern "C" fn read_dir_changes_ffi(fd : @fd_util.Fd, result : IoResult) -> Int = "moonbitlang_async_read_dir_changes"
 

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -15,7 +15,7 @@
 ///|
 pub async fn open(
   path : StringView,
-  // 0 => read only, 1 => write only, 2 => read write
+  // 0 => read only, 1 => write only, 2 => read write, 3 => directory listing
   access : Int,
   // See `@fs.CreateMode` for more details
   create~ : Int,
@@ -44,7 +44,7 @@ pub async fn open(
       let io = IoHandle::from_fd(
         fd,
         kind~,
-        is_async=!IS_WINDOWS && kind.can_poll(),
+        is_async=access is 3 || (!IS_WINDOWS && kind.can_poll()),
       )
       (io, result)
     }
@@ -254,9 +254,10 @@ pub async fn IoHandle::readdir(
   dir : IoHandle,
   buf : FixedArray[Byte],
   len : Int,
+  restart~ : Bool,
   context~ : String,
 ) -> Int {
-  let job = Job::readdir(dir.fd, buf, len)
+  let job = Job::readdir(dir.fd, buf, len, restart)
   perform_job_in_worker(job, context~)
 }
 
@@ -286,4 +287,43 @@ pub async fn realpath(path : StringView, context~ : String) -> String {
     err => raise err
   }
   job.get_realpath_result()
+}
+
+///|
+#cfg(platform="windows")
+extern "C" fn read_dir_changes_ffi(fd : @fd_util.Fd, result : IoResult) -> Int = "moonbitlang_async_read_dir_changes"
+
+///|
+/// zero return value indicates overflow
+#cfg(platform="windows")
+pub async fn IoHandle::read_dir_changes(
+  handle : IoHandle,
+  buf : FixedArray[Byte],
+  context~ : String,
+) -> Int {
+  @coroutine.check_cancellation()
+  guard curr_loop.val is Some(evloop)
+  guard handle.kind is Directory
+  let job_id = evloop.job_id
+  evloop.job_id += 1
+  let result = IoResult::for_read_dir_changes(
+    job_id,
+    buf.unsafe_reinterpret_as_bytes(),
+    len=buf.length(),
+  )
+  defer result.free()
+  let n = read_dir_changes_ffi(handle.fd, result)
+  if n >= 0 {
+    @coroutine.pause()
+    n
+  } else if @os_error.is_nonblocking_io_error() {
+    evloop.wait_for_io_result(job_id, result, handle.fd, context~)
+    result.status(handle.fd, context~) catch {
+      @os_error.OSError(_) as err if err.is_ERROR_NOTIFY_ENUM_DIR() => 0
+      err => raise err
+    }
+  } else {
+    @os_error.check_errno(context)
+    panic()
+  }
 }

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -36,7 +36,7 @@ pub fn IoHandle::from_fd(
   let context = "@event_loop.IoHandle::from_fd()"
   guard curr_loop.val is Some(evloop)
   guard evloop.fds.get(fd) is None
-  if is_async {
+  if is_async && !(kind is Unknown) {
     @fd_util.set_nonblocking(fd, context~) catch {
       err => {
         @fd_util.close(fd, kind~, context~)
@@ -51,7 +51,7 @@ pub fn IoHandle::from_fd(
 
 ///|
 #cfg(not(platform="windows"))
-fn IoHandle::prepare_read(handle : IoHandle) -> Unit raise {
+pub fn IoHandle::prepare_read(handle : IoHandle) -> Unit raise {
   guard curr_loop.val is Some(evloop)
   guard @fd_util.fd_is_valid(handle.fd) else {
     abort("file descriptor already closed")
@@ -69,7 +69,7 @@ fn IoHandle::prepare_read(handle : IoHandle) -> Unit raise {
 
 ///|
 #cfg(not(platform="windows"))
-async fn IoHandle::wait_read(handle : IoHandle) -> Unit {
+pub async fn IoHandle::wait_read(handle : IoHandle) -> Unit {
   guard (handle.events & ReadEvent) != 0
   guard @fd_util.fd_is_valid(handle.fd) else {
     abort("file descriptor already closed")

--- a/src/internal/event_loop/io_windows.c
+++ b/src/internal/event_loop/io_windows.c
@@ -39,7 +39,8 @@ enum IoResultKind {
   Socket,
   SocketWithAddr,
   Connect,
-  Accept
+  Accept,
+  ReadDirChanges
 };
 
 struct IoResult {
@@ -102,6 +103,13 @@ struct AcceptIoResult {
   // output buffer used for `AcceptEx`
   DWORD bytes_received;
   char accept_buffer[sizeof(struct sockaddr_storage) * 2];
+};
+
+struct ReadDirChangesIoResult {
+  struct IoResult header;
+
+  char *buf;
+  int32_t len;
 };
 
 static inline
@@ -186,6 +194,18 @@ struct AcceptIoResult *moonbitlang_async_make_accept_io_result(int32_t job_id) {
 }
 
 MOONBIT_FFI_EXPORT
+struct ReadDirChangesIoResult *moonbitlang_async_make_read_dir_changes_io_result(
+  int32_t job_id,
+  char *buf,
+  int32_t len
+) {
+  struct ReadDirChangesIoResult *result = MAKE_IO_RESULT(job_id, ReadDirChanges);
+  result->buf = buf;
+  result->len = len;
+  return result;
+}
+
+MOONBIT_FFI_EXPORT
 void moonbitlang_async_free_io_result(struct IoResult *obj) {
   switch (obj->kind) {
   case File:
@@ -202,6 +222,9 @@ void moonbitlang_async_free_io_result(struct IoResult *obj) {
     moonbit_decref(((struct ConnectIoResult*)obj)->addr);
     break;
   case Accept:
+    break;
+  case ReadDirChanges:
+    moonbit_decref(((struct ReadDirChangesIoResult*)obj)->buf);
     break;
   }
   free(obj);
@@ -479,6 +502,57 @@ int32_t moonbitlang_async_setup_accepted_socket(HANDLE listen_sock, HANDLE accep
 MOONBIT_FFI_EXPORT
 HANDLE moonbitlang_async_get_std_handle(int32_t id) {
   return GetStdHandle(id);
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_read_dir_changes(HANDLE dir, struct ReadDirChangesIoResult *result) {
+  DWORD bytes_returned;
+#if _WIN32_WINNT >= 0x0A00
+  BOOL ret = ReadDirectoryChangesExW(
+    dir,
+    result->buf,
+    result->len,
+    TRUE,
+    FILE_NOTIFY_CHANGE_SIZE
+    | FILE_NOTIFY_CHANGE_LAST_WRITE
+    | FILE_NOTIFY_CHANGE_FILE_NAME
+    | FILE_NOTIFY_CHANGE_DIR_NAME
+    | FILE_NOTIFY_CHANGE_CREATION,
+    &bytes_returned,
+    (LPOVERLAPPED)result,
+    NULL,
+    ReadDirectoryNotifyExtendedInformation
+  );
+#else
+  BOOL ret = ReadDirectoryChangesW(
+    dir,
+    result->buf,
+    result->len,
+    TRUE,
+    FILE_NOTIFY_CHANGE_SIZE
+    | FILE_NOTIFY_CHANGE_LAST_WRITE
+    | FILE_NOTIFY_CHANGE_FILE_NAME
+    | FILE_NOTIFY_CHANGE_DIR_NAME
+    | FILE_NOTIFY_CHANGE_CREATION,
+    &bytes_returned,
+    (LPOVERLAPPED)result,
+    NULL
+  );
+#endif
+  if (!ret)
+    return -1;
+
+  // According to https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw,
+  // `ReadDirectoryChangesW` return `TRUE` when the completion packet is succesfully queued,
+  // which contradicts with general overlapped IO practice,
+  // where the operation should fail with `ERROR_IO_PENDING`.
+  // So `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS` probably just isn't supported by `ReadDirectoryChangesW`.
+  // HOPEFULLY Microsoft won't suddenly decide that this should work someday,
+  // because that will break the code here.
+  // Also funny enough: `bytes_returned` will actually be written to some meaningful value immediately.
+  // So we cannot use that to decide if the operation has completed immediately (it probably just never will).
+  SetLastError(ERROR_IO_PENDING);
+  return -1;
 }
 
 #endif // #ifdef _WIN32

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -62,6 +62,15 @@ extern "C" fn IoResult::for_accept(job_id : Int) -> IoResult = "moonbitlang_asyn
 
 ///|
 #cfg(platform="windows")
+#owned(buf)
+extern "C" fn IoResult::for_read_dir_changes(
+  job_id : Int,
+  buf : Bytes,
+  len~ : Int,
+) -> IoResult = "moonbitlang_async_make_read_dir_changes_io_result"
+
+///|
+#cfg(platform="windows")
 extern "C" fn IoResult::free(self : IoResult) = "moonbitlang_async_free_io_result"
 
 ///|

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -34,6 +34,8 @@ pub async fn file_time_by_path(StringView, follow_symlink~ : Bool, context~ : St
 
 pub async fn getaddrinfo(StringView, context~ : String) -> Result[AddrInfo, String]
 
+pub async fn inotify_add_watch(Int, StringView, is_dir~ : Bool, context~ : String) -> Int
+
 pub async fn kind_of_fd(Int, context~ : String) -> @fd_util.FileKind
 
 pub async fn mkdir(StringView, mode~ : Int, context~ : String) -> Unit

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -93,16 +93,20 @@ pub fn IoHandle::from_fd(Int, kind~ : @fd_util.FileKind, is_async? : Bool) -> Se
 pub async fn IoHandle::fsync(Self, only_data~ : Bool, context~ : String) -> Unit
 pub fn IoHandle::kind(Self) -> @fd_util.FileKind
 pub async fn IoHandle::lock(Self, exclusive~ : Bool, context~ : String) -> Unit
+pub fn IoHandle::prepare_read(Self) -> Unit raise
 pub async fn IoHandle::read(Self, FixedArray[Byte], offset~ : Int, len~ : Int, context~ : String) -> Int
 pub async fn IoHandle::read_at(Self, FixedArray[Byte], offset~ : Int, len~ : Int, position~ : Int64, context~ : String) -> Int
-pub async fn IoHandle::readdir(Self, FixedArray[Byte], Int, context~ : String) -> Int
+pub async fn IoHandle::readdir(Self, FixedArray[Byte], Int, restart~ : Bool, context~ : String) -> Int
 pub async fn IoHandle::recvfrom(Self, FixedArray[Byte], offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 pub async fn IoHandle::sendto(Self, Bytes, offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
+pub async fn IoHandle::wait_read(Self) -> Unit
 pub async fn IoHandle::write(Self, Bytes, offset~ : Int, len~ : Int, context~ : String) -> Int
 pub async fn IoHandle::write_at(Self, Bytes, offset~ : Int, len~ : Int, position~ : Int64, context~ : String) -> Unit
 
 type OpenResult
+pub fn OpenResult::dev_id(Self) -> UInt64
 pub fn OpenResult::fd(Self) -> Int
+pub fn OpenResult::file_id(Self) -> UInt64
 pub fn OpenResult::kind(Self) -> @fd_util.FileKind
 
 pub(all) enum Platform {

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -95,7 +95,9 @@ typedef int SOCKET;
 // defined in `detect_file_kind.c`
 int32_t moonbitlang_async_kind_of_fd(HANDLE fd);
 
-#ifndef _WIN32
+#ifdef _WIN32
+int32_t moonbitlang_async_file_kind_from_attr(DWORD attrs);
+#else
 int32_t moonbitlang_async_file_kind_from_stat(struct stat *stat);
 #endif
 
@@ -685,7 +687,7 @@ struct open_job {
   int mode;
   HANDLE result;
 #ifdef _WIN32
-  int32_t kind;
+  BY_HANDLE_FILE_INFORMATION stat;
 #else
   struct stat stat;
 #endif
@@ -700,10 +702,15 @@ void free_open_job(void *obj) {
 static
 void open_job_worker(struct job *job) {
 #ifdef _WIN32
-  static int access_flags[] = { GENERIC_READ, GENERIC_WRITE, GENERIC_READ | GENERIC_WRITE };
+  static int access_flags[] = {
+    GENERIC_READ,
+    GENERIC_WRITE,
+    GENERIC_READ | GENERIC_WRITE,
+    FILE_LIST_DIRECTORY
+  };
   static int create_modes[] = { OPEN_EXISTING, TRUNCATE_EXISTING, OPEN_ALWAYS, CREATE_ALWAYS, CREATE_NEW };
 #else
-  static int access_flags[] = { O_RDONLY, O_WRONLY, O_RDWR };
+  static int access_flags[] = { O_RDONLY, O_WRONLY, O_RDWR, O_RDONLY };
   static int create_modes[] = {
     0,
     O_TRUNC,
@@ -718,6 +725,8 @@ void open_job_worker(struct job *job) {
 
 #ifdef _WIN32
   DWORD flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS;
+  if (open_job->access == 3)
+    flags |= FILE_FLAG_OVERLAPPED;
 
   DWORD access_flag = access_flags[open_job->access];
   if (open_job->append)
@@ -751,9 +760,12 @@ void open_job_worker(struct job *job) {
     }
   } while (0);
 
+  if (open_job->access == 4) {
+    printf("open() => %lx\n", open_job->result);
+  }
+
   // get the kind of the file
-  open_job->kind = moonbitlang_async_kind_of_fd(open_job->result);
-  if (open_job->kind < 0) {
+  if (!GetFileInformationByHandle(open_job->result, &open_job->stat)) {
     job->err = GetLastError();
     CloseHandle(open_job->result);
   }
@@ -813,9 +825,27 @@ HANDLE moonbitlang_async_open_job_get_fd(struct open_job *job) {
 MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_open_job_get_kind(struct open_job *job) {
 #ifdef _WIN32
-  return job->kind;
+  return moonbitlang_async_kind_from_attr(job->stat.dwFileAttributes);
 #else
   return moonbitlang_async_file_kind_from_stat(&job->stat);
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+uint64_t moonbitlang_async_open_job_get_dev_id(struct open_job *job) {
+#ifdef _WIN32
+  return job->stat.dwVolumeSerialNumber;
+#else
+  return job->stat.st_dev;
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+uint64_t moonbitlang_async_open_job_get_file_id(struct open_job *job) {
+#ifdef _WIN32
+  return ((uint64_t)(job->stat.nFileIndexHigh) << 32) | (uint64_t)(job->stat.nFileIndexLow);
+#else
+  return job->stat.st_ino;
 #endif
 }
 
@@ -1535,6 +1565,7 @@ struct readdir_job {
   HANDLE dir;
   void *out;
   int32_t len;
+  int32_t restart;
 };
 
 static
@@ -1551,7 +1582,7 @@ void readdir_job_worker(struct job *job) {
   if (
     !GetFileInformationByHandleEx(
       readdir_job->dir,
-      FileIdBothDirectoryInfo,
+      readdir_job->restart ?  FileIdBothDirectoryRestartInfo : FileIdBothDirectoryInfo,
       readdir_job->out,
       readdir_job->len
     )
@@ -1568,16 +1599,26 @@ void readdir_job_worker(struct job *job) {
 
 #elif defined(__linux__)
 
+  if (readdir_job->restart && lseek(readdir_job->dir, 0, SEEK_SET) < 0) {
+    job->err = errno;
+    return;
+  }
+
   job->ret = syscall(SYS_getdents64, readdir_job->dir, readdir_job->out, readdir_job->len);
   if (job->ret < 0)
     job->err = errno;
 
 #elif defined(__MACH__)
 
+  if (readdir_job->restart && lseek(readdir_job->dir, 0, SEEK_SET) < 0) {
+    job->err = errno;
+    return;
+  }
+
   struct attrlist attr_spec = {
     ATTR_BIT_MAP_COUNT,
     0, // reserved
-    ATTR_CMN_NAME | ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_OBJTYPE, // commonattr
+    ATTR_CMN_NAME | ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_OBJTYPE | ATTR_CMN_FILEID, // commonattr
     0, // volattr
     0, // dirattr
     0, // fileattr
@@ -1594,11 +1635,17 @@ void readdir_job_worker(struct job *job) {
 #endif
 }
 
-struct readdir_job *moonbitlang_async_make_readdir_job(HANDLE dir, void *out, int32_t len) {
+struct readdir_job *moonbitlang_async_make_readdir_job(
+  HANDLE dir,
+  void *out,
+  int32_t len,
+  int32_t restart
+) {
   struct readdir_job *job = MAKE_JOB(readdir);
   job->dir = dir;
   job->out = out;
   job->len = len;
+  job->restart = restart;
   return job;
 }
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -52,6 +52,7 @@
 #ifdef __linux__
 #include <sys/syscall.h>
 #include <linux/fs.h>
+#include <sys/inotify.h>
 #endif
 
 #ifdef __MACH__
@@ -2341,3 +2342,57 @@ struct sigwait_job *moonbitlang_async_make_sigwait_job(int *signals) {
 }
 
 #endif // #ifndef _WIN32, sigwait job
+
+#ifndef _WIN32
+
+// ===== inotify_add_watch job, add path to watch with inotify =====
+struct inotify_add_watch_job {
+  struct job job;
+  HANDLE inotify;
+  char *path;
+  int32_t is_dir;
+};
+
+static
+void free_inotify_add_watch_job(void *obj) {
+  struct inotify_add_watch_job *job = (struct inotify_add_watch_job*)obj;
+  moonbit_decref(job->path);
+}
+
+static
+void inotify_add_watch_job_worker(struct job *job) {
+  struct inotify_add_watch_job *inotify_add_watch_job = (struct inotify_add_watch_job*)job;
+
+#ifdef __linux__
+
+  uint32_t flags = inotify_add_watch_job->is_dir
+    ? IN_CREATE | IN_MOVED_FROM | IN_MOVED_TO | IN_DELETE
+    : IN_MODIFY;
+
+  job->ret = inotify_add_watch(inotify_add_watch_job->inotify, inotify_add_watch_job->path, flags);
+  if (job->ret < 0)
+    job->err = errno;
+
+#else
+
+  job->err = ENOSYS;
+
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+struct inotify_add_watch_job *moonbitlang_async_make_inotify_add_watch_job(
+  HANDLE inotify,
+  char *path,
+  int32_t is_dir
+) {
+  struct inotify_add_watch_job *job = MAKE_JOB(inotify_add_watch);
+
+  job->inotify = inotify;
+  job->path = path;
+  job->is_dir = is_dir;
+
+  return job;
+}
+
+#endif // #ifndef _WIN32, `inotify_add_watch` job

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -122,6 +122,14 @@ pub extern "C" fn OpenResult::fd(job : OpenResult) -> @fd_util.Fd = "moonbitlang
 pub extern "C" fn OpenResult::kind(job : OpenResult) -> @fd_util.FileKind = "moonbitlang_async_open_job_get_kind"
 
 ///|
+#borrow(job)
+pub extern "C" fn OpenResult::dev_id(job : OpenResult) -> UInt64 = "moonbitlang_async_open_job_get_dev_id"
+
+///|
+#borrow(job)
+pub extern "C" fn OpenResult::file_id(job : OpenResult) -> UInt64 = "moonbitlang_async_open_job_get_file_id"
+
+///|
 extern "C" fn Job::kind_of_fd(fd : @fd_util.Fd) -> Job = "moonbitlang_async_make_kind_of_fd_job"
 
 ///|
@@ -206,6 +214,7 @@ extern "C" fn Job::readdir(
   dir : @fd_util.Fd,
   buf : FixedArray[Byte],
   len : Int,
+  restart : Bool,
 ) -> Job = "moonbitlang_async_make_readdir_job"
 
 ///|

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -293,5 +293,14 @@ extern "C" fn Job::get_getaddrinfo_result(job : Job) -> AddrInfo = "moonbitlang_
 extern "C" fn Job::sigwait(signals : ReadOnlyArray[Int]) -> Job = "moonbitlang_async_make_sigwait_job"
 
 ///|
+#cfg(not(platform="windows"))
+#owned(path)
+extern "C" fn Job::inotify_add_watch(
+  inotify : @fd_util.Fd,
+  path : @os_string.OsString,
+  is_dir : Bool,
+) -> Job = "moonbitlang_async_make_inotify_add_watch_job"
+
+///|
 #cfg(platform="windows")
 let _mute_unused_warning : Unit = ignore(@c_buffer.Buffer::get)

--- a/src/os_error/error.mbt
+++ b/src/os_error/error.mbt
@@ -34,6 +34,9 @@ extern "C" fn errno_is_EACCES(errno : Int) -> Bool = "moonbitlang_async_is_EACCE
 extern "C" fn errno_is_ECONNREFUSED(errno : Int) -> Bool = "moonbitlang_async_is_ECONNREFUSED"
 
 ///|
+extern "C" fn errno_is_ERROR_NOTIFY_ENUM_DIR(errno : Int) -> Bool = "moonbitlang_async_is_ERROR_NOTIFY_ENUM_DIR"
+
+///|
 pub fn is_nonblocking_io_error() -> Bool {
   errno_is_nonblocking_io_error(get_errno())
 }
@@ -102,6 +105,13 @@ pub fn OSError::is_EACCES(err : OSError) -> Bool {
 pub fn OSError::is_ECONNREFUSED(err : OSError) -> Bool {
   let OSError(errno, ..) = err
   errno_is_ECONNREFUSED(errno)
+}
+
+///|
+/// Detect whether the error is the `ECONNREFUSED` (connection refused) error.
+pub fn OSError::is_ERROR_NOTIFY_ENUM_DIR(err : OSError) -> Bool {
+  let OSError(errno, ..) = err
+  errno_is_ERROR_NOTIFY_ENUM_DIR(errno)
 }
 
 ///|

--- a/src/os_error/pkg.generated.mbti
+++ b/src/os_error/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub fn OSError::is_ECONNREFUSED(Self) -> Bool
 pub fn OSError::is_EEXIST(Self) -> Bool
 pub fn OSError::is_EINTR(Self) -> Bool
 pub fn OSError::is_ENOENT(Self) -> Bool
+pub fn OSError::is_ERROR_NOTIFY_ENUM_DIR(Self) -> Bool
 pub fn OSError::is_nonblocking_io_error(Self) -> Bool
 pub impl Show for OSError
 

--- a/src/os_error/stub.c
+++ b/src/os_error/stub.c
@@ -88,6 +88,15 @@ int moonbitlang_async_is_ECONNREFUSED(int err) {
 }
 
 MOONBIT_FFI_EXPORT
+int moonbitlang_async_is_ERROR_NOTIFY_ENUM_DIR(int err) {
+#ifdef _WIN32
+  return err == ERROR_NOTIFY_ENUM_DIR;
+#else
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT
 char *moonbitlang_async_errno_to_string(int err) {
 #ifdef _WIN32
   LPWSTR result = 0;


### PR DESCRIPTION
This PR adds preliminary file system watching support via a type `@fs.Watcher`. A file system watcher can be created by `@fs.Watcher(<path-to-watch>)`. After that, the watcher will automatically watch for changes recursively in the watched path. Currently, only recursive directory watching is supported.

Users can use `@fs.Watcher::wait_any` to wait for any change in the watched tree. Currently only `wait_any` is available. In the future a `wait` method returning a list of events indicating what happened will be returned as well.

The implementation uses `inotify` on Linux, `kqueue` with `EVFILT_VNODE` on MacOS, and `ReadDirectoryChanges(Ex)W` on Windows. The implementation try quite hard to overcome the inherent race condition in file system watching (upon receiving an event from the OS, further changes may have been made to the file system):

- it rely solely on manual directory scanning to discover file creation/deletion, instead of relying on the path reported by `inotify`/`ReadDirectoryChangesW`. The events returned by the OS is treated merely as an indicator on which directories need scanning
- it uses unique file ID under the hood to keep track of files/directories and for rename detection
- on overflow (for `inotify` and `ReadDirectoryChanges(Ex)W`), the whole tree is re-scanned automatically, so there is no need for users to handle overflow manually
- it has builtin debouncing support: when several events happen quickly in a row, they will be reported altogether via a small timer (configurable on watcher creation)

Future directions:
- add `wait` for reporting concrete file system change events
- add polling based backend for file systems that don't support event reporting, such as the various network file systems