### PR TITLE
fix realpath implementation on Windows

### DIFF
--- a/src/fs/realpath_test.mbt
+++ b/src/fs/realpath_test.mbt
@@ -57,12 +57,33 @@ async test "realpath link to relative" {
 }
 
 ///|
-#cfg(not(platform="windows"))
-async test "realpath link to dir" {
+async test "realpath link to dir absolute" {
   @async.with_task_group() <| root => {
     guard @env.current_dir() is Some(cwd)
+    let path = match cwd {
+      [.., '/'] => cwd + "src/fs"
+      _ => cwd + "/src/fs"
+    }
+    let link_path = "_build/realpath_test_link_to_dir_absolute.test"
+    @fs.symlink(link_path, target=path)
+    root.add_defer(() => @fs.remove(link_path))
+    let rp = @fs.realpath(link_path + "/realpath_test.mbt")
+    println(rp)
+    assert_true(rp.has_prefix(cwd))
+    inspect(
+      rp[cwd.length():].replace_all(old="\\", new="/"),
+      content="/src/fs/realpath_test.mbt",
+    )
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "realpath link to dir relative" {
+  guard @env.current_dir() is Some(cwd)
+  @async.with_task_group() <| root => {
     let rel_path = "../src/fs"
-    let link_path = "_build/realpath_test_link_to_dir.test"
+    let link_path = "_build/realpath_test_link_to_dir_relative.test"
     @fs.symlink(link_path, target=rel_path)
     root.add_defer(() => @fs.remove(link_path))
     let rp = @fs.realpath(link_path + "/realpath_test.mbt")

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -288,7 +288,6 @@ pub async fn IoHandle::readdir(
 }
 
 ///|
-#cfg(not(platform="windows"))
 pub async fn realpath(path : StringView, context~ : String) -> String {
   let path_bytes = @os_string.encode(path)
   let job = Job::realpath(path_bytes)
@@ -299,22 +298,7 @@ pub async fn realpath(path : StringView, context~ : String) -> String {
     err => raise err
   }
   let c_path = job.get_realpath_result()
-  defer c_path.free()
   @os_string.decode(c_path)
-}
-
-///|
-#cfg(platform="windows")
-pub async fn realpath(path : StringView, context~ : String) -> String {
-  let path_bytes = @os_string.encode(path)
-  let job = Job::realpath(path_bytes)
-  defer job.free()
-  let _ = perform_job_in_worker(job, context~) catch {
-    @os_error.OSError(errno, context~) =>
-      raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
-    err => raise err
-  }
-  job.get_realpath_result()
 }
 
 ///|

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -1818,16 +1818,31 @@ struct readdir_job *moonbitlang_async_make_readdir_job(
 
 // ===== realpath job, get canonical representation of a path =====
 
+#ifdef _WIN32
+#define REALPATH_JOB_BUFFER_LENGTH 1024
+#endif
+
 struct realpath_job {
   struct job job;
   char *path;
   char *result;
+#ifdef _WIN32
+  // avoid some allocation in the simple case
+  WCHAR buf[REALPATH_JOB_BUFFER_LENGTH];
+#endif
 };
 
 static
 void free_realpath_job(void *obj) {
   struct realpath_job *job = (struct realpath_job*)obj;
   moonbit_decref(job->path);
+#ifdef _WIN32
+  if (job->result && job->result != (char*)job->buf)
+    free(job->result);
+#else
+  if (job->result)
+    free(job->result);
+#endif
 }
 
 static
@@ -1835,33 +1850,45 @@ void realpath_job_worker(struct job *job) {
   struct realpath_job *realpath_job = (struct realpath_job*)job;
 
 #ifdef _WIN32
-  static wchar_t buf[1024];
-  DWORD len = GetFullPathNameW(
+  HANDLE file = CreateFileW(
     (LPCWSTR)realpath_job->path,
-    1024,
-    buf,
+    0,
+    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+    NULL,
+    OPEN_EXISTING,
+    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
     NULL
   );
-
-  if (!len) {
+  if (file == INVALID_HANDLE_VALUE) {
     job->err = GetLastError();
     return;
   }
 
-  realpath_job->result = (char*)moonbit_make_string_raw(len);
-  if (len <= 1024) {
-    memcpy(realpath_job->result, buf, len * sizeof(wchar_t));
-  } else if (
-    !GetFullPathNameW(
-      (LPCWSTR)realpath_job->path,
-      len,
-      (LPWSTR)realpath_job->result,
-      NULL
-    )
-  ) {
+  DWORD len = GetFinalPathNameByHandleW(
+    file,
+    realpath_job->buf,
+    REALPATH_JOB_BUFFER_LENGTH,
+    FILE_NAME_NORMALIZED | VOLUME_NAME_DOS
+  );
+
+  if (!len) {
     job->err = GetLastError();
-    moonbit_decref(realpath_job->result);
+  } else if (len < REALPATH_JOB_BUFFER_LENGTH) {
+    realpath_job->result = (char*)realpath_job->buf;
+  } else {
+    // include the extra NUL terminator
+    realpath_job->result = malloc((len + 1) * sizeof(WCHAR));
+    len = GetFinalPathNameByHandleW(
+      file,
+      (LPWSTR)realpath_job->result,
+      len,
+      FILE_NAME_NORMALIZED | VOLUME_NAME_DOS
+    );
+    if (!len)
+      job->err = GetLastError();
   }
+
+  CloseHandle(file);
 
 #else
 
@@ -1877,11 +1904,23 @@ void realpath_job_worker(struct job *job) {
 struct realpath_job *moonbitlang_async_make_realpath_job(char *path) {
   struct realpath_job *job = MAKE_JOB(realpath);
   job->path = path;
+  job->result = 0;
   return job;
 }
 
 char *moonbitlang_async_get_realpath_result(struct realpath_job *job) {
+#ifdef _WIN32
+  if (wcsncmp((WCHAR*)job->result, L"\\\\?\\UNC\\", 8) == 0) {
+    ((WCHAR*)job->result)[6] = L'\\';
+    return job->result + 6 * sizeof(WCHAR);
+  }
+  else if (wcsncmp((WCHAR*)job->result, L"\\\\?\\", 4) == 0)
+    return job->result + 4 * sizeof(WCHAR);
+  else
+    return job->result + 8;
+#else
   return job->result;
+#endif
 }
 
 // ===== spawn job, spawn foreign process =====

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -218,12 +218,7 @@ extern "C" fn Job::readdir(
 extern "C" fn Job::realpath(path : @os_string.OsString) -> Job = "moonbitlang_async_make_realpath_job"
 
 ///|
-#cfg(not(platform="windows"))
 extern "C" fn Job::get_realpath_result(job : Job) -> @c_buffer.Buffer = "moonbitlang_async_get_realpath_result"
-
-///|
-#cfg(platform="windows")
-extern "C" fn Job::get_realpath_result(job : Job) -> String = "moonbitlang_async_get_realpath_result"
 
 ///|
 #cfg(not(platform="windows"))


### PR DESCRIPTION
closes #404

Previously `@fs.realpath` uses `GetFullPathNameW` on Windows, which does not deference symlink/reparse point. This PR fixes the implementation and use `GetFinalPathNameByHandleW` instead. This PR also eliminates the allocation of MoonBit object inside the realpath thread pool job, making the code easier to port to WASM backend. This is not solely for WASM compatibility, though: `GetFinalPathNameByHandleW` return path with extended length prefix `\\?\`, which need to be trimmed, so one extra layer of copy is unavoidable.