### PR TITLE
fs watcher: add `ignored_paths` option

### DIFF
--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -131,7 +131,7 @@ pub(all) enum SyncMode {
 pub struct Watcher {
   // private fields
 }
-pub async fn Watcher::Watcher(String, debounce_timeout? : Int, max_debounce_delay? : Int) -> Self
+pub async fn Watcher::Watcher(String, debounce_timeout? : Int, max_debounce_delay? : Int, ignored_paths? : (String) -> Bool) -> Self
 pub fn Watcher::close(Self) -> Unit
 pub async fn Watcher::wait_any(Self) -> Unit
 

--- a/src/fs/watch.mbt
+++ b/src/fs/watch.mbt
@@ -52,6 +52,8 @@ struct Watcher {
   base_path : String
   watched : Map[FileIdentity, WatchedFile]
   pending_remove : Set[FileIdentity]
+  ignored_paths : (String) -> Bool
+  mut event_count : Int
 }
 
 ///|
@@ -115,11 +117,20 @@ fn Watcher::new_backend(
 /// within the last `debounce_timeout` ms (defaults to 20ms),
 /// or if `max_debounce_delay` ms (defaults to 200ms) has elapsed since the first event.
 ///
+/// `ignored_paths`, if present, can be used to filter out paths that the user don't want to watch.
+/// When a file or directory is going to be watched, its path
+/// (relative to root of watched tree, using `/` as path separator) will be supplied to `ignored_paths`.
+/// If `ignored_paths` return `true`, the file or directory will be ignored.
+/// When a directory is ignored, all files/directories within it are also ignored.
+/// So to ignore a single directory,
+/// `ignored_paths` only need to handle paths of the files inside that ignored directory.
+///
 /// Currently, the behavior when `path` itself is renamed or removed is undefined.
 pub async fn Watcher::Watcher(
   path : String,
   debounce_timeout? : Int = 20,
   max_debounce_delay? : Int = 200,
+  ignored_paths? : (String) -> Bool = _ => false,
 ) -> Watcher {
   let context = "@fs.Watcher()"
   let path = path.trim_end(chars="/")
@@ -151,6 +162,8 @@ pub async fn Watcher::Watcher(
     base_path: path,
     watched: {},
     pending_remove: Set([]),
+    ignored_paths,
+    event_count: 0,
   }
   try {
     let backend = self.new_backend(
@@ -173,6 +186,7 @@ pub async fn Watcher::Watcher(
     }
     self.watched[root_id] = root
     self.synchronize_tree(context~)
+    self.event_count = 0
     self
   } catch {
     err => {
@@ -197,8 +211,11 @@ fn rel_path(parent : String, name : String) -> String {
 pub async fn Watcher::wait_any(self : Watcher) -> Unit {
   let context = "@fs.Watcher::wait()"
   guard self.backend is Some(backend)
-  backend.wait()
-  self.synchronize_tree(context~)
+  while self.event_count <= 0 {
+    backend.wait()
+    self.synchronize_tree(context~)
+  }
+  self.event_count = 0
   while self.pending_remove.iter().next() is Some(file_id) {
     self.pending_remove.remove(file_id)
     let file = self.watched[file_id]
@@ -257,6 +274,9 @@ async fn Watcher::add_file_at(
   path~ : String,
   context~ : String,
 ) -> Unit {
+  if (self.ignored_paths)(path) {
+    return
+  }
   if dir.children.get(name) is Some(curr_id) {
     if curr_id == file_id {
       return
@@ -264,6 +284,7 @@ async fn Watcher::add_file_at(
       self.remove_file_at(dir, name)
     }
   }
+  self.event_count += 1
   let location = (dir.file_id, name)
   let file = self.get_file_at(path~, is_dir~, file_id~, context~)
   dir.children[name] = file.file_id
@@ -318,6 +339,7 @@ async fn Watcher::scan_dir(
     removed_children.remove(ent.name)
   }
   for name in removed_children.keys() {
+    self.event_count += 1
     self.remove_file_at(dir, name)
   }
 }
@@ -341,6 +363,8 @@ async fn Watcher::synchronize_file(
     file.modified = false
     if file.is_dir {
       self.scan_dir(file, path~, context~)
+    } else {
+      self.event_count += 1
     }
   } else if file.dirty_children.iter().next() is Some((name, child_id)) {
     let child = self.watched[child_id]

--- a/src/fs/watch_test.mbt
+++ b/src/fs/watch_test.mbt
@@ -442,3 +442,149 @@ async test "watch vertical swap" {
     ),
   )
 }
+
+///|
+async test "watch ignored path" {
+  let log = []
+  @async.with_task_group(group => {
+    let path = "_build/watch_ignored_path_test"
+    let test_dir = Dir({
+      "ignored": Dir({ "file": File("abcd") }),
+      "normal": Dir({ "file": File("efgh") }),
+    })
+    test_dir.instantiate(path)
+    group.add_defer(() => {
+      @async.protect_from_cancel(() => @fs.rmdir(path, recursive=true))
+    })
+
+    let watcher = @fs.Watcher(path, ignored_paths=path => path is "ignored")
+    group.spawn_bg(no_wait=true, () => {
+      defer watcher.close()
+      for ;; {
+        watcher.wait_any()
+        log.push("watcher received change")
+      }
+    })
+
+    // 1. modify file in ignored path
+    log.push("writing to ignored/file")
+    @fs.write_file("\{path}/ignored/file", "ABCD", create_mode=OpenExisting)
+    @async.sleep(150)
+
+    // 2. modify file in normal path
+    log.push("writing to normal/file")
+    @fs.write_file("\{path}/normal/file", "EFGH", create_mode=OpenExisting)
+    @async.sleep(150)
+
+    // 3. create file in ignored directory
+    {
+      log.push("creating new file in ignored directory")
+      let file = @fs.create("\{path}/ignored/file2")
+      defer file.close()
+      @async.sleep(150)
+
+      // 4. modify content of newly created file at ignored directory
+      log.push("writing to newly created file in ignored directory")
+      file.write("ABCD")
+    }
+    @async.sleep(150)
+
+    // 5. create file in normal directory
+    {
+      log.push("creating new file in normal directory")
+      let file = @fs.create("\{path}/normal/file2")
+      defer file.close()
+      @async.sleep(150)
+
+      // 6. modify content of newly created file at normal directory
+      log.push("writing to newly created file in normal directory")
+      file.write("EFGH")
+    }
+    @async.sleep(150)
+
+    // 7. remove a file in ignored directory
+    log.push("removing file in ignored directory")
+    @fs.remove("\{path}/ignored/file")
+    @async.sleep(150)
+
+    // 8. remove a file in normal directory
+    log.push("removing file in normal directory")
+    @fs.remove("\{path}/normal/file")
+    @async.sleep(150)
+
+    // 9. remove ignored directory
+    log.push("removing ignored directory")
+    @fs.rmdir("\{path}/ignored", recursive=true)
+    @async.sleep(150)
+
+    // 10. remove normal directory
+    log.push("removing normal directory")
+    @fs.rmdir("\{path}/normal", recursive=true)
+    @async.sleep(150)
+
+    // 11. re-create directory at ignored path
+    log.push("re-creating directory at ignored path")
+    @fs.mkdir("\{path}/ignored")
+    @async.sleep(150)
+
+    // 12. create new file in re-created ignored path
+    {
+      log.push("creating new file in re-created directory at normal path")
+      let file = @fs.create("\{path}/ignored/file")
+      defer file.close()
+      @async.sleep(150)
+
+      // 13. create new file in re-created ignored path
+      log.push("writing to newly created file in ignored directory")
+      file.write("ABCD")
+    }
+    @async.sleep(150)
+
+    // 14. re-create directory at normal path
+    log.push("re-creating directory at normal path")
+    @fs.mkdir("\{path}/normal")
+    @async.sleep(150)
+
+    // 15. create new file in re-created normal path
+    {
+      log.push("creating new file in re-created directory at normal path")
+      let file = @fs.create("\{path}/normal/file")
+      defer file.close()
+      @async.sleep(150)
+
+      // 16. create new file in re-created normal path
+      log.push("writing to newly created file in normal directory")
+      file.write("EFGH")
+    }
+    @async.sleep(150)
+  })
+  inspect(
+    log.join("\n"),
+    content=(
+      #|writing to ignored/file
+      #|writing to normal/file
+      #|watcher received change
+      #|creating new file in ignored directory
+      #|writing to newly created file in ignored directory
+      #|creating new file in normal directory
+      #|watcher received change
+      #|writing to newly created file in normal directory
+      #|watcher received change
+      #|removing file in ignored directory
+      #|removing file in normal directory
+      #|watcher received change
+      #|removing ignored directory
+      #|removing normal directory
+      #|watcher received change
+      #|re-creating directory at ignored path
+      #|creating new file in re-created directory at normal path
+      #|writing to newly created file in ignored directory
+      #|re-creating directory at normal path
+      #|watcher received change
+      #|creating new file in re-created directory at normal path
+      #|watcher received change
+      #|writing to newly created file in normal directory
+      #|watcher received change
+    ),
+  )
+}


### PR DESCRIPTION
This PR introduce a new option `ignored_paths` for `@fs.Watcher(..)`. Before being watched, the relative path of every file/directory in the watched tree will be supplied to `ignored_paths`. If `ignored_paths` return `true`, that file/directory will be ignored by the watcher.