### PR TITLE
fix default length of `@os_string.decode`

### DIFF
--- a/src/internal/c_buffer/c_buffer.mbt
+++ b/src/internal/c_buffer/c_buffer.mbt
@@ -42,7 +42,7 @@ pub extern "C" fn Buffer::blit_to_bytes(
 pub extern "C" fn Buffer::get(buf : Buffer, index : Int) -> Byte = "moonbitlang_async_c_buffer_get"
 
 ///|
-pub extern "C" fn Buffer::strlen(buf : Buffer) -> Int = "moonbitlang_async_strlen"
+pub extern "C" fn Buffer::strlen(buf : Buffer, offset? : Int = 0) -> Int = "moonbitlang_async_strlen"
 
 ///|
 pub extern "C" fn Buffer::is_null(ptr : Buffer) -> Bool = "moonbitlang_async_pointer_is_null"

--- a/src/internal/c_buffer/pkg.generated.mbti
+++ b/src/internal/c_buffer/pkg.generated.mbti
@@ -16,7 +16,7 @@ pub fn Buffer::get(Self, Int) -> Byte
 pub fn Buffer::is_null(Self) -> Bool
 #as_free_fn
 pub fn Buffer::new(Int) -> Self
-pub fn Buffer::strlen(Self) -> Int
+pub fn Buffer::strlen(Self, offset? : Int) -> Int
 
 // Type aliases
 

--- a/src/internal/c_buffer/stub.c
+++ b/src/internal/c_buffer/stub.c
@@ -47,8 +47,8 @@ int moonbitlang_async_c_buffer_get(uint8_t *buf, int index) {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_strlen(char *str) {
-  return strlen(str);
+int32_t moonbitlang_async_strlen(char *str, int32_t offset) {
+  return strlen(str + offset);
 }
 
 MOONBIT_FFI_EXPORT

--- a/src/internal/os_string/os_string.mbt
+++ b/src/internal/os_string/os_string.mbt
@@ -69,7 +69,7 @@ pub impl Show for OsString with fn to_string(self) {
 pub fn decode(
   os_str : @c_buffer.Buffer,
   offset? : Int = 0,
-  len? : Int = os_str.strlen(),
+  len? : Int = os_str.strlen(offset~),
 ) -> String {
   let data = FixedArray::make(len, b'\x00')
   os_str.blit_to_bytes(dst=data, src_offset=offset, len~)

--- a/src/tls/schannel.mbt
+++ b/src/tls/schannel.mbt
@@ -583,7 +583,6 @@ pub fn Tls::server_endpoint_channel_binding(self : Tls) -> Bytes raise {
 // mute unused warning
 #cfg(platform="windows")
 let _unused : Unit = {
-  ignore(@c_buffer.Buffer::strlen)
   ignore(@bytes_util.ascii_to_string)
   ignore(@utf8.encode(""))
 }


### PR DESCRIPTION
after the introduction of optional offset, the default length of `@os_string.decode` (via `strlen`) failed to take the offset into account