### PR TITLE
Move thread-pool job storage to MoonBit allocation

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -46,6 +46,7 @@ priv struct EventLoop {
   job_queue : @deque.Deque[QueuedJob]
   idle_workers : @deque.Deque[Worker]
   running_workers : Map[Int, Worker]
+  running_jobs : Map[Int, Job]
   completed_jobs_buffer : FixedArray[Int]
   jobs : Map[Int, @coroutine.Coroutine]
   timers : @sorted_set.SortedSet[Timer]
@@ -63,6 +64,7 @@ priv struct EventLoop {
   job_queue : @deque.Deque[QueuedJob]
   idle_workers : @deque.Deque[Worker]
   running_workers : Map[Int, Worker]
+  running_jobs : Map[Int, Job]
   jobs : Map[Int, @coroutine.Coroutine]
   timers : @sorted_set.SortedSet[Timer]
   mut main : @coroutine.Coroutine?
@@ -123,6 +125,7 @@ fn EventLoop::new() -> EventLoop raise {
     job_queue: @deque.Deque([]),
     idle_workers: @deque.Deque([]),
     running_workers: {},
+    running_jobs: {},
     completed_jobs_buffer: FixedArray::make(1024, 0),
     jobs: {},
     timers: @sorted_set.SortedSet([]),
@@ -147,6 +150,7 @@ fn EventLoop::new() -> EventLoop raise {
     job_queue: @deque.Deque([]),
     idle_workers: @deque.Deque([]),
     running_workers: {},
+    running_jobs: {},
     jobs: {},
     timers: @sorted_set.SortedSet([]),
     main: None,
@@ -244,18 +248,35 @@ fn EventLoop::handle_completed_job(self : Self, job_id : Int) -> Unit {
     self.killed_by_signal = Some(job_id ^ (1 << 31))
   }
   guard self.running_workers.get(job_id) is Some(worker)
+  let waiter = self.jobs.get(job_id)
+  if waiter is None {
+    if self.running_jobs.get(job_id) is Some(job) {
+      job.cleanup()
+    }
+  }
   self.running_workers.remove(job_id)
-  match self.job_queue.pop_front() {
+  self.running_jobs.remove(job_id)
+  let next_job = while self.job_queue.pop_front() is Some(job) {
+    if self.jobs.get(job.job_id) is Some(_) {
+      break Some(job)
+    } else {
+      job.job.cleanup()
+    }
+  } nobreak {
+    None
+  }
+  match next_job {
     None => {
       worker.enter_idle()
       self.idle_workers.push_back(worker)
     }
     Some(job) => {
       self.running_workers[job.job_id] = worker
+      self.running_jobs[job.job_id] = job.job
       worker.wake(job.job_id, job.job)
     }
   }
-  if self.jobs.get(job_id) is Some(coro) {
+  if waiter is Some(coro) {
     coro.wake()
   }
 }
@@ -503,15 +524,18 @@ async fn perform_job_in_worker(
     None if evloop.running_workers.length() >= evloop.max_worker_count =>
       evloop.job_queue.push_back({ job_id, job })
     None => {
+      evloop.running_jobs[job_id] = job
       let worker = Worker::spawn(job_id, job)
       evloop.running_workers[job_id] = worker
     }
     Some(worker) => {
       evloop.running_workers[job_id] = worker
+      evloop.running_jobs[job_id] = job
       worker.wake(job_id, job)
     }
   }
   evloop.wait_for_job(job_id, cancel?)
+  job.keepalive()
   if job.err() is err && err > 0 {
     if errno_is_cancelled(err) {
       raise @coroutine.Cancelled

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -127,6 +127,9 @@ struct job {
   // it will receive the job itself as parameter.
   // extra payload can be placed after the header fields in `struct job`
   void (*worker)(struct job*);
+
+  // Optional cleanup for native resources owned by the job payload.
+  void (*cleanup)(struct job*);
 };
 
 MOONBIT_FFI_EXPORT
@@ -137,6 +140,15 @@ int64_t moonbitlang_async_job_get_ret(struct job *job) {
 MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_job_get_err(struct job *job) {
   return job->err;
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_job_cleanup(struct job *job) {
+  if (job->cleanup) {
+    void (*cleanup)(struct job*) = job->cleanup;
+    job->cleanup = 0;
+    cleanup(job);
+  }
 }
 
 // =======================================================
@@ -261,9 +273,6 @@ void moonbitlang_async_wake_worker(
   int32_t job_id,
   struct job *job
 ) {
-  if (worker->job)
-    moonbit_decref(worker->job);
-
   worker->job_id = job_id;
   worker->job = job;
 
@@ -283,9 +292,6 @@ void moonbitlang_async_wake_worker(
 
 MOONBIT_FFI_EXPORT
 void moonbitlang_async_worker_enter_idle(struct worker *worker) {
-  if (worker->job)
-    moonbit_decref(worker->job);
-
   worker->job = 0;
 }
 
@@ -453,23 +459,19 @@ int32_t moonbitlang_async_errno_is_cancelled(int32_t err) {
 
 static
 struct job *make_job(
-  int32_t size,
-  void (*free_job)(void*),
+  void *storage,
   void (*worker)(struct job*)
 ) {
-  struct job *job = (struct job*)moonbit_make_external_object(
-    free_job,
-    size
-  );
+  struct job *job = (struct job*)storage;
   job->ret = 0;
   job->err = 0;
   job->worker = worker;
+  job->cleanup = 0;
   return job;
 }
 
-#define MAKE_JOB(name) (struct name##_job*)make_job(\
-  sizeof(struct name##_job),\
-  free_##name##_job,\
+#define MAKE_JOB(storage, name) (struct name##_job*)make_job(\
+  storage,\
   name##_job_worker\
 )
 
@@ -509,10 +511,9 @@ void sleep_job_worker(struct job *job) {
 }
 
 MOONBIT_FFI_EXPORT
-struct sleep_job *moonbitlang_async_make_sleep_job(int ms) {
-  struct sleep_job *job = MAKE_JOB(sleep);
+void moonbitlang_async_make_sleep_job(void *storage, int ms) {
+  struct sleep_job *job = MAKE_JOB(storage, sleep);
   job->duration = ms;
-  return job;
 }
 
 // ===== read job, for reading non-pollable stuff =====
@@ -576,20 +577,20 @@ void read_job_worker(struct job *job) {
 #endif
 }
 
-struct read_job *moonbitlang_async_make_read_job(
+void moonbitlang_async_make_read_job(
+  void *storage,
   HANDLE fd,
   char *buf,
   int offset,
   int len,
   int64_t position
 ) {
-  struct read_job *job = MAKE_JOB(read);
+  struct read_job *job = MAKE_JOB(storage, read);
   job->fd = fd;
   job->buf = buf;
   job->offset = offset;
   job->len = len;
   job->position = position;
-  return job;
 }
 
 // ===== write job, for writing non-pollable stuff =====
@@ -657,20 +658,20 @@ void write_job_worker(struct job *job) {
 #endif
 }
 
-struct write_job *moonbitlang_async_make_write_job(
+void moonbitlang_async_make_write_job(
+  void *storage,
   HANDLE fd,
   char *buf,
   int offset,
   int len,
   int64_t position
 ) {
-  struct write_job *job = MAKE_JOB(write);
+  struct write_job *job = MAKE_JOB(storage, write);
   job->fd = fd;
   job->buf = buf;
   job->offset = offset;
   job->len = len;
   job->position = position;
-  return job;
 }
 
 // ===== open job =====
@@ -786,7 +787,8 @@ void open_job_worker(struct job *job) {
 }
 
 MOONBIT_FFI_EXPORT
-struct open_job *moonbitlang_async_make_open_job(
+void moonbitlang_async_make_open_job(
+  void *storage,
   char *filename,
   int access,
   int create_mode,
@@ -795,14 +797,13 @@ struct open_job *moonbitlang_async_make_open_job(
   int mode
 ) {
 
-  struct open_job *job = MAKE_JOB(open);
+  struct open_job *job = MAKE_JOB(storage, open);
   job->filename = filename;
   job->access = access;
   job->create_mode = create_mode;
   job->append = append;
   job->sync = sync;
   job->mode = mode;
-  return job;
 }
 
 MOONBIT_FFI_EXPORT
@@ -836,10 +837,9 @@ void kind_of_fd_job_worker(struct job *job) {
     job->err = GetLastError();
 }
 
-struct kind_of_fd_job *moonbitlang_async_make_kind_of_fd_job(HANDLE fd) {
-  struct kind_of_fd_job *job = MAKE_JOB(kind_of_fd);
+void moonbitlang_async_make_kind_of_fd_job(void *storage, HANDLE fd) {
+  struct kind_of_fd_job *job = MAKE_JOB(storage, kind_of_fd);
   job->fd = fd;
-  return job;
 }
 
 // ===== file kind by path job, get kind of path on file system =====
@@ -904,16 +904,16 @@ void file_kind_by_path_job_worker(struct job *job) {
 #endif
 }
 
-struct file_kind_by_path_job *moonbitlang_async_make_file_kind_by_path_job(
+void moonbitlang_async_make_file_kind_by_path_job(
+  void *storage,
   HANDLE parent,
   char *path,
   int follow_symlink
 ) {
-  struct file_kind_by_path_job *job = MAKE_JOB(file_kind_by_path);
+  struct file_kind_by_path_job *job = MAKE_JOB(storage, file_kind_by_path);
   job->parent = parent;
   job->path = path;
   job->follow_symlink = follow_symlink;
-  return job;
 }
 
 // ===== file size job, get size of opened file =====
@@ -948,10 +948,9 @@ void file_size_job_worker(struct job *job) {
 #endif
 }
 
-struct file_size_job *moonbitlang_async_make_file_size_job(HANDLE fd) {
-  struct file_size_job *job = MAKE_JOB(file_size);
+void moonbitlang_async_make_file_size_job(void *storage, HANDLE fd) {
+  struct file_size_job *job = MAKE_JOB(storage, file_size);
   job->fd = fd;
-  return job;
 }
 
 int64_t moonbitlang_async_get_file_size_result(struct file_size_job *job) {
@@ -993,11 +992,14 @@ void file_time_job_worker(struct job *job) {
 #endif
 }
 
-struct file_time_job *moonbitlang_async_make_file_time_job(HANDLE fd, void *out) {
-  struct file_time_job *job = MAKE_JOB(file_time);
+void moonbitlang_async_make_file_time_job(
+  void *storage,
+  HANDLE fd,
+  void *out
+) {
+  struct file_time_job *job = MAKE_JOB(storage, file_time);
   job->fd = fd;
   job->out = out;
-  return job;
 }
 
 // ===== file time by path job, get timestamp of path on file system =====
@@ -1064,16 +1066,16 @@ void file_time_by_path_job_worker(struct job *job) {
 #endif
 }
 
-struct file_time_by_path_job *moonbitlang_async_make_file_time_by_path_job(
+void moonbitlang_async_make_file_time_by_path_job(
+  void *storage,
   char *path,
   void *out,
   int follow_symlink
 ) {
-  struct file_time_by_path_job *job = MAKE_JOB(file_time_by_path);
+  struct file_time_by_path_job *job = MAKE_JOB(storage, file_time_by_path);
   job->path = path;
   job->out = out;
   job->follow_symlink = follow_symlink;
-  return job;
 }
 
 #ifndef _WIN32
@@ -1099,11 +1101,10 @@ void chmod_job_worker(struct job *job) {
     job->err = errno;
 }
 
-struct chmod_job *moonbitlang_async_make_chmod_job(char *path, int mode) {
-  struct chmod_job *job = MAKE_JOB(chmod);
+void moonbitlang_async_make_chmod_job(void *storage, char *path, int mode) {
+  struct chmod_job *job = MAKE_JOB(storage, chmod);
   job->path = path;
   job->mode = mode;
-  return job;
 }
 
  
@@ -1139,11 +1140,14 @@ void fsync_job_worker(struct job *job) {
     job->err = errno;
 }
 
-struct fsync_job *moonbitlang_async_make_fsync_job(HANDLE fd, int only_data) {
-  struct fsync_job *job = MAKE_JOB(fsync);
+void moonbitlang_async_make_fsync_job(
+  void *storage,
+  HANDLE fd,
+  int only_data
+) {
+  struct fsync_job *job = MAKE_JOB(storage, fsync);
   job->fd = fd;
   job->only_data = only_data;
-  return job;
 }
 
 // ===== flock job, place advisory lock on a file =====
@@ -1195,11 +1199,14 @@ void flock_job_worker(struct job *job) {
 #endif
 }
 
-struct flock_job *moonbitlang_async_make_flock_job(HANDLE fd, int exclusive) {
-  struct flock_job *job = MAKE_JOB(flock);
+void moonbitlang_async_make_flock_job(
+  void *storage,
+  HANDLE fd,
+  int exclusive
+) {
+  struct flock_job *job = MAKE_JOB(storage, flock);
   job->fd = fd;
   job->exclusive = exclusive;
-  return job;
 }
 
 // ===== remove job, remove file from file system =====
@@ -1228,10 +1235,9 @@ void remove_job_worker(struct job *job) {
 #endif
 }
 
-struct remove_job *moonbitlang_async_make_remove_job(char *path) {
-  struct remove_job *job = MAKE_JOB(remove);
+void moonbitlang_async_make_remove_job(void *storage, char *path) {
+  struct remove_job *job = MAKE_JOB(storage, remove);
   job->path = path;
-  return job;
 }
 
 // ===== access job, test permission of file path =====
@@ -1281,11 +1287,14 @@ void access_job_worker(struct job *job) {
 #endif
 }
 
-struct access_job *moonbitlang_async_make_access_job(char *path, int amode) {
-  struct access_job *job = MAKE_JOB(access);
+void moonbitlang_async_make_access_job(
+  void *storage,
+  char *path,
+  int amode
+) {
+  struct access_job *job = MAKE_JOB(storage, access);
   job->path = path;
   job->amode = amode;
-  return job;
 }
 
 // ===== rename job, rename file =====
@@ -1386,16 +1395,16 @@ void rename_job_worker(struct job *job) {
 #endif
 }
 
-struct rename_job *moonbitlang_async_make_rename_job(
+void moonbitlang_async_make_rename_job(
+  void *storage,
   char *old_path,
   char *new_path,
   int32_t replace
 ) {
-  struct rename_job *job = MAKE_JOB(rename);
+  struct rename_job *job = MAKE_JOB(storage, rename);
   job->old_path = old_path;
   job->new_path = new_path;
   job->replace = replace;
-  return job;
 }
 
 // ===== symlink job, create symbolic link =====
@@ -1446,11 +1455,14 @@ void symlink_job_worker(struct job *job) {
 #endif
 }
 
-struct symlink_job *moonbitlang_async_make_symlink_job(char *target, char *path) {
-  struct symlink_job *job = MAKE_JOB(symlink);
+void moonbitlang_async_make_symlink_job(
+  void *storage,
+  char *target,
+  char *path
+) {
+  struct symlink_job *job = MAKE_JOB(storage, symlink);
   job->target = target;
   job->path = path;
-  return job;
 }
 
 // ===== mkdir job, create new directory =====
@@ -1484,11 +1496,10 @@ void mkdir_job_worker(struct job *job) {
 #endif
 }
 
-struct mkdir_job *moonbitlang_async_make_mkdir_job(char *path, int mode) {
-  struct mkdir_job *job = MAKE_JOB(mkdir);
+void moonbitlang_async_make_mkdir_job(void *storage, char *path, int mode) {
+  struct mkdir_job *job = MAKE_JOB(storage, mkdir);
   job->path = path;
   job->mode = mode;
-  return job;
 }
 
 // ===== rmdir job, remove directory =====
@@ -1522,10 +1533,9 @@ void rmdir_job_worker(struct job *job) {
 #endif
 }
 
-struct rmdir_job *moonbitlang_async_make_rmdir_job(char *path) {
-  struct rmdir_job *job = MAKE_JOB(rmdir);
+void moonbitlang_async_make_rmdir_job(void *storage, char *path) {
+  struct rmdir_job *job = MAKE_JOB(storage, rmdir);
   job->path = path;
-  return job;
 }
 
 // ===== readdir job, read directory entry =====
@@ -1594,12 +1604,16 @@ void readdir_job_worker(struct job *job) {
 #endif
 }
 
-struct readdir_job *moonbitlang_async_make_readdir_job(HANDLE dir, void *out, int32_t len) {
-  struct readdir_job *job = MAKE_JOB(readdir);
+void moonbitlang_async_make_readdir_job(
+  void *storage,
+  HANDLE dir,
+  void *out,
+  int32_t len
+) {
+  struct readdir_job *job = MAKE_JOB(storage, readdir);
   job->dir = dir;
   job->out = out;
   job->len = len;
-  return job;
 }
 
 // ===== realpath job, get canonical representation of a path =====
@@ -1608,6 +1622,7 @@ struct realpath_job {
   struct job job;
   char *path;
   char *result;
+  int32_t result_len;
 };
 
 static
@@ -1621,11 +1636,10 @@ void realpath_job_worker(struct job *job) {
   struct realpath_job *realpath_job = (struct realpath_job*)job;
 
 #ifdef _WIN32
-  static wchar_t buf[1024];
   DWORD len = GetFullPathNameW(
     (LPCWSTR)realpath_job->path,
-    1024,
-    buf,
+    realpath_job->result_len,
+    (LPWSTR)realpath_job->result,
     NULL
   );
 
@@ -1634,20 +1648,12 @@ void realpath_job_worker(struct job *job) {
     return;
   }
 
-  realpath_job->result = (char*)moonbit_make_string_raw(len);
-  if (len <= 1024) {
-    memcpy(realpath_job->result, buf, len * sizeof(wchar_t));
-  } else if (
-    !GetFullPathNameW(
-      (LPCWSTR)realpath_job->path,
-      len,
-      (LPWSTR)realpath_job->result,
-      NULL
-    )
-  ) {
-    job->err = GetLastError();
-    moonbit_decref(realpath_job->result);
+  if (len >= realpath_job->result_len) {
+    job->err = ERROR_INSUFFICIENT_BUFFER;
+    return;
   }
+
+  job->ret = len;
 
 #else
 
@@ -1660,10 +1666,24 @@ void realpath_job_worker(struct job *job) {
 #endif
 }
 
-struct realpath_job *moonbitlang_async_make_realpath_job(char *path) {
-  struct realpath_job *job = MAKE_JOB(realpath);
+void moonbitlang_async_make_realpath_job(
+  void *storage,
+  char *path
+#ifdef _WIN32
+  ,
+  char *result,
+  int32_t result_len
+#endif
+) {
+  struct realpath_job *job = MAKE_JOB(storage, realpath);
   job->path = path;
-  return job;
+#ifdef _WIN32
+  job->result = result;
+  job->result_len = result_len;
+#else
+  job->result = 0;
+  job->result_len = 0;
+#endif
 }
 
 char *moonbitlang_async_get_realpath_result(struct realpath_job *job) {
@@ -1893,7 +1913,8 @@ void spawn_job_worker(struct job *job) {
   job->ret = process_info.dwProcessId;
 }
 
-struct spawn_job *moonbitlang_async_make_spawn_job(
+void moonbitlang_async_make_spawn_job(
+  void *storage,
   LPWSTR command_line,
   void *environment,
   HANDLE stdin_handle,
@@ -1902,7 +1923,7 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   LPWSTR cwd,
   int32_t is_orphan
 ) {
-  struct spawn_job *job = MAKE_JOB(spawn);
+  struct spawn_job *job = MAKE_JOB(storage, spawn);
   job->command_line = command_line;
   job->environment = environment;
   job->stdio[0] = stdin_handle;
@@ -1911,7 +1932,6 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   job->cwd = cwd;
   job->is_orphan = is_orphan;
   job->result = INVALID_HANDLE_VALUE;
-  return job;
 }
 
 HANDLE moonbitlang_async_get_spawn_job_result_handle(struct spawn_job *job) {
@@ -1937,6 +1957,18 @@ void free_wait_for_process_job(void *obj) {
 };
 
 static
+void wait_for_process_job_cleanup(struct job *job) {
+  struct wait_for_process_job *wait_for_process_job = (struct wait_for_process_job*)job;
+  if (
+    wait_for_process_job->cancel &&
+    wait_for_process_job->cancel != INVALID_HANDLE_VALUE
+  ) {
+    CloseHandle(wait_for_process_job->cancel);
+    wait_for_process_job->cancel = INVALID_HANDLE_VALUE;
+  }
+}
+
+static
 void wait_for_process_job_worker(struct job *job) {
   struct wait_for_process_job *wait_for_process_job = (struct wait_for_process_job*)job;
 
@@ -1947,15 +1979,17 @@ void wait_for_process_job_worker(struct job *job) {
     job->err = GetLastError();
   else if (result == WAIT_OBJECT_0 + 1)
     job->err = ERROR_OPERATION_ABORTED;
+  wait_for_process_job_cleanup(job);
 }
 
-struct wait_for_process_job *moonbitlang_async_make_wait_for_process_job(
+void moonbitlang_async_make_wait_for_process_job(
+  void *storage,
   HANDLE process
 ) {
-  struct wait_for_process_job *job = MAKE_JOB(wait_for_process);
+  struct wait_for_process_job *job = MAKE_JOB(storage, wait_for_process);
   job->process = process;
   job->cancel = CreateEventA(NULL, FALSE, FALSE, NULL);
-  return job;
+  job->job.cleanup = wait_for_process_job_cleanup;
 }
 
 void moonbitlang_async_cancel_wait_for_process_job(struct wait_for_process_job *job) {
@@ -2050,7 +2084,8 @@ exit:
 
 #endif // posix_spawn availability
 
-struct spawn_job *moonbitlang_async_make_spawn_job(
+void moonbitlang_async_make_spawn_job(
+  void *storage,
   char *path,
   char **args,
   char **envp,
@@ -2059,7 +2094,7 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   int stderr_fd,
   char *cwd
 ) {
-  struct spawn_job *job = MAKE_JOB(spawn);
+  struct spawn_job *job = MAKE_JOB(storage, spawn);
   job->path = path;
   job->args = args;
   job->envp = envp;
@@ -2067,7 +2102,6 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   job->stdio[1] = stdout_fd;
   job->stdio[2] = stderr_fd;
   job->cwd = cwd;
-  return job;
 }
 
 // Unix wait_for_process: blocking waitpid in worker thread
@@ -2093,12 +2127,12 @@ void wait_for_process_job_worker(struct job *job) {
   }
 }
 
-struct wait_for_process_job *moonbitlang_async_make_wait_for_process_job(
+void moonbitlang_async_make_wait_for_process_job(
+  void *storage,
   int pid
 ) {
-  struct wait_for_process_job *job = MAKE_JOB(wait_for_process);
+  struct wait_for_process_job *job = MAKE_JOB(storage, wait_for_process);
   job->pid = pid;
-  return job;
 }
 
 #endif
@@ -2131,11 +2165,14 @@ void bind_job_worker(struct job *job) {
 }
 
 MOONBIT_FFI_EXPORT
-struct bind_job *moonbitlang_async_make_bind_job(HANDLE socket, struct sockaddr *addr) {
-  struct bind_job *job = MAKE_JOB(bind);
+void moonbitlang_async_make_bind_job(
+  void *storage,
+  HANDLE socket,
+  struct sockaddr *addr
+) {
+  struct bind_job *job = MAKE_JOB(storage, bind);
   job->socket = socket;
   job->addr = addr;
-  return job;
 }
 
 // ===== getaddrinfo job, resolve host name via `getaddrinfo` =====
@@ -2163,6 +2200,19 @@ void free_getaddrinfo_job(void *obj) {
 #else
     freeaddrinfo(job->result);
 #endif
+  }
+}
+
+static
+void getaddrinfo_job_cleanup(struct job *job) {
+  struct getaddrinfo_job *getaddrinfo_job = (struct getaddrinfo_job*)job;
+  if (getaddrinfo_job->result && !getaddrinfo_job->result_fetched) {
+#ifdef _WIN32
+    FreeAddrInfoW(getaddrinfo_job->result);
+#else
+    freeaddrinfo(getaddrinfo_job->result);
+#endif
+    getaddrinfo_job->result = 0;
   }
 }
 
@@ -2214,12 +2264,12 @@ void getaddrinfo_job_worker(struct job *job) {
 #endif
 }
 
-struct getaddrinfo_job *moonbitlang_async_make_getaddrinfo_job(char *hostname) {
-  struct getaddrinfo_job *job = MAKE_JOB(getaddrinfo);
+void moonbitlang_async_make_getaddrinfo_job(void *storage, char *hostname) {
+  struct getaddrinfo_job *job = MAKE_JOB(storage, getaddrinfo);
   job->hostname = hostname;
   job->result = 0;
   job->result_fetched = 0;
-  return job;
+  job->job.cleanup = getaddrinfo_job_cleanup;
 }
 
 addrinfo_t *moonbitlang_async_get_getaddrinfo_result(struct getaddrinfo_job *job) {
@@ -2281,16 +2331,54 @@ void sigwait_job_worker(struct job *job) {
 }
 
 MOONBIT_FFI_EXPORT
-struct sigwait_job *moonbitlang_async_make_sigwait_job(int *signals) {
-  struct sigwait_job *job = MAKE_JOB(sigwait);
+void moonbitlang_async_make_sigwait_job(void *storage, int *signals) {
+  struct sigwait_job *job = MAKE_JOB(storage, sigwait);
 
   sigemptyset(&job->signals);
   for (int i = 0; i < Moonbit_array_length(signals); ++i)
     sigaddset(&job->signals, signals[i]);
 
   sigaddset(&job->signals, SIGUSR2);
-
-  return job;
 }
 
 #endif // #ifndef _WIN32, sigwait job
+
+#define UPDATE_MAX_JOB_STORAGE_SIZE(name) \
+  if (size < sizeof(struct name##_job)) \
+    size = sizeof(struct name##_job)
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_job_storage_size() {
+  size_t size = sizeof(struct sleep_job);
+
+  UPDATE_MAX_JOB_STORAGE_SIZE(read);
+  UPDATE_MAX_JOB_STORAGE_SIZE(write);
+  UPDATE_MAX_JOB_STORAGE_SIZE(open);
+  UPDATE_MAX_JOB_STORAGE_SIZE(kind_of_fd);
+  UPDATE_MAX_JOB_STORAGE_SIZE(file_kind_by_path);
+  UPDATE_MAX_JOB_STORAGE_SIZE(file_size);
+  UPDATE_MAX_JOB_STORAGE_SIZE(file_time);
+  UPDATE_MAX_JOB_STORAGE_SIZE(file_time_by_path);
+#ifndef _WIN32
+  UPDATE_MAX_JOB_STORAGE_SIZE(chmod);
+#endif
+  UPDATE_MAX_JOB_STORAGE_SIZE(fsync);
+  UPDATE_MAX_JOB_STORAGE_SIZE(flock);
+  UPDATE_MAX_JOB_STORAGE_SIZE(remove);
+  UPDATE_MAX_JOB_STORAGE_SIZE(access);
+  UPDATE_MAX_JOB_STORAGE_SIZE(rename);
+  UPDATE_MAX_JOB_STORAGE_SIZE(symlink);
+  UPDATE_MAX_JOB_STORAGE_SIZE(mkdir);
+  UPDATE_MAX_JOB_STORAGE_SIZE(rmdir);
+  UPDATE_MAX_JOB_STORAGE_SIZE(readdir);
+  UPDATE_MAX_JOB_STORAGE_SIZE(realpath);
+  UPDATE_MAX_JOB_STORAGE_SIZE(spawn);
+  UPDATE_MAX_JOB_STORAGE_SIZE(wait_for_process);
+  UPDATE_MAX_JOB_STORAGE_SIZE(bind);
+  UPDATE_MAX_JOB_STORAGE_SIZE(getaddrinfo);
+#ifndef _WIN32
+  UPDATE_MAX_JOB_STORAGE_SIZE(sigwait);
+#endif
+
+  return (int32_t)size;
+}

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -23,15 +23,32 @@ extern "C" fn init_thread_pool_ffi(notify_send : @fd_util.Fd) = "moonbitlang_asy
 extern "C" fn destroy_thread_pool() = "moonbitlang_async_destroy_thread_pool"
 
 ///|
-#owned(init_job)
-extern "C" fn Worker::spawn(init_job_id : Int, init_job : Job) -> Worker = "moonbitlang_async_spawn_worker"
+#borrow(init_job)
+extern "C" fn Worker::spawn_ffi(
+  init_job_id : Int,
+  init_job : FixedArray[Byte],
+) -> Worker = "moonbitlang_async_spawn_worker"
+
+///|
+fn Worker::spawn(init_job_id : Int, init_job : Job) -> Worker {
+  Worker::spawn_ffi(init_job_id, init_job.storage)
+}
 
 ///|
 extern "C" fn Worker::free(worker : Worker) = "moonbitlang_async_free_worker"
 
 ///|
-#owned(job)
-extern "C" fn Worker::wake(worker : Worker, job_id : Int, job : Job) = "moonbitlang_async_wake_worker"
+#borrow(job)
+extern "C" fn Worker::wake_ffi(
+  worker : Worker,
+  job_id : Int,
+  job : FixedArray[Byte],
+) = "moonbitlang_async_wake_worker"
+
+///|
+fn Worker::wake(worker : Worker, job_id : Int, job : Job) -> Unit {
+  worker.wake_ffi(job_id, job.storage)
+}
 
 ///|
 extern "C" fn Worker::enter_idle(worker : Worker) = "moonbitlang_async_worker_enter_idle"
@@ -63,41 +80,159 @@ extern "C" fn fetch_completion_ffi(
 ) -> Int = "moonbitlang_async_fetch_completion"
 
 ///|
-priv type Job
+#warnings("-unused_mut")
+priv struct Job {
+  storage : FixedArray[Byte]
+  mut bytes : Bytes?
+  mut fixed_bytes : FixedArray[Byte]?
+  mut path1 : @os_string.OsString?
+  mut path2 : @os_string.OsString?
+  mut path3 : @os_string.OsString?
+  mut path_array1 : FixedArray[@os_string.OsString?]?
+  mut path_array2 : FixedArray[@os_string.OsString?]?
+  mut file_time : @fd_util.FileTime?
+  mut signals : ReadOnlyArray[Int]?
+  mut string_result : String?
+}
 
 ///|
-#borrow(self)
-extern "C" fn Job::ret(self : Job) -> Int = "moonbitlang_async_job_get_ret"
+extern "C" fn job_storage_size() -> Int = "moonbitlang_async_job_storage_size"
 
 ///|
-#borrow(self)
-extern "C" fn Job::err(self : Job) -> Int = "moonbitlang_async_job_get_err"
+fn Job::new() -> Job {
+  {
+    storage: FixedArray::make(job_storage_size(), b'\x00'),
+    bytes: None,
+    fixed_bytes: None,
+    path1: None,
+    path2: None,
+    path3: None,
+    path_array1: None,
+    path_array2: None,
+    file_time: None,
+    signals: None,
+    string_result: None,
+  }
+}
 
 ///|
-#owned(buf)
-extern "C" fn Job::read(
+#borrow(storage)
+extern "C" fn job_ret_ffi(
+  storage : FixedArray[Byte],
+) -> Int = "moonbitlang_async_job_get_ret"
+
+///|
+fn Job::ret(self : Job) -> Int {
+  job_ret_ffi(self.storage)
+}
+
+///|
+#borrow(storage)
+extern "C" fn job_err_ffi(
+  storage : FixedArray[Byte],
+) -> Int = "moonbitlang_async_job_get_err"
+
+///|
+fn Job::err(self : Job) -> Int {
+  job_err_ffi(self.storage)
+}
+
+///|
+#borrow(storage)
+extern "C" fn job_cleanup_ffi(
+  storage : FixedArray[Byte],
+) = "moonbitlang_async_job_cleanup"
+
+///|
+fn Job::cleanup(self : Job) -> Unit {
+  job_cleanup_ffi(self.storage)
+}
+
+///|
+fn Job::keepalive(self : Job) -> Unit {
+  ignore(self.bytes)
+  ignore(self.fixed_bytes)
+  ignore(self.path1)
+  ignore(self.path2)
+  ignore(self.path3)
+  ignore(self.path_array1)
+  ignore(self.path_array2)
+  ignore(self.file_time)
+  ignore(self.signals)
+  ignore(self.string_result)
+}
+
+///|
+#cfg(target="native")
+#warnings("-unused_value")
+fn Job::sleep(time : Int) -> Job {
+  let job = Job::new()
+  init_sleep_job(job.storage, time)
+  job
+}
+
+///|
+#cfg(target="native")
+#borrow(job)
+extern "C" fn init_sleep_job(
+  job : FixedArray[Byte],
+  time : Int,
+) = "moonbitlang_async_make_sleep_job"
+
+///|
+fn Job::read(
   fd : @fd_util.Fd,
   buf : FixedArray[Byte],
   offset : Int,
   len : Int,
   // `-1` indicates no offset
   position~ : Int64,
-) -> Job = "moonbitlang_async_make_read_job"
+) -> Job {
+  let job = Job::new()
+  job.fixed_bytes = Some(buf)
+  init_read_job(job.storage, fd, buf, offset, len, position~)
+  job
+}
 
 ///|
-#owned(buf)
-extern "C" fn Job::write(
+#borrow(job, buf)
+extern "C" fn init_read_job(
+  job : FixedArray[Byte],
+  fd : @fd_util.Fd,
+  buf : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+  position~ : Int64,
+) = "moonbitlang_async_make_read_job"
+
+///|
+fn Job::write(
   fd : @fd_util.Fd,
   buf : Bytes,
   offset : Int,
   len : Int,
   // `-1` indicates no offset
   position~ : Int64,
-) -> Job = "moonbitlang_async_make_write_job"
+) -> Job {
+  let job = Job::new()
+  job.bytes = Some(buf)
+  init_write_job(job.storage, fd, buf, offset, len, position~)
+  job
+}
 
 ///|
-#owned(filename)
-extern "C" fn Job::open(
+#borrow(job, buf)
+extern "C" fn init_write_job(
+  job : FixedArray[Byte],
+  fd : @fd_util.Fd,
+  buf : Bytes,
+  offset : Int,
+  len : Int,
+  position~ : Int64,
+) = "moonbitlang_async_make_write_job"
+
+///|
+fn Job::open(
   filename : @os_string.OsString,
   // 0 => read only, 1 => write only, 2 => read write
   access : Int,
@@ -108,48 +243,141 @@ extern "C" fn Job::open(
   sync~ : Int,
   // permission for file when new file is created
   mode~ : Int,
-) -> OpenResult = "moonbitlang_async_make_open_job"
+) -> OpenResult {
+  let job = Job::new()
+  job.path1 = Some(filename)
+  init_open_job(job.storage, filename, access, create~, append~, sync~, mode~)
+  OpenResult(job)
+}
+
+///|
+#borrow(job, filename)
+extern "C" fn init_open_job(
+  job : FixedArray[Byte],
+  filename : @os_string.OsString,
+  access : Int,
+  create~ : Int,
+  append~ : Bool,
+  sync~ : Int,
+  mode~ : Int,
+) = "moonbitlang_async_make_open_job"
 
 ///|
 struct OpenResult(Job)
 
 ///|
 #borrow(job)
-pub extern "C" fn OpenResult::fd(job : OpenResult) -> @fd_util.Fd = "moonbitlang_async_open_job_get_fd"
+extern "C" fn open_result_fd_ffi(job : FixedArray[Byte]) -> @fd_util.Fd = "moonbitlang_async_open_job_get_fd"
+
+///|
+pub fn OpenResult::fd(job : OpenResult) -> @fd_util.Fd {
+  open_result_fd_ffi(job.0.storage)
+}
 
 ///|
 #borrow(job)
-pub extern "C" fn OpenResult::kind(job : OpenResult) -> @fd_util.FileKind = "moonbitlang_async_open_job_get_kind"
+extern "C" fn open_result_kind_ffi(job : FixedArray[Byte]) -> @fd_util.FileKind = "moonbitlang_async_open_job_get_kind"
 
 ///|
-extern "C" fn Job::kind_of_fd(fd : @fd_util.Fd) -> Job = "moonbitlang_async_make_kind_of_fd_job"
+pub fn OpenResult::kind(job : OpenResult) -> @fd_util.FileKind {
+  open_result_kind_ffi(job.0.storage)
+}
 
 ///|
-#owned(path)
-extern "C" fn Job::file_kind_by_path(
+fn Job::kind_of_fd(fd : @fd_util.Fd) -> Job {
+  let job = Job::new()
+  init_kind_of_fd_job(job.storage, fd)
+  job
+}
+
+///|
+#borrow(job)
+extern "C" fn init_kind_of_fd_job(
+  job : FixedArray[Byte],
+  fd : @fd_util.Fd,
+) = "moonbitlang_async_make_kind_of_fd_job"
+
+///|
+fn Job::file_kind_by_path(
   parent : @fd_util.Fd,
   path : @os_string.OsString,
   follow_symlink~ : Bool,
-) -> Job = "moonbitlang_async_make_file_kind_by_path_job"
+) -> Job {
+  let job = Job::new()
+  job.path1 = Some(path)
+  init_file_kind_by_path_job(job.storage, parent, path, follow_symlink~)
+  job
+}
 
 ///|
-extern "C" fn Job::file_size(fd : @fd_util.Fd) -> Job = "moonbitlang_async_make_file_size_job"
+#borrow(job, path)
+extern "C" fn init_file_kind_by_path_job(
+  job : FixedArray[Byte],
+  parent : @fd_util.Fd,
+  path : @os_string.OsString,
+  follow_symlink~ : Bool,
+) = "moonbitlang_async_make_file_kind_by_path_job"
+
+///|
+fn Job::file_size(fd : @fd_util.Fd) -> Job {
+  let job = Job::new()
+  init_file_size_job(job.storage, fd)
+  job
+}
 
 ///|
 #borrow(job)
-extern "C" fn Job::get_file_size_result(job : Job) -> Int64 = "moonbitlang_async_get_file_size_result"
+extern "C" fn init_file_size_job(
+  job : FixedArray[Byte],
+  fd : @fd_util.Fd,
+) = "moonbitlang_async_make_file_size_job"
 
 ///|
-#owned(out)
-extern "C" fn Job::file_time(fd : @fd_util.Fd, out : @fd_util.FileTime) -> Job = "moonbitlang_async_make_file_time_job"
+#borrow(job)
+extern "C" fn get_file_size_result_ffi(job : FixedArray[Byte]) -> Int64 = "moonbitlang_async_get_file_size_result"
 
 ///|
-#owned(path, out)
-extern "C" fn Job::file_time_by_path(
+fn Job::get_file_size_result(job : Job) -> Int64 {
+  get_file_size_result_ffi(job.storage)
+}
+
+///|
+fn Job::file_time(fd : @fd_util.Fd, out : @fd_util.FileTime) -> Job {
+  let job = Job::new()
+  job.file_time = Some(out)
+  init_file_time_job(job.storage, fd, out)
+  job
+}
+
+///|
+#borrow(job, out)
+extern "C" fn init_file_time_job(
+  job : FixedArray[Byte],
+  fd : @fd_util.Fd,
+  out : @fd_util.FileTime,
+) = "moonbitlang_async_make_file_time_job"
+
+///|
+fn Job::file_time_by_path(
   path : @os_string.OsString,
   out : @fd_util.FileTime,
   follow_symlink~ : Bool,
-) -> Job = "moonbitlang_async_make_file_time_by_path_job"
+) -> Job {
+  let job = Job::new()
+  job.path1 = Some(path)
+  job.file_time = Some(out)
+  init_file_time_by_path_job(job.storage, path, out, follow_symlink~)
+  job
+}
+
+///|
+#borrow(job, path, out)
+extern "C" fn init_file_time_by_path_job(
+  job : FixedArray[Byte],
+  path : @os_string.OsString,
+  out : @fd_util.FileTime,
+  follow_symlink~ : Bool,
+) = "moonbitlang_async_make_file_time_by_path_job"
 
 ///|
 pub(all) enum Access {
@@ -160,72 +388,239 @@ pub(all) enum Access {
 }
 
 ///|
-#owned(path)
-extern "C" fn Job::access(path : @os_string.OsString, access : Access) -> Job = "moonbitlang_async_make_access_job"
+fn Job::access(path : @os_string.OsString, access : Access) -> Job {
+  let job = Job::new()
+  job.path1 = Some(path)
+  init_access_job(job.storage, path, access)
+  job
+}
 
 ///|
-#owned(path)
-extern "C" fn Job::chmod(path : @os_string.OsString, mode : Int) -> Job = "moonbitlang_async_make_chmod_job"
+#borrow(job, path)
+extern "C" fn init_access_job(
+  job : FixedArray[Byte],
+  path : @os_string.OsString,
+  access : Access,
+) = "moonbitlang_async_make_access_job"
 
 ///|
-extern "C" fn Job::fsync(fd : @fd_util.Fd, only_data : Bool) -> Job = "moonbitlang_async_make_fsync_job"
+fn Job::chmod(path : @os_string.OsString, mode : Int) -> Job {
+  let job = Job::new()
+  job.path1 = Some(path)
+  init_chmod_job(job.storage, path, mode)
+  job
+}
 
 ///|
-extern "C" fn Job::flock(fd : @fd_util.Fd, exclusive : Bool) -> Job = "moonbitlang_async_make_flock_job"
+#borrow(job, path)
+extern "C" fn init_chmod_job(
+  job : FixedArray[Byte],
+  path : @os_string.OsString,
+  mode : Int,
+) = "moonbitlang_async_make_chmod_job"
 
 ///|
-#owned(path)
-extern "C" fn Job::remove(path : @os_string.OsString) -> Job = "moonbitlang_async_make_remove_job"
+fn Job::fsync(fd : @fd_util.Fd, only_data : Bool) -> Job {
+  let job = Job::new()
+  init_fsync_job(job.storage, fd, only_data)
+  job
+}
 
 ///|
-#owned(old_path, new_path)
-extern "C" fn Job::rename(
+#borrow(job)
+extern "C" fn init_fsync_job(
+  job : FixedArray[Byte],
+  fd : @fd_util.Fd,
+  only_data : Bool,
+) = "moonbitlang_async_make_fsync_job"
+
+///|
+fn Job::flock(fd : @fd_util.Fd, exclusive : Bool) -> Job {
+  let job = Job::new()
+  init_flock_job(job.storage, fd, exclusive)
+  job
+}
+
+///|
+#borrow(job)
+extern "C" fn init_flock_job(
+  job : FixedArray[Byte],
+  fd : @fd_util.Fd,
+  exclusive : Bool,
+) = "moonbitlang_async_make_flock_job"
+
+///|
+fn Job::remove(path : @os_string.OsString) -> Job {
+  let job = Job::new()
+  job.path1 = Some(path)
+  init_remove_job(job.storage, path)
+  job
+}
+
+///|
+#borrow(job, path)
+extern "C" fn init_remove_job(
+  job : FixedArray[Byte],
+  path : @os_string.OsString,
+) = "moonbitlang_async_make_remove_job"
+
+///|
+fn Job::rename(
   old_path : @os_string.OsString,
   new_path : @os_string.OsString,
   replace~ : Bool,
-) -> Job = "moonbitlang_async_make_rename_job"
+) -> Job {
+  let job = Job::new()
+  job.path1 = Some(old_path)
+  job.path2 = Some(new_path)
+  init_rename_job(job.storage, old_path, new_path, replace~)
+  job
+}
 
 ///|
-#owned(target, path)
-extern "C" fn Job::symlink(
+#borrow(job, old_path, new_path)
+extern "C" fn init_rename_job(
+  job : FixedArray[Byte],
+  old_path : @os_string.OsString,
+  new_path : @os_string.OsString,
+  replace~ : Bool,
+) = "moonbitlang_async_make_rename_job"
+
+///|
+fn Job::symlink(
   target : @os_string.OsString,
   path : @os_string.OsString,
-) -> Job = "moonbitlang_async_make_symlink_job"
+) -> Job {
+  let job = Job::new()
+  job.path1 = Some(target)
+  job.path2 = Some(path)
+  init_symlink_job(job.storage, target, path)
+  job
+}
 
 ///|
-#owned(path)
-extern "C" fn Job::mkdir(path : @os_string.OsString, mode : Int) -> Job = "moonbitlang_async_make_mkdir_job"
+#borrow(job, target, path)
+extern "C" fn init_symlink_job(
+  job : FixedArray[Byte],
+  target : @os_string.OsString,
+  path : @os_string.OsString,
+) = "moonbitlang_async_make_symlink_job"
 
 ///|
-#owned(path)
-extern "C" fn Job::rmdir(path : @os_string.OsString) -> Job = "moonbitlang_async_make_rmdir_job"
+fn Job::mkdir(path : @os_string.OsString, mode : Int) -> Job {
+  let job = Job::new()
+  job.path1 = Some(path)
+  init_mkdir_job(job.storage, path, mode)
+  job
+}
 
 ///|
-#owned(buf)
-extern "C" fn Job::readdir(
+#borrow(job, path)
+extern "C" fn init_mkdir_job(
+  job : FixedArray[Byte],
+  path : @os_string.OsString,
+  mode : Int,
+) = "moonbitlang_async_make_mkdir_job"
+
+///|
+fn Job::rmdir(path : @os_string.OsString) -> Job {
+  let job = Job::new()
+  job.path1 = Some(path)
+  init_rmdir_job(job.storage, path)
+  job
+}
+
+///|
+#borrow(job, path)
+extern "C" fn init_rmdir_job(
+  job : FixedArray[Byte],
+  path : @os_string.OsString,
+) = "moonbitlang_async_make_rmdir_job"
+
+///|
+fn Job::readdir(
   dir : @fd_util.Fd,
   buf : FixedArray[Byte],
   len : Int,
-) -> Job = "moonbitlang_async_make_readdir_job"
+) -> Job {
+  let job = Job::new()
+  job.fixed_bytes = Some(buf)
+  init_readdir_job(job.storage, dir, buf, len)
+  job
+}
 
 ///|
-#owned(path)
-extern "C" fn Job::realpath(path : @os_string.OsString) -> Job = "moonbitlang_async_make_realpath_job"
+#borrow(job, buf)
+extern "C" fn init_readdir_job(
+  job : FixedArray[Byte],
+  dir : @fd_util.Fd,
+  buf : FixedArray[Byte],
+  len : Int,
+) = "moonbitlang_async_make_readdir_job"
 
 ///|
 #cfg(not(platform="windows"))
-#borrow(job)
-extern "C" fn Job::get_realpath_result(job : Job) -> @c_buffer.Buffer = "moonbitlang_async_get_realpath_result"
+fn Job::realpath(path : @os_string.OsString) -> Job {
+  let job = Job::new()
+  job.path1 = Some(path)
+  init_realpath_job(job.storage, path)
+  job
+}
+
+///|
+#cfg(not(platform="windows"))
+#borrow(job, path)
+extern "C" fn init_realpath_job(
+  job : FixedArray[Byte],
+  path : @os_string.OsString,
+) = "moonbitlang_async_make_realpath_job"
 
 ///|
 #cfg(platform="windows")
-#borrow(job)
-extern "C" fn Job::get_realpath_result(job : Job) -> String = "moonbitlang_async_get_realpath_result"
+fn Job::realpath(path : @os_string.OsString) -> Job {
+  let job = Job::new()
+  let result = String::make(32768, '\u{0}')
+  job.path1 = Some(path)
+  job.string_result = Some(result)
+  init_realpath_job(job.storage, path, result, result.length())
+  job
+}
+
+///|
+#cfg(platform="windows")
+#borrow(job, path, result)
+extern "C" fn init_realpath_job(
+  job : FixedArray[Byte],
+  path : @os_string.OsString,
+  result : String,
+  result_len : Int,
+) = "moonbitlang_async_make_realpath_job"
 
 ///|
 #cfg(not(platform="windows"))
-#owned(path, args, env, cwd)
-extern "C" fn Job::spawn(
+#borrow(job)
+extern "C" fn get_realpath_result_ffi(
+  job : FixedArray[Byte],
+) -> @c_buffer.Buffer = "moonbitlang_async_get_realpath_result"
+
+///|
+#cfg(not(platform="windows"))
+fn Job::get_realpath_result(job : Job) -> @c_buffer.Buffer {
+  get_realpath_result_ffi(job.storage)
+}
+
+///|
+#cfg(platform="windows")
+fn Job::get_realpath_result(job : Job) -> String {
+  match job.string_result {
+    Some(result) => result[:job.ret()].to_owned()
+    None => abort("missing realpath output buffer")
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+fn Job::spawn(
   path : @os_string.OsString,
   args : FixedArray[@os_string.OsString?],
   env : FixedArray[@os_string.OsString?],
@@ -233,12 +628,33 @@ extern "C" fn Job::spawn(
   stdout : @fd_util.Fd,
   stderr : @fd_util.Fd,
   cwd : @os_string.OsString?,
-) -> Job = "moonbitlang_async_make_spawn_job"
+) -> Job {
+  let job = Job::new()
+  job.path1 = Some(path)
+  job.path2 = cwd
+  job.path_array1 = Some(args)
+  job.path_array2 = Some(env)
+  init_spawn_job(job.storage, path, args, env, stdin, stdout, stderr, cwd)
+  job
+}
+
+///|
+#cfg(not(platform="windows"))
+#borrow(job, path, args, env, cwd)
+extern "C" fn init_spawn_job(
+  job : FixedArray[Byte],
+  path : @os_string.OsString,
+  args : FixedArray[@os_string.OsString?],
+  env : FixedArray[@os_string.OsString?],
+  stdin : @fd_util.Fd,
+  stdout : @fd_util.Fd,
+  stderr : @fd_util.Fd,
+  cwd : @os_string.OsString?,
+) = "moonbitlang_async_make_spawn_job"
 
 ///|
 #cfg(platform="windows")
-#owned(command_line, env, cwd)
-extern "C" fn Job::spawn(
+fn Job::spawn(
   command_line : @os_string.OsString,
   env : @os_string.OsString?,
   stdin : @fd_util.Fd,
@@ -246,42 +662,154 @@ extern "C" fn Job::spawn(
   stderr : @fd_util.Fd,
   cwd : @os_string.OsString?,
   is_orphan~ : Bool,
-) -> Job = "moonbitlang_async_make_spawn_job"
+) -> Job {
+  let job = Job::new()
+  job.path1 = Some(command_line)
+  job.path2 = env
+  job.path3 = cwd
+  init_spawn_job(
+    job.storage,
+    command_line,
+    env,
+    stdin,
+    stdout,
+    stderr,
+    cwd,
+    is_orphan~,
+  )
+  job
+}
+
+///|
+#cfg(platform="windows")
+#borrow(job, command_line, env, cwd)
+extern "C" fn init_spawn_job(
+  job : FixedArray[Byte],
+  command_line : @os_string.OsString,
+  env : @os_string.OsString?,
+  stdin : @fd_util.Fd,
+  stdout : @fd_util.Fd,
+  stderr : @fd_util.Fd,
+  cwd : @os_string.OsString?,
+  is_orphan~ : Bool,
+) = "moonbitlang_async_make_spawn_job"
 
 ///|
 #cfg(platform="windows")
 #borrow(job)
-extern "C" fn Job::get_spawn_job_result_handle(job : Job) -> @fd_util.Fd = "moonbitlang_async_get_spawn_job_result_handle"
+extern "C" fn get_spawn_job_result_handle_ffi(
+  job : FixedArray[Byte],
+) -> @fd_util.Fd = "moonbitlang_async_get_spawn_job_result_handle"
+
+///|
+#cfg(platform="windows")
+fn Job::get_spawn_job_result_handle(job : Job) -> @fd_util.Fd {
+  get_spawn_job_result_handle_ffi(job.storage)
+}
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn Job::wait_for_process(pid : Int) -> Job = "moonbitlang_async_make_wait_for_process_job"
-
-///|
-#cfg(platform="windows")
-extern "C" fn Job::wait_for_process(handle : @fd_util.Fd) -> Job = "moonbitlang_async_make_wait_for_process_job"
-
-///|
-#cfg(platform="windows")
-#borrow(job)
-extern "C" fn Job::cancel_process_waiter(job : Job) = "moonbitlang_async_cancel_wait_for_process_job"
-
-///|
-#owned(addr)
-extern "C" fn Job::bind(socket : @fd_util.Fd, addr : Bytes) -> Job = "moonbitlang_async_make_bind_job"
-
-///|
-#owned(host)
-extern "C" fn Job::getaddrinfo(host : @os_string.OsString) -> Job = "moonbitlang_async_make_getaddrinfo_job"
-
-///|
-#borrow(job)
-extern "C" fn Job::get_getaddrinfo_result(job : Job) -> AddrInfo = "moonbitlang_async_get_getaddrinfo_result"
+fn Job::wait_for_process(pid : Int) -> Job {
+  let job = Job::new()
+  init_wait_for_process_job(job.storage, pid)
+  job
+}
 
 ///|
 #cfg(not(platform="windows"))
-#borrow(signals)
-extern "C" fn Job::sigwait(signals : ReadOnlyArray[Int]) -> Job = "moonbitlang_async_make_sigwait_job"
+#borrow(job)
+extern "C" fn init_wait_for_process_job(
+  job : FixedArray[Byte],
+  pid : Int,
+) = "moonbitlang_async_make_wait_for_process_job"
+
+///|
+#cfg(platform="windows")
+fn Job::wait_for_process(handle : @fd_util.Fd) -> Job {
+  let job = Job::new()
+  init_wait_for_process_job(job.storage, handle)
+  job
+}
+
+///|
+#cfg(platform="windows")
+#borrow(job)
+extern "C" fn init_wait_for_process_job(
+  job : FixedArray[Byte],
+  handle : @fd_util.Fd,
+) = "moonbitlang_async_make_wait_for_process_job"
+
+///|
+#cfg(platform="windows")
+#borrow(job)
+extern "C" fn cancel_process_waiter_ffi(
+  job : FixedArray[Byte],
+) = "moonbitlang_async_cancel_wait_for_process_job"
+
+///|
+#cfg(platform="windows")
+fn Job::cancel_process_waiter(job : Job) -> Unit {
+  cancel_process_waiter_ffi(job.storage)
+}
+
+///|
+fn Job::bind(socket : @fd_util.Fd, addr : Bytes) -> Job {
+  let job = Job::new()
+  job.bytes = Some(addr)
+  init_bind_job(job.storage, socket, addr)
+  job
+}
+
+///|
+#borrow(job, addr)
+extern "C" fn init_bind_job(
+  job : FixedArray[Byte],
+  socket : @fd_util.Fd,
+  addr : Bytes,
+) = "moonbitlang_async_make_bind_job"
+
+///|
+fn Job::getaddrinfo(host : @os_string.OsString) -> Job {
+  let job = Job::new()
+  job.path1 = Some(host)
+  init_getaddrinfo_job(job.storage, host)
+  job
+}
+
+///|
+#borrow(job, host)
+extern "C" fn init_getaddrinfo_job(
+  job : FixedArray[Byte],
+  host : @os_string.OsString,
+) = "moonbitlang_async_make_getaddrinfo_job"
+
+///|
+#borrow(job)
+extern "C" fn get_getaddrinfo_result_ffi(
+  job : FixedArray[Byte],
+) -> AddrInfo = "moonbitlang_async_get_getaddrinfo_result"
+
+///|
+fn Job::get_getaddrinfo_result(job : Job) -> AddrInfo {
+  get_getaddrinfo_result_ffi(job.storage)
+}
+
+///|
+#cfg(not(platform="windows"))
+fn Job::sigwait(signals : ReadOnlyArray[Int]) -> Job {
+  let job = Job::new()
+  job.signals = Some(signals)
+  init_sigwait_job(job.storage, signals)
+  job
+}
+
+///|
+#cfg(not(platform="windows"))
+#borrow(job, signals)
+extern "C" fn init_sigwait_job(
+  job : FixedArray[Byte],
+  signals : ReadOnlyArray[Int],
+) = "moonbitlang_async_make_sigwait_job"
 
 ///|
 #cfg(platform="windows")

--- a/src/internal/event_loop/worker_wbtest.mbt
+++ b/src/internal/event_loop/worker_wbtest.mbt
@@ -14,10 +14,6 @@
 
 ///|
 #cfg(target="native")
-extern "C" fn Job::sleep(time : Int) -> Job = "moonbitlang_async_make_sleep_job"
-
-///|
-#cfg(target="native")
 async fn perform_sleep_job(t : Int) -> Unit {
   perform_job_in_worker(Job::sleep(t), context="") |> ignore
 }


### PR DESCRIPTION
Part of #408. Stacked on #411.

## Why

Thread-pool jobs were allocated as MoonBit external objects from C. That makes
the job ABI hard to reuse for Wasm1, where MoonBit should allocate
guest-visible storage before passing it to the host.

## What

- Add a MoonBit-owned `Job` wrapper with a byte storage block sized by C.
- Change job constructors so C initializes caller-provided storage instead of
  allocating external objects.
- Keep borrowed MoonBit paths, buffers, arrays, and Windows result buffers
  alive from the MoonBit wrapper.
- Add event-loop ownership for queued/running jobs so cancellation cannot drop
  storage while workers still reference it.
- Add native cleanup hooks for abandoned host resources such as unfetched
  `getaddrinfo` results and Windows process wait handles.
- Move Windows `realpath` output into MoonBit-owned string storage.

## Why this is correct

The worker still sees the same native job payload layout, but storage is now
allocated by MoonBit. The event loop owns queued and running jobs until
completion, and C cleanup is limited to native resources rather than MoonBit
buffers.

## Review scope

This PR is intentionally the largest layer because all worker job constructors
share the same storage ABI.
