### PR TITLE
refactor process handling in event loop

### DIFF
--- a/src/internal/event_loop/epoll.c
+++ b/src/internal/event_loop/epoll.c
@@ -23,6 +23,8 @@
 #include <sys/wait.h>
 #include <linux/version.h>
 
+_Noreturn void moonbit_panic();
+
 int moonbitlang_async_event_bus_create() {
   return epoll_create1(0);
 }
@@ -37,9 +39,6 @@ static const int ev_masks[] = {
   EPOLLOUT,
   EPOLLIN | EPOLLOUT,
 };
-
-// use mask to classify different kinds of entity
-static const uint64_t pid_mask = (uint64_t)1 << 63;
 
 int moonbitlang_async_event_bus_register(int epfd, int fd, int32_t read_only) {
   // File descriptors registered with the event bus
@@ -60,49 +59,8 @@ int moonbitlang_async_event_bus_register(int epfd, int fd, int32_t read_only) {
   return epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event);
 }
 
-int moonbitlang_async_support_wait_pid_via_event_bus() {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
-  int pidfd = syscall(SYS_pidfd_open, getpid(), 0);
-  if (pidfd >= 0) {
-    close(pidfd);
-    return 1;
-  } else {
-    // TODO: check if `errno` is one of `ENOSYS` or `EPERM`.
-    return 0;
-  }
-#else
-  return 0;
-#endif
-}
-
-// return value:
-// - `>= 0`: success, return the pidfd
-// - `-1`: failure
-// - `-2`: already terminated
 int moonbitlang_async_event_bus_register_pid(int epfd, pid_t pid) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
-
-  int pidfd = syscall(SYS_pidfd_open, pid, 0);
-  if (pidfd < 0)
-    return -1;
-
-  epoll_data_t data;
-  data.u64 = pid_mask | pidfd;
-
-  struct epoll_event event = { EPOLLIN, data };
-  int ret = epoll_ctl(epfd, EPOLL_CTL_ADD, pidfd, &event);
-  if (ret < 0) {
-    close(pidfd);
-    return -1;
-  }
-
-  return pidfd;
-
-#else
-
-  return -1;
-
-#endif
+  moonbit_panic();
 }
 
 #define EVENT_BUFFER_SIZE 1024
@@ -118,13 +76,10 @@ struct epoll_event* moonbitlang_async_event_list_get(int index) {
 }
 
 int moonbitlang_async_event_get_fd(struct epoll_event *ev) {
-  return ev->data.u64 & ~pid_mask;
+  return ev->data.u64;
 }
 
 int moonbitlang_async_event_get_events(struct epoll_event *ev) {
-  if (ev->data.u64 & pid_mask)
-    return 4;
-
   if (ev->events & (EPOLLERR | EPOLLHUP | EPOLLRDHUP))
     return 3;
 

--- a/src/internal/event_loop/event_bus.mbt
+++ b/src/internal/event_loop/event_bus.mbt
@@ -57,41 +57,19 @@ fn EventBus::register(
 }
 
 ///|
-/// On Linux <5.3, `pidfd` is not supported,
-/// hence we cannot wait for a process via `epoll`.
-#cfg(not(platform="windows"))
-extern "C" fn detect_wait_pid_via_event_bus() -> Bool = "moonbitlang_async_support_wait_pid_via_event_bus"
-
-///|
-#cfg(not(platform="windows"))
-let support_wait_pid_via_event_bus : Bool = detect_wait_pid_via_event_bus()
-
-///|
 #cfg(not(platform="windows"))
 extern "C" fn EventBus::register_pid_ffi(self : EventBus, pid : Int) -> Int = "moonbitlang_async_event_bus_register_pid"
 
 ///|
+/// Return `true` if the PID is successfully registered.
+/// Return `false` if the process has already terminated.
 #cfg(not(platform="windows"))
-priv enum RegisterPidResult {
-  Running(Int)
-  Stopped
-}
-
-///|
-#cfg(not(platform="windows"))
-fn EventBus::register_pid(
-  self : EventBus,
-  pid : Int,
-) -> RegisterPidResult raise {
+fn EventBus::register_pid(self : EventBus, pid : Int) -> Bool raise {
   let ret = self.register_pid_ffi(pid)
-  if ret >= 0 {
-    Running(ret)
-  } else if ret == -2 {
-    Stopped
-  } else {
+  if ret == -1 {
     @os_error.check_errno("poll_register_pid")
-    Stopped
   }
+  ret > 0
 }
 
 ///|

--- a/src/internal/event_loop/kqueue.c
+++ b/src/internal/event_loop/kqueue.c
@@ -50,14 +50,10 @@ int moonbitlang_async_event_bus_register(int kqfd, int fd, int32_t read_only) {
   return kevent(kqfd, events, read_only ? 1 : 2, 0, 0, 0);
 }
 
-int moonbitlang_async_support_wait_pid_via_event_bus() {
-  return 1;
-}
-
 // return value:
-// - `>= 0`: success, return the pid itself
+// - `> 0`: success, return the pid itself
 // - `-1`: failure
-// - `-2`: pid already terminated
+// - `0`: pid already terminated
 int moonbitlang_async_event_bus_register_pid(int kqfd, pid_t pid) {
   struct kevent event;
 #ifdef __MACH__
@@ -68,9 +64,9 @@ int moonbitlang_async_event_bus_register_pid(int kqfd, pid_t pid) {
   int ret = kevent(kqfd, &event, 1, 0, 0, 0);
 
   if (ret >= 0) {
-    return pid;
+    return 1;
   } else if (errno == ESRCH) {
-    return -2;
+    return 0;
   } else {
     return -1;
   }

--- a/src/internal/event_loop/moon.pkg
+++ b/src/internal/event_loop/moon.pkg
@@ -48,6 +48,7 @@ options(
     "network_unix.mbt": [ "native" ],
     "network_windows.mbt": [ "native" ],
     "event_bus.mbt": [ "native" ],
+    "process.mbt": [ "native" ],
     "process_unix.mbt": [ "native" ],
     "process_windows.mbt": [ "native" ],
     "signal.mbt": [ "native" ],

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -114,10 +114,12 @@ pub(all) enum Platform {
   Windows
 }
 
-type Process
+pub struct Process {
+  pid : Int
+  // private fields
+}
 pub fn Process::close(Self) -> Unit
-pub fn Process::from_pid(Int, context~ : String) -> Self
-pub fn Process::pid(Self) -> Int
+pub fn Process::from_pid(Int, context~ : String) -> Self raise
 pub async fn Process::wait_pid(Self, context~ : String) -> Int
 
 type Timer

--- a/src/internal/event_loop/process.c
+++ b/src/internal/event_loop/process.c
@@ -15,38 +15,107 @@
  */
 
 #ifdef _WIN32
+
 #include <windows.h>
+
 #else
+
+#include <errno.h>
+#include <unistd.h>
 #include <sys/wait.h>
+
+typedef int HANDLE;
+
+#ifdef __linux__
+#include <linux/version.h>
+#include <sys/syscall.h>
+#endif
+
 #endif
 
 #include <moonbit.h>
 
+
+MOONBIT_FFI_EXPORT
+int moonbitlang_async_get_process_result(HANDLE handle, int32_t pid, int32_t *out) {
 #ifdef _WIN32
 
-MOONBIT_FFI_EXPORT
-int moonbitlang_async_get_process_result(HANDLE handle, DWORD *out) {
-  int result = GetExitCodeProcess(handle, out) ? 0 : -1;
-  return result;
-}
-
-MOONBIT_FFI_EXPORT
-HANDLE moonbitlang_async_open_pid_handle(DWORD pid) {
-  return OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-}
+  BOOL ret = GetExitCodeProcess(handle, out);
+  if (ret && *out == STILL_ACTIVE) {
+    SetLastError(ERROR_IO_PENDING);
+    return -1;
+  }
+  return ret ? 0 : - 1;
 
 #else
 
-MOONBIT_FFI_EXPORT
-int moonbitlang_async_get_process_result(pid_t pid, int *out) {
-  int wstatus;
-  int ret = waitpid(pid, &wstatus, 0);
-  if (ret > 0) {
-    *out = WEXITSTATUS(wstatus);
+#ifdef __linux__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+
+  if (handle >= 0) {
+    siginfo_t info;
+    info.si_pid = 0;
+    int ret = waitid(P_PIDFD, handle, &info, WEXITED | WSTOPPED | WNOHANG);
+
+    if (ret < 0)
+      return -1;
+
+    if (info.si_pid == 0) {
+      errno = EAGAIN;
+      return -1;
+    }
+
+    *out = info.si_status;
     return 0;
-  } else {
+  }
+
+#endif // #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+#endif // #ifdef __linux__
+
+  /* This can be either:
+     1. Linux systems without `pidfd` support.
+     2. MacOS/BSD
+  */
+  int wstatus;
+  int ret = waitpid(pid, &wstatus, WNOHANG);
+  if (ret < 0)
+    return -1;
+
+  if (ret == 0) {
+    errno = EAGAIN;
     return -1;
   }
+
+  *out = WEXITSTATUS(wstatus);
+  return 0;
+
+#endif // #ifdef _WIN32
 }
 
-#endif
+
+MOONBIT_FFI_EXPORT
+HANDLE moonbitlang_async_open_pid_handle(int32_t pid) {
+#ifdef _WIN32
+
+  return OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+
+#else
+
+#ifdef __linux__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+
+  int pidfd = syscall(SYS_pidfd_open, pid, 0);
+  if (pidfd < 0 && errno == ENOSYS || errno == EPERM)
+    // some container environments do not support `pidfd` even on Linux >= 5.3.0
+    errno = 0;
+
+  return pidfd;
+
+#endif // #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+#endif // #ifdef __linux__
+
+  errno = 0;
+  return -1;
+
+#endif // #ifdef _WIN32
+}

--- a/src/internal/event_loop/process.mbt
+++ b/src/internal/event_loop/process.mbt
@@ -1,0 +1,56 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#valtype
+pub struct Process {
+  pid : Int
+  priv handle : IoHandle?
+}
+
+///|
+pub fn Process::close(self : Process) -> Unit {
+  if self.handle is Some(io) {
+    io.close()
+  }
+}
+
+///|
+extern "C" fn open_pid_handle(pid : Int) -> @fd_util.Fd = "moonbitlang_async_open_pid_handle"
+
+///|
+pub fn Process::from_pid(pid : Int, context~ : String) -> Process raise {
+  let handle = open_pid_handle(pid)
+  let handle = if !@fd_util.fd_is_valid(handle) {
+    @os_error.check_errno(context)
+    None
+  } else {
+    IoHandle::from_fd(
+      handle,
+      kind=Unknown,
+      is_async=platform is Linux,
+      read_only=true,
+    )
+    |> Some
+  }
+  { pid, handle }
+}
+
+///|
+#borrow(out)
+extern "C" fn get_process_result(
+  handle : @fd_util.Fd,
+  pid : Int,
+  out : Ref[Int],
+) -> Int = "moonbitlang_async_get_process_result"

--- a/src/internal/event_loop/process_unix.mbt
+++ b/src/internal/event_loop/process_unix.mbt
@@ -14,29 +14,6 @@
 
 ///|
 #cfg(not(platform="windows"))
-struct Process(Int)
-
-///|
-#cfg(not(platform="windows"))
-pub fn Process::pid(self : Process) -> Int {
-  self.0
-}
-
-///|
-#cfg(not(platform="windows"))
-pub fn Process::from_pid(pid : Int, context~ : String) -> Process {
-  ignore(context)
-  Process(pid)
-}
-
-///|
-#cfg(not(platform="windows"))
-pub fn Process::close(_ : Process) -> Unit {
-
-}
-
-///|
-#cfg(not(platform="windows"))
 pub async fn spawn(
   path : @os_string.OsString,
   args : @c_buffer.Buffer,
@@ -51,50 +28,54 @@ pub async fn spawn(
   let job = Job::spawn(
     path, args, env, inherited_env_entry_count, stdin, stdout, stderr, cwd,
   )
-  defer job.free()
-  perform_job_in_worker(job, context~)
+  defer job.0.free()
+  let pid = perform_job_in_worker(job.0, context~)
+  let pidfd = job.result_handle()
+  let handle = if !@fd_util.fd_is_valid(pidfd) {
+    None
+  } else {
+    Some(IoHandle::from_fd(pidfd, kind=Unknown, read_only=true))
+  }
+  { pid, handle }
 }
 
 ///|
 #cfg(not(platform="windows"))
-#borrow(out)
-extern "C" fn get_process_result(pid : Int, out : Ref[Int]) -> Int = "moonbitlang_async_get_process_result"
-
-///|
-#cfg(not(platform="windows"))
 pub async fn Process::wait_pid(self : Process, context~ : String) -> Int {
-  let Process(pid) = self
   guard curr_loop.val is Some(evloop)
-  guard support_wait_pid_via_event_bus else {
-    // pidfd not available, fall back to blocking waitpid in worker thread.
-    // The worker reaps the child and stores the exit code in job.ret(),
-    // so return it here to avoid a second waitpid in get_process_result.
-    let job = Job::wait_for_process(pid)
-    defer job.free()
-    let exit_code = perform_job_in_worker(job, context~, cancel=job_id => {
-      evloop.cancel_job_in_worker(job_id, context~)
-    })
-    exit_code
-  }
-  match evloop.bus.register_pid(pid) {
-    Running(alt_id) => {
-      guard evloop.pids.get(alt_id) is None
-      evloop.pids[alt_id] = @coroutine.current_coroutine()
-      defer {
-        evloop.pids.remove(alt_id)
-        if platform is Linux {
-          // On Linux, the `pidfd` need to be closed
-          @fd_util.close(alt_id, kind=Unknown, context="") catch {
-            _ => ()
-          }
-        }
-      }
+  let handle = if self.handle is Some(io) { io.fd } else { @fd_util.invalid_fd }
+
+  let out = Ref(0)
+
+  if platform is Linux && self.handle is Some(io) {
+    let ret = get_process_result(handle, self.pid, out)
+    if ret >= 0 {
+      return out.val
+    }
+    if !@os_error.is_nonblocking_io_error() {
+      @os_error.check_errno(context)
+    }
+    io.wait_read()
+  } else if platform is MacOS {
+    // MacOS/BSD, use `kqueue` with `EVFILT_PROC`
+    if evloop.bus.register_pid(self.pid) {
+      guard evloop.pids.get(self.pid) is None
+      evloop.pids[self.pid] = @coroutine.current_coroutine()
+      defer evloop.pids.remove(self.pid)
       @coroutine.suspend()
     }
-    Stopped => ()
+  } else {
+    // Linux systems where pidfd is not available.
+    // Fall back to blocking waitpid in worker thread.
+    // The thread pool job will obain the exit code and reap the process.
+    let job = Job::wait_for_process(self.pid)
+    defer job.free()
+    return perform_job_in_worker(job, context~, cancel=job_id => {
+      evloop.cancel_job_in_worker(job_id, context~)
+    })
   }
-  let out = Ref(0)
-  let ret = get_process_result(pid, out)
+
+  let ret = get_process_result(handle, self.pid, out)
   if ret < 0 {
     @os_error.check_errno(context)
   }

--- a/src/internal/event_loop/process_windows.mbt
+++ b/src/internal/event_loop/process_windows.mbt
@@ -32,41 +32,6 @@ fn init_global_job_object() -> Unit raise {
 
 ///|
 #cfg(platform="windows")
-struct Process {
-  pid : Int
-  handle : @fd_util.Fd
-}
-
-///|
-#cfg(platform="windows")
-pub fn Process::pid(self : Process) -> Int {
-  self.pid
-}
-
-///|
-#cfg(platform="windows")
-extern "C" fn open_pid_handle(pid : Int) -> @fd_util.Fd = "moonbitlang_async_open_pid_handle"
-
-///|
-#cfg(platform="windows")
-pub fn Process::from_pid(pid : Int, context~ : String) -> Process raise {
-  let handle = open_pid_handle(pid)
-  if !@fd_util.fd_is_valid(handle) {
-    @os_error.check_errno(context)
-  }
-  { pid, handle }
-}
-
-///|
-#cfg(platform="windows")
-pub fn Process::close(self : Process) -> Unit {
-  @fd_util.close(self.handle, kind=Unknown, context="") catch {
-    _ => ()
-  }
-}
-
-///|
-#cfg(platform="windows")
 pub async fn spawn(
   command_line : @os_string.OsString,
   env~ : @c_buffer.Buffer,
@@ -89,29 +54,29 @@ pub async fn spawn(
     no_console_window~,
     is_orphan~,
   )
-  defer job.free()
-  let pid = perform_job_in_worker(job, context~)
-  { pid, handle: job.get_spawn_job_result_handle() }
+  defer job.0.free()
+  let pid = perform_job_in_worker(job.0, context~)
+  let handle = IoHandle::from_fd(
+    job.result_handle(),
+    kind=Unknown,
+    is_async=false,
+  )
+  { pid, handle: Some(handle) }
 }
 
 ///|
 #cfg(platform="windows")
-#borrow(out)
-extern "C" fn get_process_result(handle : @fd_util.Fd, out : Ref[Int]) -> Int = "moonbitlang_async_get_process_result"
-
-///|
-#cfg(platform="windows")
 pub async fn Process::wait_pid(self : Process, context~ : String) -> Int {
-  let job = Job::wait_for_process(self.handle)
-  let _ = {
-    defer job.free()
-    perform_job_in_worker(job, context~, cancel=_ => {
-      job.cancel_process_waiter()
-      NeedWait
-    })
-  }
+  guard self.handle is Some(io)
+  let job = Job::wait_for_process(io.fd)
+  defer job.free()
+  let _ = perform_job_in_worker(job, context~, cancel=_ => {
+    job.cancel_process_waiter()
+    NeedWait
+  })
+
   let out = Ref(0)
-  let ret = get_process_result(self.handle, out)
+  let ret = get_process_result(io.fd, self.pid, out)
   if ret < 0 {
     @os_error.check_errno(context)
   }

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -54,6 +54,7 @@
 #include <sys/syscall.h>
 #include <linux/fs.h>
 #include <sys/inotify.h>
+#include <linux/version.h>
 #endif
 
 #ifdef __MACH__
@@ -2241,6 +2242,7 @@ struct spawn_job {
   int32_t inherited_env_entry_count;
   int stdio[3];
   char *cwd;
+  int pidfd;
 };
 
 static
@@ -2256,6 +2258,8 @@ void free_spawn_job(void *obj) {
   free(job->envp);
   if (job->cwd)
     moonbit_decref(job->cwd);
+  if (job->pidfd >= 0)
+    close(job->pidfd);
 }
 
 #if defined(__ANDROID__) && __ANDROID_API__ < 28
@@ -2318,9 +2322,26 @@ void spawn_job_worker(struct job *job) {
       spawn_job->envp
     );
   }
+
+#ifdef __linux__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+  if (!job->err) {
+    spawn_job->pidfd = syscall(SYS_pidfd_open, job->ret, 0);
+    if (spawn_job->pidfd < 0 && errno != ENOSYS && errno != EPERM)
+      job->err = errno;
+  }
+#endif // #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+#endif // #ifdef __linux__
+
 exit:
   posix_spawnattr_destroy(&attr);
   posix_spawn_file_actions_destroy(&file_actions);
+}
+
+int moonbitlang_async_get_spawn_job_result_handle(struct spawn_job *job) {
+  int result = job->pidfd;
+  job->pidfd = -1;
+  return result;
 }
 
 #endif // posix_spawn availability
@@ -2344,6 +2365,7 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   job->stdio[1] = stdout_fd;
   job->stdio[2] = stderr_fd;
   job->cwd = cwd;
+  job->pidfd = -1;
   return job;
 }
 

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -221,6 +221,9 @@ extern "C" fn Job::realpath(path : @os_string.OsString) -> Job = "moonbitlang_as
 extern "C" fn Job::get_realpath_result(job : Job) -> @c_buffer.Buffer = "moonbitlang_async_get_realpath_result"
 
 ///|
+priv struct SpawnJob(Job)
+
+///|
 #cfg(not(platform="windows"))
 #owned(path, args, env, cwd)
 extern "C" fn Job::spawn(
@@ -232,7 +235,7 @@ extern "C" fn Job::spawn(
   stdout : @fd_util.Fd,
   stderr : @fd_util.Fd,
   cwd : @os_string.OsString?,
-) -> Job = "moonbitlang_async_make_spawn_job"
+) -> SpawnJob = "moonbitlang_async_make_spawn_job"
 
 ///|
 #cfg(platform="windows")
@@ -246,11 +249,10 @@ extern "C" fn Job::spawn(
   cwd : @os_string.OsString?,
   no_console_window~ : Bool,
   is_orphan~ : Bool,
-) -> Job = "moonbitlang_async_make_spawn_job"
+) -> SpawnJob = "moonbitlang_async_make_spawn_job"
 
 ///|
-#cfg(platform="windows")
-extern "C" fn Job::get_spawn_job_result_handle(job : Job) -> @fd_util.Fd = "moonbitlang_async_get_spawn_job_result_handle"
+extern "C" fn SpawnJob::result_handle(job : SpawnJob) -> @fd_util.Fd = "moonbitlang_async_get_spawn_job_result_handle"
 
 ///|
 #cfg(not(platform="windows"))

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -42,7 +42,7 @@ pub async fn spawn_orphan(
   cwd? : StringView,
   no_console_window? : Bool = false,
 ) -> Int {
-  raw_spawn(
+  let proc = raw_spawn(
     cmd,
     args,
     extra_env~,
@@ -54,7 +54,9 @@ pub async fn spawn_orphan(
     no_console_window~,
     is_orphan=true,
     context="@process.spawn_orphan()",
-  ).pid()
+  )
+  defer proc.close()
+  proc.pid
 }
 
 ///|
@@ -143,7 +145,7 @@ pub async fn run(
     context~,
   )
   defer process.close()
-  let pid = process.pid()
+  let pid = process.pid
   process.wait_pid(context~) catch {
     _ if @coroutine.is_being_cancelled() =>
       @async.protect_from_cancel() <| () => {
@@ -227,7 +229,7 @@ pub async fn[X] spawn(
     is_orphan=false,
     context~,
   )
-  let pid = process.pid()
+  let pid = process.pid
   let result = group.spawn(no_wait?, () => {
     defer process.close()
     process.wait_pid(context~) catch {


### PR DESCRIPTION
This PR refactors process handling in the event loop, improving code sharing between Unix/Windows and overall robustness:

- The `@event_loop.Process` now has uniform structure on all platforms. It has an optional `@event_loop.IoHandle` for the pseudo process handle on Windows/`pidfd` on Linux if supported. This makes `pidfd` lifetime management much more cleaner on Linux
- Some misc code sharing can be performed
- `pidfd` waiting is now implemented via the general `IoHandle::wait_read`, no more special treatment necessary for pidfd on Linux

`spawn` and `wait_pid` remain platform dependent, due to the inherent difference in underlying OS mechanism used.