### PR TITLE
avoid C buffer slice in `readdir` logic

### DIFF
--- a/src/fs/dir.c
+++ b/src/fs/dir.c
@@ -113,20 +113,20 @@ int32_t moonbitlang_async_dir_entry_get_name_len(char *buf, int32_t offset) {
 }
 
 MOONBIT_FFI_EXPORT
-char *moonbitlang_async_dir_entry_get_name(char *buf, int32_t offset) {
-  sys_dirent *ent = (sys_dirent *)(buf + offset);
+int32_t moonbitlang_async_dir_entry_get_name_offset(char *buf, int32_t offset) {
 
 #ifdef _WIN32
 
-  return (char*)ent->FileName;
+  return offsetof(sys_dirent, FileName);
 
 #elif defined(__MACH__)
 
-  return ((char*)&ent->d_name) + ent->d_name.attr_dataoffset;
+  sys_dirent *ent = (sys_dirent *)(buf + offset);
+  return offsetof(sys_dirent, d_name) + ent->d_name.attr_dataoffset;
 
 #elif defined(__linux__)
 
-  return ent->d_name;
+  return offsetof(sys_dirent, d_name);
 
 #else
 

--- a/src/fs/dir.mbt
+++ b/src/fs/dir.mbt
@@ -85,10 +85,13 @@ priv enum DirectoryState {
 }
 
 ///|
+priv struct DirectoryBuffer(@c_buffer.Buffer)
+
+///|
 /// A directory in file system
 struct Directory {
   io : @event_loop.IoHandle
-  buf : @c_buffer.Buffer
+  buf : DirectoryBuffer
   buf_len : Int
   // The offset of the next entry in the buffer
   mut offset : Int
@@ -105,7 +108,7 @@ struct Directory {
 ///|
 pub fn Directory::close(self : Directory) -> Unit {
   self.io.close()
-  self.buf.free()
+  self.buf.0.free()
 }
 
 ///|
@@ -154,38 +157,29 @@ fn Directory::from_io_handle(io : @event_loop.IoHandle) -> Directory {
 }
 
 ///|
-extern "C" fn Directory::entry_length(
-  buf : @c_buffer.Buffer,
-  offset : Int,
-) -> Int = "moonbitlang_async_dir_entry_length"
+extern "C" fn DirectoryBuffer::entry_length(self : Self, offset : Int) -> Int = "moonbitlang_async_dir_entry_length"
 
 ///|
-extern "C" fn Directory::entry_name_len(
-  buf : @c_buffer.Buffer,
-  offset : Int,
-) -> Int = "moonbitlang_async_dir_entry_get_name_len"
+extern "C" fn DirectoryBuffer::entry_name_len(self : Self, offset : Int) -> Int = "moonbitlang_async_dir_entry_get_name_len"
 
 ///|
-extern "C" fn Directory::entry_name(
-  buf : @c_buffer.Buffer,
+extern "C" fn DirectoryBuffer::entry_name_offset(
+  self : Self,
   offset : Int,
-) -> @c_buffer.Buffer = "moonbitlang_async_dir_entry_get_name"
+) -> Int = "moonbitlang_async_dir_entry_get_name_offset"
 
 ///|
-extern "C" fn Directory::entry_is_dir(
-  buf : @c_buffer.Buffer,
-  offset : Int,
-) -> Int = "moonbitlang_async_dir_entry_is_dir"
+extern "C" fn DirectoryBuffer::entry_is_dir(self : Self, offset : Int) -> Int = "moonbitlang_async_dir_entry_is_dir"
 
 ///|
-extern "C" fn Directory::entry_is_hidden(
-  buf : @c_buffer.Buffer,
+extern "C" fn DirectoryBuffer::entry_is_hidden(
+  self : Self,
   offset : Int,
 ) -> Bool = "moonbitlang_async_dir_entry_is_hidden"
 
 ///|
-extern "C" fn Directory::entry_file_id(
-  buf : @c_buffer.Buffer,
+extern "C" fn DirectoryBuffer::entry_file_id(
+  self : Self,
   offset : Int,
 ) -> UInt64 = "moonbitlang_async_dir_entry_get_file_id"
 
@@ -238,7 +232,7 @@ async fn Directory::next_aux(
     NeedMoreEntry => {
       dir.offset = 0
       dir.count = 0
-      dir.job_ret = dir.io.readdir(dir.buf, dir.buf_len, restart~, context~)
+      dir.job_ret = dir.io.readdir(dir.buf.0, dir.buf_len, restart~, context~)
       if dir.job_ret is 0 {
         dir.state = NoMoreEntry
         return None
@@ -247,7 +241,7 @@ async fn Directory::next_aux(
       }
     }
   }
-  let entry_len = Directory::entry_length(dir.buf, dir.offset)
+  let entry_len = dir.buf.entry_length(dir.offset)
   let offset = dir.offset
   dir.offset += entry_len
   dir.count += 1
@@ -259,17 +253,18 @@ async fn Directory::next_aux(
   if need_more_entry {
     dir.state = NeedMoreEntry
   }
-  if !include_hidden && Directory::entry_is_hidden(dir.buf, offset) {
+  if !include_hidden && dir.buf.entry_is_hidden(offset) {
     return dir.next_aux(include_special~, include_hidden~, context~)
   }
   let name = @os_string.decode(
-    Directory::entry_name(dir.buf, offset),
-    len=Directory::entry_name_len(dir.buf, offset),
+    dir.buf.0,
+    offset=offset + dir.buf.entry_name_offset(offset),
+    len=dir.buf.entry_name_len(offset),
   )
   if !include_special && name is ("." | "..") {
     return dir.next_aux(include_special~, include_hidden~, context~)
   }
-  let is_dir = match Directory::entry_is_dir(dir.buf, offset) {
+  let is_dir = match dir.buf.entry_is_dir(offset) {
     0 => false
     1..<_ => true
     _..<0 => {
@@ -282,7 +277,7 @@ async fn Directory::next_aux(
       kind is Directory
     }
   }
-  let file_id = Directory::entry_file_id(dir.buf, offset)
+  let file_id = dir.buf.entry_file_id(offset)
   Some({ name, is_dir, file_id })
 }
 

--- a/src/internal/c_buffer/c_buffer.mbt
+++ b/src/internal/c_buffer/c_buffer.mbt
@@ -20,8 +20,9 @@ pub type Buffer
 #borrow(src)
 pub extern "C" fn Buffer::blit_from_bytes(
   dst : Buffer,
+  dst_offset? : Int = 0,
   src~ : Bytes,
-  offset~ : Int,
+  src_offset? : Int = 0,
   len~ : Int,
 ) = "moonbitlang_async_blit_to_c"
 
@@ -29,8 +30,9 @@ pub extern "C" fn Buffer::blit_from_bytes(
 #borrow(dst)
 pub extern "C" fn Buffer::blit_to_bytes(
   src : Buffer,
+  src_offset? : Int = 0,
   dst~ : FixedArray[Byte],
-  offset~ : Int,
+  dst_offset? : Int = 0,
   len~ : Int,
 ) = "moonbitlang_async_blit_from_c"
 

--- a/src/internal/c_buffer/pkg.generated.mbti
+++ b/src/internal/c_buffer/pkg.generated.mbti
@@ -8,8 +8,8 @@ package "moonbitlang/async/internal/c_buffer"
 // Types and methods
 #external
 pub type Buffer
-pub fn Buffer::blit_from_bytes(Self, src~ : Bytes, offset~ : Int, len~ : Int) -> Unit
-pub fn Buffer::blit_to_bytes(Self, dst~ : FixedArray[Byte], offset~ : Int, len~ : Int) -> Unit
+pub fn Buffer::blit_from_bytes(Self, dst_offset? : Int, src~ : Bytes, src_offset? : Int, len~ : Int) -> Unit
+pub fn Buffer::blit_to_bytes(Self, src_offset? : Int, dst~ : FixedArray[Byte], dst_offset? : Int, len~ : Int) -> Unit
 pub fn Buffer::free(Self) -> Unit
 #alias("_[_]")
 pub fn Buffer::get(Self, Int) -> Byte

--- a/src/internal/c_buffer/stub.c
+++ b/src/internal/c_buffer/stub.c
@@ -20,13 +20,25 @@
 #include <moonbit.h>
 
 MOONBIT_FFI_EXPORT
-void moonbitlang_async_blit_to_c(char *dst, char *src, int offset, int len) {
-  memcpy(dst, src + offset, len);
+void moonbitlang_async_blit_to_c(
+  char *dst,
+  int32_t dst_offset,
+  char *src,
+  int32_t src_offset,
+  int32_t len
+) {
+  memcpy(dst + dst_offset, src + src_offset, len);
 }
 
 MOONBIT_FFI_EXPORT
-void moonbitlang_async_blit_from_c(char *src, char *dst, int offset, int len) {
-  memcpy(dst + offset, src, len);
+void moonbitlang_async_blit_from_c(
+  char *src,
+  int32_t src_offset,
+  char *dst,
+  int32_t dst_offset,
+  int32_t len
+) {
+  memcpy(dst + dst_offset, src + src_offset, len);
 }
 
 MOONBIT_FFI_EXPORT

--- a/src/internal/os_string/os_string.mbt
+++ b/src/internal/os_string/os_string.mbt
@@ -68,16 +68,21 @@ pub impl Show for OsString with fn to_string(self) {
 #cfg(not(platform="windows"))
 pub fn decode(
   os_str : @c_buffer.Buffer,
+  offset? : Int = 0,
   len? : Int = os_str.strlen(),
 ) -> String {
   let data = FixedArray::make(len, b'\x00')
-  os_str.blit_to_bytes(dst=data, offset=0, len~)
+  os_str.blit_to_bytes(dst=data, src_offset=offset, len~)
   @utf8.decode_lossy(data.unsafe_reinterpret_as_bytes())
 }
 
 ///|
 #cfg(platform="windows")
-pub extern "C" fn decode(os_str : @c_buffer.Buffer, len? : Int = -1) -> String = "moonbitlang_async_c_buffer_as_string"
+pub extern "C" fn decode(
+  os_str : @c_buffer.Buffer,
+  offset? : Int = 0,
+  len? : Int = -1,
+) -> String = "moonbitlang_async_c_buffer_as_string"
 
 ///|
 #cfg(platform="windows")

--- a/src/internal/os_string/pkg.generated.mbti
+++ b/src/internal/os_string/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn decode(@c_buffer.Buffer, len? : Int) -> String
+pub fn decode(@c_buffer.Buffer, offset? : Int, len? : Int) -> String
 
 pub fn encode(StringView) -> OsString
 

--- a/src/internal/os_string/stub.c
+++ b/src/internal/os_string/stub.c
@@ -19,9 +19,9 @@
 #include <moonbit.h>
 
 MOONBIT_FFI_EXPORT
-moonbit_string_t moonbitlang_async_c_buffer_as_string(wchar_t *str, int32_t len) {
+moonbit_string_t moonbitlang_async_c_buffer_as_string(wchar_t *str, int32_t offset, int32_t len) {
   size_t bytes = len == -1 ? wcslen(str) * sizeof(wchar_t) : len;
   moonbit_string_t result = moonbit_make_string(bytes / 2, 0);
-  memcpy(result, str, bytes);
+  memcpy(result, (char*)str + offset, bytes);
   return result;
 }

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -289,7 +289,7 @@ fn BIO::read(bio : BIO, dst : @c_buffer.Buffer, len : Int) -> Int {
   let len = @cmp.minimum(read_buf.len, len)
   dst.blit_from_bytes(
     src=read_buf.buf.unsafe_reinterpret_as_bytes(),
-    offset=read_buf.start,
+    src_offset=read_buf.start,
     len~,
   )
   read_buf.drop(len)
@@ -308,7 +308,7 @@ fn BIO::write(bio : BIO, src : @c_buffer.Buffer, len : Int) -> Int {
     -1
   }
   let len = @cmp.minimum(len, remaining)
-  src.blit_to_bytes(dst=ep.write_buf.buf, offset=end, len~)
+  src.blit_to_bytes(dst=ep.write_buf.buf, dst_offset=end, len~)
   ep.write_buf.len += len
   len
 }
@@ -698,7 +698,7 @@ pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
     raise TlsError(err_get_error())
   }
   let result = FixedArray::make(len.val, b'\x00')
-  hash.blit_to_bytes(dst=result, offset=0, len=len.val)
+  hash.blit_to_bytes(dst=result, len=len.val)
   result.unsafe_reinterpret_as_bytes()
 }
 


### PR DESCRIPTION
Avoid taking slice of a C buffer. C buffer slice without ownership is hard to port to WASM backend.