### PR TITLE
[codex] fix Windows realpath

### DIFF
--- a/src/fs/realpath_test.mbt
+++ b/src/fs/realpath_test.mbt
@@ -24,6 +24,62 @@ async test "realpath absolute" {
 }
 
 ///|
+#cfg(platform="windows")
+async test "realpath missing path windows" {
+  try @fs.realpath("_build\\realpath_test_missing.test") catch {
+    @os_error.OSError(_) as err if err.is_ENOENT() => ()
+    err => fail("incorrect error: \{err}")
+  } noraise {
+    path => fail("`@fs.realpath` unexpectedly succeeded: \{path}")
+  }
+}
+
+///|
+#cfg(platform="windows")
+async test "realpath junction to dir windows" {
+  @async.with_task_group() <| group => {
+    let target_dir = "_build\\realpath_test_junction_target"
+    let target_file = "\{target_dir}\\file.txt"
+    let junction_path = "_build\\realpath_test_junction"
+    @fs.rmdir(junction_path) catch {
+      _ => ()
+    }
+    @fs.rmdir(target_dir, recursive=true) catch {
+      _ => ()
+    }
+    @fs.mkdir(target_dir, recursive=true)
+    @fs.write_file(target_file, "content", create_mode=CreateOrTruncate)
+    group.add_defer(() => {
+      @fs.rmdir(junction_path) catch {
+        _ => ()
+      }
+      @fs.rmdir(target_dir, recursive=true) catch {
+        _ => ()
+      }
+    })
+    let target_realpath = @fs.realpath(target_file).replace_all(
+      old="\\",
+      new="/",
+    )
+    let code = @process.run("cmd", [
+      "/c",
+      "mklink",
+      "/J",
+      junction_path,
+      @fs.realpath(target_dir),
+    ])
+    if code != 0 {
+      fail("failed to create junction: \{code}")
+    }
+    let link_realpath = @fs.realpath("\{junction_path}\\file.txt").replace_all(
+      old="\\",
+      new="/",
+    )
+    assert_eq(link_realpath, target_realpath)
+  }
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "realpath link to absolute" {
   @async.with_task_group() <| root => {

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -15,6 +15,9 @@
  */
 
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
 #include <moonbit.h>
 
 #ifdef _WIN32
@@ -1664,38 +1667,90 @@ void free_realpath_job(void *obj) {
   moonbit_decref(job->path);
 }
 
+#ifdef _WIN32
+
+static
+char *moonbitlang_async_make_windows_realpath_string(WCHAR *path, DWORD len) {
+  if (len >= 8 && wcsncmp(path, L"\\\\?\\UNC\\", 8) == 0) {
+    char *result = (char*)moonbit_make_string_raw(len - 6);
+    WCHAR *out = (WCHAR*)result;
+    out[0] = L'\\';
+    out[1] = L'\\';
+    memcpy(out + 2, path + 8, (len - 8) * sizeof(WCHAR));
+    return result;
+  }
+
+  if (len >= 4 && wcsncmp(path, L"\\\\?\\", 4) == 0) {
+    path += 4;
+    len -= 4;
+  }
+
+  char *result = (char*)moonbit_make_string_raw(len);
+  memcpy(result, path, len * sizeof(WCHAR));
+  return result;
+}
+
+#endif
+
 static
 void realpath_job_worker(struct job *job) {
   struct realpath_job *realpath_job = (struct realpath_job*)job;
 
 #ifdef _WIN32
-  static wchar_t buf[1024];
-  DWORD len = GetFullPathNameW(
+  HANDLE file = CreateFileW(
     (LPCWSTR)realpath_job->path,
-    1024,
-    buf,
+    FILE_READ_ATTRIBUTES,
+    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+    NULL,
+    OPEN_EXISTING,
+    FILE_FLAG_BACKUP_SEMANTICS,
     NULL
   );
 
-  if (!len) {
+  if (file == INVALID_HANDLE_VALUE) {
     job->err = GetLastError();
     return;
   }
 
-  realpath_job->result = (char*)moonbit_make_string_raw(len);
-  if (len <= 1024) {
-    memcpy(realpath_job->result, buf, len * sizeof(wchar_t));
-  } else if (
-    !GetFullPathNameW(
-      (LPCWSTR)realpath_job->path,
-      len,
-      (LPWSTR)realpath_job->result,
-      NULL
-    )
-  ) {
-    job->err = GetLastError();
-    moonbit_decref(realpath_job->result);
+  WCHAR stack_buf[1024];
+  DWORD capacity = sizeof(stack_buf) / sizeof(stack_buf[0]);
+  WCHAR *buf = stack_buf;
+  DWORD len = 0;
+
+  while (1) {
+    len = GetFinalPathNameByHandleW(
+      file,
+      buf,
+      capacity,
+      FILE_NAME_NORMALIZED | VOLUME_NAME_DOS
+    );
+
+    if (!len) {
+      job->err = GetLastError();
+      if (buf != stack_buf)
+        free(buf);
+      CloseHandle(file);
+      return;
+    }
+
+    if (len < capacity)
+      break;
+
+    if (buf != stack_buf)
+      free(buf);
+    capacity = len + 1;
+    buf = (WCHAR*)malloc(capacity * sizeof(WCHAR));
+    if (!buf) {
+      job->err = ERROR_NOT_ENOUGH_MEMORY;
+      CloseHandle(file);
+      return;
+    }
   }
+
+  realpath_job->result = moonbitlang_async_make_windows_realpath_string(buf, len);
+  if (buf != stack_buf)
+    free(buf);
+  CloseHandle(file);
 
 #else
 


### PR DESCRIPTION
## Summary

Fix `@fs.realpath` on Windows so it uses the opened file handle to resolve the final path instead of only normalizing the input string with `GetFullPathNameW`.

## Root cause

The previous Windows implementation used `GetFullPathNameW`, which removes `.` and `..` but does not require the path to exist and does not unfold symlinks, junctions, or other reparse points. It also used a static temporary buffer inside the worker thread implementation.

## Changes

- Open the Windows path with `CreateFileW` and resolve it with `GetFinalPathNameByHandleW`.
- Strip `\\?\` and `\\?\UNC\` namespace prefixes before returning the MoonBit string.
- Use per-call buffers for the Windows realpath worker.
- Add Windows regression tests for missing paths and directory junction resolution.

## Validation

- `moon check` passed with existing deprecated `try?` warnings.
- `moon test src/fs/realpath_test.mbt` passed.
- `moon test src/fs` passed.
- `moon test src/fs/realpath_test.mbt --release` passed.
- `moon fmt` completed.
- `moon info` completed with no interface changes.
- `git diff --check` passed.

Notes:

- `moon check --deny-warn` is currently blocked by existing deprecated `try?` warnings outside this change.
- Full local `moon test` reached 524/528 passing; the failures were unrelated local/environment issues: `src/process/test_programs/` is an ignored generated directory that appears in process directory listing snapshots, and DNS resolution expectations differed on this machine.