### PR TITLE
allocate `readdir` buffer externally

### DIFF
--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -88,7 +88,8 @@ priv enum DirectoryState {
 /// A directory in file system
 struct Directory {
   io : @event_loop.IoHandle
-  buf : FixedArray[Byte]
+  buf : @c_buffer.Buffer
+  buf_len : Int
   // The offset of the next entry in the buffer
   mut offset : Int
   // The number of entries already consumed
@@ -104,6 +105,7 @@ struct Directory {
 ///|
 pub fn Directory::close(self : Directory) -> Unit {
   self.io.close()
+  self.buf.free()
 }
 
 ///|
@@ -139,12 +141,11 @@ async fn opendir_aux(path : StringView, context~ : String) -> Directory {
 
 ///|
 fn Directory::from_io_handle(io : @event_loop.IoHandle) -> Directory {
+  let buf_len = @cmp.maximum(1024, Directory::min_buffer_size())
   {
     io,
-    buf: FixedArray::make(
-      @cmp.maximum(Directory::min_buffer_size(), 1024),
-      b'\x00',
-    ),
+    buf: @c_buffer.new(buf_len),
+    buf_len,
     offset: 0,
     count: 0,
     job_ret: 0,
@@ -153,44 +154,38 @@ fn Directory::from_io_handle(io : @event_loop.IoHandle) -> Directory {
 }
 
 ///|
-#borrow(buf)
 extern "C" fn Directory::entry_length(
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
   offset : Int,
 ) -> Int = "moonbitlang_async_dir_entry_length"
 
 ///|
-#borrow(buf)
 extern "C" fn Directory::entry_name_len(
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
   offset : Int,
 ) -> Int = "moonbitlang_async_dir_entry_get_name_len"
 
 ///|
-#borrow(buf)
 extern "C" fn Directory::entry_name(
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
   offset : Int,
 ) -> @c_buffer.Buffer = "moonbitlang_async_dir_entry_get_name"
 
 ///|
-#borrow(buf)
 extern "C" fn Directory::entry_is_dir(
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
   offset : Int,
 ) -> Int = "moonbitlang_async_dir_entry_is_dir"
 
 ///|
-#borrow(buf)
 extern "C" fn Directory::entry_is_hidden(
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
   offset : Int,
 ) -> Bool = "moonbitlang_async_dir_entry_is_hidden"
 
 ///|
-#borrow(buf)
 extern "C" fn Directory::entry_file_id(
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
   offset : Int,
 ) -> UInt64 = "moonbitlang_async_dir_entry_get_file_id"
 
@@ -243,12 +238,7 @@ async fn Directory::next_aux(
     NeedMoreEntry => {
       dir.offset = 0
       dir.count = 0
-      dir.job_ret = dir.io.readdir(
-        dir.buf,
-        dir.buf.length(),
-        restart~,
-        context~,
-      )
+      dir.job_ret = dir.io.readdir(dir.buf, dir.buf_len, restart~, context~)
       if dir.job_ret is 0 {
         dir.state = NoMoreEntry
         return None

--- a/src/fs/watch_windows.mbt
+++ b/src/fs/watch_windows.mbt
@@ -129,9 +129,8 @@ priv type WindowsWatcherEvent
 
 ///|
 #cfg(platform="windows")
-#borrow(buf)
 extern "C" fn WindowsWatcher::get_os_event(
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
   offset : Int,
 ) -> WindowsWatcherEvent = "moonbitlang_async_watcher_get_event"
 
@@ -164,9 +163,11 @@ extern "C" fn WindowsWatcherEvent::get_parent_file_id(event : Self) -> UInt64 = 
 async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
   defer self.root.close()
   let context = "@fs.Watcher::wait()"
-  let buf = FixedArray::make(WindowsWatcher::event_buffer_size(), b'\x00')
+  let buf_len = WindowsWatcher::event_buffer_size()
+  let buf = @c_buffer.new(buf_len)
+  defer buf.free()
   for ;; {
-    let n = self.root.read_dir_changes(buf, context~)
+    let n = self.root.read_dir_changes(buf, buf_len, context~)
     self.debounce_timer.refresh()
     if n is 0 {
       // overflow

--- a/src/internal/c_buffer/c_buffer.mbt
+++ b/src/internal/c_buffer/c_buffer.mbt
@@ -47,3 +47,7 @@ pub extern "C" fn Buffer::is_null(ptr : Buffer) -> Bool = "moonbitlang_async_poi
 
 ///|
 pub extern "C" fn Buffer::free(buf : Buffer) = "free"
+
+///|
+#as_free_fn
+pub extern "C" fn Buffer::new(size : Int) -> Buffer = "moonbitlang_async_make_c_buffer"

--- a/src/internal/c_buffer/pkg.generated.mbti
+++ b/src/internal/c_buffer/pkg.generated.mbti
@@ -14,6 +14,8 @@ pub fn Buffer::free(Self) -> Unit
 #alias("_[_]")
 pub fn Buffer::get(Self, Int) -> Byte
 pub fn Buffer::is_null(Self) -> Bool
+#as_free_fn
+pub fn Buffer::new(Int) -> Self
 pub fn Buffer::strlen(Self) -> Int
 
 // Type aliases

--- a/src/internal/c_buffer/stub.c
+++ b/src/internal/c_buffer/stub.c
@@ -44,6 +44,12 @@ char *moonbitlang_async_null_pointer() {
   return 0;
 }
 
+MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_pointer_is_null(void *ptr) {
   return ptr == 0;
+}
+
+MOONBIT_FFI_EXPORT
+void *moonbitlang_async_make_c_buffer(int32_t size) {
+  return malloc(size);
 }

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -283,7 +283,7 @@ pub async fn rmdir(path : StringView, context~ : String) -> Unit {
 ///|
 pub async fn IoHandle::readdir(
   dir : IoHandle,
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
   len : Int,
   restart~ : Bool,
   context~ : String,

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -334,15 +334,13 @@ extern "C" fn read_dir_changes_ffi(fd : @fd_util.Fd, result : IoResult) -> Int =
 #cfg(platform="windows")
 pub async fn IoHandle::read_dir_changes(
   handle : IoHandle,
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
+  len : Int,
   context~ : String,
 ) -> Int {
   @coroutine.check_cancellation()
   guard handle.kind is Directory
-  let result = IoResult::for_read_dir_changes(
-    buf.unsafe_reinterpret_as_bytes(),
-    len=buf.length(),
-  )
+  let result = IoResult::for_read_dir_changes(buf, len~)
   defer result.free()
   let n = read_dir_changes_ffi(handle.fd, result)
   if n >= 0 {

--- a/src/internal/event_loop/io_windows.c
+++ b/src/internal/event_loop/io_windows.c
@@ -114,6 +114,7 @@ struct AcceptIoResult {
 struct ReadDirChangesIoResult {
   struct IoResult header;
 
+  // this buffer should be allocated in C
   char *buf;
   int32_t len;
 };
@@ -224,9 +225,7 @@ void moonbitlang_async_free_io_result(struct IoResult *obj) {
     moonbit_decref(((struct ConnectIoResult*)obj)->addr);
     break;
   case Accept:
-    break;
   case ReadDirChanges:
-    moonbit_decref(((struct ReadDirChangesIoResult*)obj)->buf);
     break;
   }
   free(obj);

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -62,9 +62,8 @@ extern "C" fn IoResult::for_accept() -> IoResult = "moonbitlang_async_make_accep
 
 ///|
 #cfg(platform="windows")
-#owned(buf)
 extern "C" fn IoResult::for_read_dir_changes(
-  buf : Bytes,
+  buf : @c_buffer.Buffer,
   len~ : Int,
 ) -> IoResult = "moonbitlang_async_make_read_dir_changes_io_result"
 

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -103,7 +103,7 @@ pub fn IoHandle::kind(Self) -> @fd_util.FileKind
 pub async fn IoHandle::lock(Self, exclusive~ : Bool, context~ : String) -> Unit
 pub async fn IoHandle::read(Self, FixedArray[Byte], offset~ : Int, len~ : Int, context~ : String) -> Int
 pub async fn IoHandle::read_at(Self, FixedArray[Byte], offset~ : Int, len~ : Int, position~ : Int64, context~ : String) -> Int
-pub async fn IoHandle::readdir(Self, FixedArray[Byte], Int, restart~ : Bool, context~ : String) -> Int
+pub async fn IoHandle::readdir(Self, @c_buffer.Buffer, Int, restart~ : Bool, context~ : String) -> Int
 pub async fn IoHandle::recvfrom(Self, FixedArray[Byte], offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 pub async fn IoHandle::sendto(Self, Bytes, offset~ : Int, len~ : Int, addr~ : Bytes, context~ : String) -> Int
 pub async fn IoHandle::wait_read(Self) -> Unit

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -1748,10 +1748,7 @@ struct readdir_job {
 };
 
 static
-void free_readdir_job(void *obj) {
-  struct readdir_job *job = (struct readdir_job*)obj;
-  moonbit_decref(job->out);
-}
+void free_readdir_job(void *obj) {}
 
 static
 void readdir_job_worker(struct job *job) {

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -205,10 +205,9 @@ extern "C" fn Job::mkdir(path : @os_string.OsString, mode : Int) -> Job = "moonb
 extern "C" fn Job::rmdir(path : @os_string.OsString) -> Job = "moonbitlang_async_make_rmdir_job"
 
 ///|
-#owned(buf)
 extern "C" fn Job::readdir(
   dir : @fd_util.Fd,
-  buf : FixedArray[Byte],
+  buf : @c_buffer.Buffer,
   len : Int,
   restart : Bool,
 ) -> Job = "moonbitlang_async_make_readdir_job"

--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -112,7 +112,7 @@ let ipv6_any : Addr = Addr::new_ipv6(FixedArray::make(16, 0), 0, scope_id=0)
 
 ///|
 #borrow(addr)
-extern "C" fn Addr::get_ipv6_bytes(addr : Addr) -> @c_buffer.Buffer = "moonbitlang_async_addr_get_ipv6_bytes"
+extern "C" fn Addr::get_ipv6_bytes_offset(addr : Addr) -> Int = "moonbitlang_async_addr_get_ipv6_bytes_offset"
 
 ///|
 #borrow(addr)
@@ -127,7 +127,7 @@ pub impl Show for Addr with fn output(self, logger) {
   if self.is_ipv6() {
     // IPv6 address format
     logger <+ "["
-    write_ipv6_str(self.get_ipv6_bytes(), logger)
+    write_ipv6_str(self.0[self.get_ipv6_bytes_offset():], logger)
     let scope_id = self.scope_id()
     if scope_id > 0 {
       let interface = if_indextoname(scope_id, context="") catch {

--- a/src/socket/addr_utils.mbt
+++ b/src/socket/addr_utils.mbt
@@ -248,7 +248,7 @@ fn parse_port(port_str : StringView) -> Int raise InvalidAddr {
 }
 
 ///|
-fn write_ipv6_str(addr : @c_buffer.Buffer, logger : &Logger) -> Unit {
+fn write_ipv6_str(addr : BytesView, logger : &Logger) -> Unit {
   let mut longest_zero_group = None
   fn add_zero_group(start, end) {
     if end > start {

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -419,9 +419,10 @@ int32_t moonbitlang_async_addr_is_multicast(void *addr_bytes) {
 }
 
 MOONBIT_FFI_EXPORT
-uint8_t *moonbitlang_async_addr_get_ipv6_bytes(struct sockaddr_in6 *addr) {
-  return addr->sin6_addr.s6_addr;
+int32_t moonbitlang_async_addr_get_ipv6_bytes_offset(struct sockaddr_in6 *addr) {
+  return offsetof(struct sockaddr_in6, sin6_addr.s6_addr);
 }
+
 MOONBIT_FFI_EXPORT
 uint32_t moonbitlang_async_addr_get_ipv6_scope_id(struct sockaddr_in6 *addr) {
   return addr->sin6_scope_id;


### PR DESCRIPTION
Allocate the buffer used for reading directory entry externally using `malloc`, instead of allocating it as a MoonBit object. The lifetime of the buffer is straightforward (tied to the directory object), so this is doable. This change will simplify WASM adoption, because it avoid the need for passing a MoonBit buffer to the thread pool and taking slice of a MoonBit object.