### PR TITLE
temporarily reduce max concurrent tests to stabilize CI

### DIFF
--- a/src/fs/moon.pkg
+++ b/src/fs/moon.pkg
@@ -25,7 +25,7 @@ import {
 } for "test"
 
 options(
-  "max-concurrent-tests": 5,
+  "max-concurrent-tests": 3,
   "native-stub": [
     "stub.c",
     "dir.c",

--- a/src/fs/watch_test.mbt
+++ b/src/fs/watch_test.mbt
@@ -529,7 +529,7 @@ async test "watch ignored path" {
 
     // 12. create new file in re-created ignored path
     {
-      log.push("creating new file in re-created directory at normal path")
+      log.push("creating new file in re-created directory at ignored path")
       let file = @fs.create("\{path}/ignored/file")
       defer file.close()
       @async.sleep(150)
@@ -577,7 +577,7 @@ async test "watch ignored path" {
       #|removing normal directory
       #|watcher received change
       #|re-creating directory at ignored path
-      #|creating new file in re-created directory at normal path
+      #|creating new file in re-created directory at ignored path
       #|writing to newly created file in ignored directory
       #|re-creating directory at normal path
       #|watcher received change


### PR DESCRIPTION
Currently `println` has some performance issue on Windows, while `moon test --enable-coverage` do a lot of `println`. This result in long block in main thread due to coverage code, causing test failure. This PR temporarily reduce the number of concurrent tests in `src/fs` to workaround the issue. The `println` performance issue should be fixed in the next compiler release.