### PR TITLE
avoid allocation in C stub

### DIFF
--- a/src/fs/stub.c
+++ b/src/fs/stub.c
@@ -91,45 +91,28 @@ int moonbitlang_async_unlock_file(int fd) {
 
 #endif
 
+MOONBIT_FFI_EXPORT
+void *moonbitlang_async_get_tmp_path() {
 #ifdef _WIN32
 
-MOONBIT_FFI_EXPORT
-moonbit_string_t moonbitlang_async_get_tmp_path() {
-  static wchar_t buffer[1024];
+  static wchar_t buffer[MAX_PATH + 1];
 
-  const DWORD buffer_len = sizeof(buffer) / sizeof(wchar_t);
-  DWORD len = GetTempPath2W(buffer_len, buffer);
+  DWORD len = GetTempPath2W(MAX_PATH + 1, buffer);
 
   if (len == 0) {
     return NULL;
   }
 
-  if (len > buffer_len) {
-    moonbit_string_t str = moonbit_make_string_raw(len - 1);
-    len = GetTempPath2W(len, (LPWSTR)str);
-    return len == 0 ? NULL : str;
-  } else {
-    moonbit_string_t str = moonbit_make_string_raw(len);
-    memcpy(str, buffer, len * sizeof(wchar_t));
-    return str;
-  }
-}
+  return buffer;
 
-#else
+#elif defined(__ANDROID__)
 
-moonbit_string_t moonbitlang_async_get_tmp_path() {
-  const char *path;
-#ifdef __ANDROID__
   const char *tmpdir = getenv("TMPDIR");
-  path = tmpdir ? tmpdir : "/data/local/tmp/";
+  return tmpdir ? tmpdir : "/data/local/tmp/";
+
 #else
-  path = "/tmp/";
+
+  return "/tmp/";
+
 #endif
-  size_t len = strlen(path);
-  moonbit_string_t str = moonbit_make_string_raw(len);
-  for (size_t i = 0; i < len; i++) {
-    ((uint16_t*)str)[i] = (uint16_t)(unsigned char)path[i];
-  }
-  return str;
 }
-#endif

--- a/src/fs/tmpdir.mbt
+++ b/src/fs/tmpdir.mbt
@@ -23,15 +23,16 @@ let tmpdir_seed : @random.Rand = {
 }
 
 ///|
-extern "C" fn get_tmp_path_ffi() -> String? = "moonbitlang_async_get_tmp_path"
+extern "C" fn get_tmp_path_ffi() -> @c_buffer.Buffer = "moonbitlang_async_get_tmp_path"
 
 ///|
 let tmp_base_path : String = {
-  guard get_tmp_path_ffi() is Some(path) else {
+  let path = get_tmp_path_ffi()
+  if path.is_null() {
     let err = @os_error.errno_to_string(@os_error.get_errno())
     abort("failed to obtain directory for temporary files: \{err}")
   }
-  path
+  @os_string.decode(path)
 }
 
 ///|

--- a/src/socket/ifname.mbt
+++ b/src/socket/ifname.mbt
@@ -58,7 +58,7 @@ extern "C" fn if_nametoindex_ffi(
 extern "C" fn if_indextoname_ffi(
   global_sock : @fd_util.Fd,
   index : UInt,
-) -> @os_string.OsString? = "moonbitlang_async_if_indextoname"
+) -> @c_buffer.Buffer = "moonbitlang_async_if_indextoname"
 
 ///|
 #doc(hidden)
@@ -77,9 +77,8 @@ pub fn if_nametoindex(name : StringView, context~ : String) -> UInt raise {
 #internal(internal, "for internal use only")
 pub fn if_indextoname(index : UInt, context~ : String) -> String raise {
   let name = if_indextoname_ffi(global_ifname_socket.val, index)
-  guard name is Some(os_name) else {
+  if name.is_null() {
     @os_error.check_errno("\{context}: if_indextoname(\{index})")
-    panic()
   }
-  os_name.to_string()
+  @os_string.decode(name)
 }

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -558,7 +558,7 @@ MOONBIT_FFI_EXPORT
 void *moonbitlang_async_if_indextoname(HANDLE sock, uint32_t index) {
 #ifdef _WIN32
 
-  WCHAR buf[NDIS_IF_MAX_STRING_SIZE + 1];
+  static WCHAR buf[NDIS_IF_MAX_STRING_SIZE + 1];
   NET_LUID luid;
 
   int err = ConvertInterfaceIndexToLuid(index, &luid);
@@ -573,37 +573,25 @@ void *moonbitlang_async_if_indextoname(HANDLE sock, uint32_t index) {
     return 0;
   }
 
-  int len = wcslen(buf);
-  moonbit_string_t str = moonbit_make_string_raw(len);
-  memcpy(str, buf, len * sizeof(WCHAR));
-
-  return str;
+  return buf;
 
 #elif defined(__linux__)
 
-  struct ifreq ifreq;
+  static struct ifreq ifreq;
   ifreq.ifr_ifindex = index;
 
   if (ioctl(sock, SIOCGIFNAME, &ifreq) < 0)
     return 0;
 
-  int len = strlen(ifreq.ifr_name);
-  moonbit_bytes_t str = moonbit_make_bytes_raw(len);
-  memcpy(str, ifreq.ifr_name, len);
-
-  return str;
+  return ifreq.ifr_name;
 
 #else
 
-  char buf[IF_NAMESIZE];
+  static char buf[IF_NAMESIZE];
   if (!if_indextoname(index, buf))
     return 0;
 
-  int len = strlen(buf);
-  moonbit_bytes_t str = moonbit_make_bytes_raw(len);
-  memcpy(str, buf, len);
-
-  return str;
+  return buf;
 
 #endif
 }

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -304,22 +304,20 @@ void moonbitlang_async_tls_ssl_free(SSL *ssl) {
   SSL_free(ssl);
 }
 
-moonbit_bytes_t moonbitlang_async_tls_ssl_get_peer_certificate(SSL *ssl) {
-  X509 *cert = SSL_get1_peer_certificate(ssl);
-  if (!cert) return 0;
+X509 *moonbitlang_async_tls_ssl_get_peer_certificate(SSL *ssl) {
+  return SSL_get1_peer_certificate(ssl);
+}
 
-  int len = i2d_X509_AUX(cert, 0);
-  if (len < 0) goto handle_error;
+int32_t moonbitlang_async_tls_peer_certificate_length(X509 *cert) {
+  return i2d_X509_AUX(cert, 0);
+}
 
-  moonbit_bytes_t result = moonbit_make_bytes_raw(len);
-  unsigned char *buf = result;
+void moonbitlang_async_tls_peer_certificate_blit_to(X509 *cert, unsigned char *buf) {
   i2d_X509_AUX(cert, &buf);
-  X509_free(cert);
-  return result;
+}
 
-handle_error:
+void moonbitlang_async_tls_free_peer_certificate(X509 *cert) {
   X509_free(cert);
-  return 0;
 }
 
 static

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -304,8 +304,10 @@ void moonbitlang_async_tls_ssl_free(SSL *ssl) {
   SSL_free(ssl);
 }
 
-X509 *moonbitlang_async_tls_ssl_get_peer_certificate(SSL *ssl) {
-  return SSL_get1_peer_certificate(ssl);
+X509 *moonbitlang_async_tls_ssl_get_certificate(SSL *ssl, int32_t is_client) {
+  return is_client
+    ? SSL_get1_peer_certificate(ssl)
+    : SSL_get_certificate(ssl);
 }
 
 int32_t moonbitlang_async_tls_peer_certificate_length(X509 *cert) {
@@ -320,15 +322,15 @@ void moonbitlang_async_tls_free_peer_certificate(X509 *cert) {
   X509_free(cert);
 }
 
-static
-moonbit_bytes_t hash_server_endpoint_certificate(X509 *cert) {
+MOONBIT_FFI_EXPORT
+void *moonbitlang_async_tls_hash_server_endpoint_certificate(X509 *cert, uint32_t *len_out) {
+  static unsigned char digest_buf[MAX_DIGEST_LEN];
+
   int signature_nid = X509_get_signature_nid(cert);
   int digest_nid = 0;
   int public_key_nid = 0;
   const EVP_MD *digest = 0;
   const char *digest_name = 0;
-  unsigned int digest_len = 0;
-  unsigned char digest_buf[MAX_DIGEST_LEN];
 
   if (!OBJ_find_sigid_algs(signature_nid, &digest_nid, &public_key_nid))
     return 0;
@@ -346,43 +348,28 @@ moonbit_bytes_t hash_server_endpoint_certificate(X509 *cert) {
   if (!digest)
     return 0;
 
-  if (!X509_digest(cert, digest, digest_buf, &digest_len))
+  if (!X509_digest(cert, digest, digest_buf, len_out))
     return 0;
 
-  moonbit_bytes_t result = moonbit_make_bytes_raw(digest_len);
-  memcpy(result, digest_buf, digest_len);
-  return result;
+  return digest_buf;
 }
 
-moonbit_bytes_t moonbitlang_async_tls_ssl_unique_channel_binding(SSL *ssl, int32_t is_client) {
-  size_t len = is_client ?
+int32_t moonbitlang_async_tls_ssl_unique_channel_binding_length(SSL *ssl, int32_t is_client) {
+  return is_client ?
     SSL_get_finished(ssl, 0, 0) :
     SSL_get_peer_finished(ssl, 0, 0);
-  if (len == 0)
-    return 0;
-
-  moonbit_bytes_t result = moonbit_make_bytes_raw(len);
-  size_t copied = is_client ?
-    SSL_get_finished(ssl, result, len) :
-    SSL_get_peer_finished(ssl, result, len);
-  if (copied != len)
-    return 0;
-  return result;
 }
 
-moonbit_bytes_t moonbitlang_async_tls_ssl_server_endpoint_channel_binding(SSL *ssl, int32_t is_client) {
+void moonbitlang_async_tls_ssl_unique_channel_binding(
+  SSL *ssl,
+  void *buf,
+  int32_t len,
+  int32_t is_client
+) {
   if (is_client) {
-    X509 *cert = SSL_get1_peer_certificate(ssl);
-    if (!cert)
-      return 0;
-    moonbit_bytes_t result = hash_server_endpoint_certificate(cert);
-    X509_free(cert);
-    return result;
+    SSL_get_finished(ssl, buf, len);
   } else {
-    X509 *cert = SSL_get_certificate(ssl);
-    if (!cert)
-      return 0;
-    return hash_server_endpoint_certificate(cert);
+    SSL_get_peer_finished(ssl, buf, len);
   }
 }
 

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -98,7 +98,28 @@ extern "C" fn SSL::accept(self : SSL) -> Int = "moonbitlang_async_tls_ssl_accept
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn SSL::get_peer_certificate(self : SSL) -> Bytes? = "moonbitlang_async_tls_ssl_get_peer_certificate"
+priv struct PeerCertificate(@c_buffer.Buffer)
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn PeerCertificate::free(self : PeerCertificate) -> Unit = "moonbitlang_async_tls_free_peer_certificate"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn PeerCertificate::length(self : PeerCertificate) -> Int = "moonbitlang_async_tls_peer_certificate_length"
+
+///|
+#cfg(not(platform="windows"))
+#borrow(buf)
+extern "C" fn PeerCertificate::blit_to(
+  self : PeerCertificate,
+  buf : FixedArray[Byte],
+  len~ : Int,
+) -> Unit = "moonbitlang_async_tls_peer_certificate_blit_to"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn SSL::get_peer_certificate(self : SSL) -> PeerCertificate = "moonbitlang_async_tls_ssl_get_peer_certificate"
 
 ///|
 #cfg(not(platform="windows"))
@@ -604,11 +625,20 @@ pub async fn Tls::shutdown(self : Tls) -> Unit {
 /// Therefore the return type is `Bytes?` instead of `Bytes`.
 #cfg(not(platform="windows"))
 pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
-  let result = self.ssl.get_peer_certificate()
-  if result is None && err_peek_error_code() != 0 {
-    raise TlsError(err_get_error())
+  let cert = self.ssl.get_peer_certificate()
+  if cert.0.is_null() {
+    if err_peek_error_code() != 0 {
+      raise TlsError(err_get_error())
+    } else {
+      return None
+    }
   }
-  result
+  defer cert.free()
+  let len = cert.length()
+  guard len > 0
+  let result = FixedArray::make(len, b'\x00')
+  cert.blit_to(result, len~)
+  Some(result.unsafe_reinterpret_as_bytes())
 }
 
 ///|

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -119,21 +119,35 @@ extern "C" fn PeerCertificate::blit_to(
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn SSL::get_peer_certificate(self : SSL) -> PeerCertificate = "moonbitlang_async_tls_ssl_get_peer_certificate"
+#borrow(len)
+extern "C" fn PeerCertificate::server_endpoint_hash(
+  self : PeerCertificate,
+  len~ : Ref[Int],
+) -> @c_buffer.Buffer = "moonbitlang_async_tls_hash_server_endpoint_certificate"
 
 ///|
 #cfg(not(platform="windows"))
+extern "C" fn SSL::get_certificate(
+  self : SSL,
+  is_client~ : Bool,
+) -> PeerCertificate = "moonbitlang_async_tls_ssl_get_certificate"
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn SSL::unique_channel_binding_length(
+  self : SSL,
+  is_client~ : Bool,
+) -> Int = "moonbitlang_async_tls_ssl_unique_channel_binding_length"
+
+///|
+#cfg(not(platform="windows"))
+#borrow(buf)
 extern "C" fn SSL::unique_channel_binding(
   self : SSL,
+  buf : FixedArray[Byte],
+  len~ : Int,
   is_client~ : Bool,
-) -> Bytes? = "moonbitlang_async_tls_ssl_unique_channel_binding"
-
-///|
-#cfg(not(platform="windows"))
-extern "C" fn SSL::server_endpoint_channel_binding(
-  self : SSL,
-  is_client~ : Bool,
-) -> Bytes? = "moonbitlang_async_tls_ssl_server_endpoint_channel_binding"
+) -> Unit = "moonbitlang_async_tls_ssl_unique_channel_binding"
 
 ///|
 pub(all) enum X509FileType {
@@ -625,7 +639,8 @@ pub async fn Tls::shutdown(self : Tls) -> Unit {
 /// Therefore the return type is `Bytes?` instead of `Bytes`.
 #cfg(not(platform="windows"))
 pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
-  let cert = self.ssl.get_peer_certificate()
+  guard self.is_client else { None }
+  let cert = self.ssl.get_certificate(is_client=true)
   if cert.0.is_null() {
     if err_peek_error_code() != 0 {
       raise TlsError(err_get_error())
@@ -646,15 +661,17 @@ pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
 /// according to RFC 5929
 #cfg(not(platform="windows"))
 pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
-  match self.ssl.unique_channel_binding(is_client=self.is_client) {
-    Some(binding) => binding
-    None =>
-      if err_peek_error_code() != 0 {
-        raise TlsError(err_get_error())
-      } else {
-        raise TlsError("tls-unique channel binding unavailable")
-      }
+  let len = self.ssl.unique_channel_binding_length(is_client=self.is_client)
+  guard len > 0 else {
+    if err_peek_error_code() != 0 {
+      raise TlsError(err_get_error())
+    } else {
+      raise TlsError("tls-unique channel binding unavailable")
+    }
   }
+  let result = FixedArray::make(len, b'\x00')
+  self.ssl.unique_channel_binding(result, len~, is_client=self.is_client)
+  result.unsafe_reinterpret_as_bytes()
 }
 
 ///|
@@ -664,15 +681,25 @@ pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
 /// so `tls-unique` is the more recommended approach when available.
 #cfg(not(platform="windows"))
 pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
-  match self.ssl.server_endpoint_channel_binding(is_client=self.is_client) {
-    Some(binding) => binding
-    None =>
-      if err_peek_error_code() != 0 {
-        raise TlsError(err_get_error())
-      } else {
-        raise TlsError("tls-server-endpoint channel binding unavailable")
-      }
+  let cert = self.ssl.get_certificate(is_client=self.is_client)
+  if cert.0.is_null() {
+    if err_peek_error_code() != 0 {
+      raise TlsError(err_get_error())
+    } else {
+      raise TlsError("tls-server-endpoint channel binding unavailable")
+    }
   }
+  // for the server, the result is obtained by `SSL_get_certificate`,
+  // which should not be freed by us according to https://docs.openssl.org/3.3/man3/SSL_get_certificate
+  defer (if self.is_client { cert.free() })
+  let len = Ref(0)
+  let hash = cert.server_endpoint_hash(len~)
+  if hash.is_null() {
+    raise TlsError(err_get_error())
+  }
+  let result = FixedArray::make(len.val, b'\x00')
+  hash.blit_to_bytes(dst=result, offset=0, len=len.val)
+  result.unsafe_reinterpret_as_bytes()
 }
 
 ///|

--- a/src/tls/schannel.c
+++ b/src/tls/schannel.c
@@ -569,41 +569,6 @@ int32_t moonbitlang_async_schannel_shutdown(struct Context *ctx) {
   return ApplyControlToken(&ctx->context, &buf_desc);
 }
 
-static
-moonbit_bytes_t get_channel_binding(struct Context *ctx, int attribute) {
-  SecPkgContext_Bindings bindings;
-  int32_t err = QueryContextAttributes(&ctx->context, attribute, &bindings);
-  if (err != SEC_E_OK) {
-    SetLastError(err);
-    return 0;
-  }
-
-  if (!bindings.Bindings) {
-    FreeContextBuffer(bindings.Bindings);
-    return 0;
-  }
-
-  unsigned long data_offset = bindings.Bindings->dwApplicationDataOffset;
-  unsigned long data_len = bindings.Bindings->cbApplicationDataLength;
-  if (
-    data_offset > bindings.BindingsLength ||
-    data_len > bindings.BindingsLength - data_offset
-  ) {
-    SetLastError(ERROR_INVALID_DATA);
-    FreeContextBuffer(bindings.Bindings);
-    return 0;
-  }
-
-  moonbit_bytes_t result = moonbit_make_bytes_raw(data_len);
-  memcpy(
-    result,
-    ((unsigned char *)bindings.Bindings) + data_offset,
-    data_len
-  );
-  FreeContextBuffer(bindings.Bindings);
-  return result;
-}
-
 MOONBIT_FFI_EXPORT
 CERT_CONTEXT *moonbitlang_async_schannel_get_peer_certificate(struct Context *ctx) {
   CERT_CONTEXT *cert = 0;
@@ -637,13 +602,43 @@ void moonbitlang_async_schannel_peer_certificate_blit_to(
   memcpy(buf, cert->pbCertEncoded, len);
 }
 
+static
+SEC_CHANNEL_BINDINGS *get_channel_binding(struct Context *ctx, int attribute) {
+  SecPkgContext_Bindings bindings;
+  int32_t err = QueryContextAttributes(&ctx->context, attribute, &bindings);
+  if (err != SEC_E_OK) {
+    SetLastError(err);
+    return 0;
+  }
+  return bindings.Bindings;
+}
+
 MOONBIT_FFI_EXPORT
-moonbit_bytes_t moonbitlang_async_schannel_unique_channel_binding(struct Context *ctx) {
+int32_t moonbitlang_async_schannel_channel_binding_length(SEC_CHANNEL_BINDINGS *bindings) {
+  return bindings->cbApplicationDataLength;
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_schannel_channel_binding_blit_to(
+  SEC_CHANNEL_BINDINGS *bindings,
+  void *buf,
+  int32_t len
+) {
+  memcpy(buf, ((unsigned char *)bindings) + bindings->dwApplicationDataOffset, len);
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_schannel_free_channel_binding(SEC_CHANNEL_BINDINGS *bindings) {
+  FreeContextBuffer(bindings);
+}
+
+MOONBIT_FFI_EXPORT
+SEC_CHANNEL_BINDINGS *moonbitlang_async_schannel_unique_channel_binding(struct Context *ctx) {
   return get_channel_binding(ctx, SECPKG_ATTR_UNIQUE_BINDINGS);
 }
 
 MOONBIT_FFI_EXPORT
-moonbit_bytes_t moonbitlang_async_schannel_server_endpoint_channel_binding(struct Context *ctx) {
+SEC_CHANNEL_BINDINGS *moonbitlang_async_schannel_server_endpoint_channel_binding(struct Context *ctx) {
   return get_channel_binding(ctx, SECPKG_ATTR_ENDPOINT_BINDINGS);
 }
 

--- a/src/tls/schannel.c
+++ b/src/tls/schannel.c
@@ -605,23 +605,36 @@ moonbit_bytes_t get_channel_binding(struct Context *ctx, int attribute) {
 }
 
 MOONBIT_FFI_EXPORT
-moonbit_bytes_t moonbitlang_async_schannel_get_peer_certificate(struct Context *ctx) {
+CERT_CONTEXT *moonbitlang_async_schannel_get_peer_certificate(struct Context *ctx) {
   CERT_CONTEXT *cert = 0;
   int err = QueryContextAttributes(&ctx->context, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &cert);
   if (err != SEC_E_OK && err != SEC_E_NO_CREDENTIALS) {
     SetLastError(err);
     return 0;
-  }
-
-  if (!cert) {
+  } else {
     SetLastError(0);
-    return 0;
   }
 
-  moonbit_bytes_t result = moonbit_make_bytes_raw(cert->cbCertEncoded);
-  memcpy(result, cert->pbCertEncoded, cert->cbCertEncoded);
+  return cert;
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_schannel_free_peer_certificate(CERT_CONTEXT *cert) {
   CertFreeCertificateContext(cert);
-  return result;
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_schannel_peer_certificate_length(CERT_CONTEXT *cert) {
+  return cert->cbCertEncoded;
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_schannel_peer_certificate_blit_to(
+  CERT_CONTEXT *cert,
+  void *buf,
+  int32_t len
+) {
+  memcpy(buf, cert->pbCertEncoded, len);
 }
 
 MOONBIT_FFI_EXPORT

--- a/src/tls/schannel.mbt
+++ b/src/tls/schannel.mbt
@@ -483,15 +483,36 @@ extern "C" fn Schannel::get_peer_certificate(ch : Schannel) -> PeerCertificate =
 
 ///|
 #cfg(platform="windows")
+priv struct ChannelBinding(@c_buffer.Buffer)
+
+///|
+#cfg(platform="windows")
+extern "C" fn ChannelBinding::free(self : ChannelBinding) -> Unit = "moonbitlang_async_schannel_free_channel_binding"
+
+///|
+#cfg(platform="windows")
+extern "C" fn ChannelBinding::length(self : ChannelBinding) -> Int = "moonbitlang_async_schannel_channel_binding_length"
+
+///|
+#cfg(platform="windows")
+#borrow(buf)
+extern "C" fn ChannelBinding::blit_to(
+  self : ChannelBinding,
+  buf : FixedArray[Byte],
+  len~ : Int,
+) -> Unit = "moonbitlang_async_schannel_channel_binding_blit_to"
+
+///|
+#cfg(platform="windows")
 #borrow(ch)
-extern "C" fn Schannel::unique_channel_binding(ch : Schannel) -> Bytes? = "moonbitlang_async_schannel_unique_channel_binding"
+extern "C" fn Schannel::unique_channel_binding(ch : Schannel) -> ChannelBinding = "moonbitlang_async_schannel_unique_channel_binding"
 
 ///|
 #cfg(platform="windows")
 #borrow(ch)
 extern "C" fn Schannel::server_endpoint_channel_binding(
   ch : Schannel,
-) -> Bytes? = "moonbitlang_async_schannel_server_endpoint_channel_binding"
+) -> ChannelBinding = "moonbitlang_async_schannel_server_endpoint_channel_binding"
 
 ///|
 #cfg(platform="windows")
@@ -512,21 +533,31 @@ pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
 }
 
 ///|
+#cfg(platform="windows")
+fn ChannelBinding::to_bytes(self : ChannelBinding) -> Bytes {
+  defer self.free()
+  let len = self.length()
+  guard len > 0
+  let buf = FixedArray::make(len, b'\x00')
+  self.blit_to(buf, len~)
+  buf.unsafe_reinterpret_as_bytes()
+}
+
+///|
 /// Return `tls-unique` type of channel binding data for this TLS connection,
 /// according to RFC 5929
 #cfg(platform="windows")
 pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
-  match self.context.unique_channel_binding() {
-    Some(binding) => binding
-    None => {
-      let errno = @os_error.get_errno()
-      if errno != 0 {
-        raise TlsError(@os_error.errno_to_string(errno))
-      } else {
-        raise TlsError("tls-unique channel binding unavailable")
-      }
+  let binding = self.context.unique_channel_binding()
+  if binding.0.is_null() {
+    let errno = @os_error.get_errno()
+    if errno != 0 {
+      raise TlsError(@os_error.errno_to_string(errno))
+    } else {
+      raise TlsError("tls-unique channel binding unavailable")
     }
   }
+  binding.to_bytes()
 }
 
 ///|
@@ -536,17 +567,16 @@ pub fn Tls::unique_channel_binding(self : Tls) -> Bytes raise {
 /// so `tls-unique` is the more recommended approach when available.
 #cfg(platform="windows")
 pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
-  match self.context.server_endpoint_channel_binding() {
-    Some(binding) => binding
-    None => {
-      let errno = @os_error.get_errno()
-      if errno != 0 {
-        raise TlsError(@os_error.errno_to_string(errno))
-      } else {
-        raise TlsError("tls-server-endpoint channel binding unavailable")
-      }
+  let binding = self.context.server_endpoint_channel_binding()
+  if binding.0.is_null() {
+    let errno = @os_error.get_errno()
+    if errno != 0 {
+      raise TlsError(@os_error.errno_to_string(errno))
+    } else {
+      raise TlsError("tls-server-endpoint channel binding unavailable")
     }
   }
+  binding.to_bytes()
 }
 
 ///|

--- a/src/tls/schannel.mbt
+++ b/src/tls/schannel.mbt
@@ -457,8 +457,29 @@ pub async fn Tls::shutdown(self : Tls) -> Unit {
 
 ///|
 #cfg(platform="windows")
+priv struct PeerCertificate(@c_buffer.Buffer)
+
+///|
+#cfg(platform="windows")
+extern "C" fn PeerCertificate::free(self : PeerCertificate) -> Unit = "moonbitlang_async_schannel_free_peer_certificate"
+
+///|
+#cfg(platform="windows")
+extern "C" fn PeerCertificate::length(self : PeerCertificate) -> Int = "moonbitlang_async_schannel_peer_certificate_length"
+
+///|
+#cfg(platform="windows")
+#borrow(buf)
+extern "C" fn PeerCertificate::blit_to(
+  self : PeerCertificate,
+  buf : FixedArray[Byte],
+  len~ : Int,
+) -> Unit = "moonbitlang_async_schannel_peer_certificate_blit_to"
+
+///|
+#cfg(platform="windows")
 #borrow(ch)
-extern "C" fn Schannel::get_peer_certificate(ch : Schannel) -> Bytes? = "moonbitlang_async_schannel_get_peer_certificate"
+extern "C" fn Schannel::get_peer_certificate(ch : Schannel) -> PeerCertificate = "moonbitlang_async_schannel_get_peer_certificate"
 
 ///|
 #cfg(platform="windows")
@@ -475,14 +496,19 @@ extern "C" fn Schannel::server_endpoint_channel_binding(
 ///|
 #cfg(platform="windows")
 pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
-  let result = self.context.get_peer_certificate()
-  if result is None {
-    let errno = @os_error.get_errno()
-    if errno != 0 {
-      raise TlsError(@os_error.errno_to_string(errno))
-    }
+  let cert = self.context.get_peer_certificate()
+  if cert.0.is_null() {
+    @os_error.check_errno("@tls.Tls::get_peer_certificate()")
+    // if the error number is 0,
+    // no error is happening, the certificate simply does not exist
+    return None
   }
-  result
+  defer cert.free()
+  let len = cert.length()
+  guard len > 0
+  let result = FixedArray::make(len, b'\x00')
+  cert.blit_to(result, len~)
+  Some(result.unsafe_reinterpret_as_bytes())
 }
 
 ///|


### PR DESCRIPTION
In order to support WASM backend for `moonbitlang/async` in the future, allocation of MoonBit object in C stub must be avoided, because WASM runtime cannot allocate MoonBit objects in wasm1 backend. This PR solves the simple ones:

- `if_indextoname`
- base path for `@fs.tmpdir`
- `@tls.Tls::{get_peer_certificate,get_unique_channel_binding,get_server_endpoint_channel_binding}`

The trick is similar: obtain the length of result first, allocate from the MoonBit side, and copy later.

There are several other remaining allocation site in C stub after this PR:

- current environment handling in `@process`
- allocation of thread pool job
- allocation inside `realpath_job`

these allocation sites are trickier to eliminate, and may require larger refactor. So they will go into their own PR.