### PR TITLE
`@fs.symlink()`: create NTFS junction on Windows if possible

### DIFF
--- a/src/fs/mkdir_test.mbt
+++ b/src/fs/mkdir_test.mbt
@@ -24,14 +24,14 @@ async test "mkdir" {
 }
 
 ///|
-#cfg(not(platform="windows"))
 async test "rmdir recursive" {
+  guard @env.current_dir() is Some(cwd)
   let path = "_build/rmdir_test"
   @fs.mkdir(path, permission=0o755)
   @fs.write_file("\{path}/file", "", create_mode=CreateOrTruncate)
   @fs.mkdir("\{path}/inner")
   @fs.write_file("\{path}/inner/file", "", create_mode=CreateOrTruncate)
-  @fs.symlink("\{path}/symlink", target="../../target")
+  @fs.symlink("\{path}/symlink", target="\{cwd}/_build")
   @test_util.assert_raise_async(() => @fs.rmdir(path))
   @fs.rmdir(path, recursive=true)
 }

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -47,7 +47,7 @@ pub async fn rename(StringView, StringView, replace? : Bool) -> Unit
 
 pub async fn rmdir(StringView, recursive? : Bool) -> Unit
 
-pub async fn symlink(target~ : StringView, StringView) -> Unit
+pub async fn symlink(target~ : StringView, StringView, force_symlink? : Bool) -> Unit
 
 pub async fn tmpdir(prefix~ : StringView) -> String
 

--- a/src/fs/stat_test.mbt
+++ b/src/fs/stat_test.mbt
@@ -14,12 +14,24 @@
 
 ///|
 #cfg(not(platform="windows"))
-async test "stat" {
-  let link_path = "_build/fs_stat_test"
+async test "kind of symlink to regular" {
+  let link_path = "_build/stat_symlink_to_regular_test"
   @fs.symlink(link_path, target="../LICENSE")
   @async.with_task_group() <| group => {
     group.add_defer(() => @fs.remove(link_path))
     debug_inspect(@fs.kind(link_path), content="Regular")
+    debug_inspect(@fs.kind(link_path, follow_symlink=false), content="SymLink")
+  }
+}
+
+///|
+async test "kind of symlink to directory" {
+  guard @env.current_dir() is Some(cwd)
+  let link_path = "_build/stat_symlink_to_dir_test"
+  @fs.symlink(link_path, target="\{cwd}/_build")
+  @async.with_task_group() <| group => {
+    group.add_defer(() => @fs.remove(link_path))
+    debug_inspect(@fs.kind(link_path), content="Directory")
     debug_inspect(@fs.kind(link_path, follow_symlink=false), content="SymLink")
   }
 }

--- a/src/fs/utils.mbt
+++ b/src/fs/utils.mbt
@@ -124,8 +124,24 @@ pub async fn realpath(path : StringView) -> String {
 
 ///|
 /// Create a symbolic link to `old_path` at `new_path`.
-pub async fn symlink(target~ : StringView, path : StringView) -> Unit {
-  @event_loop.symlink(target, path, context="@fs.link()")
+///
+/// On Windows, creating true symbolic link requires admin privilege.
+/// So `@fs.symlink()` will try to create NTFS junction when feasible,
+/// which is similar to symlink in characteristics.
+/// NTFS junction is not as flexible as symlink, it will only be created when:
+///
+/// 1. the target path is an existing directory
+/// 2. the target path is onn the same local machine
+/// 3. the link is created on a NTFS volume
+///
+/// To force creation of true symbolic link on Windows, pass `force_symlink=true`.
+/// `force_symlink` has no effect on non-Windows platforms.
+pub async fn symlink(
+  target~ : StringView,
+  path : StringView,
+  force_symlink? : Bool = false,
+) -> Unit {
+  @event_loop.symlink(target, path, force_symlink~, context="@fs.symlink()")
 }
 
 ///|

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -227,11 +227,12 @@ pub async fn rename(
 pub async fn symlink(
   target : StringView,
   path : StringView,
+  force_symlink~ : Bool,
   context~ : String,
 ) -> Unit {
   let target_bytes = @os_string.encode(target)
   let path_bytes = @os_string.encode(path)
-  let job = Job::symlink(target_bytes, path_bytes)
+  let job = Job::symlink(target_bytes, path_bytes, force_symlink~)
   defer job.free()
   try perform_job_in_worker(job, context~) catch {
     @os_error.OSError(errno, context~) =>

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -64,7 +64,7 @@ pub let stdin : IoHandle
 
 pub let stdout : IoHandle
 
-pub async fn symlink(StringView, StringView, context~ : String) -> Unit
+pub async fn symlink(StringView, StringView, force_symlink~ : Bool, context~ : String) -> Unit
 
 pub fn with_event_loop(async () -> Unit) -> Unit raise
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -26,6 +26,7 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>
+#include <stddef.h>
 
 #else
 
@@ -1249,7 +1250,22 @@ static
 void remove_job_worker(struct job *job) {
   struct remove_job *remove_job = (struct remove_job*)job;
 #ifdef _WIN32
-  if (!DeleteFileW((LPCWSTR)remove_job->path))
+  DWORD attrs = GetFileAttributesW((LPCWSTR)remove_job->path);
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    job->err = GetLastError();
+    return;
+  }
+
+  BOOL ret;
+  // Simulate POSIX behavior on Windows.
+  // Maybe we should just merge `@fs.remove` and `@fs.rmdir`?
+  if ((attrs & FILE_ATTRIBUTE_DIRECTORY) && (attrs & FILE_ATTRIBUTE_REPARSE_POINT)) {
+    ret = RemoveDirectoryW((LPCWSTR)remove_job->path);
+  } else {
+    ret = DeleteFileW((LPCWSTR)remove_job->path);
+  }
+
+  if (!ret)
     job->err = GetLastError();
 #else
   job->ret = remove(remove_job->path);
@@ -1434,6 +1450,7 @@ struct symlink_job {
   struct job job;
   char *target;
   char *path;
+  int32_t force_symlink;
 };
 
 static
@@ -1443,25 +1460,170 @@ void free_symlink_job(void *obj) {
   moonbit_decref(job->path);
 }
 
+#ifdef _WIN32
+typedef struct {
+    USHORT SubstituteNameOffset;
+    USHORT SubstituteNameLength;
+    USHORT PrintNameOffset;
+    USHORT PrintNameLength;
+    WCHAR  PathBuffer[1];
+} MOUNT_POINT_REPARSE_BUFFER;
+
+typedef struct {
+  ULONG ReparseTag;
+  USHORT ReparseDataLength;
+  USHORT Reserved;
+  MOUNT_POINT_REPARSE_BUFFER MountPointReparseBuffer;
+} REPARSE_DATA_BUFFER;
+#endif
+
 static
 void symlink_job_worker(struct job *job) {
   struct symlink_job *symlink_job = (struct symlink_job*)job;
 
 #ifdef _WIN32
+
+  int target_len = Moonbit_array_length(symlink_job->target);
   LPCWSTR target = (LPCWSTR)symlink_job->target;
   LPCWSTR path = (LPCWSTR)symlink_job->path;
 
   DWORD attrs = GetFileAttributesW(target);
-  if (attrs == INVALID_FILE_ATTRIBUTES) {
+  BOOL is_dir = attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY);
+
+  // create NTFS junction if possible
+  if (symlink_job->force_symlink)
+    goto symlink_fallback;
+
+  if (!is_dir)
+    goto symlink_fallback;
+
+  if (wcsncmp(target, L"\\??\\", 4) == 0 || wcsncmp(target, L"\\\\?\\", 4) == 0) {
+    target += 4;
+    target_len -= 4;
+  }
+
+  if (
+    target_len >= 3
+    && ('a' <= target[0] && target[0] <= 'z' || 'A' <= target[0] && target[0] <= 'Z')
+    && target[1] == ':'
+    && (target[2] == '\\' || target[2] == '/')
+  ) {
+    // normal absolute path
+  } else if (wcsncmp(target, L"\\", 2) == 0) {
+    // UNC path for network resource, does not support junction
+    goto symlink_fallback;
+  } else {
+    // relaive path, does not support junction
+    goto symlink_fallback;
+  }
+
+  if (!CreateDirectoryW(path, NULL)) {
     job->err = GetLastError();
     return;
   }
+
+  HANDLE link = CreateFileW(
+    path,
+    GENERIC_WRITE,
+    0,
+    NULL,
+    OPEN_EXISTING,
+    FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+    NULL
+  );
+  if (link == INVALID_HANDLE_VALUE) {
+    job->err = GetLastError();
+    RemoveDirectoryW(path);
+    return;
+  }
+
+  DWORD substitute_name_len =
+    2 * target_len
+    + 8 // NT path "\??\" prefix for substitute path
+  ;
+  DWORD print_name_len = 2 * target_len;
+
+  DWORD path_buffer_length =
+    substitute_name_len
+    + print_name_len
+    + 4 // NUL terminator for substitute path and print path
+  ;
+
+  DWORD reparse_buffer_length =
+    offsetof(MOUNT_POINT_REPARSE_BUFFER, PathBuffer)
+    + path_buffer_length;
+
+  DWORD buffer_size =
+    offsetof(REPARSE_DATA_BUFFER, MountPointReparseBuffer)
+    + reparse_buffer_length;
+
+  REPARSE_DATA_BUFFER *buf = (REPARSE_DATA_BUFFER*)malloc(buffer_size);
+  buf->ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
+  buf->ReparseDataLength = reparse_buffer_length;
+  buf->Reserved = 0;
+  buf->MountPointReparseBuffer.SubstituteNameOffset = 0;
+  buf->MountPointReparseBuffer.SubstituteNameLength = substitute_name_len;
+  memcpy(
+    buf->MountPointReparseBuffer.PathBuffer,
+    L"\\??\\",
+    8
+  );
+  memcpy(
+    buf->MountPointReparseBuffer.PathBuffer + 4,
+    target,
+    target_len * 2 + 2
+  );
+  for (WCHAR *ptr = buf->MountPointReparseBuffer.PathBuffer + 4; *ptr; ++ptr) {
+    // substitute path does not support forward slash
+    if (*ptr == L'/')
+      *ptr = L'\\';
+  }
+  buf->MountPointReparseBuffer.PrintNameOffset = substitute_name_len + 2;
+  buf->MountPointReparseBuffer.PrintNameLength = print_name_len;
+  memcpy(
+    buf->MountPointReparseBuffer.PathBuffer + 5 + target_len,
+    // avoid substituting forward slash twice, reuse the substituted result
+    buf->MountPointReparseBuffer.PathBuffer + 4,
+    target_len * 2 + 2
+  );
+
+  DWORD bytes_returned = 0;
+  BOOL ok = DeviceIoControl(
+    link,
+    FSCTL_SET_REPARSE_POINT,
+    buf,
+    buffer_size,
+    NULL,
+    0,
+    &bytes_returned,
+    NULL
+  );
+  int err = GetLastError();
+  free(buf);
+  CloseHandle(link);
+
+  if (!ok) {
+    RemoveDirectoryW(path);
+    if (err == ERROR_INVALID_PARAMETER) {
+      // this is mainly for handling non-NTFS volume.
+      // There are other cases that will also generate `ERROR_INVALID_PARAMETER`,
+      // such as invalid character in path.
+      // But for those cases, the symlink fallback path will give a similar error,
+      // so the net result is still the same.
+      goto symlink_fallback;
+    }
+    job->err = err;
+  }
+
+  return;
+
+symlink_fallback:
 
   if (
     !CreateSymbolicLinkW(
       (LPCWSTR)symlink_job->path,
       (LPCWSTR)symlink_job->target,
-      attrs & FILE_ATTRIBUTE_DIRECTORY ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0
+      is_dir ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0
     )
   ) {
     job->err = GetLastError();
@@ -1476,10 +1638,15 @@ void symlink_job_worker(struct job *job) {
 #endif
 }
 
-struct symlink_job *moonbitlang_async_make_symlink_job(char *target, char *path) {
+struct symlink_job *moonbitlang_async_make_symlink_job(
+  char *target,
+  char *path,
+  int32_t force_symlink
+) {
   struct symlink_job *job = MAKE_JOB(symlink);
   job->target = target;
   job->path = path;
+  job->force_symlink = force_symlink;
   return job;
 }
 

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -193,6 +193,7 @@ extern "C" fn Job::rename(
 extern "C" fn Job::symlink(
   target : @os_string.OsString,
   path : @os_string.OsString,
+  force_symlink~ : Bool,
 ) -> Job = "moonbitlang_async_make_symlink_job"
 
 ///|


### PR DESCRIPTION
Previously, `@fs.symlink` create symbolic links on Windows. However, creating symbolic link requires admin privilege on Windows, making the API hard to use and test. When the link target is an existing directory on local NTFS volume, Windows has support for NTFS junction, which is highly similar to a symbolic link in characteristics, and does not require admin privilege to create.

This PR let `@fs.symlink` automatically create NTFS junction on Windows whenever possible. When NTFS junction is not applicable (target is not directory, network share or non-NTFS volume, relative link), `@fs.symlink` fallback to symbolic link creation. `@fs.symlink` now also accept an extra optional parameter `force_symlink? : Bool = false`. When set to `true`, NTFS junction creation will be disabled. `force_symlink` has no effect on non-Windows platforms.

This PR also fixes a bug in symlink handling for `@fs.remove`, previously uncatched due to difficulty in testing symlink on Windows. In POSIX, a symbolic link to a directory should be removed using `remove` instead of `rmdir`. But on Windows, symbolic link to a directory should be removed using `RemoveDirectory` instead of `DeleteFile`. So previously the behavior of `@fs.remove` is inconsistent on different platforms. This PR let `@fs.remove` detect symlink to directory before actually removing the file, and automatically choose the correct method to simulate POSIX behavior.