### PR TITLE
Move socket ifname buffer to MoonBit allocation

### DIFF
--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -19,23 +19,56 @@ priv enum AddrFamily {
 }
 
 ///|
-/// IPv4 address + port number
 #warnings("-unused_constructor")
 struct Addr(Bytes) derive(Eq, Compare, Hash)
 
 ///|
-pub extern "C" fn Addr::new(ip : UInt, port : Int) -> Addr = "moonbitlang_async_make_ip_addr"
+extern "C" fn ipv4_addr_size() -> Int = "moonbitlang_async_ipv4_addr_size"
 
 ///|
-extern "C" fn Addr::empty(family : AddrFamily) -> Addr = "moonbitlang_async_make_empty_addr"
+extern "C" fn ipv6_addr_size() -> Int = "moonbitlang_async_ipv6_addr_size"
 
 ///|
-#borrow(ip)
-extern "C" fn Addr::new_ipv6(
+#borrow(addr)
+extern "C" fn init_ip_addr(addr : Bytes, ip : UInt, port : Int) = "moonbitlang_async_init_ip_addr"
+
+///|
+pub fn Addr::new(ip : UInt, port : Int) -> Addr {
+  let addr = Bytes::make(ipv4_addr_size(), 0)
+  init_ip_addr(addr, ip, port)
+  Addr(addr)
+}
+
+///|
+#borrow(addr)
+extern "C" fn init_empty_addr(addr : Bytes, family : AddrFamily) = "moonbitlang_async_init_empty_addr"
+
+///|
+fn Addr::empty(family : AddrFamily) -> Addr {
+  let size = match family {
+    IPv4 => ipv4_addr_size()
+    IPv6 => ipv6_addr_size()
+  }
+  let addr = Bytes::make(size, 0)
+  init_empty_addr(addr, family)
+  Addr(addr)
+}
+
+///|
+#borrow(addr, ip)
+extern "C" fn init_ipv6_addr(
+  addr : Bytes,
   ip : FixedArray[Byte],
   port : Int,
   scope_id~ : UInt,
-) -> Addr = "moonbitlang_async_make_ipv6_addr"
+) = "moonbitlang_async_init_ipv6_addr"
+
+///|
+fn Addr::new_ipv6(ip : FixedArray[Byte], port : Int, scope_id~ : UInt) -> Addr {
+  let addr = Bytes::make(ipv6_addr_size(), 0)
+  init_ipv6_addr(addr, ip, port, scope_id~)
+  Addr(addr)
+}
 
 ///|
 #borrow(addr)
@@ -135,7 +168,28 @@ extern "C" fn AddrInfo::is_null(self : AddrInfo) -> Bool = "moonbitlang_async_ad
 
 ///|
 /// Convert AddrInfo to Addr(support both IPv4 and IPv6)
-extern "C" fn AddrInfo::to_addr(self : AddrInfo, port : Int) -> Addr = "moonbitlang_async_addrinfo_to_addr"
+extern "C" fn AddrInfo::addr_size(self : AddrInfo) -> Int = "moonbitlang_async_addrinfo_addr_size"
+
+///|
+#borrow(out)
+extern "C" fn AddrInfo::fill_addr(
+  self : AddrInfo,
+  out : Bytes,
+  port : Int,
+) -> Bool = "moonbitlang_async_addrinfo_fill_addr"
+
+///|
+fn AddrInfo::to_addr(self : AddrInfo, port : Int) -> Addr {
+  let size = self.addr_size()
+  guard size > 0 else {
+    abort("unsupported address family returned from getaddrinfo")
+  }
+  let addr = Bytes::make(size, 0)
+  guard self.fill_addr(addr, port) else {
+    abort("failed to copy address returned from getaddrinfo")
+  }
+  Addr(addr)
+}
 
 ///|
 extern "C" fn AddrInfo::next(self : AddrInfo) -> AddrInfo = "moonbitlang_async_addrinfo_get_next"

--- a/src/socket/ifname.mbt
+++ b/src/socket/ifname.mbt
@@ -55,10 +55,80 @@ extern "C" fn if_nametoindex_ffi(
 ) -> UInt = "moonbitlang_async_if_nametoindex"
 
 ///|
-extern "C" fn if_indextoname_ffi(
+#cfg(not(platform="windows"))
+#borrow(out)
+extern "C" fn if_indextoname_fill_ffi(
   global_sock : @fd_util.Fd,
   index : UInt,
-) -> @os_string.OsString? = "moonbitlang_async_if_indextoname"
+  out : Bytes,
+  len : Int,
+) -> Int = "moonbitlang_async_if_indextoname_fill"
+
+///|
+#cfg(platform="windows")
+#borrow(out)
+extern "C" fn if_indextoname_fill_ffi(
+  global_sock : @fd_util.Fd,
+  index : UInt,
+  out : String,
+  len : Int,
+) -> Int = "moonbitlang_async_if_indextoname_fill"
+
+///|
+#cfg(platform="windows")
+fn if_indextoname_ffi(
+  global_sock : @fd_util.Fd,
+  index : UInt,
+) -> @os_string.OsString? {
+  let buffer_len = 1024
+  let buffer = String::make(buffer_len, '\u{0}')
+  let actual_len = if_indextoname_fill_ffi(
+    global_sock,
+    index,
+    buffer,
+    buffer_len,
+  )
+  if 0 <= actual_len && actual_len <= buffer_len {
+    Some(@os_string.OsString::from_string(buffer[:actual_len].to_owned()))
+  } else if actual_len > buffer_len {
+    let result = String::make(actual_len, '\u{0}')
+    if if_indextoname_fill_ffi(global_sock, index, result, actual_len) == actual_len {
+      Some(@os_string.OsString::from_string(result))
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+fn if_indextoname_ffi(
+  global_sock : @fd_util.Fd,
+  index : UInt,
+) -> @os_string.OsString? {
+  let buffer_len = 1024
+  let buffer = Bytes::make(buffer_len, 0)
+  let actual_len = if_indextoname_fill_ffi(
+    global_sock,
+    index,
+    buffer,
+    buffer_len,
+  )
+  if 0 <= actual_len && actual_len <= buffer_len {
+    Some(@os_string.OsString::from_bytes(buffer[:actual_len].to_owned()))
+  } else if actual_len > buffer_len {
+    let result = Bytes::make(actual_len, 0)
+    if if_indextoname_fill_ffi(global_sock, index, result, actual_len) == actual_len {
+      Some(@os_string.OsString::from_bytes(result))
+    } else {
+      None
+    }
+  } else {
+    None
+  }
+}
 
 ///|
 #doc(hidden)

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -571,7 +571,12 @@ uint32_t moonbitlang_async_if_nametoindex(HANDLE sock, const char *name) {
 }
 
 MOONBIT_FFI_EXPORT
-void *moonbitlang_async_if_indextoname(HANDLE sock, uint32_t index) {
+int32_t moonbitlang_async_if_indextoname_fill(
+  HANDLE sock,
+  uint32_t index,
+  void *out,
+  int32_t out_len
+) {
 #ifdef _WIN32
 
   WCHAR buf[NDIS_IF_MAX_STRING_SIZE + 1];
@@ -580,20 +585,21 @@ void *moonbitlang_async_if_indextoname(HANDLE sock, uint32_t index) {
   int err = ConvertInterfaceIndexToLuid(index, &luid);
   if (err) {
     SetLastError(err);
-    return 0;
+    return -1;
   }
 
   err = ConvertInterfaceLuidToAlias(&luid, buf, NDIS_IF_MAX_STRING_SIZE + 1);
   if (err) {
     SetLastError(err);
-    return 0;
+    return -1;
   }
 
   int len = wcslen(buf);
-  moonbit_string_t str = moonbit_make_string_raw(len);
-  memcpy(str, buf, len * sizeof(WCHAR));
+  if (len > out_len)
+    return len;
 
-  return str;
+  memcpy(out, buf, len * sizeof(WCHAR));
+  return len;
 
 #elif defined(__linux__)
 
@@ -601,25 +607,27 @@ void *moonbitlang_async_if_indextoname(HANDLE sock, uint32_t index) {
   ifreq.ifr_ifindex = index;
 
   if (ioctl(sock, SIOCGIFNAME, &ifreq) < 0)
-    return 0;
+    return -1;
 
   int len = strlen(ifreq.ifr_name);
-  moonbit_bytes_t str = moonbit_make_bytes_raw(len);
-  memcpy(str, ifreq.ifr_name, len);
+  if (len > out_len)
+    return len;
 
-  return str;
+  memcpy(out, ifreq.ifr_name, len);
+  return len;
 
 #else
 
   char buf[IF_NAMESIZE];
   if (!if_indextoname(index, buf))
-    return 0;
+    return -1;
 
   int len = strlen(buf);
-  moonbit_bytes_t str = moonbit_make_bytes_raw(len);
-  memcpy(str, buf, len);
+  if (len > out_len)
+    return len;
 
-  return str;
+  memcpy(out, buf, len);
+  return len;
 
 #endif
 }

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -355,50 +355,50 @@ int moonbitlang_async_enable_keepalive(
 #endif
 
 MOONBIT_FFI_EXPORT
-void *moonbitlang_async_make_ip_addr(uint32_t ip, int port) {
-  // For IPv4, create traditional sockaddr_in structure
-  struct sockaddr_in *addr = (struct sockaddr_in*)moonbit_make_bytes(
-    sizeof(struct sockaddr_in),
-    0
-  );
-  addr->sin_family = AF_INET;
-  addr->sin_port = htons(port);
-  addr->sin_addr.s_addr = htonl(ip);
-  return addr;
+int32_t moonbitlang_async_ipv4_addr_size() {
+  return sizeof(struct sockaddr_in);
 }
 
 MOONBIT_FFI_EXPORT
-void *moonbitlang_async_make_empty_addr(int family) {
+int32_t moonbitlang_async_ipv6_addr_size() {
+  return sizeof(struct sockaddr_in6);
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_init_ip_addr(void *addr_bytes, uint32_t ip, int port) {
+  struct sockaddr_in *addr = (struct sockaddr_in*)addr_bytes;
+  memset(addr, 0, sizeof(struct sockaddr_in));
+  addr->sin_family = AF_INET;
+  addr->sin_port = htons(port);
+  addr->sin_addr.s_addr = htonl(ip);
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_init_empty_addr(void *addr_bytes, int family) {
   if (family == 4) {
-    struct sockaddr *addr = (struct sockaddr*)moonbit_make_bytes(
-      sizeof(struct sockaddr_in),
-      0
-    );
+    struct sockaddr *addr = (struct sockaddr*)addr_bytes;
+    memset(addr, 0, sizeof(struct sockaddr_in));
     addr->sa_family = AF_INET;
-    return addr;
   } else {
-    struct sockaddr *addr = (struct sockaddr*)moonbit_make_bytes(
-      sizeof(struct sockaddr_in6),
-      0
-    );
+    struct sockaddr *addr = (struct sockaddr*)addr_bytes;
+    memset(addr, 0, sizeof(struct sockaddr_in6));
     addr->sa_family = AF_INET6;
-    return addr;
   };
 }
 
 MOONBIT_FFI_EXPORT
-void *moonbitlang_async_make_ipv6_addr(uint8_t *ip, int port, uint32_t scope_id) {
-  // For IPv6, create sockaddr_in6 structure directly
-  struct sockaddr_in6 *addr = (struct sockaddr_in6*)moonbit_make_bytes(
-    sizeof(struct sockaddr_in6),
-    0
-  );
+void moonbitlang_async_init_ipv6_addr(
+  void *addr_bytes,
+  uint8_t *ip,
+  int port,
+  uint32_t scope_id
+) {
+  struct sockaddr_in6 *addr = (struct sockaddr_in6*)addr_bytes;
+  memset(addr, 0, sizeof(struct sockaddr_in6));
   addr->sin6_family = AF_INET6;
-  addr->sin6_flowinfo = 0;
   addr->sin6_port = htons(port);
   memcpy(&addr->sin6_addr, ip, 16);
   addr->sin6_scope_id = scope_id;
-  return addr;
 }
 
 MOONBIT_FFI_EXPORT
@@ -475,31 +475,42 @@ addrinfo_t *moonbitlang_async_addrinfo_get_next(addrinfo_t *addrinfo) {
 }
 
 MOONBIT_FFI_EXPORT
-void* moonbitlang_async_addrinfo_to_addr(addrinfo_t *addrinfo, int port) {
+int32_t moonbitlang_async_addrinfo_addr_size(addrinfo_t *addrinfo) {
   if (addrinfo == NULL || addrinfo->ai_addr == NULL) {
-    return NULL;
+    return 0;
   }
 
   if (addrinfo->ai_family == AF_INET) {
-    // IPv4
-    struct sockaddr_in *addr = (struct sockaddr_in*)moonbit_make_bytes(
-      sizeof(struct sockaddr_in),
-      0
-    );
+    return sizeof(struct sockaddr_in);
+  } else if (addrinfo->ai_family == AF_INET6) {
+    return sizeof(struct sockaddr_in6);
+  } else {
+    return 0;
+  }
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_addrinfo_fill_addr(
+  addrinfo_t *addrinfo,
+  void *addr_out,
+  int port
+) {
+  if (addrinfo == NULL || addrinfo->ai_addr == NULL) {
+    return 0;
+  }
+
+  if (addrinfo->ai_family == AF_INET) {
+    struct sockaddr_in *addr = (struct sockaddr_in*)addr_out;
     memcpy(addr, addrinfo->ai_addr, sizeof(struct sockaddr_in));
     addr->sin_port = htons(port);
-    return addr;
+    return 1;
   } else if (addrinfo->ai_family == AF_INET6) {
-    // IPv6
-    struct sockaddr_in6 *addr = (struct sockaddr_in6*)moonbit_make_bytes(
-      sizeof(struct sockaddr_in6),
-      0
-    );
+    struct sockaddr_in6 *addr = (struct sockaddr_in6*)addr_out;
     memcpy(addr, addrinfo->ai_addr, sizeof(struct sockaddr_in6));
     addr->sin6_port = htons(port);
-    return addr;
+    return 1;
   } else {
-      return NULL;
+    return 0;
   }
 }
 


### PR DESCRIPTION
Part of #408. Stacked on #409.

## Why

`if_indextoname` returned a MoonBit-visible `OsString` allocated by C. For
Wasm1 reuse, MoonBit should own the returned string/bytes storage and pass a
caller-provided buffer to the host.

## What

- Replace the allocation-returning `if_indextoname` C shim with a
  fill-return-length shim.
- Allocate the temporary output buffer in MoonBit for both Windows and
  non-Windows builds.
- Retry with an exact-size MoonBit buffer when C reports that the initial buffer
  was too small.

## Why this is correct

C still performs the platform-specific interface lookup, but it now only
returns errors or the actual interface-name length. It copies into the
MoonBit-provided buffer only when it fits, so the `OsString` storage returned to
MoonBit callers is MoonBit-owned.

## Review scope

This PR is limited to interface-name output allocation. Socket address buffers
are split into #409; the general fill-return shims remain stacked after this
PR.
