### PR TITLE
allow executing `.com` file on Windows

### DIFF
--- a/src/process/basic_test.mbt
+++ b/src/process/basic_test.mbt
@@ -59,3 +59,15 @@ async test "basic_cat" {
     }
   }
 }
+
+///|
+#cfg(platform="windows")
+async test "execute .com file" {
+  let (_, output) = @process.collect_stdout("chcp.com", [])
+  guard output.binary().chop_suffix(b"\r\n") is Some(output) &&
+    output.rev_find(b" ") is Some(index) &&
+    index + 1 < output.length() else {
+    fail("invalid output format from chcp")
+  }
+  let _code = @string.parse_int(@utf8.decode(output[index + 1:]))
+}

--- a/src/process/moon.pkg
+++ b/src/process/moon.pkg
@@ -14,6 +14,7 @@ import {
 import {
   "moonbitlang/core/env",
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/string",
   "moonbitlang/async/fs",
   "moonbitlang/async/internal/test_util",
 } for "test"

--- a/src/process/windows.mbt
+++ b/src/process/windows.mbt
@@ -84,7 +84,7 @@ async fn raw_spawn(
   context~ : String,
 ) -> @event_loop.Process {
   let cmd = match cmd {
-    [.., .. ".exe"] => cmd
+    [.., .. ".exe"] | [.., .. ".com"] => cmd
     _ => cmd + ".exe"
   }
   let command_line = StringBuilder::new()


### PR DESCRIPTION
closes #414.

See #414 for more details and background info.