### PR TITLE
Move socket address buffers to MoonBit allocation

### DIFF
--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -19,23 +19,66 @@ priv enum AddrFamily {
 }
 
 ///|
-/// IPv4 address + port number
 #warnings("-unused_constructor")
 struct Addr(Bytes) derive(Eq, Compare, Hash)
 
 ///|
-pub extern "C" fn Addr::new(ip : UInt, port : Int) -> Addr = "moonbitlang_async_make_ip_addr"
+extern "C" fn get_ipv4_addr_size() -> Int = "moonbitlang_async_ipv4_addr_size"
 
 ///|
-extern "C" fn Addr::empty(family : AddrFamily) -> Addr = "moonbitlang_async_make_empty_addr"
+let ipv4_addr_size : Int = get_ipv4_addr_size()
 
 ///|
-#borrow(ip)
-extern "C" fn Addr::new_ipv6(
+extern "C" fn get_ipv6_addr_size() -> Int = "moonbitlang_async_ipv6_addr_size"
+
+///|
+let ipv6_addr_size : Int = get_ipv6_addr_size()
+
+///|
+#borrow(addr)
+extern "C" fn init_ip_addr(addr : Bytes, ip : UInt, port : Int) = "moonbitlang_async_init_ip_addr"
+
+///|
+pub fn Addr::new(ip : UInt, port : Int) -> Addr {
+  let addr = Bytes::make(ipv4_addr_size, 0)
+  init_ip_addr(addr, ip, port)
+  Addr(addr)
+}
+
+///|
+#borrow(addr, ip)
+extern "C" fn init_ipv6_addr(
+  addr : Bytes,
   ip : FixedArray[Byte],
   port : Int,
   scope_id~ : UInt,
-) -> Addr = "moonbitlang_async_make_ipv6_addr"
+) = "moonbitlang_async_init_ipv6_addr"
+
+///|
+fn Addr::new_ipv6(ip : FixedArray[Byte], port : Int, scope_id~ : UInt) -> Addr {
+  let addr = Bytes::make(ipv6_addr_size, 0)
+  init_ipv6_addr(addr, ip, port, scope_id~)
+  Addr(addr)
+}
+
+///|
+let empty_ipv6_bytes : FixedArray[Byte] = FixedArray::make(16, 0)
+
+///|
+fn Addr::empty(family : AddrFamily) -> Addr {
+  match family {
+    IPv4 => {
+      let addr = Bytes::make(ipv4_addr_size, 0)
+      init_ip_addr(addr, 0, 0)
+      Addr(addr)
+    }
+    IPv6 => {
+      let addr = Bytes::make(ipv6_addr_size, 0)
+      init_ipv6_addr(addr, empty_ipv6_bytes, 0, scope_id=0)
+      Addr(addr)
+    }
+  }
+}
 
 ///|
 #borrow(addr)
@@ -134,7 +177,22 @@ extern "C" fn AddrInfo::is_null(self : AddrInfo) -> Bool = "moonbitlang_async_ad
 
 ///|
 /// Convert AddrInfo to Addr(support both IPv4 and IPv6)
-extern "C" fn AddrInfo::to_addr(self : AddrInfo, port : Int) -> Addr = "moonbitlang_async_addrinfo_to_addr"
+extern "C" fn AddrInfo::addr_size(self : AddrInfo) -> Int = "moonbitlang_async_addrinfo_addr_size"
+
+///|
+#borrow(out)
+extern "C" fn AddrInfo::fill_addr(
+  self : AddrInfo,
+  out : Bytes,
+  port : Int,
+) -> Unit = "moonbitlang_async_addrinfo_fill_addr"
+
+///|
+fn AddrInfo::to_addr(self : AddrInfo, port : Int) -> Addr {
+  let addr = Bytes::make(self.addr_size(), 0)
+  self.fill_addr(addr, port)
+  Addr(addr)
+}
 
 ///|
 extern "C" fn AddrInfo::next(self : AddrInfo) -> AddrInfo = "moonbitlang_async_addrinfo_get_next"

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -355,50 +355,34 @@ int moonbitlang_async_enable_keepalive(
 #endif
 
 MOONBIT_FFI_EXPORT
-void *moonbitlang_async_make_ip_addr(uint32_t ip, int port) {
-  // For IPv4, create traditional sockaddr_in structure
-  struct sockaddr_in *addr = (struct sockaddr_in*)moonbit_make_bytes(
-    sizeof(struct sockaddr_in),
-    0
-  );
+int32_t moonbitlang_async_ipv4_addr_size() {
+  return sizeof(struct sockaddr_in);
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_ipv6_addr_size() {
+  return sizeof(struct sockaddr_in6);
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_init_ip_addr(struct sockaddr_in *addr, uint32_t ip, int port) {
   addr->sin_family = AF_INET;
   addr->sin_port = htons(port);
   addr->sin_addr.s_addr = htonl(ip);
-  return addr;
 }
 
 MOONBIT_FFI_EXPORT
-void *moonbitlang_async_make_empty_addr(int family) {
-  if (family == 4) {
-    struct sockaddr *addr = (struct sockaddr*)moonbit_make_bytes(
-      sizeof(struct sockaddr_in),
-      0
-    );
-    addr->sa_family = AF_INET;
-    return addr;
-  } else {
-    struct sockaddr *addr = (struct sockaddr*)moonbit_make_bytes(
-      sizeof(struct sockaddr_in6),
-      0
-    );
-    addr->sa_family = AF_INET6;
-    return addr;
-  };
-}
-
-MOONBIT_FFI_EXPORT
-void *moonbitlang_async_make_ipv6_addr(uint8_t *ip, int port, uint32_t scope_id) {
-  // For IPv6, create sockaddr_in6 structure directly
-  struct sockaddr_in6 *addr = (struct sockaddr_in6*)moonbit_make_bytes(
-    sizeof(struct sockaddr_in6),
-    0
-  );
+void moonbitlang_async_init_ipv6_addr(
+  struct sockaddr_in6 *addr,
+  uint8_t *ip,
+  int port,
+  uint32_t scope_id
+) {
   addr->sin6_family = AF_INET6;
   addr->sin6_flowinfo = 0;
   addr->sin6_port = htons(port);
   memcpy(&addr->sin6_addr, ip, 16);
   addr->sin6_scope_id = scope_id;
-  return addr;
 }
 
 MOONBIT_FFI_EXPORT
@@ -475,31 +459,42 @@ addrinfo_t *moonbitlang_async_addrinfo_get_next(addrinfo_t *addrinfo) {
 }
 
 MOONBIT_FFI_EXPORT
-void* moonbitlang_async_addrinfo_to_addr(addrinfo_t *addrinfo, int port) {
+int32_t moonbitlang_async_addrinfo_addr_size(addrinfo_t *addrinfo) {
   if (addrinfo == NULL || addrinfo->ai_addr == NULL) {
-    return NULL;
+    return 0;
   }
 
   if (addrinfo->ai_family == AF_INET) {
-    // IPv4
-    struct sockaddr_in *addr = (struct sockaddr_in*)moonbit_make_bytes(
-      sizeof(struct sockaddr_in),
-      0
-    );
+    return sizeof(struct sockaddr_in);
+  } else if (addrinfo->ai_family == AF_INET6) {
+    return sizeof(struct sockaddr_in6);
+  } else {
+    return 0;
+  }
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_addrinfo_fill_addr(
+  addrinfo_t *addrinfo,
+  void *addr_out,
+  int port
+) {
+  if (addrinfo == NULL || addrinfo->ai_addr == NULL) {
+    return;
+  }
+
+  if (addrinfo->ai_family == AF_INET) {
+    struct sockaddr_in *addr = (struct sockaddr_in*)addr_out;
     memcpy(addr, addrinfo->ai_addr, sizeof(struct sockaddr_in));
     addr->sin_port = htons(port);
-    return addr;
+    return;
   } else if (addrinfo->ai_family == AF_INET6) {
-    // IPv6
-    struct sockaddr_in6 *addr = (struct sockaddr_in6*)moonbit_make_bytes(
-      sizeof(struct sockaddr_in6),
-      0
-    );
+    struct sockaddr_in6 *addr = (struct sockaddr_in6*)addr_out;
     memcpy(addr, addrinfo->ai_addr, sizeof(struct sockaddr_in6));
     addr->sin6_port = htons(port);
-    return addr;
+    return;
   } else {
-      return NULL;
+    return;
   }
 }
 


### PR DESCRIPTION
Part of #408.

## Why

Socket address helpers allocated MoonBit-visible `Addr` buffers from C. That
does not match the Wasm1 allocation model, where MoonBit should allocate guest
memory and pass it to the host.

## What

- Move `Addr` construction to MoonBit-owned `Bytes`.
- Change C socket address constructors into size/init helpers.
- Change `AddrInfo::to_addr` to allocate the destination buffer in MoonBit.

## Why this is correct

Socket addresses have fixed native sizes, so MoonBit can allocate the exact
storage before C initializes it. `AddrInfo::to_addr` now queries the required
address size first and asks C only to copy into caller-provided storage.

## Review scope

This PR is limited to socket address buffer ownership. Interface-name output
allocation is split into #413.
