### PR TITLE
fix MacOS wait PID failure

### DIFF
--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -55,6 +55,8 @@ pub async fn rmdir(StringView, context~ : String) -> Unit
 
 pub fn set_global_cancellation_signals(ReadOnlyArray[Int]) -> Unit
 
+pub async fn sleep(Int) -> Unit
+
 pub async fn spawn(@os_string.OsString, @c_buffer.Buffer, env~ : @c_buffer.Buffer, inherited_env_entry_count~ : Int, stdin~ : Int, stdout~ : Int, stderr~ : Int, cwd~ : @os_string.OsString?, context~ : String) -> Process
 
 pub let stderr : Result[IoHandle, Error]

--- a/src/internal/event_loop/process_unix.mbt
+++ b/src/internal/event_loop/process_unix.mbt
@@ -77,6 +77,18 @@ pub async fn Process::wait_pid(self : Process, context~ : String) -> Int {
 
   let ret = get_process_result(handle, self.pid, out)
   if ret < 0 {
+    if platform is MacOS {
+      // On MacOS, when `kevent` report `ESRCH`,
+      // there is a small window where `waitpid(.., WNOHANG)` may still return zero.
+      // Work around this race condition by waiting again after a small timeout.
+      while @os_error.is_nonblocking_io_error() {
+        sleep(10)
+        let ret = get_process_result(handle, self.pid, out)
+        if ret >= 0 {
+          return out.val
+        }
+      }
+    }
     @os_error.check_errno(context)
   }
   out.val

--- a/src/internal/event_loop/timer.js.mbt
+++ b/src/internal/event_loop/timer.js.mbt
@@ -31,3 +31,11 @@ pub fn Timer::new(duration : Int, f : () -> Unit) -> Timer {
 ///|
 pub extern "js" fn Timer::cancel(self : Timer) =
   #| (timer) => clearTimeout(timer)
+
+///|
+pub async fn sleep(duration : Int) -> Unit {
+  let coro = @coroutine.current_coroutine()
+  let timer = Timer::new(duration, () => coro.wake())
+  defer timer.cancel()
+  @coroutine.suspend()
+}

--- a/src/internal/event_loop/timer.mbt
+++ b/src/internal/event_loop/timer.mbt
@@ -50,3 +50,11 @@ impl Compare for Timer with fn compare(t1, t2) {
     o => o
   }
 }
+
+///|
+pub async fn sleep(duration : Int) -> Unit {
+  let coro = @coroutine.current_coroutine()
+  let timer = Timer::new(duration, () => coro.wake())
+  defer timer.cancel()
+  @coroutine.suspend()
+}

--- a/src/internal/event_loop/unimplemented.mbt
+++ b/src/internal/event_loop/unimplemented.mbt
@@ -37,3 +37,10 @@ pub fn Timer::cancel(timer : Timer) -> Unit {
   ignore(timer)
   abort("`Timer::cancel()` is unimplemented on WASM backend")
 }
+
+///|
+#warnings("-unused_async")
+pub async fn sleep(duration : Int) -> Unit {
+  ignore(duration)
+  abort("`sleep()` is unimplemented on WASM backend")
+}

--- a/src/timer.mbt
+++ b/src/timer.mbt
@@ -16,12 +16,7 @@
 /// `sleep` will wait for the given time (in milliseconds) before returning.
 /// Other task can still run while current task is sleeping.
 /// If current task is cancelled, `sleep` will return early with an error.
-pub async fn sleep(duration : Int) -> Unit {
-  let coro = @coroutine.current_coroutine()
-  let timer = @event_loop.Timer::new(duration, () => coro.wake())
-  defer timer.cancel()
-  @coroutine.suspend()
-}
+pub using @event_loop {sleep}
 
 ///|
 priv enum TimerState {


### PR DESCRIPTION
A recent refactor wrongly dropped the fix in #88. This PR re-introduce the fix in #88. Instead of perform a blocking wait, this PR uses small timeout + retry to work around the race window between `kevent` failing with `ESRCH` and the child process enter waitable state.