### PR TITLE
report error on unexpected EOF for fixed length HTTP body

### DIFF
--- a/src/http/parser.mbt
+++ b/src/http/parser.mbt
@@ -139,6 +139,9 @@ impl @io.Reader for Reader with fn _direct_read(self, buf, offset~, max_len~) {
         max_len~,
         limit=remaining,
       )
+      if produced is 0 {
+        raise @io.ReaderClosed
+      }
       let remaining = remaining - consumed
       self.body = if remaining == 0 {
         if self.gzip is Some(gzip) {
@@ -395,6 +398,8 @@ async fn Reader::read_response(
   // Other cases are handled in `read_headers` when parsing the headers, which will set the body kind accordingly.
   if should_read_body_until_close(code, headers, self.body, request_method) {
     self.body = WaitConnectionClose // Read until connection close
+  } else if request_method is Some(Head) {
+    self.body = Empty
   }
 
   { code, reason, headers, cookies }

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -93,6 +93,31 @@ async test "read_request fixed body" {
 }
 
 ///|
+async test "read_request fixed body early EOF" {
+  @async.with_task_group() <| root => {
+    let (r, w) = @io.pipe()
+    root.spawn_bg() <| () => {
+      defer w.close()
+      w
+      ..write("GET / HTTP/1.1\r\n")
+      ..write("Host: x.y.org\r\n")
+      ..write("User-Agent: MoonBit\r\n")
+      ..write("Content-Length: 8\r\n\r\n")
+      .write("message")
+    }
+    defer r.close()
+    let input = Reader::new(r)
+    let _request = input.read_request()
+    debug_inspect(
+      @test_util.expect_error_async(() => input.read_all().binary()),
+      content=(
+        #|ReaderClosed
+      ),
+    )
+  }
+}
+
+///|
 async test "read_request chunked" {
   let log = StringBuilder::new()
   @async.with_task_group() <| root => {


### PR DESCRIPTION
Previously, the HTTP body parser does not perform length validation for fixed length body (i.e. `Content-Length`), this will result in unexpected EOF from the transport layer not being reported as error. This PR fixes the issue. The HTTP body will now raise `@io.ReaderClosed` on unexpected EOF for fixed length body.

The fix reveal another bug in previous code base. For `HEAD` request, the response body is always empty, but `Content-Length` etc. can still be set to indicate what the client would get if a `GET` request is made. So for response to `HEAD` request, we should ignore `Content-Length` etc., but this logic was not implemented previously. Due to the lack of length validation, test for this behavior accidentally passed. This PR also fixes this problem: the response body to a `HEAD` request is now always assumed to be empty, no matter what headers are set.