### PR TITLE
[breaking] do not abort program when stdio initialization failed

### DIFF
--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -56,11 +56,11 @@ pub fn set_global_cancellation_signals(ReadOnlyArray[Int]) -> Unit
 
 pub async fn spawn(@os_string.OsString, FixedArray[@os_string.OsString?], env~ : FixedArray[@os_string.OsString?], stdin~ : Int, stdout~ : Int, stderr~ : Int, cwd~ : @os_string.OsString?, context~ : String) -> Process
 
-pub let stderr : IoHandle
+pub let stderr : Result[IoHandle, Error]
 
-pub let stdin : IoHandle
+pub let stdin : Result[IoHandle, Error]
 
-pub let stdout : IoHandle
+pub let stdout : Result[IoHandle, Error]
 
 pub async fn symlink(StringView, StringView, force_symlink~ : Bool, context~ : String) -> Unit
 

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -57,7 +57,7 @@ let stdio_handles : Map[@fd_util.Fd, IoHandle] = {}
 
 ///|
 #cfg(platform="windows")
-fn setup_stdio(id : Int, context~ : String) -> IoHandle {
+fn setup_stdio(id : Int, context~ : String) -> IoHandle raise {
   // The value comes from https://learn.microsoft.com/en-us/windows/console/getstdhandle
   let fd = get_std_handle(-10 - id)
   if !@fd_util.fd_is_valid(fd) {

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -29,11 +29,9 @@ fn kind_of_fd_sync(
 
 ///|
 #cfg(not(platform="windows"))
-fn setup_stdio(fd : Int, context~ : String) -> IoHandle {
-  let kind = kind_of_fd_sync(fd, context~) catch {
-    err => abort("\{context}: \{err}")
-  }
-  let is_async = try! @fd_util.fd_is_nonblocking(fd, context~)
+fn setup_stdio(fd : Int, context~ : String) -> IoHandle raise {
+  let kind = kind_of_fd_sync(fd, context~)
+  let is_async = @fd_util.fd_is_nonblocking(fd, context~)
   let handle = { fd, kind, is_async, events: NoEvent, read: None, write: None }
   register_hook(
     init=() => {
@@ -63,8 +61,7 @@ fn setup_stdio(id : Int, context~ : String) -> IoHandle {
   // The value comes from https://learn.microsoft.com/en-us/windows/console/getstdhandle
   let fd = get_std_handle(-10 - id)
   if !@fd_util.fd_is_valid(fd) {
-    let errno = @os_error.get_errno()
-    abort("\{context}: \{@os_error.errno_to_string(errno)}")
+    @os_error.check_errno(context)
   }
   if stdio_handles.get(fd) is Some(handle) {
     // when `stdout` and `stderr` are redirected to the same file/pipe,
@@ -72,11 +69,7 @@ fn setup_stdio(id : Int, context~ : String) -> IoHandle {
     // In this case, avoid problem caused by duplicated handle value
     return handle
   }
-  let kind = kind_of_fd_sync(fd, context~) catch {
-    @os_error.OSError(errno, context~) =>
-      abort("\{context}: \{@os_error.errno_to_string(errno)}")
-    err => abort("\{context}: \{err}")
-  }
+  let kind = kind_of_fd_sync(fd, context~)
   let handle = {
     fd,
     kind,
@@ -102,10 +95,28 @@ fn setup_stdio(id : Int, context~ : String) -> IoHandle {
 }
 
 ///|
-pub let stdin : IoHandle = setup_stdio(0, context="initialize `stdin`")
+pub let stdin : Result[IoHandle, Error] = try
+  setup_stdio(0, context="initialize `stdin`")
+catch {
+  err => Err(err)
+} noraise {
+  handle => Ok(handle)
+}
 
 ///|
-pub let stdout : IoHandle = setup_stdio(1, context="initialize `stdout`")
+pub let stdout : Result[IoHandle, Error] = try
+  setup_stdio(1, context="initialize `stdout`")
+catch {
+  err => Err(err)
+} noraise {
+  handle => Ok(handle)
+}
 
 ///|
-pub let stderr : IoHandle = setup_stdio(2, context="initialize `stderr`")
+pub let stderr : Result[IoHandle, Error] = try
+  setup_stdio(2, context="initialize `stderr`")
+catch {
+  err => Err(err)
+} noraise {
+  handle => Ok(handle)
+}

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -167,7 +167,7 @@ pub async fn redirect_from_file(path : String) -> &ProcessInput {
 ///|
 /// An entity that can be used to redirect stdin of a process
 trait ProcessInput {
-  fn fd(Self) -> @fd_util.Fd
+  fn fd(Self) -> @fd_util.Fd raise
   fn after_spawn(Self) -> Unit = _
 }
 
@@ -189,7 +189,7 @@ pub impl ProcessInput for @stdio.Input with fn fd(self) {
 ///|
 /// An entity that can be used to redirect stdout/stderr of a process
 trait ProcessOutput {
-  fn fd(Self) -> @fd_util.Fd
+  fn fd(Self) -> @fd_util.Fd raise
   fn after_spawn(Self) -> Unit = _
 }
 

--- a/src/stdio/pkg.generated.mbti
+++ b/src/stdio/pkg.generated.mbti
@@ -16,11 +16,11 @@ pub let stdout : Output
 
 // Types and methods
 type Input
-pub fn Input::fd(Self) -> Int
+pub fn Input::fd(Self) -> Int raise
 pub impl @io.Reader for Input
 
 type Output
-pub fn Output::fd(Self) -> Int
+pub fn Output::fd(Self) -> Int raise
 pub impl @io.Writer for Output
 
 // Type aliases

--- a/src/stdio/stdio.mbt
+++ b/src/stdio/stdio.mbt
@@ -14,18 +14,20 @@
 
 ///|
 struct Input {
-  io : @event_loop.IoHandle
+  io : Result[@event_loop.IoHandle, Error]
   read_buf : @io.ReaderBuffer
 }
 
 ///|
-pub fn Input::fd(self : Input) -> @fd_util.Fd {
-  self.io.fd()
+pub fn Input::fd(self : Input) -> @fd_util.Fd raise {
+  self.io.unwrap_or_error().fd()
 }
 
 ///|
 pub impl @io.Reader for Input with fn _direct_read(self, buf, offset~, max_len~) {
-  self.io.read(buf, offset~, len=max_len, context="@stdio.Input::read()")
+  self.io
+  .unwrap_or_error()
+  .read(buf, offset~, len=max_len, context="@stdio.Input::read()")
 }
 
 ///|
@@ -34,16 +36,18 @@ pub impl @io.Reader for Input with fn _get_internal_buffer(self) {
 }
 
 ///|
-struct Output(@event_loop.IoHandle)
+struct Output(Result[@event_loop.IoHandle, Error])
 
 ///|
-pub fn Output::fd(self : Output) -> @fd_util.Fd {
-  self.0.fd()
+pub fn Output::fd(self : Output) -> @fd_util.Fd raise {
+  self.0.unwrap_or_error().fd()
 }
 
 ///|
 pub impl @io.Writer for Output with fn write_once(self, buf, offset~, len~) {
-  self.0.write(buf, offset~, len~, context="@fs.File::write()")
+  self.0
+  .unwrap_or_error()
+  .write(buf, offset~, len~, context="@fs.File::write()")
 }
 
 ///|

--- a/src/stdio/stdio.mbt
+++ b/src/stdio/stdio.mbt
@@ -19,6 +19,12 @@ struct Input {
 }
 
 ///|
+/// Return the file descriptor of an input channel.
+///
+/// If the initialization of the input channel failed,
+/// for example when `stdin` does not exist (Windows) or is not a valid fd (Unix-like),
+/// This method will fail with error.
+/// So `.fd()` can be used as a way to tell if `stdin` is valid.
 pub fn Input::fd(self : Input) -> @fd_util.Fd raise {
   self.io.unwrap_or_error().fd()
 }
@@ -39,6 +45,12 @@ pub impl @io.Reader for Input with fn _get_internal_buffer(self) {
 struct Output(Result[@event_loop.IoHandle, Error])
 
 ///|
+/// Return the file descriptor of an output channel.
+///
+/// If the initialization of the output channel failed,
+/// for example when `stdout` does not exist (Windows) or is not a valid fd (Unix-like),
+/// This method will fail with error.
+/// So `.fd()` can be used as a way to tell if `stdout`/`stderr` is valid.
 pub fn Output::fd(self : Output) -> @fd_util.Fd raise {
   self.0.unwrap_or_error().fd()
 }
@@ -52,8 +64,9 @@ pub impl @io.Writer for Output with fn write_once(self, buf, offset~, len~) {
 
 ///|
 /// The standard input channel.
-/// Using this value will result in standard input being set to non-blocking mode.
-/// The standard input will be reset to its original state after the program exits.
+///
+/// If `stdin` does not exist or is invalid,
+/// all operations on `stdin` will immediately fail with error.
 pub let stdin : Input = {
   io: @event_loop.stdin,
   read_buf: @io.ReaderBuffer::new(),
@@ -61,12 +74,14 @@ pub let stdin : Input = {
 
 ///|
 /// The standard output channel.
-/// Using this value will result in standard output being set to non-blocking mode.
-/// The standard output will be reset to its original state after the program exits.
+///
+/// If `stdout` does not exist or is invalid,
+/// all operations on `stdout` will immediately fail with error.
 pub let stdout : Output = @event_loop.stdout
 
 ///|
 /// The standard error channel.
-/// Using this value will result in standard error being set to non-blocking mode.
-/// The standard error will be reset to its original state after the program exits.
+///
+/// If `stderr` does not exist or is invalid,
+/// all operations on `stderr` will immediately fail with error.
 pub let stderr : Output = @event_loop.stderr


### PR DESCRIPTION
Previously, when `@stdio.{stdin,stdout,stderr}` are mentioned in the program, and the initialization process of these objects failed, the program will crash immediately. But this is not very desirable, because there are cases where stdio initialization may fail:

- on Windows, `GetStdHandle` may return `INVALID_HANDLE_VALUE`, and parent process may pass `INVALID_HANDLE_VALUE` to explicitly mute stdio channels
- on Linux/MacOS, the special file descriptor 0/1/2 may be invalid (i.e. no corresponding file description)

Currently, program merely mentioning `@stdio` stuff, event when not actually using them at runtime, will crash immediately in the above scenarios. This PR fixes this problem: instead of crashing the program, error in initialization of stdio channels are delayed to actual operations on these channels, such as reading/writing. So there will be no more early crashes caused by invalid stdio handle.

This PR is breaking, because `@stdio.{stdin,stdout,stderr}.fd()` may now raise error. This is intended behavior, just incompatible with the old signature. In the future `.fd()` can be used as a way to tell if a stdio channel is valid.