### PR TITLE
add mutex helper type

### DIFF
--- a/src/mutex.mbt
+++ b/src/mutex.mbt
@@ -1,0 +1,62 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A mutex for synchronization between multiple tasks.
+/// Essentially a mutex is just a semaphore of size one.
+#valtype
+struct Mutex {
+  semaphore : Semaphore
+}
+
+///|
+/// Create a new mutex.
+/// The mutex is initially in released state.
+pub fn Mutex::Mutex() -> Mutex {
+  { semaphore: Semaphore(1) }
+}
+
+///|
+/// Acquire the mutex.
+///
+/// If the mutex is already acquired by someone else,
+/// `acquire` will wait until the mutex is released.
+///
+/// If several tasks are both waiting for the mutex,
+/// they will acquire the mutex in a first-come-first-serve manner
+///
+/// `acquire` is cancellation safe.
+/// When `acquire` is cancelled, it will never trigger any side effect.
+/// In particular, a cancelled `acquire` request will never actually acquire the mutex.
+pub async fn Mutex::acquire(self : Mutex) -> Unit {
+  self.semaphore.acquire()
+}
+
+///|
+/// Try to acquire the mutex, but do not wait for it.
+/// If the mutex is currently available, it will be acquired and `true` will be returned.
+/// If the mutex is currently not available, `false` will be returned.
+///
+/// `try_acquire` follow the same FIFO rule of `acquire`:
+/// if there are `acquire` call waiting for the mutex, `try_acquire` always return `false`.
+pub fn Mutex::try_acquire(self : Mutex) -> Bool {
+  self.semaphore.try_acquire()
+}
+
+///|
+/// Release the mutex.
+/// The mutex must have been acquired, otherwise the program will abort.
+pub fn Mutex::release(self : Mutex) -> Unit {
+  self.semaphore.release()
+}

--- a/src/mutex_test.mbt
+++ b/src/mutex_test.mbt
@@ -1,0 +1,104 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "mutex basic" {
+  let log = []
+  @async.with_task_group() <| group => {
+    let mutex = @async.Mutex()
+    for i in 0..<3 {
+      group.spawn_bg() <| () => {
+        mutex.acquire()
+        log.push("task \{i} acquired mutex")
+        @async.sleep(300)
+        mutex.release()
+      }
+    }
+    @async.sleep(150)
+    for _ in 0..<3 {
+      log.push("tick")
+      @async.sleep(300)
+    }
+  }
+  json_inspect(log, content=[
+    "task 0 acquired mutex", "tick", "task 1 acquired mutex", "tick", "task 2 acquired mutex",
+    "tick",
+  ])
+}
+
+///|
+async test "mutex cancellation" {
+  @async.with_task_group() <| group => {
+    let mutex = @async.Mutex()
+    group.spawn_bg() <| () => {
+      mutex.acquire()
+      @async.sleep(500)
+      mutex.release()
+    }
+    debug_inspect(
+      try? @async.with_timeout(250, () => mutex.acquire()),
+      content="Err(TimeoutError)",
+    )
+    @async.sleep(500)
+    inspect(mutex.try_acquire(), content="true")
+  }
+}
+
+///|
+async test "mutex cancellation no_swallow" {
+  let log = []
+  @async.with_task_group() <| group => {
+    let mutex = @async.Mutex()
+    mutex.acquire()
+    let acquire_taskire_task = group.spawn(() => {
+      mutex.acquire()
+      log.push("acquire() succeed")
+    })
+    @async.sleep(100)
+    mutex.release()
+    acquire_taskire_task.cancel()
+    @async.sleep(100)
+    inspect(mutex.try_acquire(), content="false")
+  }
+  json_inspect(log, content=["acquire() succeed"])
+}
+
+///|
+async test "mutex fairness" {
+  let log = []
+  @async.with_task_group() <| group => {
+    let mutex = @async.Mutex()
+    group.spawn_bg() <| () => {
+      for _ in 0..<3 {
+        mutex.acquire()
+        log.push("task 1 acquired mutex")
+        @async.sleep(200)
+        mutex.release()
+      }
+    }
+    group.spawn_bg() <| () => {
+      @async.sleep(100)
+      for _ in 0..<3 {
+        mutex.acquire()
+        log.push("task 2 acquired mutex")
+        @async.sleep(200)
+        mutex.release()
+      }
+    }
+  }
+  json_inspect(log, content=[
+    "task 1 acquired mutex", "task 2 acquired mutex", "task 1 acquired mutex", "task 2 acquired mutex",
+    "task 1 acquired mutex", "task 2 acquired mutex",
+  ])
+}

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -54,6 +54,14 @@ pub struct Lazy[X] {
 pub fn[X] Lazy::Lazy(async () -> X) -> Self[X]
 pub async fn[X] Lazy::wait(Self[X]) -> X
 
+pub struct Mutex {
+  // private fields
+}
+pub fn Mutex::Mutex() -> Self
+pub async fn Mutex::acquire(Self) -> Unit
+pub fn Mutex::release(Self) -> Unit
+pub fn Mutex::try_acquire(Self) -> Bool
+
 pub(all) enum RetryMethod {
   Immediate
   FixedDelay(Int)


### PR DESCRIPTION
This PR adds a helper type `@async.Mutex`, which is internally just a semaphore of size 1. But the concept of a mutex is more well-known than a semaphore, so providing such a helper type can improve code readability.