### PR TITLE
avoid buffer silce in file system watcher

### DIFF
--- a/src/fs/watch_inotify.c
+++ b/src/fs/watch_inotify.c
@@ -18,7 +18,6 @@
 
 #include <sys/inotify.h>
 #include <unistd.h>
-#include <stdlib.h>
 #include <limits.h>
 #include <errno.h>
 
@@ -62,18 +61,9 @@ int32_t moonbitlang_async_inotify_event_buffer_size() {
 }
 
 MOONBIT_FFI_EXPORT
-struct inotify_event *moonbitlang_async_inotify_get_event(const char *buf, int32_t offset) {
+int32_t moonbitlang_async_inotify_fetch_event(int inotify, void *buf, int32_t buf_len) {
 #ifdef __linux__
-  return (struct inotify_event*)(buf + offset);
-#else
-  moonbit_panic();
-#endif
-}
-
-MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_inotify_fetch_event(int inotify, void *buf) {
-#ifdef __linux__
-  int ret = read(inotify, buf, Moonbit_array_length(buf));
+  int ret = read(inotify, buf, buf_len);
   if (ret > 0) {
     return ret;
   } else if (errno == EAGAIN) {
@@ -87,7 +77,8 @@ int32_t moonbitlang_async_inotify_fetch_event(int inotify, void *buf) {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_inotify_event_get_size(struct inotify_event *event) {
+int32_t moonbitlang_async_inotify_event_get_size(char *buf, int32_t offset) {
+  struct inotify_event *event = (struct inotify_event*)(buf + offset);
 #ifdef __linux__
   return sizeof(struct inotify_event) + event->len;
 #else
@@ -96,7 +87,8 @@ int32_t moonbitlang_async_inotify_event_get_size(struct inotify_event *event) {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_inotify_event_get_wd(struct inotify_event *event) {
+int32_t moonbitlang_async_inotify_event_get_wd(char *buf, int32_t offset) {
+  struct inotify_event *event = (struct inotify_event*)(buf + offset);
 #ifdef __linux__
   return event->wd;
 #else
@@ -105,7 +97,8 @@ int32_t moonbitlang_async_inotify_event_get_wd(struct inotify_event *event) {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_inotify_event_has_relevant_event(struct inotify_event *event) {
+int32_t moonbitlang_async_inotify_event_has_relevant_event(char *buf, int32_t offset) {
+  struct inotify_event *event = (struct inotify_event*)(buf + offset);
 #ifdef __linux__
   return (event->mask & (IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO)) != 0;
 #else
@@ -114,7 +107,8 @@ int32_t moonbitlang_async_inotify_event_has_relevant_event(struct inotify_event 
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_inotify_event_has_overflow(struct inotify_event *event) {
+int32_t moonbitlang_async_inotify_event_has_overflow(char *buf, int32_t offset) {
+  struct inotify_event *event = (struct inotify_event*)(buf + offset);
 #ifdef __linux__
   return (event->mask & IN_Q_OVERFLOW) != 0;
 #else
@@ -123,7 +117,8 @@ int32_t moonbitlang_async_inotify_event_has_overflow(struct inotify_event *event
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_inotify_event_has_ignore(struct inotify_event *event) {
+int32_t moonbitlang_async_inotify_event_has_ignore(char *buf, int32_t offset) {
+  struct inotify_event *event = (struct inotify_event*)(buf + offset);
 #ifdef __linux__
   return (event->mask & IN_IGNORED) != 0;
 #else

--- a/src/fs/watch_inotify.mbt
+++ b/src/fs/watch_inotify.mbt
@@ -151,20 +151,11 @@ impl WatcherBackend for InotifyWatcher with fn remove_file(self, wd, context~) {
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn InotifyWatcher::event_buffer_size() -> Int = "moonbitlang_async_inotify_event_buffer_size"
+priv struct InotifyEventBuffer(@c_buffer.Buffer)
 
 ///|
 #cfg(not(platform="windows"))
-#external
-priv type InotifyEvent
-
-///|
-#cfg(not(platform="windows"))
-#borrow(buf)
-extern "C" fn InotifyWatcher::get_os_event(
-  buf : FixedArray[Byte],
-  offset : Int,
-) -> InotifyEvent = "moonbitlang_async_inotify_get_event"
+extern "C" fn InotifyEventBuffer::size() -> Int = "moonbitlang_async_inotify_event_buffer_size"
 
 ///|
 /// Return value:
@@ -175,36 +166,48 @@ extern "C" fn InotifyWatcher::get_os_event(
 #borrow(buf)
 extern "C" fn InotifyWatcher::fetch_os_event(
   watcher : @fd_util.Fd,
-  buf : FixedArray[Byte],
+  buf : InotifyEventBuffer,
+  len~ : Int,
 ) -> Int = "moonbitlang_async_inotify_fetch_event"
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn InotifyEvent::get_size(event : InotifyEvent) -> Int = "moonbitlang_async_inotify_event_get_size"
+extern "C" fn InotifyEventBuffer::get_size(self : Self, offset : Int) -> Int = "moonbitlang_async_inotify_event_get_size"
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn InotifyEvent::get_wd(event : InotifyEvent) -> @fd_util.Fd = "moonbitlang_async_inotify_event_get_wd"
+extern "C" fn InotifyEventBuffer::get_wd(
+  self : Self,
+  offset : Int,
+) -> @fd_util.Fd = "moonbitlang_async_inotify_event_get_wd"
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn InotifyEvent::has_relevant_evnet(event : InotifyEvent) -> Bool = "moonbitlang_async_inotify_event_has_relevant_event"
+extern "C" fn InotifyEventBuffer::has_relevant_event(
+  self : Self,
+  offset : Int,
+) -> Bool = "moonbitlang_async_inotify_event_has_relevant_event"
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn InotifyEvent::has_overflow(event : InotifyEvent) -> Bool = "moonbitlang_async_inotify_event_has_overflow"
+extern "C" fn InotifyEventBuffer::has_overflow(
+  self : Self,
+  offset : Int,
+) -> Bool = "moonbitlang_async_inotify_event_has_overflow"
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn InotifyEvent::has_ignore(event : InotifyEvent) -> Bool = "moonbitlang_async_inotify_event_has_ignore"
+extern "C" fn InotifyEventBuffer::has_ignore(self : Self, offset : Int) -> Bool = "moonbitlang_async_inotify_event_has_ignore"
 
 ///|
 #cfg(not(platform="windows"))
 async fn InotifyWatcher::process_events(self : InotifyWatcher) -> Unit {
   let context = "@fs.Watcher::wait()"
-  let buf = FixedArray::make(InotifyWatcher::event_buffer_size(), b'\x00')
+  let buf_len = InotifyEventBuffer::size()
+  let buf = InotifyEventBuffer(@c_buffer.new(buf_len))
+  defer buf.0.free()
   for ;; {
-    let n = InotifyWatcher::fetch_os_event(self.inotify.fd(), buf)
+    let n = InotifyWatcher::fetch_os_event(self.inotify.fd(), buf, len=buf_len)
     if n < 0 {
       @os_error.check_errno(context)
     }
@@ -216,22 +219,19 @@ async fn InotifyWatcher::process_events(self : InotifyWatcher) -> Unit {
       continue
     }
     self.debounce_timer.refresh()
-    let mut offset = 0
-    while offset < n {
-      let event = InotifyWatcher::get_os_event(buf, offset)
-      offset += event.get_size()
-      let wd = event.get_wd()
-      if event.has_ignore() {
+    for offset = 0; offset < n; offset = offset + buf.get_size(offset) {
+      let wd = buf.get_wd(offset)
+      if buf.has_ignore(offset) {
         self.watched.remove(wd)
         continue
       }
 
-      if event.has_overflow() {
+      if buf.has_overflow(offset) {
         self.watcher.overflow()
         continue
       }
 
-      if event.has_relevant_evnet() {
+      if buf.has_relevant_event(offset) {
         let id = self.watched[wd]
         self.watcher.mark_as_modified(id)
       }

--- a/src/fs/watch_kqueue.c
+++ b/src/fs/watch_kqueue.c
@@ -103,27 +103,9 @@ int moonbitlang_async_kqueue_watcher_remove_file(int kq, int fd) {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_kqueue_watcher_event_size() {
+int32_t moonbitlang_async_kqueue_watcher_fetch_event(int kq, void *buf, int32_t buf_len) {
 #ifdef __MACH__
-  return sizeof(struct kevent);
-#else
-  moonbit_panic();
-#endif
-}
-
-MOONBIT_FFI_EXPORT
-struct kevent *moonbitlang_async_kqueue_watcher_get_event(struct kevent *buf, int32_t index) {
-#ifdef __MACH__
-  return buf + index;
-#else
-  moonbit_panic();
-#endif
-}
-
-MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_kqueue_watcher_fetch_event(int kq, void *buf) {
-#ifdef __MACH__
-  int buffer_size = Moonbit_array_length(buf) / sizeof(struct kevent);
+  int buffer_size = buf_len / sizeof(struct kevent);
   struct timespec timeout = { 0, 0 };
   return kevent(kq, 0, 0, buf, buffer_size, &timeout);
 #else
@@ -132,18 +114,18 @@ int32_t moonbitlang_async_kqueue_watcher_fetch_event(int kq, void *buf) {
 }
 
 MOONBIT_FFI_EXPORT
-int moonbitlang_async_kqueue_watcher_event_get_fd(struct kevent *event) {
+int moonbitlang_async_kqueue_watcher_event_get_fd(struct kevent *events, int32_t index) {
 #ifdef __MACH__
-  return event->ident;
+  return events[index].ident;
 #else
   moonbit_panic();
 #endif
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_kqueue_watcher_event_has_modify(struct kevent *event) {
+int32_t moonbitlang_async_kqueue_watcher_event_has_modify(struct kevent *events, int32_t index) {
 #ifdef __MACH__
-  return (event->fflags & (NOTE_WRITE | NOTE_EXTEND)) != 0;
+  return (events[index].fflags & (NOTE_WRITE | NOTE_EXTEND)) != 0;
 #else
   moonbit_panic();
 #endif

--- a/src/fs/watch_kqueue.mbt
+++ b/src/fs/watch_kqueue.mbt
@@ -25,7 +25,8 @@ priv struct KqueueWatcher {
   kqueue : @event_loop.IoHandle
   watched : Map[@fd_util.Fd, KqueueWatchedFile]
   watcher : Watcher
-  event_buffer : FixedArray[Byte]
+  event_buffer : KqueueEventBuffer
+  event_buffer_len : Int
   debounce_timeout : Int
   max_debounce_delay : Int
 }
@@ -36,7 +37,11 @@ extern "C" fn KqueueWatcher::new_ffi() -> @fd_util.Fd = "moonbitlang_async_kqueu
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn KqueueWatcher::event_buffer_size() -> Int = "moonbitlang_async_kqueue_watcher_buffer_size"
+priv struct KqueueEventBuffer(@c_buffer.Buffer)
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn KqueueEventBuffer::size() -> Int = "moonbitlang_async_kqueue_watcher_buffer_size"
 
 ///|
 #cfg(not(platform="windows"))
@@ -50,6 +55,7 @@ fn KqueueWatcher::KqueueWatcher(
   if !@fd_util.fd_is_valid(kqueue) {
     @os_error.check_errno(context)
   }
+  let event_buffer_len = KqueueEventBuffer::size()
   {
     kqueue: @event_loop.IoHandle::from_fd(
       kqueue,
@@ -59,7 +65,8 @@ fn KqueueWatcher::KqueueWatcher(
     ),
     watched: {},
     watcher,
-    event_buffer: FixedArray::make(KqueueWatcher::event_buffer_size(), 0),
+    event_buffer: @c_buffer.new(event_buffer_len),
+    event_buffer_len,
     debounce_timeout,
     max_debounce_delay,
   }
@@ -73,6 +80,7 @@ impl WatcherBackend for KqueueWatcher with fn close(self) {
     file.io.close()
   }
   self.watched.clear()
+  self.event_buffer.0.free()
 }
 
 ///|
@@ -122,19 +130,6 @@ impl WatcherBackend for KqueueWatcher with fn remove_file(self, fd, context~) {
 }
 
 ///|
-#cfg(not(platform="windows"))
-#external
-priv type KqueueEvent
-
-///|
-#cfg(not(platform="windows"))
-#borrow(buf)
-extern "C" fn KqueueWatcher::get_os_event(
-  buf : FixedArray[Byte],
-  index : Int,
-) -> KqueueEvent = "moonbitlang_async_kqueue_watcher_get_event"
-
-///|
 /// Return value:
 /// - positive => number of bytes written
 /// - zero => no more event available currently
@@ -143,16 +138,17 @@ extern "C" fn KqueueWatcher::get_os_event(
 #borrow(buf)
 extern "C" fn KqueueWatcher::fetch_os_event(
   watcher : @fd_util.Fd,
-  buf : FixedArray[Byte],
+  buf : KqueueEventBuffer,
+  len~ : Int,
 ) -> Int = "moonbitlang_async_kqueue_watcher_fetch_event"
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn KqueueEvent::fd(event : KqueueEvent) -> @fd_util.Fd = "moonbitlang_async_kqueue_watcher_event_get_fd"
+extern "C" fn KqueueEventBuffer::fd(self : Self, index : Int) -> @fd_util.Fd = "moonbitlang_async_kqueue_watcher_event_get_fd"
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn KqueueEvent::has_modify(event : KqueueEvent) -> Bool = "moonbitlang_async_kqueue_watcher_event_has_modify"
+extern "C" fn KqueueEventBuffer::has_modify(self : Self, index : Int) -> Bool = "moonbitlang_async_kqueue_watcher_event_has_modify"
 
 ///|
 #cfg(not(platform="windows"))
@@ -183,7 +179,11 @@ async fn KqueueWatcher::process_events(
   timeout~ : Int?,
   context~ : String,
 ) -> Unit {
-  let n = KqueueWatcher::fetch_os_event(self.kqueue.fd(), self.event_buffer)
+  let n = KqueueWatcher::fetch_os_event(
+    self.kqueue.fd(),
+    self.event_buffer,
+    len=self.event_buffer_len,
+  )
   if n < 0 {
     @os_error.check_errno(context)
   }
@@ -194,9 +194,8 @@ async fn KqueueWatcher::process_events(
     }
   }
   for i in 0..<n {
-    let event = KqueueWatcher::get_os_event(self.event_buffer, i)
-    let fd = event.fd()
-    if event.has_modify() {
+    let fd = self.event_buffer.fd(i)
+    if self.event_buffer.has_modify(i) {
       let { file_id, .. } = self.watched[fd]
       self.watcher.mark_as_modified(file_id)
     }

--- a/src/fs/watch_windows.c
+++ b/src/fs/watch_windows.c
@@ -51,23 +51,26 @@ fs_event_t *moonbitlang_async_watcher_get_event(char *buf, int32_t offset) {
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_watcher_event_get_size(fs_event_t *event) {
+int32_t moonbitlang_async_watcher_event_get_size(char *buf, int32_t offset) {
+  fs_event_t *event = (fs_event_t*)(buf + offset);
   return event->NextEntryOffset;
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_watcher_event_is_modify_event(fs_event_t *event) {
+int32_t moonbitlang_async_watcher_event_is_modify_event(char *buf, int32_t offset) {
+  fs_event_t *event = (fs_event_t*)(buf + offset);
   return event->Action == FILE_ACTION_MODIFIED;
 }
 
 MOONBIT_FFI_EXPORT
-int32_t moonbitlang_async_watcher_event_get_path_len(fs_event_t *event) {
+int32_t moonbitlang_async_watcher_event_get_path_len(char *buf, int32_t offset) {
+  fs_event_t *event = (fs_event_t*)(buf + offset);
   return event->FileNameLength;
 }
 
 MOONBIT_FFI_EXPORT
-WCHAR *moonbitlang_async_watcher_event_get_path(fs_event_t *event) {
-  return event->FileName;
+int32_t moonbitlang_async_watcher_event_get_path_offset() {
+  return offsetof(fs_event_t, FileName);
 }
 
 MOONBIT_FFI_EXPORT

--- a/src/fs/watch_windows.mbt
+++ b/src/fs/watch_windows.mbt
@@ -120,54 +120,53 @@ extern "C" fn WindowsWatcher::has_ReadDirectoryChangesExW() -> Bool = "moonbitla
 
 ///|
 #cfg(platform="windows")
-extern "C" fn WindowsWatcher::event_buffer_size() -> Int = "moonbitlang_async_watcher_event_buffer_size"
+priv struct WindowsWatcherBuf(@c_buffer.Buffer)
 
 ///|
 #cfg(platform="windows")
-#external
-priv type WindowsWatcherEvent
+extern "C" fn WindowsWatcherBuf::size() -> Int = "moonbitlang_async_watcher_event_buffer_size"
 
 ///|
 #cfg(platform="windows")
-extern "C" fn WindowsWatcher::get_os_event(
-  buf : @c_buffer.Buffer,
+extern "C" fn WindowsWatcherBuf::event_size(self : Self, offset : Int) -> Int = "moonbitlang_async_watcher_event_get_size"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherBuf::is_modify(self : Self, offset : Int) -> Bool = "moonbitlang_async_watcher_event_is_modify_event"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherBuf::get_path_len(self : Self, offset : Int) -> Int = "moonbitlang_async_watcher_event_get_path_len"
+
+///|
+/// Get the offset of path data inside the event
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherBuf::get_path_offset() -> Int = "moonbitlang_async_watcher_event_get_path_offset"
+
+///|
+#cfg(platform="windows")
+extern "C" fn WindowsWatcherBuf::get_file_id(
+  self : Self,
   offset : Int,
-) -> WindowsWatcherEvent = "moonbitlang_async_watcher_get_event"
+) -> UInt64 = "moonbitlang_async_watcher_event_get_file_id"
 
 ///|
 #cfg(platform="windows")
-extern "C" fn WindowsWatcherEvent::get_size(event : Self) -> Int = "moonbitlang_async_watcher_event_get_size"
-
-///|
-#cfg(platform="windows")
-extern "C" fn WindowsWatcherEvent::is_modify(event : Self) -> Bool = "moonbitlang_async_watcher_event_is_modify_event"
-
-///|
-#cfg(platform="windows")
-extern "C" fn WindowsWatcherEvent::get_path_len(event : Self) -> Int = "moonbitlang_async_watcher_event_get_path_len"
-
-///|
-#cfg(platform="windows")
-extern "C" fn WindowsWatcherEvent::get_path(event : Self) -> @c_buffer.Buffer = "moonbitlang_async_watcher_event_get_path"
-
-///|
-#cfg(platform="windows")
-extern "C" fn WindowsWatcherEvent::get_file_id(event : Self) -> UInt64 = "moonbitlang_async_watcher_event_get_file_id"
-
-///|
-#cfg(platform="windows")
-extern "C" fn WindowsWatcherEvent::get_parent_file_id(event : Self) -> UInt64 = "moonbitlang_async_watcher_event_get_parent_file_id"
+extern "C" fn WindowsWatcherBuf::get_parent_file_id(
+  self : Self,
+  offset : Int,
+) -> UInt64 = "moonbitlang_async_watcher_event_get_parent_file_id"
 
 ///|
 #cfg(platform="windows")
 async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
   defer self.root.close()
   let context = "@fs.Watcher::wait()"
-  let buf_len = WindowsWatcher::event_buffer_size()
-  let buf = @c_buffer.new(buf_len)
-  defer buf.free()
+  let buf_len = WindowsWatcherBuf::size()
+  let buf = WindowsWatcherBuf(@c_buffer.new(buf_len))
+  defer buf.0.free()
   for ;; {
-    let n = self.root.read_dir_changes(buf, buf_len, context~)
+    let n = self.root.read_dir_changes(buf.0, buf_len, context~)
     self.debounce_timer.refresh()
     if n is 0 {
       // overflow
@@ -176,23 +175,21 @@ async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
     }
     let mut offset = 0
     while offset < n {
-      let event = WindowsWatcher::get_os_event(buf, offset)
-      let size = event.get_size()
-      if size is 0 {
-        offset = n
-      } else {
-        offset += size
-      }
+      let size = buf.event_size(offset)
       let file_id : FileIdentity = if WindowsWatcher::has_ReadDirectoryChangesExW() {
-        let file_id = if event.is_modify() {
-          event.get_file_id()
+        let file_id = if buf.is_modify(offset) {
+          buf.get_file_id(offset)
         } else {
-          event.get_parent_file_id()
+          buf.get_parent_file_id(offset)
         }
         { dev_id: self.dev_id, file_id }
       } else {
-        let path = @os_string.decode(event.get_path(), len=event.get_path_len())
-        let path = if event.is_modify() {
+        let path = @os_string.decode(
+          buf.0,
+          offset=offset + WindowsWatcherBuf::get_path_offset(),
+          len=buf.get_path_len(offset),
+        )
+        let path = if buf.is_modify(offset) {
           path[:]
         } else {
           for i in path.length()>..0 {
@@ -217,9 +214,14 @@ async fn WindowsWatcher::event_handler(self : WindowsWatcher) -> Unit {
         file_id
       }
       if self.watcher.watched.get(file_id) is Some(file) {
-        if !(event.is_modify() && file.is_dir) {
+        if !(buf.is_modify(offset) && file.is_dir) {
           self.watcher.mark_as_modified(file_id)
         }
+      }
+      if size is 0 {
+        offset = n
+      } else {
+        offset += size
       }
     }
     if self.waiter is Some(coro) {


### PR DESCRIPTION
Avoid passing slice of a complete C buffer or MoonBit object as `@c_buffer.Buffer` in file system watcher, making future WASM support easier.