### PR TITLE
[codex] Fix Windows process command resolution for explicit non-.exe commands

### DIFF
--- a/src/process/basic_test.mbt
+++ b/src/process/basic_test.mbt
@@ -36,6 +36,7 @@ async test "basic_ls" {
       "wait_test.mbt", "basic_test.mbt", "cancel_test.mbt", "helper_test.mbt", "cancellation.mbt",
       "redirect_test.mbt", "unimplemented.mbt", "pkg.generated.mbti", "commands_for_test.mbt",
       "unimplemented_test.mbt", "spawn_in_group_test.mbt", "windows_escape_wbtest.mbt",
+      "windows_command_resolution_test.mbt",
     ])
   }
 }

--- a/src/process/cwd_test.mbt
+++ b/src/process/cwd_test.mbt
@@ -41,6 +41,7 @@ async test "set cwd" {
       "wait_test.mbt", "basic_test.mbt", "cancel_test.mbt", "helper_test.mbt", "cancellation.mbt",
       "redirect_test.mbt", "unimplemented.mbt", "pkg.generated.mbti", "commands_for_test.mbt",
       "unimplemented_test.mbt", "spawn_in_group_test.mbt", "windows_escape_wbtest.mbt",
+      "windows_command_resolution_test.mbt",
     ])
   }
 }

--- a/src/process/moon.pkg
+++ b/src/process/moon.pkg
@@ -34,6 +34,7 @@ options(
     "spawn_in_group_test.mbt": [ "native" ],
     "unix.mbt": [ "native" ],
     "wait_test.mbt": [ "native" ],
+    "windows_command_resolution_test.mbt": [ "native" ],
     "windows.mbt": [ "native" ],
   },
 )

--- a/src/process/windows.mbt
+++ b/src/process/windows.mbt
@@ -83,10 +83,6 @@ async fn raw_spawn(
   is_orphan~ : Bool,
   context~ : String,
 ) -> @event_loop.Process {
-  let cmd = match cmd {
-    [.., .. ".exe"] => cmd
-    _ => cmd + ".exe"
-  }
   let command_line = StringBuilder::new()
   command_line.write_arg_with_windows_escape(cmd)
   for arg in args {

--- a/src/process/windows_command_resolution_test.mbt
+++ b/src/process/windows_command_resolution_test.mbt
@@ -15,12 +15,33 @@
 
 ///|
 #cfg(platform="windows")
-async test "run explicit .com command" {
-  let (exit_code, output) = @process.collect_stdout("more.com", ["/?"])
+async test "run bare .exe command" {
+  let (exit_code, output) = @process.collect_stdout("where", ["where"])
   inspect(exit_code, content="0")
-  let text = output.text()
-  inspect(
-    text.contains("Displays output one screen at a time."),
-    content="true",
-  )
+  inspect(output.text().contains("where.exe"), content="true")
+}
+
+///|
+#cfg(platform="windows")
+async test "run explicit .exe command" {
+  let (exit_code, output) = @process.collect_stdout("where.exe", ["where"])
+  inspect(exit_code, content="0")
+  inspect(output.text().contains("where.exe"), content="true")
+}
+
+///|
+#cfg(platform="windows")
+async test "reject bare .com command" {
+  try ignore(@process.collect_stdout("more", ["/?"])) catch {
+    _ => inspect(true, content="true")
+  } noraise {
+    _ => fail("expected bare .com command to fail")
+  }
+}
+
+///|
+#cfg(platform="windows")
+async test "run explicit .com command" {
+  let (exit_code, _) = @process.collect_stdout("more.com", ["/?"])
+  inspect(exit_code, content="0")
 }

--- a/src/process/windows_command_resolution_test.mbt
+++ b/src/process/windows_command_resolution_test.mbt
@@ -1,0 +1,26 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(platform="windows")
+async test "run explicit .com command" {
+  let (exit_code, output) = @process.collect_stdout("more.com", ["/?"])
+  inspect(exit_code, content="0")
+  let text = output.text()
+  inspect(
+    text.contains("Displays output one screen at a time."),
+    content="true",
+  )
+}


### PR DESCRIPTION
## Why

The Windows process launcher rewrote every command that did not already end
with `.exe` to `cmd + ".exe"` before spawning it.

That rewrite was incorrect for explicit non-`.exe` commands such as
`more.com`, which became `more.com.exe` and failed with "file not found".

The rewrite was also unnecessary for ordinary bare commands. In this workspace,
`moon run test_programs/spawn -- where where` succeeds without any manual
suffix rewrite, which shows that Windows process creation already resolves
common bare commands correctly.

## What

- Remove the Windows-only `.exe` suffix rewrite in `src/process/windows.mbt`.
- Add focused Windows regression tests for:
  `where`, `where.exe`, `more`, and `more.com`.
- Validate explicit `.com` execution by successful process completion instead
  of decoding localized help text as UTF-8.
- Update the process directory-list expectations to include the new test file.

## Why this is correct

This change preserves the caller-provided command exactly as given instead of
applying a lossy heuristic before `CreateProcessW`.

That is more correct because:

- explicit executable names like `more.com` stay valid
- explicit executable paths with non-`.exe` suffixes are no longer corrupted
- bare commands still work through the platform's own resolution rules

In other words, the runtime should not second-guess Windows command lookup by
blindly appending `.exe`.

## Validation

- `moon test src/process/basic_test.mbt --target native`
- `moon test src/process/cwd_test.mbt --target native`
- `moon test src/process/windows_command_resolution_test.mbt --target native`
- `moon run test_programs/spawn -- more.com /?`

## Review scope

This PR is limited to Windows process command resolution and the related
regression coverage in `src/process`.
