### PR TITLE
remove `@event_loop.IS_WINDOWS` in favor of `@event_loop.platform`

### DIFF
--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -31,12 +31,12 @@ pub async fn mkdir(
     @os_error.OSError(_) as err if recursive && err.is_ENOENT() => {
       let last_path_sep_index = match path.rev_find("/") {
         Some(index) => index
-        None if @event_loop.IS_WINDOWS && path.rev_find("\\") is Some(index) =>
-          index
+        None if @event_loop.platform is Windows &&
+          path.rev_find("\\") is Some(index) => index
         None => raise err
       }
       let parent = path[:last_path_sep_index].trim_end(chars="/")
-      let parent = if @event_loop.IS_WINDOWS {
+      let parent = if @event_loop.platform is Windows {
         parent.trim_end(chars="\\")
       } else {
         parent
@@ -57,7 +57,7 @@ pub async fn mkdir(
 pub async fn rmdir(path : StringView, recursive? : Bool = false) -> Unit {
   let context = "@fs.rmdir()"
   if recursive {
-    let base = if @event_loop.IS_WINDOWS {
+    let base = if @event_loop.platform is Windows {
       path.trim_end(chars="/\\")
     } else {
       path.trim_end(chars="/")

--- a/src/fs/watch.mbt
+++ b/src/fs/watch.mbt
@@ -137,7 +137,7 @@ pub async fn Watcher::Watcher(
   let path = if path is "" { "/" } else { path.to_owned() }
   let (root_file, root_id) = @event_loop.open(
     path,
-    if @event_loop.IS_WINDOWS {
+    if @event_loop.platform is Windows {
       3
     } else {
       0

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -13,14 +13,6 @@
 // limitations under the License.
 
 ///|
-#cfg(not(platform="windows"))
-pub const IS_WINDOWS : Bool = false
-
-///|
-#cfg(platform="windows")
-pub const IS_WINDOWS : Bool = true
-
-///|
 pub(all) enum Platform {
   Linux = 0
   MacOS = 1

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -52,7 +52,7 @@ pub async fn open(
       let io = IoHandle::from_fd(
         fd,
         kind~,
-        is_async=access is 3 || (!IS_WINDOWS && kind.can_poll()),
+        is_async=access is 3 || (!(platform is Windows) && kind.can_poll()),
       )
       (io, { dev_id: job.dev_id(), file_id: job.file_id() })
     }

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -8,8 +8,6 @@ import {
 }
 
 // Values
-pub const IS_WINDOWS : Bool = false
-
 pub let _SIGBREAK : Int
 
 pub let _SIGHUP : Int

--- a/src/process/commands_for_test.mbt
+++ b/src/process/commands_for_test.mbt
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 ///|
-let is_windows : Bool = @event_loop.IS_WINDOWS
+let is_windows : Bool = @event_loop.platform is Windows
 
 ///|
 let shell : String = if is_windows { "powershell" } else { "sh" }

--- a/src/socket/multicast_test.mbt
+++ b/src/socket/multicast_test.mbt
@@ -122,7 +122,7 @@ async test "multicast no loopback" {
     )
     defer client.close()
     @async.sleep(200)
-    if @event_loop.IS_WINDOWS {
+    if @event_loop.platform is Windows {
       server.set_multicast_loopback(false)
     } else {
       client.set_multicast_loopback(false)
@@ -130,7 +130,7 @@ async test "multicast no loopback" {
     client.set_multicast_ttl(0)
     log.push("client sending: abcd")
     let _ = client.send(b"abcd")
-    if @event_loop.IS_WINDOWS {
+    if @event_loop.platform is Windows {
       server.set_multicast_loopback(true)
     } else {
       client.set_multicast_loopback(true)
@@ -226,14 +226,14 @@ async test "multicast no loopback v6" {
     @async.sleep(200)
     client.set_multicast_interface_v6(test_interface)
     client.set_multicast_ttl(0)
-    if @event_loop.IS_WINDOWS {
+    if @event_loop.platform is Windows {
       server.set_multicast_loopback(false)
     } else {
       client.set_multicast_loopback(false)
     }
     log.push("client sending: abcd")
     let _ = client.send(b"abcd")
-    if @event_loop.IS_WINDOWS {
+    if @event_loop.platform is Windows {
       server.set_multicast_loopback(true)
     } else {
       client.set_multicast_loopback(true)

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -84,7 +84,7 @@ pub async fn TcpServer::TcpServer(
         @os_error.check_errno(context)
       }
     }
-    if !@event_loop.IS_WINDOWS && reuse_addr {
+    if !(@event_loop.platform is Windows) && reuse_addr {
       guard allow_reuse_addr(sock) >= 0 else { @os_error.check_errno(context) }
     }
     io.bind(addr.0, context~)

--- a/src/socket/udp.mbt
+++ b/src/socket/udp.mbt
@@ -48,7 +48,7 @@ pub async fn UdpClient::UdpClient(addr : Addr) -> UdpClient {
   let io = @event_loop.IoHandle::from_fd(sock, kind=Socket)
   try {
     let dst_addr = if addr.is_multicast() {
-      if @event_loop.IS_WINDOWS {
+      if @event_loop.platform is Windows {
         let local_addr = match family {
           IPv4 => ipv4_any
           IPv6 => ipv6_any
@@ -278,7 +278,7 @@ pub async fn UdpServer::multicast(
   let sock = make_udp_socket(family, multicast=true, context~)
   let io = @event_loop.IoHandle::from_fd(sock, kind=Socket)
   try {
-    if @event_loop.IS_WINDOWS {
+    if @event_loop.platform is Windows {
       let local_addr = Addr::new(0, multi_addr.port())
       io.bind(local_addr.0, context~)
     } else {


### PR DESCRIPTION
The constant `@event_loop.IS_WINDOWS` is not compatible with future WASM support, because on WASM backend, the actual platform cannot be known statically. This PR removes the `IS_WINDOWS` constant and favor the global variable `@event_loop.platform` instead.