### PR TITLE
Fix `@io.pipe()` cancellation safety issue

### DIFF
--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -344,7 +344,9 @@ pub async fn IoHandle::read_dir_changes(
   defer result.free()
   let n = read_dir_changes_ffi(handle.fd, result)
   if n >= 0 {
-    @coroutine.pause()
+    // The `pause` here prevent a busy loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     n
   } else if @os_error.is_nonblocking_io_error() {
     handle.wait_read(result, context~)

--- a/src/internal/event_loop/io.wasm.mbt
+++ b/src/internal/event_loop/io.wasm.mbt
@@ -322,7 +322,9 @@ async fn IoHandle::read_via_event_bus_unix(
 ) -> Int {
   let ret = read_ffi(handle.fd, buf, offset~, len~)
   if ret >= 0 {
-    @coroutine.pause()
+    // The `pause` here prevent a busy read loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {
@@ -352,7 +354,9 @@ async fn IoHandle::write_via_event_bus_unix(
 ) -> Int {
   let ret = write_ffi(handle.fd, buf, offset~, len~)
   if ret >= 0 {
-    @coroutine.pause()
+    // The `pause` here prevent a busy write loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {
@@ -489,7 +493,9 @@ async fn IoHandle::generic_read_windows(
 ) -> Int {
   let n = read_io_result_ffi(handle.fd, result)
   if n >= 0 {
-    @coroutine.pause()
+    // The `pause` here prevent a busy read loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     n
   } else if @os_error.is_nonblocking_io_error() {
     handle.wait_read_result(result, context~)
@@ -555,7 +561,9 @@ async fn IoHandle::generic_write_windows(
 ) -> Int {
   let n = write_io_result_ffi(handle.fd, result)
   if n >= 0 {
-    @coroutine.pause()
+    // The `pause` here prevent a busy write loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     n
   } else if @os_error.is_nonblocking_io_error() {
     handle.wait_write_result(result, context~)

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -62,7 +62,9 @@ async fn IoHandle::read_via_event_bus(
 ) -> Int {
   let ret = read_ffi(handle.fd, buf, offset~, len~)
   if ret >= 0 {
-    @coroutine.pause()
+    // The `pause` here prevent a busy read loop from exhausting the whole program
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {
@@ -98,7 +100,9 @@ async fn IoHandle::write_via_event_bus(
 ) -> Int {
   let ret = write_ffi(handle.fd, buf, offset~, len~)
   if ret >= 0 {
-    @coroutine.pause()
+    // The `pause` here prevent a busy write loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -186,12 +186,14 @@ async fn IoHandle::generic_read(
 ) -> Int {
   let n = read_ffi(handle.fd, result)
   if n >= 0 {
+    // The `pause` here prevent a busy read loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     // It is important to note that the logic here is correct
     // only if `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS` is set
     // via `SetFileCompletionNotificationModes`.
     // Otherwise, even if the read operation itself indicates immediate success,
     // we still need to wait for the completion packet to obtain correct result.
-    @coroutine.pause()
     n
   } else if @os_error.is_nonblocking_io_error() {
     handle.wait_read(result, context~)
@@ -252,7 +254,9 @@ async fn IoHandle::generic_write(
 ) -> Int {
   let n = write_ffi(handle.fd, result)
   if n >= 0 {
-    @coroutine.pause()
+    // The `pause` here prevent a busy write loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     // It is important to note that the logic here is correct
     // only if `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS` is set
     // via `SetFileCompletionNotificationModes`.

--- a/src/internal/event_loop/network_unix.mbt
+++ b/src/internal/event_loop/network_unix.mbt
@@ -36,7 +36,9 @@ pub async fn IoHandle::recvfrom(
   @coroutine.check_cancellation()
   let ret = recvfrom_ffi(handle.fd, buf, offset~, len~, addr~)
   if ret >= 0 {
-    @coroutine.pause()
+    // The `pause` here prevent a busy loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {
@@ -75,7 +77,7 @@ pub async fn IoHandle::sendto(
   @coroutine.check_cancellation()
   let ret = sendto_ffi(handle.fd, buf, offset~, len~, addr~)
   if ret >= 0 {
-    @coroutine.pause()
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {
@@ -138,6 +140,9 @@ pub async fn IoHandle::accept(
   @coroutine.check_cancellation()
   let conn = accept_ffi(handle.fd, addr)
   let conn = if conn >= 0 {
+    // The `pause` here prevent a busy `accept` loop from exhausting the whole program,
+    // and give chance for other tasks to execute.
+    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     conn
   } else if @os_error.is_nonblocking_io_error() {
     handle.wait_read()

--- a/src/io/pipe.mbt
+++ b/src/io/pipe.mbt
@@ -94,13 +94,21 @@ pub fn PipeWrite::close(self : PipeWrite) -> Unit {
 pub impl Reader for PipeRead with fn _direct_read(self, dst, offset~, max_len~) {
   let PipeRead(self) = self
   guard self.reader is NoReader
+  @coroutine.check_cancellation()
   match self.writer {
     NoWriter => {
       let coro = @coroutine.current_coroutine()
       let reader = HasReader(coro~, buf=dst, offset~, max_len~, result=0)
       self.reader = reader
       defer (if self.reader is HasReader(_) { self.reader = NoReader })
-      @coroutine.suspend()
+      @coroutine.suspend() catch {
+        _ if reader is HasReader(result~, ..) && result > 0 =>
+          // if data is already transferred to the reader
+          // within the same scheduler round of cancellaiton,
+          // swallow the cancellation to avoid data loss
+          return result
+        err => raise err
+      }
       guard reader is HasReader(result~, ..)
       result
     }
@@ -110,7 +118,10 @@ pub impl Reader for PipeRead with fn _direct_read(self, dst, offset~, max_len~) 
       dst.blit_from_bytes(offset, writer.buf, writer.offset, len)
       writer.result = len
       writer.coro.wake()
-      @coroutine.pause()
+      // The pause here is not cancellable,
+      // because otherwise the writer cannot have correct knowledge on what is written,
+      // making writing not cancellation safe.
+      @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
       len
     }
   }
@@ -133,13 +144,22 @@ pub suberror PipeClosed derive(Debug, ToJson)
 pub impl Writer for PipeWrite with fn write_once(self, buf, offset~, len~) {
   let PipeWrite(self) = self
   guard self.writer is NoWriter
+  @coroutine.check_cancellation()
   match self.reader {
     NoReader => {
       let coro = @coroutine.current_coroutine()
       let writer = HasWriter(coro~, buf~, offset~, len~, result=0)
       self.writer = writer
       defer (if self.writer is HasWriter(_) { self.writer = NoWriter })
-      @coroutine.suspend()
+      @coroutine.suspend() catch {
+        _ if self.writer is HasWriter(result~, ..) && result > 0 =>
+          // if data is already transferred to the reader
+          // within the same scheduler round of cancellaiton,
+          // swallow the cancellation so that the writer side
+          // can have correct knowledge of what is written
+          return result
+        err => raise err
+      }
       guard writer is HasWriter(result~, ..)
       guard result > 0 else { raise PipeClosed }
       result
@@ -158,7 +178,11 @@ pub impl Writer for PipeWrite with fn write_once(self, buf, offset~, len~) {
       // because in that case, an immediate write + read combo after this write
       // may complete faster than the previous read.
       // The `pause` here is also vital for preventing stackoverflow in a busy loop.
-      @coroutine.pause()
+      //
+      // The pause here is not cancellable,
+      // because otherwise the writer cannot have correct knowledge on what is written,
+      // making writing not cancellation safe.
+      @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
       len
     }
   }

--- a/src/io/pipe_test.mbt
+++ b/src/io/pipe_test.mbt
@@ -1,0 +1,109 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "PipeRead blocked cancellation safety" {
+  let (r, w) = @io.pipe()
+  @async.with_task_group <| group => {
+    let reader = group.spawn() <| () => {
+      defer r.close()
+      debug_inspect(
+        r.read_some(),
+        content=(
+          #|Some(<Bytes: [0x61, 0x62, 0x63, 0x64]>)
+        ),
+      )
+    }
+    defer w.close()
+    @async.pause()
+    reader.cancel()
+    inspect(w.write_once(b"abcd", offset=0, len=4), content="4")
+    // `reader` should succeed here
+    reader.wait()
+  }
+}
+
+///|
+async test "PipeWrite blocked cancellation safety" {
+  let (r, w) = @io.pipe()
+  @async.with_task_group <| group => {
+    let writer = group.spawn() <| () => {
+      defer w.close()
+      inspect(
+        w.write_once(b"abcd", offset=0, len=4),
+        content=(
+          #|4
+        ),
+      )
+    }
+    defer r.close()
+    @async.pause()
+    writer.cancel()
+    debug_inspect(
+      r.read_some(),
+      content=(
+        #|Some(<Bytes: [0x61, 0x62, 0x63, 0x64]>)
+      ),
+    )
+    // `reader` should succeed here
+    writer.wait()
+  }
+}
+
+///|
+async test "PipeRead immediate cancellation safety" {
+  let (r, w) = @io.pipe()
+  @async.with_task_group <| group => {
+    let reader = group.spawn() <| () => {
+      defer r.close()
+      debug_inspect(
+        r.read_some(),
+        content=(
+          #|Some(<Bytes: [0x61, 0x62, 0x63, 0x64]>)
+        ),
+      )
+    }
+    defer w.close()
+    inspect(w.write_once(b"abcd", offset=0, len=4), content="4")
+    reader.cancel()
+    // `reader` should succeed here
+    reader.wait()
+  }
+}
+
+///|
+async test "PipeWrite immediate cancellation safety" {
+  let (r, w) = @io.pipe()
+  @async.with_task_group <| group => {
+    let writer = group.spawn() <| () => {
+      defer w.close()
+      inspect(
+        w.write_once(b"abcd", offset=0, len=4),
+        content=(
+          #|4
+        ),
+      )
+    }
+    defer r.close()
+    debug_inspect(
+      r.read_some(),
+      content=(
+        #|Some(<Bytes: [0x61, 0x62, 0x63, 0x64]>)
+      ),
+    )
+    writer.cancel()
+    // `reader` should succeed here
+    writer.wait()
+  }
+}


### PR DESCRIPTION
closes #448

Primitive read/write operation (`read`/`write_once` etc.) should be cancellation safe (cancelled = no side effect) for `@io.pipe()`. But currently, if the reader/writer is cancelled within the same scheduler round they received/transferred data, the read/write operation will be cancelled despite the data transfer happening, leading to data loss/writer has wrong knowledge of what is happening.

This PR fixes the problem by swallowing the cancellation signal if data transfer already happened. In addition to the blocked read/write case, when read/write succeed immediately, a `pause` will be made to avoid some race condition and prevent hot loops exhausting the main thread. That `pause` is currently cancellable, which also break cancellation safety. This issue is fixed here as well.

The `pause` pattern is also present in many other places, in particular IO primitives. Those places suffer the same problem. So all `@coroutine.pause()` call sites are now wrapped with `@coroutine.protect_from_cancel`. Note that hot loops are still cancellable, because cancellation is checked explicitly via `@coroutine.check_cancellation` before each of these operations.