### PR TITLE
Move simple C shim outputs to MoonBit allocation

### DIFF
--- a/src/fs/stub.c
+++ b/src/fs/stub.c
@@ -94,30 +94,18 @@ int moonbitlang_async_unlock_file(int fd) {
 #ifdef _WIN32
 
 MOONBIT_FFI_EXPORT
-moonbit_string_t moonbitlang_async_get_tmp_path() {
-  static wchar_t buffer[1024];
+int32_t moonbitlang_async_fill_tmp_path(moonbit_string_t out, int32_t out_len) {
+  DWORD len = GetTempPath2W(out_len, (LPWSTR)out);
 
-  const DWORD buffer_len = sizeof(buffer) / sizeof(wchar_t);
-  DWORD len = GetTempPath2W(buffer_len, buffer);
+  if (len == 0)
+    return -1;
 
-  if (len == 0) {
-    return NULL;
-  }
-
-  if (len > buffer_len) {
-    moonbit_string_t str = moonbit_make_string_raw(len - 1);
-    len = GetTempPath2W(len, (LPWSTR)str);
-    return len == 0 ? NULL : str;
-  } else {
-    moonbit_string_t str = moonbit_make_string_raw(len);
-    memcpy(str, buffer, len * sizeof(wchar_t));
-    return str;
-  }
+  return len;
 }
 
 #else
 
-moonbit_string_t moonbitlang_async_get_tmp_path() {
+int32_t moonbitlang_async_fill_tmp_path(moonbit_string_t out, int32_t out_len) {
   const char *path;
 #ifdef __ANDROID__
   const char *tmpdir = getenv("TMPDIR");
@@ -125,11 +113,12 @@ moonbit_string_t moonbitlang_async_get_tmp_path() {
 #else
   path = "/tmp/";
 #endif
-  size_t len = strlen(path);
-  moonbit_string_t str = moonbit_make_string_raw(len);
+  int32_t len = strlen(path);
+  if (len > out_len)
+    return len;
   for (size_t i = 0; i < len; i++) {
-    ((uint16_t*)str)[i] = (uint16_t)(unsigned char)path[i];
+    ((uint16_t*)out)[i] = (uint16_t)(unsigned char)path[i];
   }
-  return str;
+  return len;
 }
 #endif

--- a/src/fs/tmpdir.mbt
+++ b/src/fs/tmpdir.mbt
@@ -23,7 +23,32 @@ let tmpdir_seed : @random.Rand = {
 }
 
 ///|
-extern "C" fn get_tmp_path_ffi() -> String? = "moonbitlang_async_get_tmp_path"
+#borrow(out)
+extern "C" fn fill_tmp_path_ffi(out : String, len : Int) -> Int = "moonbitlang_async_fill_tmp_path"
+
+///|
+fn get_tmp_path_ffi() -> String? {
+  let buffer_len = 1024
+  let buffer = String::make(buffer_len, '\u{0}')
+  let actual_len = fill_tmp_path_ffi(buffer, buffer_len)
+  if 0 <= actual_len && actual_len < buffer_len {
+    Some(buffer[:actual_len].to_owned())
+  } else if actual_len >= buffer_len {
+    let result = String::make(actual_len, '\u{0}')
+    let final_len = fill_tmp_path_ffi(result, actual_len)
+    if 0 <= final_len && final_len <= actual_len {
+      if final_len == actual_len {
+        Some(result)
+      } else {
+        Some(result[:final_len].to_owned())
+      }
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
 
 ///|
 let tmp_base_path : String = {

--- a/src/internal/os_string/os_string.mbt
+++ b/src/internal/os_string/os_string.mbt
@@ -23,6 +23,20 @@ struct OsString(String)
 
 ///|
 #cfg(not(platform="windows"))
+#internal(internal, "for internal FFI wrappers only")
+pub fn OsString::from_bytes(data : Bytes) -> OsString {
+  OsString(data)
+}
+
+///|
+#cfg(platform="windows")
+#internal(internal, "for internal FFI wrappers only")
+pub fn OsString::from_string(data : String) -> OsString {
+  OsString(data)
+}
+
+///|
+#cfg(not(platform="windows"))
 pub fn encode(str : StringView) -> OsString {
   @utf8.encode(str)
 }
@@ -65,7 +79,35 @@ pub fn decode(
 
 ///|
 #cfg(platform="windows")
-pub extern "C" fn decode(os_str : @c_buffer.Buffer, len? : Int = -1) -> String = "moonbitlang_async_c_buffer_as_string"
+#borrow(out)
+extern "C" fn decode_fill(
+  os_str : @c_buffer.Buffer,
+  len : Int,
+  out : String,
+  out_len : Int,
+) -> Int = "moonbitlang_async_c_buffer_fill_string"
+
+///|
+#cfg(platform="windows")
+pub fn decode(os_str : @c_buffer.Buffer, len? : Int = -1) -> String {
+  let buffer_len = if len >= 0 { len / 2 } else { 1024 }
+  let buffer = String::make(buffer_len, '\u{0}')
+  let actual_len = decode_fill(os_str, len, buffer, buffer_len)
+  if actual_len <= buffer_len {
+    if actual_len == buffer_len {
+      buffer
+    } else {
+      buffer[:actual_len].to_owned()
+    }
+  } else {
+    let result = String::make(actual_len, '\u{0}')
+    if decode_fill(os_str, len, result, actual_len) == actual_len {
+      result
+    } else {
+      ""
+    }
+  }
+}
 
 ///|
 #cfg(platform="windows")

--- a/src/internal/os_string/stub.c
+++ b/src/internal/os_string/stub.c
@@ -19,9 +19,16 @@
 #include <moonbit.h>
 
 MOONBIT_FFI_EXPORT
-moonbit_string_t moonbitlang_async_c_buffer_as_string(wchar_t *str, int32_t len) {
+int32_t moonbitlang_async_c_buffer_fill_string(
+  wchar_t *str,
+  int32_t len,
+  moonbit_string_t out,
+  int32_t out_len
+) {
   size_t bytes = len == -1 ? wcslen(str) * sizeof(wchar_t) : len;
-  moonbit_string_t result = moonbit_make_string(bytes / 2, 0);
-  memcpy(result, str, bytes);
-  return result;
+  int32_t actual_len = bytes / 2;
+  if (actual_len <= out_len) {
+    memcpy(out, str, bytes);
+  }
+  return actual_len;
 }

--- a/src/process/stub.c
+++ b/src/process/stub.c
@@ -24,22 +24,23 @@
 
 extern char **environ;
 
-moonbit_bytes_t *moonbitlang_async_get_curr_env() {
+int32_t moonbitlang_async_curr_env_count() {
   int len = 0;
   for (char **cursor = environ; *cursor; ++cursor)
     ++len;
+  return len;
+}
 
-  moonbit_bytes_t *result = (moonbit_bytes_t*)moonbit_make_ref_array(len + 1, 0);
-  for (int i = 0; i < len; ++i) {
-    char *entry = environ[i];
-    int len = strlen(entry) + 1;
-    moonbit_bytes_t bytes = moonbit_make_bytes(len, 0);
-    memcpy(bytes, entry, len);
-    result[i] = bytes;
+int32_t moonbitlang_async_curr_env_fill_entry(
+  int32_t index,
+  moonbit_bytes_t out,
+  int32_t out_len
+) {
+  int32_t len = strlen(environ[index]) + 1;
+  if (len <= out_len) {
+    memcpy(out, environ[index], len);
   }
-  result[len] = 0;
-
-  return result;
+  return len;
 }
 
 void moonbitlang_async_terminate_process(pid_t pid, int signal) {

--- a/src/process/test_programs/dump_env/main.mbt
+++ b/src/process/test_programs/dump_env/main.mbt
@@ -17,13 +17,41 @@
 extern "C" fn init_env() = "init_env"
 
 ///|
+extern "C" fn free_env() = "free_env"
+
+///|
 #cfg(platform="windows")
-extern "C" fn next_entry() -> String = "next_entry"
+#borrow(out)
+extern "C" fn next_entry_fill(
+  out : String,
+  out_len : Int,
+) -> Int = "next_entry_fill"
+
+///|
+#cfg(platform="windows")
+fn next_entry() -> String {
+  let buffer_len = 32768
+  let buffer = String::make(buffer_len, '\u{0}')
+  let actual_len = next_entry_fill(buffer, buffer_len)
+  if 0 < actual_len && actual_len <= buffer_len {
+    buffer[:actual_len].to_owned()
+  } else if actual_len > buffer_len {
+    let result = String::make(actual_len, '\u{0}')
+    if next_entry_fill(result, actual_len) == actual_len {
+      result
+    } else {
+      ""
+    }
+  } else {
+    ""
+  }
+}
 
 ///|
 #cfg(platform="windows")
 fn main {
   init_env()
+  defer free_env()
   while next_entry() is entry && entry.length() > 0 {
     println(entry)
   }
@@ -31,12 +59,37 @@ fn main {
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn next_entry() -> Bytes = "next_entry"
+#borrow(out)
+extern "C" fn next_entry_fill(
+  out : Bytes,
+  out_len : Int,
+) -> Int = "next_entry_fill"
+
+///|
+#cfg(not(platform="windows"))
+fn next_entry() -> Bytes {
+  let buffer_len = 32768
+  let buffer = Bytes::make(buffer_len, 0)
+  let actual_len = next_entry_fill(buffer, buffer_len)
+  if 0 < actual_len && actual_len <= buffer_len {
+    buffer[:actual_len].to_owned()
+  } else if actual_len > buffer_len {
+    let result = Bytes::make(actual_len, 0)
+    if next_entry_fill(result, actual_len) == actual_len {
+      result
+    } else {
+      b""
+    }
+  } else {
+    b""
+  }
+}
 
 ///|
 #cfg(not(platform="windows"))
 fn main {
   init_env()
+  defer free_env()
   while next_entry() is entry && entry.length() > 0 {
     println(@utf8.decode_lossy(entry))
   }

--- a/src/process/test_programs/dump_env/stub.c
+++ b/src/process/test_programs/dump_env/stub.c
@@ -20,26 +20,39 @@
 
 #include <windows.h>
 
+LPWCH env_block = NULL;
 LPWCH env_ptr = NULL;
 
 MOONBIT_FFI_EXPORT
 void init_env() {
-  env_ptr = GetEnvironmentStringsW();
+  if (env_block)
+    FreeEnvironmentStringsW(env_block);
+  env_block = GetEnvironmentStringsW();
+  env_ptr = env_block;
 }
 
 MOONBIT_FFI_EXPORT
-moonbit_string_t next_entry(){
+void free_env() {
+  if (env_block)
+    FreeEnvironmentStringsW(env_block);
+  env_block = NULL;
+  env_ptr = NULL;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t next_entry_fill(moonbit_string_t out, int32_t out_len) {
   if (!env_ptr)
-    return moonbit_make_string_raw(0);
+    return 0;
 
   int len = wcslen(env_ptr);
   if (len == 0)
-    return moonbit_make_string_raw(0);
+    return 0;
 
-  moonbit_string_t result = moonbit_make_string_raw(len);
-  memcpy(result, env_ptr, len * sizeof(WCHAR));
-  env_ptr += len + 1;
-  return result;
+  if (len <= out_len) {
+    memcpy(out, env_ptr, len * sizeof(WCHAR));
+    env_ptr += len + 1;
+  }
+  return len;
 }
 
 #else
@@ -49,19 +62,28 @@ moonbit_string_t next_entry(){
 extern char **environ;
 char **cursor = 0;
 
+MOONBIT_FFI_EXPORT
 void init_env() {
   cursor = environ;
 }
 
-moonbit_bytes_t next_entry() {
+MOONBIT_FFI_EXPORT
+void free_env() {}
+
+MOONBIT_FFI_EXPORT
+int32_t next_entry_fill(moonbit_bytes_t out, int32_t out_len) {
   if (cursor == 0 || *cursor == 0)
-    return moonbit_make_bytes_raw(0);
+    return 0;
 
   int len = strlen(*cursor);
-  moonbit_bytes_t result = moonbit_make_bytes_raw(len);
-  memcpy(result, *cursor, len);
-  cursor += 1;
-  return result;
+  if (len == 0)
+    return 0;
+
+  if (len <= out_len) {
+    memcpy(out, *cursor, len);
+    cursor += 1;
+  }
+  return len;
 }
 
 #endif

--- a/src/process/unix.mbt
+++ b/src/process/unix.mbt
@@ -14,7 +14,37 @@
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn get_curr_env() -> FixedArray[@os_string.OsString?] = "moonbitlang_async_get_curr_env"
+extern "C" fn curr_env_count() -> Int = "moonbitlang_async_curr_env_count"
+
+///|
+#cfg(not(platform="windows"))
+#borrow(out)
+extern "C" fn curr_env_fill_entry(
+  index : Int,
+  out : Bytes,
+  len : Int,
+) -> Int = "moonbitlang_async_curr_env_fill_entry"
+
+///|
+#cfg(not(platform="windows"))
+fn get_curr_env() -> FixedArray[@os_string.OsString?] {
+  let count = curr_env_count()
+  let result = FixedArray::make(count + 1, None)
+  let buffer_len = 32768
+  for i in 0..<count {
+    let buffer = Bytes::make(buffer_len, 0)
+    let len = curr_env_fill_entry(i, buffer, buffer_len)
+    let entry = if len <= buffer_len {
+      buffer[:len].to_owned()
+    } else {
+      let entry = Bytes::make(len, 0)
+      ignore(curr_env_fill_entry(i, entry, len))
+      entry
+    }
+    result[i] = Some(@os_string.OsString::from_bytes(entry))
+  }
+  result
+}
 
 ///|
 #cfg(not(platform="windows"))

--- a/src/process/windows.c
+++ b/src/process/windows.c
@@ -19,18 +19,21 @@
 #include <windows.h>
 #include <moonbit.h>
 
-moonbit_string_t moonbitlang_async_get_curr_env() {
+int32_t moonbitlang_async_curr_env_fill(moonbit_string_t out, int32_t out_len) {
   LPWCH env_block = GetEnvironmentStringsW();
   if (!env_block)
-    return moonbit_make_string(0, 0);
+    return 0;
 
-  int len = 1;
-  while (env_block[len - 1] != 0 || env_block[len] != 0) {
+  int len = 0;
+  while (env_block[len] != 0 || env_block[len + 1] != 0) {
     ++len;
   }
-  moonbit_string_t result = moonbit_make_string_raw(len);
-  memcpy(result, env_block, len * sizeof(WCHAR));
-  return result;
+  len += 2;
+  if (len <= out_len) {
+    memcpy(out, env_block, len * sizeof(WCHAR));
+  }
+  FreeEnvironmentStringsW(env_block);
+  return len;
 }
 
 void moonbitlang_async_terminate_process(DWORD pid, int signal) {

--- a/src/process/windows.mbt
+++ b/src/process/windows.mbt
@@ -14,7 +14,28 @@
 
 ///|
 #cfg(platform="windows")
-extern "C" fn get_curr_env() -> String = "moonbitlang_async_get_curr_env"
+#borrow(out)
+extern "C" fn curr_env_fill(out : String, len : Int) -> Int = "moonbitlang_async_curr_env_fill"
+
+///|
+#cfg(platform="windows")
+fn get_curr_env() -> String {
+  let buffer_len = 32768
+  let buffer = String::make(buffer_len, '\u{0}')
+  let actual_len = curr_env_fill(buffer, buffer_len)
+  if 0 < actual_len && actual_len <= buffer_len {
+    buffer[:actual_len].to_owned()
+  } else if actual_len > buffer_len {
+    let result = String::make(actual_len, '\u{0}')
+    if curr_env_fill(result, actual_len) == actual_len {
+      result
+    } else {
+      ""
+    }
+  } else {
+    ""
+  }
+}
 
 ///|
 #cfg(platform="windows")


### PR DESCRIPTION
Part of #408. Stacked on #413.

## Why

Several small C shims allocate returned `String`, `Bytes`, or arrays directly.
For Wasm1 reuse, MoonBit should own those visible allocations and C should only
fill caller-provided memory.

## What

- Move temporary path allocation and retry logic into MoonBit.
- Move Unix and Windows current-environment allocation into MoonBit.
- Move the dump-env helper to caller-provided output buffers.
- Move Windows OS-string decode output allocation into MoonBit.

## Why this is correct

Each shim now returns the actual required length. C copies into the
MoonBit-provided buffer only when it fits; otherwise MoonBit allocates the
reported size and retries. The Windows environment block keeps its full
double-null-terminated representation.

## Review scope

This PR is limited to simple synchronous fill-return shims and test helper
bindings. TLS and thread-pool jobs are split into later PRs.
