### PR TITLE
fix stdio detach handling, support multiple event loop in same process

### DIFF
--- a/src/internal/event_loop/io.mbt
+++ b/src/internal/event_loop/io.mbt
@@ -26,10 +26,11 @@ pub fn IoHandle::kind(handle : IoHandle) -> @fd_util.FileKind {
 /// Close a file descriptor and detach it from the event loop.
 /// This function is idempotent: it is safe to call `.close()` multiple times.
 pub fn IoHandle::close(handle : IoHandle) -> Unit {
-  let fd = handle.detach_from_event_loop()
-  if @fd_util.fd_is_valid(fd) {
-    @fd_util.close(fd, kind=handle.kind, context="") catch {
+  handle.detach_from_event_loop()
+  if @fd_util.fd_is_valid(handle.fd) {
+    @fd_util.close(handle.fd, kind=handle.kind, context="") catch {
       _ => ()
     }
   }
+  handle.fd = @fd_util.invalid_fd
 }

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -121,18 +121,15 @@ async fn IoHandle::wait_write(handle : IoHandle) -> Unit {
 /// but does not close the file descriptor itself.
 /// The underlying file descriptor is returned.
 #cfg(not(platform="windows"))
-pub fn IoHandle::detach_from_event_loop(handle : IoHandle) -> @fd_util.Fd {
+pub fn IoHandle::detach_from_event_loop(handle : IoHandle) -> Unit {
   guard curr_loop.val is Some(evloop)
-  guard @fd_util.fd_is_valid(handle.fd) else { @fd_util.invalid_fd }
+  guard @fd_util.fd_is_valid(handle.fd) else { return }
   evloop.fds.remove(handle.fd)
   if !(handle.events is NoEvent) {
     evloop.poll.remove(handle.fd, events=handle.events) catch {
       err => abort("detach \{handle.fd} from loop: \{err}")
     }
   }
-  let fd = handle.fd
-  handle.fd = @fd_util.invalid_fd
-  fd
 }
 
 ///|

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -175,13 +175,10 @@ pub fn IoHandle::from_fd(
 
 ///|
 #cfg(platform="windows")
-pub fn IoHandle::detach_from_event_loop(handle : IoHandle) -> @fd_util.Fd {
+pub fn IoHandle::detach_from_event_loop(handle : IoHandle) -> Unit {
   guard curr_loop.val is Some(evloop)
-  guard @fd_util.fd_is_valid(handle.fd) else { @fd_util.invalid_fd }
+  guard @fd_util.fd_is_valid(handle.fd) else { return }
   evloop.fds.remove(handle.fd)
-  let fd = handle.fd
-  handle.fd = @fd_util.invalid_fd
-  fd
 }
 
 ///|

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -89,7 +89,7 @@ pub async fn IoHandle::accept(Self, Bytes, context~ : String) -> Self
 pub async fn IoHandle::bind(Self, Bytes, context~ : String) -> Unit
 pub fn IoHandle::close(Self) -> Unit
 pub async fn IoHandle::connect(Self, Bytes, context~ : String) -> Unit
-pub fn IoHandle::detach_from_event_loop(Self) -> Int
+pub fn IoHandle::detach_from_event_loop(Self) -> Unit
 pub fn IoHandle::fd(Self) -> Int
 pub fn IoHandle::from_fd(Int, kind~ : @fd_util.FileKind, is_async? : Bool) -> Self raise
 pub async fn IoHandle::fsync(Self, only_data~ : Bool, context~ : String) -> Unit

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -42,7 +42,7 @@ fn setup_stdio(fd : Int, context~ : String) -> IoHandle {
       evloop.fds[fd] = handle
     },
     exit=() => {
-      let _ = handle.detach_from_event_loop()
+      handle.detach_from_event_loop()
       handle.events = NoEvent
     },
   )
@@ -85,7 +85,7 @@ fn setup_stdio(id : Int, context~ : String) -> IoHandle {
       guard evloop.fds.get(fd) is None
       evloop.fds[fd] = handle
     },
-    exit=() => ignore(handle.detach_from_event_loop()),
+    exit=() => handle.detach_from_event_loop(),
   )
   handle
 }

--- a/src/raw_fd/raw_fd_test.mbt
+++ b/src/raw_fd/raw_fd_test.mbt
@@ -101,7 +101,8 @@ async test "file as raw fd" {
     mode=0,
     context="file as raw fd test",
   )
-  let fd = io.detach_from_event_loop()
+  let fd = io.fd()
+  io.detach_from_event_loop()
   let file = @raw_fd.RawFd(fd)
   defer file.close()
   assert_true(@event_loop.kind_of_fd(fd, context="kind_of_fd") is Regular)
@@ -130,7 +131,8 @@ async test "file as raw fd stream" {
     mode=0,
     context="file as raw fd test",
   )
-  let fd = io.detach_from_event_loop()
+  let fd = io.fd()
+  io.detach_from_event_loop()
   let file = @raw_fd.RawFdStream(fd)
   defer file.close()
   assert_true(@event_loop.kind_of_fd(fd, context="kind_of_fd") is Regular)


### PR DESCRIPTION
The previous stdio logic for handling multiple event loop within the same process (one after another, not overlapping. For testing purpose only) is incorrect. If `stdio` is used in tests with multiple event loops (for logging purpose for example), the program will crash. This PR fixes the issue.