### PR TITLE
add `@io.MemoryReader` type

### DIFF
--- a/src/io/README.mbt.md
+++ b/src/io/README.mbt.md
@@ -9,6 +9,7 @@ Asynchronous I/O abstraction for MoonBit. This package provides fundamental abst
   - [Reader Trait](#reader-trait)
   - [Writer Trait](#writer-trait)
   - [Data Trait](#data-trait)
+- [wrap in-memory data into reader](#wrap-in-memory-data-into-reader)
 - [Buffered I/O](#buffered-io)
   - [BufferedReader](#bufferedreader)
   - [BufferedWriter](#bufferedwriter)
@@ -299,6 +300,55 @@ async test "read_until - used to read file line by line" {
   }
   inspect(lines.length(), content="202")
   assert_eq(lines.join("\n") + "\n", @fs.read_file("LICENSE").text())
+}
+```
+
+## Wrap In-memory Data Into Reader
+
+`MemoryReader` wraps an async writer callback as a `Reader`. The callback receives an auxiliary writer, runs in the background, and any data written to that writer becomes readable from the `MemoryReader`. This is useful when an API expects a `Reader`, but the data is produced in memory or generated incrementally.
+
+The reader reaches EOF when the callback returns normally. If the callback raises an error, read operations fail with the same error. Closing the reader cancels the background callback if it is still running.
+
+```moonbit check
+///|
+async test "MemoryReader - generate reader content in memory" {
+  let r = @io.MemoryReader() <| w => {
+    w.write("hello, ")
+    @async.sleep(10)
+    w.write("MoonBit")
+  }
+  defer r.close()
+  inspect(r.read_all().text(), content="hello, MoonBit")
+}
+
+///|
+async test "MemoryReader - stream generated chunks" {
+  let r = @io.MemoryReader() <| w => {
+    for part in ["ab", "cd", "ef"] {
+      w.write(part)
+      @async.sleep(10)
+    }
+  }
+  defer r.close()
+  debug_inspect(
+    r.read_some().map(data => @utf8.decode(data)),
+    content=(
+      #|Some("ab")
+    ),
+  )
+  debug_inspect(
+    r.read_some().map(data => @utf8.decode(data)),
+    content=(
+      #|Some("cd")
+    ),
+  )
+  debug_inspect(
+    r.read_some().map(data => @utf8.decode(data)),
+    content=(
+      #|Some("ef")
+    ),
+  )
+  debug_inspect(r.read_some(), content="None")
 }
 ```
 
@@ -609,6 +659,12 @@ A buffered reader that wraps around a normal reader. Methods include:
 - `find_opt(target)` - Find substring (returns None if not found)
 - `read_line()` - Read line until newline
 
+### MemoryReader
+
+A reader backed by an async in-memory writer callback. Methods include:
+- `MemoryReader(callback)` - Create a reader and run `callback` in the background with an auxiliary writer
+- `close()` - Close the reader and cancel the background callback if it is still running
+
 ### BufferedWriter
 
 A buffered writer with fixed-size buffer. Methods include:
@@ -637,4 +693,3 @@ Error raised when attempting to read from a closed reader.
   `.text()` and `.json()` methods need to perform decoding and parsing, so users should cache the result of these conversion methods instead of calling them repeatedly
 
 For more examples and detailed usage, explore the test suites in this package—they double as executable documentation.
-

--- a/src/io/memory_reader.mbt
+++ b/src/io/memory_reader.mbt
@@ -1,0 +1,68 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A reader for transferring data in-memory.
+/// This is useful for passing in-memory to reader-receiving API.
+struct MemoryReader {
+  reader : PipeRead
+  writer : @coroutine.Coroutine
+}
+
+///|
+/// Create a in-memory reader by providing a data-writting function.
+/// The callback receive a auxiliary writer as argument,
+/// data written to the writer can be read from the in-memory reader.
+///
+/// The callback function will be run in a background task.
+/// the reader will reach EOF hen the callback function terminates normally.
+///
+/// If the callback function failed,
+/// all read operation on the in-memory reader will fail with the same error.
+///
+/// If the reader is closed before the callback completes,
+/// the callback will be cancelled automatically.
+pub fn MemoryReader::MemoryReader(f : async (&Writer) -> Unit) -> MemoryReader {
+  let (r, w) = pipe()
+  let writer = @coroutine.spawn() <| () => {
+    defer w.close()
+    f(w)
+  }
+  { reader: r, writer }
+}
+
+///|
+/// Close the reader.
+/// If the writer callback is still running, it will be cancelled.
+pub fn MemoryReader::close(self : MemoryReader) -> Unit {
+  self.reader.close()
+  self.writer.cancel()
+}
+
+///|
+pub impl Reader for MemoryReader with fn _get_internal_buffer(self) {
+  self.reader._get_internal_buffer()
+}
+
+///|
+pub impl Reader for MemoryReader with fn _direct_read(
+  self,
+  buf,
+  offset~,
+  max_len~,
+) {
+  let n = self.reader._direct_read(buf, offset~, max_len~)
+  self.writer.check_error()
+  n
+}

--- a/src/io/memory_reader_test.mbt
+++ b/src/io/memory_reader_test.mbt
@@ -1,0 +1,81 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "MemoryReader basic" {
+  let log = []
+  let r = @io.MemoryReader() <| w => {
+    for data in ["abcd", "1234", "xyzw"] {
+      log.push("writing \{data}")
+      w.write(data)
+      @async.sleep(150)
+    }
+  }
+  defer r.close()
+  while r.read_some() is Some(data) {
+    log.push("received \{@utf8.decode(data)}")
+  }
+  json_inspect(log, content=[
+    "writing abcd", "received abcd", "writing 1234", "received 1234", "writing xyzw",
+    "received xyzw",
+  ])
+}
+
+///|
+async test "MemoryReader cancel" {
+  let log = []
+  let r = @io.MemoryReader() <| w => {
+    for i = 0; ; i = i + 1 {
+      try w.write("#\{i}") catch {
+        err => {
+          log.push("`write` fail with \{err}")
+          raise err
+        }
+      } noraise {
+        _ => log.push("written #\{i} successfully")
+      }
+    }
+  }
+  for _ in 0..<3 {
+    guard r.read_some() is Some(data) else { break }
+    @async.sleep(50)
+    log.push("received \{@utf8.decode(data)}")
+  }
+  r.close()
+  @async.sleep(50)
+  json_inspect(log, content=[
+    "written #0 successfully", "received #0", "written #1 successfully", "received #1",
+    "written #2 successfully", "received #2", "`write` fail with Cancelled",
+  ])
+}
+
+///|
+async test "MemoryReader failure" {
+  let r = @io.MemoryReader() <| _ => {
+    @async.sleep(150)
+    raise Failure::Failure("failure")
+  }
+  defer r.close()
+  try r.read_all().text() catch {
+    err =>
+      inspect(
+        err,
+        content=(
+          #|Failure(failure)
+        ),
+      )
+  } noraise {
+    _ => fail("expected failure, but program does not raise any error")
+  }
+}

--- a/src/io/pkg.generated.mbti
+++ b/src/io/pkg.generated.mbti
@@ -28,6 +28,13 @@ pub(all) enum Encoding {
   UTF8
 }
 
+pub struct MemoryReader {
+  // private fields
+}
+pub fn MemoryReader::MemoryReader(async (&Writer) -> Unit) -> Self
+pub fn MemoryReader::close(Self) -> Unit
+pub impl Reader for MemoryReader
+
 type PipeRead
 pub fn PipeRead::close(Self) -> Unit
 pub impl Reader for PipeRead


### PR DESCRIPTION
This PR introduces a new type `@io.MemoryReader`, which allows wrapping in-memory data into a reader. This is useful for passing in-memory data to API that accept a reader. `@io.MemoryReader` can be created with `@io.MemoryReader(f)`, where `f` is a callback that receive an auxiliary writer as argument. Data written to the auxiliary writer can be read from the resulting reader. Some semantic details:

- when `f` terminates normally, the reader will reach EOF
- when `f` fails, all read operations on the reader will fail with the same error
- `f` will be run in a background task, if the reader is closed before `f` terminates, the task will be cancelled