### PR TITLE
allow passing `CREATE_NO_WINDOW` on Windows in process creation

### DIFF
--- a/src/internal/event_loop/process_windows.mbt
+++ b/src/internal/event_loop/process_windows.mbt
@@ -74,6 +74,7 @@ pub async fn spawn(
   stdout~ : @fd_util.Fd,
   stderr~ : @fd_util.Fd,
   cwd~ : @os_string.OsString?,
+  no_console_window~ : Bool,
   is_orphan~ : Bool,
   context~ : String,
 ) -> Process {
@@ -85,6 +86,7 @@ pub async fn spawn(
     stdout,
     stderr,
     cwd,
+    no_console_window~,
     is_orphan~,
   )
   defer job.free()

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -1987,6 +1987,7 @@ struct spawn_job {
   void *environment;
   HANDLE stdio[3];
   LPWSTR cwd;
+  int32_t no_console_window;
   int32_t is_orphan;
   HANDLE result;
 };
@@ -2038,6 +2039,9 @@ void spawn_job_worker(struct job *job) {
     CREATE_NEW_PROCESS_GROUP // so that we can gracefully terminate this process
                              // via sending Ctrl+Break console event
     | CREATE_UNICODE_ENVIRONMENT;
+
+    if (spawn_job->no_console_window)
+      create_flags |= CREATE_NO_WINDOW;
 
   STARTUPINFOEXW startup_info;
   memset(&startup_info, 0, sizeof(STARTUPINFOEXW));
@@ -2153,6 +2157,7 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   HANDLE stdout_handle,
   HANDLE stderr_handle,
   LPWSTR cwd,
+  int32_t no_console_window,
   int32_t is_orphan
 ) {
   struct spawn_job *job = MAKE_JOB(spawn);
@@ -2162,6 +2167,7 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   job->stdio[1] = stdout_handle;
   job->stdio[2] = stderr_handle;
   job->cwd = cwd;
+  job->no_console_window = no_console_window;
   job->is_orphan = is_orphan;
   job->result = INVALID_HANDLE_VALUE;
   return job;

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -243,6 +243,7 @@ extern "C" fn Job::spawn(
   stdout : @fd_util.Fd,
   stderr : @fd_util.Fd,
   cwd : @os_string.OsString?,
+  no_console_window~ : Bool,
   is_orphan~ : Bool,
 ) -> Job = "moonbitlang_async_make_spawn_job"
 

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -11,13 +11,13 @@ import {
 }
 
 // Values
-pub async fn collect_output(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, cwd? : StringView) -> (Int, &@io.Data, &@io.Data)
+pub async fn collect_output(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, cwd? : StringView, no_console_window? : Bool) -> (Int, &@io.Data, &@io.Data)
 
-pub async fn collect_output_merged(StringView, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, cwd? : StringView) -> (Int, &@io.Data)
+pub async fn collect_output_merged(StringView, Array[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, cwd? : StringView, no_console_window? : Bool) -> (Int, &@io.Data)
 
-pub async fn collect_stderr(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, cwd? : StringView) -> (Int, &@io.Data)
+pub async fn collect_stderr(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, cwd? : StringView, no_console_window? : Bool) -> (Int, &@io.Data)
 
-pub async fn collect_stdout(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stderr? : &ProcessOutput, cwd? : StringView) -> (Int, &@io.Data)
+pub async fn collect_stdout(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stderr? : &ProcessOutput, cwd? : StringView, no_console_window? : Bool) -> (Int, &@io.Data)
 
 pub fn graceful_cancel(timeout~ : Int, signal? : @signal.Signal) -> CancellationHandler
 
@@ -31,11 +31,11 @@ pub async fn redirect_from_file(String) -> &ProcessInput
 #label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
 pub async fn redirect_to_file(String, append? : Bool, create_mode? : @fs.CreateMode, permission? : Int, create? : Int, truncate? : Bool) -> &ProcessOutput
 
-pub async fn run(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : StringView, cancel_handler? : CancellationHandler) -> Int
+pub async fn run(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : StringView, no_console_window? : Bool, cancel_handler? : CancellationHandler) -> Int
 
-pub async fn[X] spawn(@async.TaskGroup[X], StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : StringView, cancel_handler? : CancellationHandler, no_wait? : Bool) -> Process
+pub async fn[X] spawn(@async.TaskGroup[X], StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : StringView, no_console_window? : Bool, cancel_handler? : CancellationHandler, no_wait? : Bool) -> Process
 
-pub async fn spawn_orphan(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : StringView) -> Int
+pub async fn spawn_orphan(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : StringView, no_console_window? : Bool) -> Int
 
 pub async fn wait_pid(Int) -> Int
 

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -40,6 +40,7 @@ pub async fn spawn_orphan(
   stdout? : &ProcessOutput,
   stderr? : &ProcessOutput,
   cwd? : StringView,
+  no_console_window? : Bool = false,
 ) -> Int {
   raw_spawn(
     cmd,
@@ -50,6 +51,7 @@ pub async fn spawn_orphan(
     stdout~,
     stderr~,
     cwd~,
+    no_console_window~,
     is_orphan=true,
     context="@process.spawn_orphan()",
   ).pid()
@@ -98,6 +100,13 @@ pub async fn wait_pid(pid : Int) -> Int {
 /// If `cwd` is present, the spawned command will be executed
 /// in the directory specified by `cwd`.
 ///
+/// When `no_console_window` is `true` (`false` by default),
+/// creation of a new console window will be disabled on Windows.
+/// By default a new console window may be created
+/// when the calling process is a GUI application
+/// and the child process is a conlose application.
+/// `no_console_window` has no effect on non-Windows platforms.
+///
 /// If current task is cancelled while blocking,
 /// `cancel_handler` will be used to automatically stop the process.
 /// `@process.run` will not return until the process terminates, even if cancelled.
@@ -116,6 +125,7 @@ pub async fn run(
   stdout? : &ProcessOutput,
   stderr? : &ProcessOutput,
   cwd? : StringView,
+  no_console_window? : Bool = false,
   cancel_handler? : CancellationHandler = graceful_cancel(timeout=5000),
 ) -> Int {
   let context = "@process.run()"
@@ -128,6 +138,7 @@ pub async fn run(
     stdout~,
     stderr~,
     cwd~,
+    no_console_window~,
     is_orphan=false,
     context~,
   )
@@ -198,6 +209,7 @@ pub async fn[X] spawn(
   stdout? : &ProcessOutput,
   stderr? : &ProcessOutput,
   cwd? : StringView,
+  no_console_window? : Bool = false,
   cancel_handler? : CancellationHandler = graceful_cancel(timeout=5000),
   no_wait? : Bool,
 ) -> Process {
@@ -211,6 +223,7 @@ pub async fn[X] spawn(
     stdout~,
     stderr~,
     cwd~,
+    no_console_window~,
     is_orphan=false,
     context~,
   )
@@ -244,12 +257,23 @@ pub async fn collect_stdout(
   stdin? : &ProcessInput,
   stderr? : &ProcessOutput,
   cwd? : StringView,
+  no_console_window? : Bool,
 ) -> (Int, &@io.Data) {
   let (r, w) = read_from_process()
   @async.with_task_group() <| group => {
     defer r.close()
     let exit_code = group.spawn(() => {
-      run(cmd, args, extra_env~, inherit_env~, stdin?, stdout=w, stderr?, cwd?)
+      run(
+        cmd,
+        args,
+        extra_env~,
+        inherit_env~,
+        stdin?,
+        stdout=w,
+        stderr?,
+        cwd?,
+        no_console_window?,
+      )
     })
     let output = r.read_all()
     (exit_code.wait(), output)
@@ -269,12 +293,23 @@ pub async fn collect_stderr(
   stdin? : &ProcessInput,
   stdout? : &ProcessOutput,
   cwd? : StringView,
+  no_console_window? : Bool,
 ) -> (Int, &@io.Data) {
   let (r, w) = read_from_process()
   @async.with_task_group() <| group => {
     defer r.close()
     let exit_code = group.spawn(() => {
-      run(cmd, args, extra_env~, inherit_env~, stdin?, stdout?, stderr=w, cwd?)
+      run(
+        cmd,
+        args,
+        extra_env~,
+        inherit_env~,
+        stdin?,
+        stdout?,
+        stderr=w,
+        cwd?,
+        no_console_window?,
+      )
     })
     let output = r.read_all()
     (exit_code.wait(), output)
@@ -294,6 +329,7 @@ pub async fn collect_output(
   inherit_env? : Bool = true,
   stdin? : &ProcessInput,
   cwd? : StringView,
+  no_console_window? : Bool,
 ) -> (Int, &@io.Data, &@io.Data) {
   let (r_out, w_out) = read_from_process()
   let (r_err, w_err) = read_from_process()
@@ -308,6 +344,7 @@ pub async fn collect_output(
         stdout=w_out,
         stderr=w_err,
         cwd?,
+        no_console_window?,
       )
     })
     let stdout = group.spawn(() => {
@@ -335,12 +372,23 @@ pub async fn collect_output_merged(
   inherit_env? : Bool = true,
   stdin? : &ProcessInput,
   cwd? : StringView,
+  no_console_window? : Bool,
 ) -> (Int, &@io.Data) {
   let (r, w) = read_from_process()
   @async.with_task_group() <| group => {
     defer r.close()
     let exit_code = group.spawn(() => {
-      run(cmd, args, extra_env~, inherit_env~, stdin?, stdout=w, stderr=w, cwd?)
+      run(
+        cmd,
+        args,
+        extra_env~,
+        inherit_env~,
+        stdin?,
+        stdout=w,
+        stderr=w,
+        cwd?,
+        no_console_window?,
+      )
     })
     let output = r.read_all()
     (exit_code.wait(), output)

--- a/src/process/unix.mbt
+++ b/src/process/unix.mbt
@@ -31,6 +31,7 @@ async fn raw_spawn(
   stdout~ : &ProcessOutput?,
   stderr~ : &ProcessOutput?,
   cwd~ : StringView?,
+  no_console_window~ : Bool,
   is_orphan~ : Bool,
   context~ : String,
 ) -> @event_loop.Process {
@@ -95,5 +96,6 @@ async fn raw_spawn(
   // currently auto kill child process on hard termination is not supported on Unix,
   // so `is_orphan` makes no difference on actual spawning
   ignore(is_orphan)
+  ignore(no_console_window)
   @event_loop.spawn(cmd, argv, env~, stdin~, stdout~, stderr~, cwd~, context~)
 }

--- a/src/process/windows.mbt
+++ b/src/process/windows.mbt
@@ -80,6 +80,7 @@ async fn raw_spawn(
   stdout~ : &ProcessOutput?,
   stderr~ : &ProcessOutput?,
   cwd~ : StringView?,
+  no_console_window~ : Bool,
   is_orphan~ : Bool,
   context~ : String,
 ) -> @event_loop.Process {
@@ -147,6 +148,7 @@ async fn raw_spawn(
     stdout~,
     stderr~,
     cwd~,
+    no_console_window~,
     is_orphan~,
     context~,
   )


### PR DESCRIPTION
This PR add a new option, `no_console_window? : Bool` (defaults to `false`), to various process creation API in `@process`. This option has no effect on non-Windows platforms. On Windows, `no_console_window=true` will result in `CREATE_NO_WINDOW` being passed to `CreateProcess`. By default, if the parent process is a GUI application and the spawned process is a console application, Windows automatically create a new console window for the child process. Passing `CREATE_NO_WINDOW`  (`no_console_window=true`) disable the creation of this new console window.