### PR TITLE
manually manage lifetime of job objects

### DIFF
--- a/src/fs/watch.mbt
+++ b/src/fs/watch.mbt
@@ -13,11 +13,7 @@
 // limitations under the License.
 
 ///|
-#valtype
-priv struct FileIdentity {
-  dev_id : UInt64
-  file_id : UInt64
-} derive(Eq, Hash)
+using @event_loop {type FileIdentity}
 
 ///|
 priv struct WatchedFile {
@@ -139,7 +135,7 @@ pub async fn Watcher::Watcher(
   let context = "@fs.Watcher()"
   let path = path.trim_end(chars="/")
   let path = if path is "" { "/" } else { path.to_owned() }
-  let (root_file, root_file_info) = @event_loop.open(
+  let (root_file, root_id) = @event_loop.open(
     path,
     if @event_loop.IS_WINDOWS {
       3
@@ -155,10 +151,6 @@ pub async fn Watcher::Watcher(
   guard root_file.kind() is Directory else {
     root_file.close()
     raise @os_error.OSError(@os_error.errno_ENOTDIR, context~)
-  }
-  let root_id = {
-    dev_id: root_file_info.dev_id(),
-    file_id: root_file_info.file_id(),
   }
   let self = {
     backend: None,

--- a/src/fs/watch_windows.mbt
+++ b/src/fs/watch_windows.mbt
@@ -182,12 +182,13 @@ async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
       } else {
         offset += size
       }
-      let file_id = if WindowsWatcher::has_ReadDirectoryChangesExW() {
-        if event.is_modify() {
+      let file_id : FileIdentity = if WindowsWatcher::has_ReadDirectoryChangesExW() {
+        let file_id = if event.is_modify() {
           event.get_file_id()
         } else {
           event.get_parent_file_id()
         }
+        { dev_id: self.dev_id, file_id }
       } else {
         let path = @os_string.decode(event.get_path(), len=event.get_path_len())
         let path = if event.is_modify() {
@@ -202,7 +203,7 @@ async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
           }
         }
         // file change in the root directory
-        let (file, file_info) = @event_loop.open(
+        let (file, file_id) = @event_loop.open(
           "\{self.watcher.base_path}\\\{path}",
           0,
           create=0,
@@ -212,9 +213,8 @@ async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
           context~,
         )
         file.close()
-        file_info.file_id()
+        file_id
       }
-      let file_id = { dev_id: self.dev_id, file_id }
       if self.watcher.watched.get(file_id) is Some(file) {
         if !(event.is_modify() && file.is_dir) {
           self.watcher.mark_as_modified(file_id)

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -35,6 +35,7 @@ pub async fn open(
 ) -> (IoHandle, FileIdentity) {
   let path_bytes = @os_string.encode(path)
   let job = Job::open(path_bytes, access, create~, append~, sync~, mode~)
+  defer job.0.free()
   fn cancel(job_id) raise {
     guard curr_loop.val is Some(evloop)
     evloop.cancel_job_in_worker(job_id, context~)
@@ -63,8 +64,9 @@ pub async fn kind_of_fd(
   fd : @fd_util.Fd,
   context~ : String,
 ) -> @fd_util.FileKind {
-  perform_job_in_worker(Job::kind_of_fd(fd), context~)
-  |> @fd_util.FileKind::unsafe_from_int
+  let job = Job::kind_of_fd(fd)
+  defer job.free()
+  perform_job_in_worker(job, context~) |> @fd_util.FileKind::unsafe_from_int
 }
 
 ///|
@@ -80,6 +82,7 @@ pub async fn file_kind_by_path(
 ) -> @fd_util.FileKind {
   let path_bytes = @os_string.encode(path)
   let job = Job::file_kind_by_path(parent, path_bytes, follow_symlink~)
+  defer job.free()
   try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
@@ -92,6 +95,7 @@ pub async fn file_kind_by_path(
 ///|
 pub async fn file_size(fd : @fd_util.Fd, context~ : String) -> Int64 {
   let job = Job::file_size(fd)
+  defer job.free()
   let _ = perform_job_in_worker(job, context~)
   job.get_file_size_result()
 }
@@ -103,6 +107,7 @@ pub async fn file_time(
 ) -> @fd_util.FileTime {
   let result = @fd_util.FileTime::new()
   let job = Job::file_time(fd, result)
+  defer job.free()
   let _ = perform_job_in_worker(job, context~)
   result
 }
@@ -116,6 +121,7 @@ pub async fn file_time_by_path(
   let path_bytes = @os_string.encode(path)
   let result = @fd_util.FileTime::new()
   let job = Job::file_time_by_path(path_bytes, result, follow_symlink~)
+  defer job.free()
   try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
@@ -129,7 +135,9 @@ pub async fn file_time_by_path(
 ///|
 pub async fn access(path : StringView, acc : Access, context~ : String) -> Int {
   let path_bytes = @os_string.encode(path)
-  perform_job_in_worker(Job::access(path_bytes, acc), context~) catch {
+  let job = Job::access(path_bytes, acc)
+  defer job.free()
+  perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
     err => raise err
@@ -139,7 +147,9 @@ pub async fn access(path : StringView, acc : Access, context~ : String) -> Int {
 ///|
 pub async fn chmod(path : StringView, mode : Int, context~ : String) -> Unit {
   let path_bytes = @os_string.encode(path)
-  try perform_job_in_worker(Job::chmod(path_bytes, mode), context~) catch {
+  let job = Job::chmod(path_bytes, mode)
+  defer job.free()
+  try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
     err => raise err
@@ -154,7 +164,9 @@ pub async fn IoHandle::fsync(
   only_data~ : Bool,
   context~ : String,
 ) -> Unit {
-  perform_job_in_worker(Job::fsync(handle.fd, only_data), context~) |> ignore
+  let job = Job::fsync(handle.fd, only_data)
+  defer job.free()
+  perform_job_in_worker(job, context~) |> ignore
 }
 
 ///|
@@ -164,8 +176,10 @@ pub async fn IoHandle::lock(
   context~ : String,
 ) -> Unit {
   guard curr_loop.val is Some(evloop)
+  let job = Job::flock(handle.fd, exclusive)
+  defer job.free()
   perform_job_in_worker(
-    Job::flock(handle.fd, exclusive),
+    job,
     cancel=job_id => evloop.cancel_job_in_worker(job_id, context~),
     context~,
   )
@@ -175,7 +189,9 @@ pub async fn IoHandle::lock(
 ///|
 pub async fn remove(path : StringView, context~ : String) -> Unit {
   let path_bytes = @os_string.encode(path)
-  try perform_job_in_worker(Job::remove(path_bytes), context~) catch {
+  let job = Job::remove(path_bytes)
+  defer job.free()
+  try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
     err => raise err
@@ -193,12 +209,9 @@ pub async fn rename(
 ) -> Unit {
   let old_path_bytes = @os_string.encode(old_path)
   let new_path_bytes = @os_string.encode(new_path)
-  try
-    perform_job_in_worker(
-      Job::rename(old_path_bytes, new_path_bytes, replace~),
-      context~,
-    )
-  catch {
+  let job = Job::rename(old_path_bytes, new_path_bytes, replace~)
+  defer job.free()
+  try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(
         errno,
@@ -218,9 +231,9 @@ pub async fn symlink(
 ) -> Unit {
   let target_bytes = @os_string.encode(target)
   let path_bytes = @os_string.encode(path)
-  try
-    perform_job_in_worker(Job::symlink(target_bytes, path_bytes), context~)
-  catch {
+  let job = Job::symlink(target_bytes, path_bytes)
+  defer job.free()
+  try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(
         errno,
@@ -235,7 +248,9 @@ pub async fn symlink(
 ///|
 pub async fn mkdir(path : StringView, mode~ : Int, context~ : String) -> Unit {
   let path_bytes = @os_string.encode(path)
-  try perform_job_in_worker(Job::mkdir(path_bytes, mode), context~) catch {
+  let job = Job::mkdir(path_bytes, mode)
+  defer job.free()
+  try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
     err => raise err
@@ -247,7 +262,9 @@ pub async fn mkdir(path : StringView, mode~ : Int, context~ : String) -> Unit {
 ///|
 pub async fn rmdir(path : StringView, context~ : String) -> Unit {
   let path_bytes = @os_string.encode(path)
-  try perform_job_in_worker(Job::rmdir(path_bytes), context~) catch {
+  let job = Job::rmdir(path_bytes)
+  defer job.free()
+  try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
     err => raise err
@@ -265,6 +282,7 @@ pub async fn IoHandle::readdir(
   context~ : String,
 ) -> Int {
   let job = Job::readdir(dir.fd, buf, len, restart)
+  defer job.free()
   perform_job_in_worker(job, context~)
 }
 
@@ -273,6 +291,7 @@ pub async fn IoHandle::readdir(
 pub async fn realpath(path : StringView, context~ : String) -> String {
   let path_bytes = @os_string.encode(path)
   let job = Job::realpath(path_bytes)
+  defer job.free()
   let _ = perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
@@ -288,6 +307,7 @@ pub async fn realpath(path : StringView, context~ : String) -> String {
 pub async fn realpath(path : StringView, context~ : String) -> String {
   let path_bytes = @os_string.encode(path)
   let job = Job::realpath(path_bytes)
+  defer job.free()
   let _ = perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
@@ -306,6 +326,7 @@ pub async fn inotify_add_watch(
 ) -> @fd_util.Fd {
   let path_bytes = @os_string.encode(path)
   let job = Job::inotify_add_watch(inotify, path_bytes, is_dir)
+  defer job.free()
   perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -13,6 +13,13 @@
 // limitations under the License.
 
 ///|
+#valtype
+pub(all) struct FileIdentity {
+  dev_id : UInt64
+  file_id : UInt64
+} derive(Eq, Hash)
+
+///|
 pub async fn open(
   path : StringView,
   // 0 => read only, 1 => write only, 2 => read write, 3 => directory listing
@@ -25,28 +32,28 @@ pub async fn open(
   // permission for file when new file is created
   mode~ : Int,
   context~ : String,
-) -> (IoHandle, OpenResult) {
+) -> (IoHandle, FileIdentity) {
   let path_bytes = @os_string.encode(path)
-  let result = Job::open(path_bytes, access, create~, append~, sync~, mode~)
+  let job = Job::open(path_bytes, access, create~, append~, sync~, mode~)
   fn cancel(job_id) raise {
     guard curr_loop.val is Some(evloop)
     evloop.cancel_job_in_worker(job_id, context~)
   }
 
-  try perform_job_in_worker(result.0, context~, cancel~) catch {
+  try perform_job_in_worker(job.0, context~, cancel~) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
     err => raise err
   } noraise {
     _ => {
-      let fd = result.fd()
-      let kind = result.kind()
+      let fd = job.fd()
+      let kind = job.kind()
       let io = IoHandle::from_fd(
         fd,
         kind~,
         is_async=access is 3 || (!IS_WINDOWS && kind.can_poll()),
       )
-      (io, result)
+      (io, { dev_id: job.dev_id(), file_id: job.file_id() })
     }
   }
 }

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -177,6 +177,7 @@ pub async fn IoHandle::read(
       None
     }
     let job = Job::read(handle.fd, buf, offset, len, position=-1)
+    defer job.free()
     perform_job_in_worker(job, context~, cancel?)
   }
 }
@@ -193,6 +194,7 @@ pub async fn IoHandle::read_at(
 ) -> Int {
   guard !handle.kind.can_poll()
   let job = Job::read(handle.fd, buf, offset, len, position~)
+  defer job.free()
   perform_job_in_worker(job, context~)
 }
 
@@ -241,6 +243,7 @@ pub async fn IoHandle::write(
       None
     }
     let job = Job::write(handle.fd, buf, offset, len, position=-1)
+    defer job.free()
     perform_job_in_worker(job, context~, cancel?)
   }
 }
@@ -257,5 +260,6 @@ pub async fn IoHandle::write_at(
 ) -> Unit {
   guard !handle.kind.can_poll()
   let job = Job::write(handle.fd, buf, offset, len, position~)
+  defer job.free()
   perform_job_in_worker(job, context~) |> ignore
 }

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -257,6 +257,7 @@ pub async fn IoHandle::read(
       len,
       position=handle.read_offset,
     )
+    defer job.free()
     let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
     let n = perform_job_in_worker(job, context~, cancel~) catch {
       @os_error.OSError(errno, ..) if errno_is_read_eof(errno) => 0
@@ -306,6 +307,7 @@ pub async fn IoHandle::read_at(
   guard curr_loop.val is Some(evloop)
   guard handle.kind is Regular
   let job = Job::read(handle.fd, buf, offset, len, position~)
+  defer job.free()
   let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
   perform_job_in_worker(job, context~, cancel~) catch {
     @os_error.OSError(errno, ..) if errno_is_read_eof(errno) => 0
@@ -368,6 +370,7 @@ pub async fn IoHandle::write(
       len,
       position=handle.write_offset,
     )
+    defer job.free()
     let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
     let n = perform_job_in_worker(job, context~, cancel~)
     handle.write_offset += n.to_int64()
@@ -400,6 +403,7 @@ pub async fn IoHandle::write_at(
   guard curr_loop.val is Some(evloop)
   guard handle.kind is Regular
   let job = Job::write(handle.fd, buf, offset, len, position~)
+  defer job.free()
   let cancel = job_id => evloop.cancel_job_in_worker(job_id, context~)
   ignore(perform_job_in_worker(job, context~, cancel~))
 }

--- a/src/internal/event_loop/network.mbt
+++ b/src/internal/event_loop/network.mbt
@@ -37,17 +37,47 @@ pub async fn getaddrinfo(
   host : StringView,
   context~ : String,
 ) -> Result[AddrInfo, String] {
+  @coroutine.check_cancellation()
   let host_bytes = @os_string.encode(host)
   let job = Job::getaddrinfo(host_bytes)
-  let ret = perform_job_in_worker(job, cancel=_ => NoWait, context~) catch {
-    @os_error.OSError(errno, context~) =>
-      raise @os_error.OSError(errno, context="\{context}: \{host.escape()}")
-    err => raise err
+  let mut result = Err("")
+  let mut terminated = false
+  defer {
+    terminated = true
   }
-  if ret != 0 {
-    Err(gai_error_to_string(ret))
-  } else {
-    Ok(job.get_getaddrinfo_result())
+  // `getaddrinfo` cannot be cancelled,
+  // but it always does not have any critical side effect.
+  // So our strategy here is to keep `getaddrinfo` running on cancellation,
+  // let a background task wait for its completion and perform cleanup, 
+  // while not waiting for the result in the main task
+  try
+    @coroutine.spawn(() => {
+      defer job.free()
+      let ret = perform_job_in_worker(job, context~) catch {
+        @os_error.OSError(errno, context~) =>
+          raise @os_error.OSError(errno, context="\{context}: \{host.escape()}")
+        err => raise err
+      }
+      // if the outer `getaddrinfo` call already terminated,
+      // we should not extract the result from the job,
+      // instead we should let `job.free` free the result.
+      guard !terminated else { return }
+      if ret != 0 {
+        result = Err(gai_error_to_string(ret))
+      } else {
+        result = Ok(job.get_getaddrinfo_result())
+      }
+    }).wait()
+  catch {
+    _ if result is Ok(_) =>
+      // corner case: if the job happens to complete at the same tick as cancellation,
+      // as long as `get_getaddrinfo_result` is called,
+      // we should treat `getaddrinfo` as successful anyway,
+      // otherwise the result will leak
+      return result
+    err => raise err
+  } noraise {
+    _ => result
   }
 }
 
@@ -58,5 +88,7 @@ pub async fn IoHandle::bind(
   context~ : String,
 ) -> Unit {
   @coroutine.check_cancellation()
-  ignore(perform_job_in_worker(Job::bind(handle.fd, addr), context~))
+  let job = Job::bind(handle.fd, addr)
+  defer job.free()
+  ignore(perform_job_in_worker(job, context~))
 }

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -40,7 +40,7 @@ pub async fn kind_of_fd(Int, context~ : String) -> @fd_util.FileKind
 
 pub async fn mkdir(StringView, mode~ : Int, context~ : String) -> Unit
 
-pub async fn open(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> (IoHandle, OpenResult)
+pub async fn open(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> (IoHandle, FileIdentity)
 
 pub let platform : Platform
 
@@ -84,6 +84,11 @@ pub(all) enum Access {
 #external
 pub type AddrInfo
 
+pub(all) struct FileIdentity {
+  dev_id : UInt64
+  file_id : UInt64
+} derive(Eq, Hash)
+
 type IoHandle
 pub async fn IoHandle::accept(Self, Bytes, context~ : String) -> Self
 pub async fn IoHandle::bind(Self, Bytes, context~ : String) -> Unit
@@ -104,12 +109,6 @@ pub async fn IoHandle::sendto(Self, Bytes, offset~ : Int, len~ : Int, addr~ : By
 pub async fn IoHandle::wait_read(Self) -> Unit
 pub async fn IoHandle::write(Self, Bytes, offset~ : Int, len~ : Int, context~ : String) -> Int
 pub async fn IoHandle::write_at(Self, Bytes, offset~ : Int, len~ : Int, position~ : Int64, context~ : String) -> Unit
-
-type OpenResult
-pub fn OpenResult::dev_id(Self) -> UInt64
-pub fn OpenResult::fd(Self) -> Int
-pub fn OpenResult::file_id(Self) -> UInt64
-pub fn OpenResult::kind(Self) -> @fd_util.FileKind
 
 pub(all) enum Platform {
   Linux

--- a/src/internal/event_loop/process_unix.mbt
+++ b/src/internal/event_loop/process_unix.mbt
@@ -47,10 +47,9 @@ pub async fn spawn(
   cwd~ : @os_string.OsString?,
   context~ : String,
 ) -> Process {
-  perform_job_in_worker(
-    Job::spawn(path, args, env, stdin, stdout, stderr, cwd),
-    context~,
-  )
+  let job = Job::spawn(path, args, env, stdin, stdout, stderr, cwd)
+  defer job.free()
+  perform_job_in_worker(job, context~)
 }
 
 ///|
@@ -68,6 +67,7 @@ pub async fn Process::wait_pid(self : Process, context~ : String) -> Int {
     // The worker reaps the child and stores the exit code in job.ret(),
     // so return it here to avoid a second waitpid in get_process_result.
     let job = Job::wait_for_process(pid)
+    defer job.free()
     let exit_code = perform_job_in_worker(job, context~, cancel=job_id => {
       evloop.cancel_job_in_worker(job_id, context~)
     })

--- a/src/internal/event_loop/process_windows.mbt
+++ b/src/internal/event_loop/process_windows.mbt
@@ -87,6 +87,7 @@ pub async fn spawn(
     cwd,
     is_orphan~,
   )
+  defer job.free()
   let pid = perform_job_in_worker(job, context~)
   { pid, handle: job.get_spawn_job_result_handle() }
 }
@@ -100,11 +101,13 @@ extern "C" fn get_process_result(handle : @fd_util.Fd, out : Ref[Int]) -> Int = 
 #cfg(platform="windows")
 pub async fn Process::wait_pid(self : Process, context~ : String) -> Int {
   let job = Job::wait_for_process(self.handle)
-  perform_job_in_worker(job, context~, cancel=_ => {
-    job.cancel_process_waiter()
-    NeedWait
-  })
-  |> ignore
+  let _ = {
+    defer job.free()
+    perform_job_in_worker(job, context~, cancel=_ => {
+      job.cancel_process_waiter()
+      NeedWait
+    })
+  }
   let out = Ref(0)
   let ret = get_process_result(self.handle, out)
   if ret < 0 {

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -64,7 +64,9 @@ fn setup_signal_handler() -> @coroutine.Coroutine {
       guard curr_loop.val is Some(evloop)
       evloop.cancel_job_in_worker(job_id, context~)
     }
-    let _ = perform_job_in_worker(Job::sigwait(all_signals), context~, cancel~)
+    let job = Job::sigwait(all_signals)
+    defer job.free()
+    ignore <| perform_job_in_worker(job, context~, cancel~)
   }
 }
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -130,10 +130,19 @@ struct job {
   // it will receive the job itself as parameter.
   // extra payload can be placed after the header fields in `struct job`
   void (*worker)(struct job*);
+
+  // finalizer for the job
+  void (*free)(void *);
 };
 
 MOONBIT_FFI_EXPORT
-int64_t moonbitlang_async_job_get_ret(struct job *job) {
+void moonbitlang_async_free_job(struct job *job) {
+  (job->free)(job);
+  free(job);
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_job_get_ret(struct job *job) {
   return job->ret;
 }
 
@@ -264,9 +273,6 @@ void moonbitlang_async_wake_worker(
   int32_t job_id,
   struct job *job
 ) {
-  if (worker->job)
-    moonbit_decref(worker->job);
-
   worker->job_id = job_id;
   worker->job = job;
 
@@ -286,9 +292,6 @@ void moonbitlang_async_wake_worker(
 
 MOONBIT_FFI_EXPORT
 void moonbitlang_async_worker_enter_idle(struct worker *worker) {
-  if (worker->job)
-    moonbit_decref(worker->job);
-
   worker->job = 0;
 }
 
@@ -457,16 +460,14 @@ int32_t moonbitlang_async_errno_is_cancelled(int32_t err) {
 static
 struct job *make_job(
   int32_t size,
-  void (*free_job)(void*),
+  void (*free)(void*),
   void (*worker)(struct job*)
 ) {
-  struct job *job = (struct job*)moonbit_make_external_object(
-    free_job,
-    size
-  );
+  struct job *job = (struct job*)malloc(size);
   job->ret = 0;
   job->err = 0;
   job->worker = worker;
+  job->free = free;
   return job;
 }
 

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -23,14 +23,12 @@ extern "C" fn init_thread_pool_ffi(notify_send : @fd_util.Fd) = "moonbitlang_asy
 extern "C" fn destroy_thread_pool() = "moonbitlang_async_destroy_thread_pool"
 
 ///|
-#owned(init_job)
 extern "C" fn Worker::spawn(init_job_id : Int, init_job : Job) -> Worker = "moonbitlang_async_spawn_worker"
 
 ///|
 extern "C" fn Worker::free(worker : Worker) = "moonbitlang_async_free_worker"
 
 ///|
-#owned(job)
 extern "C" fn Worker::wake(worker : Worker, job_id : Int, job : Job) = "moonbitlang_async_wake_worker"
 
 ///|
@@ -63,14 +61,16 @@ extern "C" fn fetch_completion_ffi(
 ) -> Int = "moonbitlang_async_fetch_completion"
 
 ///|
+#external
 priv type Job
 
 ///|
-#borrow(self)
+extern "C" fn Job::free(self : Job) -> Unit = "moonbitlang_async_free_job"
+
+///|
 extern "C" fn Job::ret(self : Job) -> Int = "moonbitlang_async_job_get_ret"
 
 ///|
-#borrow(self)
 extern "C" fn Job::err(self : Job) -> Int = "moonbitlang_async_job_get_err"
 
 ///|
@@ -114,19 +114,15 @@ extern "C" fn Job::open(
 priv struct OpenJob(Job)
 
 ///|
-#borrow(job)
 extern "C" fn OpenJob::fd(job : OpenJob) -> @fd_util.Fd = "moonbitlang_async_open_job_get_fd"
 
 ///|
-#borrow(job)
 extern "C" fn OpenJob::kind(job : OpenJob) -> @fd_util.FileKind = "moonbitlang_async_open_job_get_kind"
 
 ///|
-#borrow(job)
 extern "C" fn OpenJob::dev_id(job : OpenJob) -> UInt64 = "moonbitlang_async_open_job_get_dev_id"
 
 ///|
-#borrow(job)
 extern "C" fn OpenJob::file_id(job : OpenJob) -> UInt64 = "moonbitlang_async_open_job_get_file_id"
 
 ///|
@@ -144,7 +140,6 @@ extern "C" fn Job::file_kind_by_path(
 extern "C" fn Job::file_size(fd : @fd_util.Fd) -> Job = "moonbitlang_async_make_file_size_job"
 
 ///|
-#borrow(job)
 extern "C" fn Job::get_file_size_result(job : Job) -> Int64 = "moonbitlang_async_get_file_size_result"
 
 ///|
@@ -223,12 +218,10 @@ extern "C" fn Job::realpath(path : @os_string.OsString) -> Job = "moonbitlang_as
 
 ///|
 #cfg(not(platform="windows"))
-#borrow(job)
 extern "C" fn Job::get_realpath_result(job : Job) -> @c_buffer.Buffer = "moonbitlang_async_get_realpath_result"
 
 ///|
 #cfg(platform="windows")
-#borrow(job)
 extern "C" fn Job::get_realpath_result(job : Job) -> String = "moonbitlang_async_get_realpath_result"
 
 ///|
@@ -259,7 +252,6 @@ extern "C" fn Job::spawn(
 
 ///|
 #cfg(platform="windows")
-#borrow(job)
 extern "C" fn Job::get_spawn_job_result_handle(job : Job) -> @fd_util.Fd = "moonbitlang_async_get_spawn_job_result_handle"
 
 ///|
@@ -272,7 +264,6 @@ extern "C" fn Job::wait_for_process(handle : @fd_util.Fd) -> Job = "moonbitlang_
 
 ///|
 #cfg(platform="windows")
-#borrow(job)
 extern "C" fn Job::cancel_process_waiter(job : Job) = "moonbitlang_async_cancel_wait_for_process_job"
 
 ///|
@@ -284,7 +275,6 @@ extern "C" fn Job::bind(socket : @fd_util.Fd, addr : Bytes) -> Job = "moonbitlan
 extern "C" fn Job::getaddrinfo(host : @os_string.OsString) -> Job = "moonbitlang_async_make_getaddrinfo_job"
 
 ///|
-#borrow(job)
 extern "C" fn Job::get_getaddrinfo_result(job : Job) -> AddrInfo = "moonbitlang_async_get_getaddrinfo_result"
 
 ///|

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -108,26 +108,26 @@ extern "C" fn Job::open(
   sync~ : Int,
   // permission for file when new file is created
   mode~ : Int,
-) -> OpenResult = "moonbitlang_async_make_open_job"
+) -> OpenJob = "moonbitlang_async_make_open_job"
 
 ///|
-struct OpenResult(Job)
-
-///|
-#borrow(job)
-pub extern "C" fn OpenResult::fd(job : OpenResult) -> @fd_util.Fd = "moonbitlang_async_open_job_get_fd"
+priv struct OpenJob(Job)
 
 ///|
 #borrow(job)
-pub extern "C" fn OpenResult::kind(job : OpenResult) -> @fd_util.FileKind = "moonbitlang_async_open_job_get_kind"
+extern "C" fn OpenJob::fd(job : OpenJob) -> @fd_util.Fd = "moonbitlang_async_open_job_get_fd"
 
 ///|
 #borrow(job)
-pub extern "C" fn OpenResult::dev_id(job : OpenResult) -> UInt64 = "moonbitlang_async_open_job_get_dev_id"
+extern "C" fn OpenJob::kind(job : OpenJob) -> @fd_util.FileKind = "moonbitlang_async_open_job_get_kind"
 
 ///|
 #borrow(job)
-pub extern "C" fn OpenResult::file_id(job : OpenResult) -> UInt64 = "moonbitlang_async_open_job_get_file_id"
+extern "C" fn OpenJob::dev_id(job : OpenJob) -> UInt64 = "moonbitlang_async_open_job_get_dev_id"
+
+///|
+#borrow(job)
+extern "C" fn OpenJob::file_id(job : OpenJob) -> UInt64 = "moonbitlang_async_open_job_get_file_id"
 
 ///|
 extern "C" fn Job::kind_of_fd(fd : @fd_util.Fd) -> Job = "moonbitlang_async_make_kind_of_fd_job"

--- a/src/internal/event_loop/worker_wbtest.mbt
+++ b/src/internal/event_loop/worker_wbtest.mbt
@@ -19,7 +19,9 @@ extern "C" fn Job::sleep(time : Int) -> Job = "moonbitlang_async_make_sleep_job"
 ///|
 #cfg(target="native")
 async fn perform_sleep_job(t : Int) -> Unit {
-  perform_job_in_worker(Job::sleep(t), context="") |> ignore
+  let job = Job::sleep(t)
+  defer job.free()
+  perform_job_in_worker(job, context="") |> ignore
 }
 
 ///|


### PR DESCRIPTION
Previously, job objects in the thread pool are managed using `moonbit_make_external_object`. But this is not compatible with future WASM support. This PR switch to manual  memory management for job objects. For most API the lifetime is straightforward. The only tricky case is `getaddrinfo`, where the surface `getaddrinfo` call may return before the thread pool job completes on cancellation. To handle this case, a separated coroutine is used to catch the eventual completion of the `getaddrinfo` job and perform cleanup.