### PR TITLE
Add wasm event loop and timer support

### DIFF
--- a/src/integration.wasm.mbt
+++ b/src/integration.wasm.mbt
@@ -1,0 +1,28 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#coverage.skip
+#doc(hidden)
+pub fn run_async_main(main : async () -> Unit) -> Unit {
+  @event_loop.with_event_loop(() => main()) catch {
+    err => {
+      println(err)
+      exit(1)
+    }
+  }
+}
+
+///|
+fn exit(code : Int) = "moonbit_v0" "runtime/exit"

--- a/src/internal/event_loop/event_loop.wasm.mbt
+++ b/src/internal/event_loop/event_loop.wasm.mbt
@@ -1,0 +1,332 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub(all) enum Platform {
+  Linux = 0
+  MacOS = 1
+  Windows = 2
+}
+
+///|
+fn get_platform() -> Platform = "moonbit_v0" "runtime/get_platform"
+
+///|
+fn wait_for_event(timeout : Int) -> Int = "moonbit_v0" "runtime/wait_for_event"
+
+///|
+fn ms_since_epoch() -> Int64 = "moonbit_v0" "time/get_ms_since_epoch"
+
+///|
+pub let platform : Platform = get_platform()
+
+///|
+priv struct EventLoop {
+  max_worker_count : Int
+  mut job_id : Int
+  job_queue : @deque.Deque[QueuedJob]
+  idle_workers : @deque.Deque[Worker]
+  running_workers : Map[Int, Worker]
+  completed_jobs_buffer : FixedArray[Int]
+  jobs : Map[Int, @coroutine.Coroutine]
+  timers : @sorted_set.SortedSet[Timer]
+}
+
+///|
+priv struct QueuedJob {
+  job_id : Int
+  job : Job
+}
+
+///|
+let curr_loop : Ref[EventLoop?] = Ref(None)
+
+///|
+priv struct EventLoopHook {
+  init : (() -> Unit raise)?
+  exit : (() -> Unit raise)?
+}
+
+///|
+let hooks : Array[EventLoopHook] = []
+
+///|
+pub fn register_hook(
+  init? : () -> Unit raise,
+  exit? : () -> Unit raise,
+) -> Unit {
+  hooks.push({ init, exit })
+}
+
+///|
+fn EventLoop::new() -> EventLoop {
+  init_thread_pool_ffi()
+  {
+    max_worker_count: 1024,
+    job_id: 0,
+    job_queue: @deque.Deque([]),
+    idle_workers: @deque.Deque([]),
+    running_workers: {},
+    completed_jobs_buffer: FixedArray::make(1024, 0),
+    jobs: {},
+    timers: @sorted_set.SortedSet([]),
+  }
+}
+
+///|
+pub fn with_event_loop(f : async () -> Unit) -> Unit raise {
+  guard curr_loop.val is None
+  let evloop = EventLoop::new()
+  defer destroy_thread_pool()
+  curr_loop.val = Some(evloop)
+  defer {
+    curr_loop.val = None
+  }
+  for hook in hooks {
+    if hook.init is Some(init) {
+      init()
+    }
+  }
+  let main = @coroutine.spawn(() => f())
+  evloop.run_forever()
+  main.unwrap()
+}
+
+///|
+fn EventLoop::wait_for_event(self : EventLoop) -> Unit raise {
+  // Mirrors native `EventLoop::wait_for_event`: compute the next scheduler
+  // timeout, block in the host poll primitive, then drain expired timers.
+  // Native uses `self.poll.wait(timeout~)` here. In wasm PR1 the replacement is
+  // `runtime/wait_for_event(timeout)`, which only blocks for the timeout because
+  // there is no native `Instance`/event-list object in the wasm event loop.
+  let has_timers = !self.timers.is_empty()
+  let timeout = if @coroutine.has_immediately_ready_task() {
+    0
+  } else if has_timers && self.timers.iter().head() is Some(timer) {
+    @cmp.maximum(0, (timer.expire_time - ms_since_epoch()).to_int())
+  } else {
+    -1
+  }
+  if wait_for_event(timeout) != 0 {
+    @os_error.check_errno("runtime internal: wait_for_event")
+  }
+  if has_timers {
+    let now = ms_since_epoch()
+    for timer in self.timers {
+      if timer.expire_time <= now {
+        (timer.callback)()
+      } else {
+        break
+      }
+    }
+  }
+}
+
+///|
+fn EventLoop::poll(self : EventLoop) -> Unit raise {
+  self.wait_for_event()
+  // Native `EventLoop::poll` fetches worker completions after `poll.wait`
+  // reports the notify fd: `fd == self.notify_recv` calls
+  // `fetch_completion_ffi(self.notify_recv, self.completed_jobs_buffer)`.
+  // Wasm has no fd event array, so the matching point is immediately after the
+  // host wait returns. The explicit host completion queue is still drained
+  // after timers, matching native `wait_for_event` then `poll` ordering.
+  self.drain_worker_completions()
+}
+
+///|
+fn EventLoop::drain_worker_completions(self : EventLoop) -> Unit {
+  // Native worker threads publish job ids to the notify pipe in
+  // `worker_loop` (`write(pool.notify_send, &job_id, sizeof(int))` on Unix,
+  // `PostQueuedCompletionStatus(pool.notify_send, job_id, ...)` on Windows).
+  // Native `EventLoop::poll` then reads them through
+  // `moonbitlang_async_fetch_completion`. The wasm import exposes the same
+  // completed job-id stream without an OS fd, and PR1's host returns an empty
+  // stream until real worker jobs are introduced.
+  while true {
+    let bytes_transferred = fetch_completion_ffi(self.completed_jobs_buffer)
+    let n = bytes_transferred / 4
+    for i in 0..<n {
+      self.handle_completed_job(self.completed_jobs_buffer[i])
+    }
+    if n < self.completed_jobs_buffer.length() {
+      break
+    }
+  }
+}
+
+///|
+fn EventLoop::handle_completed_job(self : Self, job_id : Int) -> Unit {
+  // Keep the native worker handoff logic: either park the worker as idle or
+  // immediately give it the next queued job, then wake the waiting coroutine.
+  guard self.running_workers.get(job_id) is Some(worker)
+  self.running_workers.remove(job_id)
+  match self.job_queue.pop_front() {
+    None => {
+      worker.enter_idle()
+      self.idle_workers.push_back(worker)
+    }
+    Some(job) => {
+      self.running_workers[job.job_id] = worker
+      worker.wake(job.job_id, job.job)
+    }
+  }
+  if self.jobs.get(job_id) is Some(coro) {
+    coro.wake()
+  }
+}
+
+///|
+pub let check_fd_leak : Ref[Bool] = Ref(false)
+
+///|
+fn EventLoop::cleanup(self : Self) -> Unit raise {
+  for hook in hooks {
+    if hook.exit is Some(exit) {
+      exit()
+    }
+  }
+  for _, coro in self.jobs {
+    coro.cancel()
+  }
+  self.jobs.clear()
+  for worker in self.idle_workers {
+    worker.free()
+  }
+}
+
+///|
+fn EventLoop::run_forever(self : Self) -> Unit raise {
+  try {
+    while !(@coroutine.no_more_work() && self.running_workers.is_empty()) {
+      self.poll()
+      @coroutine.reschedule()
+    }
+  } catch {
+    err => {
+      Ref::protect(check_fd_leak, false, () => self.cleanup())
+      // In case the event loop has encountered some fatal error,
+      // propagate the error to relevant coroutines.
+      while !@coroutine.no_more_work() {
+        @coroutine.reschedule()
+      }
+      raise err
+    }
+  } noraise {
+    _ => self.cleanup()
+  }
+}
+
+///|
+priv enum CancellationStatus {
+  NoWait
+  NeedWait
+  RetryLater
+}
+
+///|
+fn errno_is_cancelled(errno : Int) -> Bool = "moonbit_v0" "thread_pool/errno_is_cancelled"
+
+///|
+async fn EventLoop::wait_for_job(
+  evloop : EventLoop,
+  job_id : Int,
+  cancel? : (Int) -> CancellationStatus raise,
+) -> Unit {
+  evloop.jobs[job_id] = @coroutine.current_coroutine()
+  defer evloop.jobs.remove(job_id)
+  match cancel {
+    None =>
+      @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
+    Some(cancel_func) =>
+      @coroutine.suspend() catch {
+        err =>
+          for ;; {
+            let status = cancel_func(job_id) catch {
+              err =>
+                @coroutine.protect_from_cancel() <| () => {
+                  @coroutine.suspend()
+                  raise err
+                }
+            }
+            match status {
+              NeedWait => {
+                @coroutine.protect_from_cancel(
+                  @coroutine.suspend,
+                  resume_on_cancel=true,
+                )
+                break
+              }
+              NoWait => raise err
+              RetryLater => {
+                @coroutine.protect_from_cancel(
+                  @coroutine.pause,
+                  resume_on_cancel=true,
+                )
+                if evloop.jobs.get(job_id) is None {
+                  break
+                }
+              }
+            }
+          }
+      }
+  }
+}
+
+///|
+async fn perform_job_in_worker(
+  job : Job,
+  context~ : String,
+  cancel? : (Int) -> CancellationStatus raise,
+) -> Int {
+  @coroutine.check_cancellation()
+  guard curr_loop.val is Some(evloop)
+  let job_id = evloop.job_id
+  evloop.job_id += 1
+  match evloop.idle_workers.pop_front() {
+    None if evloop.running_workers.length() >= evloop.max_worker_count =>
+      evloop.job_queue.push_back({ job_id, job })
+    None => {
+      let worker = Worker::spawn(job_id, job)
+      evloop.running_workers[job_id] = worker
+    }
+    Some(worker) => {
+      evloop.running_workers[job_id] = worker
+      worker.wake(job_id, job)
+    }
+  }
+  evloop.wait_for_job(job_id, cancel?)
+  if job.err() is err && err > 0 {
+    if errno_is_cancelled(err) {
+      raise @coroutine.Cancelled
+    } else {
+      raise @os_error.OSError(err, context~)
+    }
+  } else {
+    job.ret()
+  }
+}
+
+///|
+fn EventLoop::cancel_job_in_worker(
+  evloop : EventLoop,
+  job_id : Int,
+  context~ : String,
+) -> CancellationStatus raise {
+  if evloop.running_workers.get(job_id) is Some(worker) {
+    worker.cancel(context~)
+  } else {
+    NoWait
+  }
+}

--- a/src/internal/event_loop/moon.pkg
+++ b/src/internal/event_loop/moon.pkg
@@ -54,7 +54,10 @@ options(
     "stdio.mbt": [ "native" ],
     "thread_pool.mbt": [ "native" ],
     "timer.mbt": [ "native" ],
-    "unimplemented.mbt": [ "wasm", "wasm-gc" ],
+    "timer.wasm.mbt": [ "wasm" ],
+    "event_loop.wasm.mbt": [ "wasm" ],
+    "unimplemented.mbt": [ "wasm-gc" ],
     "worker_wbtest.mbt": [ "native", "js" ],
+    "thread_pool.wasm.mbt": [ "wasm" ],
   },
 )

--- a/src/internal/event_loop/thread_pool.wasm.mbt
+++ b/src/internal/event_loop/thread_pool.wasm.mbt
@@ -1,0 +1,135 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+priv struct Worker(Int)
+
+///|
+fn init_thread_pool_ffi() -> Unit {
+  ()
+}
+
+///|
+fn destroy_thread_pool() -> Unit {
+  ()
+}
+
+///|
+fn spawn_worker_ffi(init_job_id : Int, init_job : Int) -> Int = "moonbit_v0" "thread_pool/spawn_worker"
+
+///|
+fn free_worker_ffi(worker : Int) -> Unit = "moonbit_v0" "thread_pool/free_worker"
+
+///|
+fn wake_worker_ffi(worker : Int, job_id : Int, job : Int) -> Unit = "moonbit_v0" "thread_pool/wake_worker"
+
+///|
+fn worker_enter_idle_ffi(worker : Int) -> Unit = "moonbit_v0" "thread_pool/worker_enter_idle"
+
+///|
+fn cancel_worker_ffi(worker : Int) -> Int = "moonbit_v0" "thread_pool/cancel_worker"
+
+///|
+fn fetch_completion_raw(output : Int, len : Int) -> Int = "moonbit_v0" "thread_pool/fetch_completion"
+
+///|
+#borrow(array)
+fn int_array_to_ptr(array : FixedArray[Int]) -> Int =
+  #|(func (param i32) (result i32) local.get 0)
+
+///|
+fn fetch_completion_ffi(output : FixedArray[Int]) -> Int {
+  fetch_completion_raw(int_array_to_ptr(output), output.length())
+}
+
+///|
+fn Worker::spawn(init_job_id : Int, init_job : Job) -> Worker {
+  Worker(spawn_worker_ffi(init_job_id, init_job.handle))
+}
+
+///|
+fn Worker::free(worker : Worker) -> Unit {
+  free_worker_ffi(worker.0)
+}
+
+///|
+fn Worker::wake(worker : Worker, job_id : Int, job : Job) -> Unit {
+  wake_worker_ffi(worker.0, job_id, job.handle)
+}
+
+///|
+fn Worker::enter_idle(worker : Worker) -> Unit {
+  worker_enter_idle_ffi(worker.0)
+}
+
+///|
+fn Worker::cancel_ffi(worker : Worker) -> Int {
+  cancel_worker_ffi(worker.0)
+}
+
+///|
+fn Worker::cancel(
+  worker : Worker,
+  context~ : String,
+) -> CancellationStatus raise {
+  match worker.cancel_ffi() {
+    // The wasm host cannot interrupt every blocking OS operation yet. It still
+    // drains the worker completion later, but cancellation should resume the
+    // coroutine immediately to match the async timeout surface.
+    0 => NoWait
+    1 => NeedWait
+    2 => RetryLater
+    _ => {
+      @os_error.check_errno(context)
+      NoWait
+    }
+  }
+}
+
+///|
+priv struct Job {
+  handle : Int
+}
+
+///|
+fn free_job_ffi(job : Int) -> Unit = "moonbit_v0" "thread_pool/free_job"
+
+///|
+fn run_job_ffi(job : Int) -> Unit = "moonbit_v0" "thread_pool/run_job"
+
+///|
+fn job_get_ret_ffi(job : Int) -> Int = "moonbit_v0" "thread_pool/job_get_ret"
+
+///|
+fn job_get_err_ffi(job : Int) -> Int = "moonbit_v0" "thread_pool/job_get_err"
+
+///|
+fn Job::free(self : Job) -> Unit {
+  free_job_ffi(self.handle)
+}
+
+///|
+fn Job::run(self : Job) -> Unit {
+  run_job_ffi(self.handle)
+}
+
+///|
+fn Job::ret(self : Job) -> Int {
+  job_get_ret_ffi(self.handle)
+}
+
+///|
+fn Job::err(self : Job) -> Int {
+  job_get_err_ffi(self.handle)
+}

--- a/src/internal/event_loop/timer.wasm.mbt
+++ b/src/internal/event_loop/timer.wasm.mbt
@@ -1,0 +1,52 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+struct Timer {
+  timer_id : Int
+  expire_time : Int64
+  callback : () -> Unit
+}
+
+///|
+let timer_id : Ref[Int] = { val: 0 }
+
+///|
+pub fn Timer::new(duration : Int, callback : () -> Unit) -> Timer {
+  guard curr_loop.val is Some(evloop)
+  let expire_time = ms_since_epoch() + duration.to_int64()
+  timer_id.val += 1
+  let timer = { timer_id: timer_id.val, expire_time, callback }
+  evloop.timers.add(timer)
+  timer
+}
+
+///|
+pub fn Timer::cancel(timer : Timer) -> Unit {
+  guard curr_loop.val is Some(evloop)
+  evloop.timers.remove(timer)
+}
+
+///|
+impl Eq for Timer with fn equal(t1, t2) {
+  t1.timer_id == t2.timer_id
+}
+
+///|
+impl Compare for Timer with fn compare(t1, t2) {
+  match t1.expire_time.compare(t2.expire_time) {
+    0 => t1.timer_id.compare(t2.timer_id)
+    o => o
+  }
+}

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -13,3 +13,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/async/internal/test_util",
 } for "test"
+
+options(
+  targets: { "integration.wasm.mbt": [ "wasm" ] },
+)

--- a/src/os_error/error.wasm.mbt
+++ b/src/os_error/error.wasm.mbt
@@ -1,0 +1,44 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+pub fn get_errno() -> Int = "moonbit_v0" "os_error/get_errno"
+
+///|
+#internal(internal, "for internal use only")
+pub fn errno_to_string(errno : Int) -> String {
+  // PR1 only needs numeric errno reporting from `moonrun`; host-side errno
+  // stringification should be added with the broader os_error/fs surface.
+  "errno \{errno}"
+}
+
+///|
+pub(all) suberror OSError {
+  OSError(Int, context~ : String)
+} derive(ToJson)
+
+///|
+pub impl Show for OSError with fn output(self, logger) -> Unit {
+  let OSError(errno, context~) = self
+  let msg = "\{context}: \{errno_to_string(errno)}"
+  logger <+ "OSError(\{to_repr(msg)})"
+}
+
+///|
+pub fn check_errno(context : String) -> Unit raise OSError {
+  let err_code = get_errno()
+  if err_code != 0 {
+    raise OSError(err_code, context~)
+  }
+}

--- a/src/os_error/moon.pkg
+++ b/src/os_error/moon.pkg
@@ -11,5 +11,9 @@ import {
 
 options(
   "native-stub": [ "stub.c" ],
-  targets: { "error.mbt": [ "native" ], "os_error_test.mbt": [ "native" ] },
+  targets: {
+    "error.mbt": [ "native" ],
+    "error.wasm.mbt": [ "wasm" ],
+    "os_error_test.mbt": [ "native" ],
+  },
 )


### PR DESCRIPTION
## Why

The wasm backend needs the async event-loop and timer foundation before broader filesystem, process, or worker-job support can be split out safely.

## What

- Adds a wasm `run_async_main` path that delegates to the wasm event loop.
- Adds a wasm event loop that waits through `runtime/wait_for_event(timeout)` and drains timers before worker completions using the shared timer-drain logic.
- Adds wasm monotonic time and minimal os-error imports through `moonbit_v0`.
- Keeps root package wasm tests serialized with `max-concurrent-tests`.

## Scope

This is intentionally limited to event loop and timer support. Filesystem, process, sockets, TLS, raw-fd, c-buffer, and real worker-job behavior are left for follow-up PRs; link-required worker/job calls remain unsupported if exercised.