### PR TITLE
deprecate body for HTTP GET helpers

### DIFF
--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -267,6 +267,7 @@ pub async fn Client::request(
 
 ///|
 /// Perform a `GET` request to the server, see `Client::request` for more details.
+#label_migration(body, fill=false, msg="`GET` request should not contain a body")
 pub async fn Client::get(
   self : Client,
   path : String,

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -266,6 +266,7 @@ pub async fn Client::skip_response_body(self : Client) -> Unit {
 
 ///|
 /// Perform a `GET` request to the server, see `Client::request` for more details.
+#label_migration(body, fill=false, msg="`GET` request should not contain a body")
 pub async fn Client::get(
   self : Client,
   path : String,

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -9,8 +9,10 @@ import {
 }
 
 // Values
+#label_migration(body, fill=false, msg="`GET` request should not contain a body")
 pub async fn get(String, headers? : Map[String, String], body? : &@io.Data, proxy? : Client) -> (Response, &@io.Data)
 
+#label_migration(body, fill=false, msg="`GET` request should not contain a body")
 pub async fn get_stream(String, headers? : Map[String, String], body? : &@io.Data, proxy? : Client) -> (Response, Client)
 
 pub async fn post(String, &@io.Data, headers? : Map[String, String], proxy? : Client) -> (Response, &@io.Data)
@@ -56,6 +58,7 @@ pub fn Client::close(Self) -> Unit
 pub async fn Client::end_request(Self) -> Response
 pub async fn Client::enter_passthrough_mode(Self) -> Unit
 pub async fn Client::flush(Self) -> Unit
+#label_migration(body, fill=false, msg="`GET` request should not contain a body")
 pub async fn Client::get(Self, String, extra_headers? : Map[String, String], body? : &@io.Data) -> Response
 pub async fn Client::post(Self, String, &@io.Data, extra_headers? : Map[String, String]) -> Response
 pub async fn Client::put(Self, String, &@io.Data, extra_headers? : Map[String, String]) -> Response

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -96,6 +96,7 @@ async fn perform_request(
 /// `proxy` is not supported on JavaScript backend.
 ///
 /// See `Client::request` for more details.
+#label_migration(body, fill=false, msg="`GET` request should not contain a body")
 pub async fn get(
   uri : String,
   headers? : Map[String, String] = {},
@@ -137,6 +138,7 @@ pub async fn post(
 ///
 /// Note that the returned client must be manually closed via `.close()`
 /// to close the underlying connection used for the request.
+#label_migration(body, fill=false, msg="`GET` request should not contain a body")
 pub async fn get_stream(
   uri : String,
   headers? : Map[String, String] = {},


### PR DESCRIPTION
This PR deprecates the optional `body` parameter for the various HTTP `GET` helpers, because `GET` request should never contain a body according to the HTTP RFC. If the user really need to perform a non-compliant `GET` request with body, the generic `Client::request` method can still be used.