### PR TITLE
Move TLS returned bytes to MoonBit allocation

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -304,26 +304,36 @@ void moonbitlang_async_tls_ssl_free(SSL *ssl) {
   SSL_free(ssl);
 }
 
-moonbit_bytes_t moonbitlang_async_tls_ssl_get_peer_certificate(SSL *ssl) {
+int32_t moonbitlang_async_tls_ssl_get_peer_certificate(
+  SSL *ssl,
+  moonbit_bytes_t out,
+  int32_t len
+) {
   X509 *cert = SSL_get1_peer_certificate(ssl);
   if (!cert) return 0;
 
-  int len = i2d_X509_AUX(cert, 0);
-  if (len < 0) goto handle_error;
+  int expected_len = i2d_X509_AUX(cert, 0);
+  if (expected_len < 0) {
+    X509_free(cert);
+    return -1;
+  }
+  if (len < expected_len) {
+    X509_free(cert);
+    return expected_len;
+  }
 
-  moonbit_bytes_t result = moonbit_make_bytes_raw(len);
-  unsigned char *buf = result;
-  i2d_X509_AUX(cert, &buf);
+  unsigned char *buf = out;
+  int written = i2d_X509_AUX(cert, &buf);
   X509_free(cert);
-  return result;
-
-handle_error:
-  X509_free(cert);
-  return 0;
+  return written;
 }
 
 static
-moonbit_bytes_t hash_server_endpoint_certificate(X509 *cert) {
+int32_t hash_server_endpoint_certificate(
+  X509 *cert,
+  moonbit_bytes_t out,
+  int32_t len
+) {
   int signature_nid = X509_get_signature_nid(cert);
   int digest_nid = 0;
   int public_key_nid = 0;
@@ -333,11 +343,11 @@ moonbit_bytes_t hash_server_endpoint_certificate(X509 *cert) {
   unsigned char digest_buf[MAX_DIGEST_LEN];
 
   if (!OBJ_find_sigid_algs(signature_nid, &digest_nid, &public_key_nid))
-    return 0;
+    return -1;
 
   digest_name = OBJ_nid2sn(digest_nid);
   if (!digest_name)
-    return 0;
+    return -1;
 
   if (strcmp(digest_name, "MD5") == 0 || strcmp(digest_name, "SHA1") == 0) {
     digest = EVP_sha256();
@@ -346,45 +356,54 @@ moonbit_bytes_t hash_server_endpoint_certificate(X509 *cert) {
   }
 
   if (!digest)
-    return 0;
+    return -1;
 
   if (!X509_digest(cert, digest, digest_buf, &digest_len))
-    return 0;
+    return -1;
 
-  moonbit_bytes_t result = moonbit_make_bytes_raw(digest_len);
-  memcpy(result, digest_buf, digest_len);
-  return result;
+  if (!out) return digest_len;
+  if (len < digest_len) return digest_len;
+  memcpy(out, digest_buf, digest_len);
+  return digest_len;
 }
 
-moonbit_bytes_t moonbitlang_async_tls_ssl_unique_channel_binding(SSL *ssl, int32_t is_client) {
+int32_t moonbitlang_async_tls_ssl_unique_channel_binding(
+  SSL *ssl,
+  int32_t is_client,
+  moonbit_bytes_t out,
+  int32_t out_len
+) {
   size_t len = is_client ?
     SSL_get_finished(ssl, 0, 0) :
     SSL_get_peer_finished(ssl, 0, 0);
   if (len == 0)
     return 0;
-
-  moonbit_bytes_t result = moonbit_make_bytes_raw(len);
+  if (out_len < len)
+    return len;
   size_t copied = is_client ?
-    SSL_get_finished(ssl, result, len) :
-    SSL_get_peer_finished(ssl, result, len);
-  if (copied != len)
-    return 0;
-  return result;
+    SSL_get_finished(ssl, out, out_len) :
+    SSL_get_peer_finished(ssl, out, out_len);
+  return copied;
 }
 
-moonbit_bytes_t moonbitlang_async_tls_ssl_server_endpoint_channel_binding(SSL *ssl, int32_t is_client) {
+int32_t moonbitlang_async_tls_ssl_server_endpoint_channel_binding(
+  SSL *ssl,
+  int32_t is_client,
+  moonbit_bytes_t out,
+  int32_t len
+) {
   if (is_client) {
     X509 *cert = SSL_get1_peer_certificate(ssl);
     if (!cert)
       return 0;
-    moonbit_bytes_t result = hash_server_endpoint_certificate(cert);
+    int32_t result = hash_server_endpoint_certificate(cert, out, len);
     X509_free(cert);
     return result;
   } else {
     X509 *cert = SSL_get_certificate(ssl);
     if (!cert)
       return 0;
-    return hash_server_endpoint_certificate(cert);
+    return hash_server_endpoint_certificate(cert, out, len);
   }
 }
 

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -98,21 +98,103 @@ extern "C" fn SSL::accept(self : SSL) -> Int = "moonbitlang_async_tls_ssl_accept
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn SSL::get_peer_certificate(self : SSL) -> Bytes? = "moonbitlang_async_tls_ssl_get_peer_certificate"
+#borrow(out)
+extern "C" fn SSL::get_peer_certificate_fill(
+  self : SSL,
+  out : Bytes,
+  len : Int,
+) -> Int = "moonbitlang_async_tls_ssl_get_peer_certificate"
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn SSL::unique_channel_binding(
-  self : SSL,
-  is_client~ : Bool,
-) -> Bytes? = "moonbitlang_async_tls_ssl_unique_channel_binding"
+fn SSL::get_peer_certificate(self : SSL) -> Bytes? {
+  let buffer_len = 16384
+  let buffer = Bytes::make(buffer_len, 0)
+  let actual_len = self.get_peer_certificate_fill(buffer, buffer_len)
+  if 0 < actual_len && actual_len <= buffer_len {
+    Some(buffer[:actual_len].to_owned())
+  } else if actual_len > buffer_len {
+    let result = Bytes::make(actual_len, 0)
+    if self.get_peer_certificate_fill(result, actual_len) == actual_len {
+      Some(result)
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn SSL::server_endpoint_channel_binding(
+#borrow(out)
+extern "C" fn SSL::unique_channel_binding_fill(
   self : SSL,
   is_client~ : Bool,
-) -> Bytes? = "moonbitlang_async_tls_ssl_server_endpoint_channel_binding"
+  out : Bytes,
+  len : Int,
+) -> Int = "moonbitlang_async_tls_ssl_unique_channel_binding"
+
+///|
+#cfg(not(platform="windows"))
+fn SSL::unique_channel_binding(self : SSL, is_client~ : Bool) -> Bytes? {
+  let buffer_len = 1024
+  let buffer = Bytes::make(buffer_len, 0)
+  let actual_len = self.unique_channel_binding_fill(
+    is_client~,
+    buffer,
+    buffer_len,
+  )
+  if 0 < actual_len && actual_len <= buffer_len {
+    Some(buffer[:actual_len].to_owned())
+  } else if actual_len > buffer_len {
+    let result = Bytes::make(actual_len, 0)
+    if self.unique_channel_binding_fill(is_client~, result, actual_len) == actual_len {
+      Some(result)
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+#borrow(out)
+extern "C" fn SSL::server_endpoint_channel_binding_fill(
+  self : SSL,
+  is_client~ : Bool,
+  out : Bytes,
+  len : Int,
+) -> Int = "moonbitlang_async_tls_ssl_server_endpoint_channel_binding"
+
+///|
+#cfg(not(platform="windows"))
+fn SSL::server_endpoint_channel_binding(
+  self : SSL,
+  is_client~ : Bool,
+) -> Bytes? {
+  let buffer_len = 64
+  let buffer = Bytes::make(buffer_len, 0)
+  let actual_len = self.server_endpoint_channel_binding_fill(
+    is_client~,
+    buffer,
+    buffer_len,
+  )
+  if 0 < actual_len && actual_len <= buffer_len {
+    Some(buffer[:actual_len].to_owned())
+  } else if actual_len > buffer_len {
+    let result = Bytes::make(actual_len, 0)
+    if self.server_endpoint_channel_binding_fill(is_client~, result, actual_len) == actual_len {
+      Some(result)
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
 
 ///|
 pub(all) enum X509FileType {

--- a/src/tls/schannel.c
+++ b/src/tls/schannel.c
@@ -570,12 +570,17 @@ int32_t moonbitlang_async_schannel_shutdown(struct Context *ctx) {
 }
 
 static
-moonbit_bytes_t get_channel_binding(struct Context *ctx, int attribute) {
+int32_t fill_channel_binding(
+  struct Context *ctx,
+  int attribute,
+  moonbit_bytes_t out,
+  int32_t out_len
+) {
   SecPkgContext_Bindings bindings;
   int32_t err = QueryContextAttributes(&ctx->context, attribute, &bindings);
   if (err != SEC_E_OK) {
     SetLastError(err);
-    return 0;
+    return -1;
   }
 
   if (!bindings.Bindings) {
@@ -591,26 +596,34 @@ moonbit_bytes_t get_channel_binding(struct Context *ctx, int attribute) {
   ) {
     SetLastError(ERROR_INVALID_DATA);
     FreeContextBuffer(bindings.Bindings);
-    return 0;
+    return -1;
   }
 
-  moonbit_bytes_t result = moonbit_make_bytes_raw(data_len);
+  if (data_len > out_len) {
+    FreeContextBuffer(bindings.Bindings);
+    return data_len;
+  }
+
   memcpy(
-    result,
+    out,
     ((unsigned char *)bindings.Bindings) + data_offset,
     data_len
   );
   FreeContextBuffer(bindings.Bindings);
-  return result;
+  return data_len;
 }
 
 MOONBIT_FFI_EXPORT
-moonbit_bytes_t moonbitlang_async_schannel_get_peer_certificate(struct Context *ctx) {
+int32_t moonbitlang_async_schannel_get_peer_certificate(
+  struct Context *ctx,
+  moonbit_bytes_t out,
+  int32_t out_len
+) {
   CERT_CONTEXT *cert = 0;
   int err = QueryContextAttributes(&ctx->context, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &cert);
   if (err != SEC_E_OK && err != SEC_E_NO_CREDENTIALS) {
     SetLastError(err);
-    return 0;
+    return -1;
   }
 
   if (!cert) {
@@ -618,20 +631,30 @@ moonbit_bytes_t moonbitlang_async_schannel_get_peer_certificate(struct Context *
     return 0;
   }
 
-  moonbit_bytes_t result = moonbit_make_bytes_raw(cert->cbCertEncoded);
-  memcpy(result, cert->pbCertEncoded, cert->cbCertEncoded);
+  int32_t len = cert->cbCertEncoded;
+  if (len <= out_len) {
+    memcpy(out, cert->pbCertEncoded, len);
+  }
   CertFreeCertificateContext(cert);
-  return result;
+  return len;
 }
 
 MOONBIT_FFI_EXPORT
-moonbit_bytes_t moonbitlang_async_schannel_unique_channel_binding(struct Context *ctx) {
-  return get_channel_binding(ctx, SECPKG_ATTR_UNIQUE_BINDINGS);
+int32_t moonbitlang_async_schannel_unique_channel_binding(
+  struct Context *ctx,
+  moonbit_bytes_t out,
+  int32_t out_len
+) {
+  return fill_channel_binding(ctx, SECPKG_ATTR_UNIQUE_BINDINGS, out, out_len);
 }
 
 MOONBIT_FFI_EXPORT
-moonbit_bytes_t moonbitlang_async_schannel_server_endpoint_channel_binding(struct Context *ctx) {
-  return get_channel_binding(ctx, SECPKG_ATTR_ENDPOINT_BINDINGS);
+int32_t moonbitlang_async_schannel_server_endpoint_channel_binding(
+  struct Context *ctx,
+  moonbit_bytes_t out,
+  int32_t out_len
+) {
+  return fill_channel_binding(ctx, SECPKG_ATTR_ENDPOINT_BINDINGS, out, out_len);
 }
 
 MOONBIT_FFI_EXPORT

--- a/src/tls/schannel.mbt
+++ b/src/tls/schannel.mbt
@@ -457,20 +457,90 @@ pub async fn Tls::shutdown(self : Tls) -> Unit {
 
 ///|
 #cfg(platform="windows")
-#borrow(ch)
-extern "C" fn Schannel::get_peer_certificate(ch : Schannel) -> Bytes? = "moonbitlang_async_schannel_get_peer_certificate"
-
-///|
-#cfg(platform="windows")
-#borrow(ch)
-extern "C" fn Schannel::unique_channel_binding(ch : Schannel) -> Bytes? = "moonbitlang_async_schannel_unique_channel_binding"
-
-///|
-#cfg(platform="windows")
-#borrow(ch)
-extern "C" fn Schannel::server_endpoint_channel_binding(
+#borrow(ch, out)
+extern "C" fn Schannel::get_peer_certificate_fill(
   ch : Schannel,
-) -> Bytes? = "moonbitlang_async_schannel_server_endpoint_channel_binding"
+  out : Bytes,
+  len : Int,
+) -> Int = "moonbitlang_async_schannel_get_peer_certificate"
+
+///|
+#cfg(platform="windows")
+fn Schannel::get_peer_certificate(ch : Schannel) -> Bytes? {
+  let buffer_len = 16384
+  let buffer = Bytes::make(buffer_len, 0)
+  let actual_len = ch.get_peer_certificate_fill(buffer, buffer_len)
+  if 0 < actual_len && actual_len <= buffer_len {
+    Some(buffer[:actual_len].to_owned())
+  } else if actual_len > buffer_len {
+    let result = Bytes::make(actual_len, 0)
+    if ch.get_peer_certificate_fill(result, actual_len) == actual_len {
+      Some(result)
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
+
+///|
+#cfg(platform="windows")
+#borrow(ch, out)
+extern "C" fn Schannel::unique_channel_binding_fill(
+  ch : Schannel,
+  out : Bytes,
+  len : Int,
+) -> Int = "moonbitlang_async_schannel_unique_channel_binding"
+
+///|
+#cfg(platform="windows")
+fn Schannel::unique_channel_binding(ch : Schannel) -> Bytes? {
+  let buffer_len = 1024
+  let buffer = Bytes::make(buffer_len, 0)
+  let actual_len = ch.unique_channel_binding_fill(buffer, buffer_len)
+  if 0 < actual_len && actual_len <= buffer_len {
+    Some(buffer[:actual_len].to_owned())
+  } else if actual_len > buffer_len {
+    let result = Bytes::make(actual_len, 0)
+    if ch.unique_channel_binding_fill(result, actual_len) == actual_len {
+      Some(result)
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
+
+///|
+#cfg(platform="windows")
+#borrow(ch, out)
+extern "C" fn Schannel::server_endpoint_channel_binding_fill(
+  ch : Schannel,
+  out : Bytes,
+  len : Int,
+) -> Int = "moonbitlang_async_schannel_server_endpoint_channel_binding"
+
+///|
+#cfg(platform="windows")
+fn Schannel::server_endpoint_channel_binding(ch : Schannel) -> Bytes? {
+  let buffer_len = 1024
+  let buffer = Bytes::make(buffer_len, 0)
+  let actual_len = ch.server_endpoint_channel_binding_fill(buffer, buffer_len)
+  if 0 < actual_len && actual_len <= buffer_len {
+    Some(buffer[:actual_len].to_owned())
+  } else if actual_len > buffer_len {
+    let result = Bytes::make(actual_len, 0)
+    if ch.server_endpoint_channel_binding_fill(result, actual_len) == actual_len {
+      Some(result)
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
 
 ///|
 #cfg(platform="windows")


### PR DESCRIPTION
Part of #408. Stacked on #410.

## Why

OpenSSL and Schannel certificate/channel-binding helpers returned `Bytes`
allocated by C. Wasm1 needs MoonBit to own visible buffers.

## What

- Change OpenSSL peer certificate and channel binding helpers to fill
  MoonBit-provided buffers and return actual lengths.
- Change Schannel peer certificate and channel binding helpers to the same
  pattern.
- Keep absent/error behavior mapped through the existing `Bytes?` wrappers.

## Why this is correct

TLS outputs are either absent, error, or byte sequences with known actual length
after querying the native API. The MoonBit wrappers use scratch buffers and
retry with exact buffers when required; C only copies into caller-provided
memory.

## Review scope

This PR is limited to TLS returned-byte allocation. Thread-pool job storage
remains in the next PR.
