### PR TITLE
fix UTF8 validation for WebSocket

### DIFF
--- a/src/websocket/utf8_validation_wbtest.mbt
+++ b/src/websocket/utf8_validation_wbtest.mbt
@@ -20,7 +20,7 @@ test "validate utf8 single byte" {
 ///|
 test "validate utf8 two bytes" {
   debug_inspect(verify_utf8([0xc0], remaining=0), content="1")
-  debug_inspect(verify_utf8([0xc0, 0x80], remaining=0), content="0")
+  debug_inspect(verify_utf8([0xdf, 0x80], remaining=0), content="0")
   debug_inspect(
     @test.expect_error(() => verify_utf8([0xc0, 0x79], remaining=0)),
     content=(
@@ -33,7 +33,7 @@ test "validate utf8 two bytes" {
 test "validate utf8 three bytes" {
   debug_inspect(verify_utf8([0xe0], remaining=0), content="2")
   debug_inspect(verify_utf8([0xe0, 0x80], remaining=0), content="1")
-  debug_inspect(verify_utf8([0xe0, 0x80, 0x80], remaining=0), content="0")
+  debug_inspect(verify_utf8([0xef, 0x80, 0x80], remaining=0), content="0")
   debug_inspect(
     @test.expect_error(() => verify_utf8([0xe0, 0x79], remaining=0)),
     content=(
@@ -53,7 +53,7 @@ test "validate utf8 four bytes" {
   debug_inspect(verify_utf8([0xf0], remaining=0), content="3")
   debug_inspect(verify_utf8([0xf0, 0x80], remaining=0), content="2")
   debug_inspect(verify_utf8([0xf0, 0x80, 0x80], remaining=0), content="1")
-  debug_inspect(verify_utf8([0xf0, 0x80, 0x80, 0x80], remaining=0), content="0")
+  debug_inspect(verify_utf8([0xf7, 0x80, 0x80, 0x80], remaining=0), content="0")
   debug_inspect(
     @test.expect_error(() => verify_utf8([0xf0, 0x79], remaining=0)),
     content=(
@@ -75,6 +75,16 @@ test "validate utf8 four bytes" {
   debug_inspect(
     verify_utf8([0xf0, 0x80, 0x80, 0x80, 0x79], remaining=0),
     content="0",
+  )
+}
+
+///|
+test "invalid utf8 first byte" {
+  debug_inspect(
+    @test.expect_error(() => verify_utf8([0xf8], remaining=0)),
+    content=(
+      #|Malformed(<BytesView: [0xf8]>)
+    ),
   )
 }
 

--- a/src/websocket/utils.mbt
+++ b/src/websocket/utils.mbt
@@ -97,7 +97,7 @@ fn verify_utf8(data : BytesView, remaining~ : Int) -> Int raise {
       (0, 0..<0x80) => continue i + 1, 0
       (0, 0xc0..<0xe0) => continue i + 1, 1
       (0, 0xe0..<0xf0) => continue i + 1, 2
-      (0, 0xf0) => continue i + 1, 3
+      (0, 0xf0..<0xf8) => continue i + 1, 3
       (0, _) => {
         ignore(@utf8.decode(data[i:i + 1]))
         panic()


### PR DESCRIPTION
Current WebSocket UTF8 validation for text message does not handle four byte UTF8 encoding properly. It has incorrect assumption on the first byte's value range. This PR fixes the problem.