### PR TITLE
expose `chmod` on Windows, let it fail with error

### DIFF
--- a/src/fs/utils.mbt
+++ b/src/fs/utils.mbt
@@ -148,10 +148,12 @@ pub async fn symlink(
 /// Change the permission of a file.
 /// Permission is represented as an integer in UNIX permission style.
 /// For example, `0o640` means:
+///
 /// - the owner of the file can read and write the file (`6`)
 /// - users in the owner group of the file can read the file (`4`)
 /// - other users can do nothing to the file
-#cfg(not(platform="windows"))
+///
+/// On Windows, `@fs.chmod` is not supported, and will fail with error.
 pub async fn chmod(path : StringView, mode : Int) -> Unit {
   @event_loop.chmod(path, mode, context="@fs.chmod()")
 }

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -1107,13 +1107,12 @@ struct file_time_by_path_job *moonbitlang_async_make_file_time_by_path_job(
   return job;
 }
 
-#ifndef _WIN32
 // ===== chmod job, change permission of file =====
 
 struct chmod_job {
   struct job job;
   char *path;
-  mode_t mode;
+  int mode;
 };
 
 static
@@ -1124,10 +1123,18 @@ void free_chmod_job(void *obj) {
 
 static
 void chmod_job_worker(struct job *job) {
+#ifdef _WIN32
+
+  job->err = ERROR_NOT_SUPPORTED;
+
+#else
+
   struct chmod_job *chmod_job = (struct chmod_job*)job;
   job->ret = chmod(chmod_job->path, chmod_job->mode);
   if (job->ret < 0)
     job->err = errno;
+
+#endif
 }
 
 struct chmod_job *moonbitlang_async_make_chmod_job(char *path, int mode) {
@@ -1137,8 +1144,6 @@ struct chmod_job *moonbitlang_async_make_chmod_job(char *path, int mode) {
   return job;
 }
 
- 
-#endif
 // ===== fsync job, synchronize file modification to disk =====
 
 struct fsync_job {

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -288,7 +288,3 @@ extern "C" fn Job::inotify_add_watch(
   path : @os_string.OsString,
   is_dir : Bool,
 ) -> Job = "moonbitlang_async_make_inotify_add_watch_job"
-
-///|
-#cfg(platform="windows")
-let _mute_unused_warning : Unit = ignore(@c_buffer.Buffer::get)


### PR DESCRIPTION
This make the behavior more consistent with future WASM support