### PR TITLE
tls: load OpenSSL lazily on first TLS use, not at startup

### DIFF
--- a/src/tls/crypto_util.mbt
+++ b/src/tls/crypto_util.mbt
@@ -56,7 +56,7 @@ extern "C" fn sha1_ffi(src : Bytes, len : Int, dst : FixedArray[Byte]) = "moonbi
 ///|
 #cfg(not(platform="windows"))
 #internal(internal, "for internal use only")
-pub fn sha1(src : Bytes) -> Bytes {
+pub fn sha1(src : Bytes) -> Bytes raise {
   // Reachable with no prior TLS connection (e.g. a plain `ws://` handshake).
   load_openssl()
   let result = FixedArray::make(20, b'\x00')

--- a/src/tls/crypto_util.mbt
+++ b/src/tls/crypto_util.mbt
@@ -23,6 +23,8 @@ extern "C" fn rand_bytes_ffi(buf : FixedArray[Byte], num : Int) -> Int = "moonbi
 #cfg(not(platform="windows"))
 #internal(internal, "for internal use only")
 pub fn rand_bytes(num : Int) -> Bytes raise {
+  // Reachable with no prior TLS connection (e.g. a plain `ws://` handshake).
+  load_openssl()
   let result = FixedArray::make(num, b'\x00')
   if rand_bytes_ffi(result, num) != 1 {
     raise Failure::Failure(err_get_error())
@@ -55,6 +57,8 @@ extern "C" fn sha1_ffi(src : Bytes, len : Int, dst : FixedArray[Byte]) = "moonbi
 #cfg(not(platform="windows"))
 #internal(internal, "for internal use only")
 pub fn sha1(src : Bytes) -> Bytes {
+  // Reachable with no prior TLS connection (e.g. a plain `ws://` handshake).
+  load_openssl()
   let result = FixedArray::make(20, b'\x00')
   sha1_ffi(src, src.length(), result)
   result.unsafe_reinterpret_as_bytes()

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -27,7 +27,7 @@ extern "C" fn SSL_CTX::client_ffi(load_default_verify_path~ : Bool) -> SSL_CTX =
 
 ///|
 #cfg(not(platform="windows"))
-fn SSL_CTX::client(load_default_verify_path~ : Bool) -> SSL_CTX {
+fn SSL_CTX::client(load_default_verify_path~ : Bool) -> SSL_CTX raise {
   load_openssl()
   SSL_CTX::client_ffi(load_default_verify_path~)
 }
@@ -38,7 +38,7 @@ extern "C" fn SSL_CTX::server_ffi() -> SSL_CTX = "moonbitlang_async_tls_server_c
 
 ///|
 #cfg(not(platform="windows"))
-fn SSL_CTX::server() -> SSL_CTX {
+fn SSL_CTX::server() -> SSL_CTX raise {
   load_openssl()
   SSL_CTX::server_ffi()
 }
@@ -61,13 +61,13 @@ let client_ctx_cell : Ref[SSL_CTX?] = Ref(None)
 
 ///|
 #cfg(not(platform="windows"))
-fn client_ctx() -> SSL_CTX {
+fn client_ctx() -> SSL_CTX raise {
   match client_ctx_cell.val {
     Some(ctx) => ctx
     None => {
       let ctx = SSL_CTX::client(load_default_verify_path=true)
       guard !ctx.is_null() else {
-        abort("failed to initialize SSL client context")
+        raise TlsError("failed to initialize SSL client context")
       }
       client_ctx_cell.val = Some(ctx)
       ctx
@@ -81,13 +81,13 @@ let server_ctx_cell : Ref[SSL_CTX?] = Ref(None)
 
 ///|
 #cfg(not(platform="windows"))
-fn server_ctx() -> SSL_CTX {
+fn server_ctx() -> SSL_CTX raise {
   match server_ctx_cell.val {
     Some(ctx) => ctx
     None => {
       let ctx = SSL_CTX::server()
       guard !ctx.is_null() else {
-        abort("failed to initialize SSL server context")
+        raise TlsError("failed to initialize SSL server context")
       }
       server_ctx_cell.val = Some(ctx)
       ctx
@@ -305,7 +305,7 @@ extern "C" fn create_bio_ffi(data : Transport) -> BIO = "moonbitlang_async_tls_c
 ///|
 // Also the sole consumer of the BIO method table `load_openssl` registers.
 #cfg(not(platform="windows"))
-fn create_bio(data : Transport) -> BIO {
+fn create_bio(data : Transport) -> BIO raise {
   load_openssl()
   create_bio_ffi(data)
 }
@@ -385,7 +385,7 @@ fn[R : @io.Reader, W : @io.Writer] Tls::from_pair(
   w : W,
   is_client~ : Bool,
   host~ : String?,
-) -> Tls {
+) -> Tls raise {
   let transport = Transport::new(r, w)
   let rbio = create_bio(transport)
   let wbio = create_bio(transport)

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -23,11 +23,25 @@ extern "C" fn SSL_CTX::is_null(self : SSL_CTX) -> Bool = "moonbitlang_async_tls_
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn SSL_CTX::client(load_default_verify_path~ : Bool) -> SSL_CTX = "moonbitlang_async_tls_client_ctx"
+extern "C" fn SSL_CTX::client_ffi(load_default_verify_path~ : Bool) -> SSL_CTX = "moonbitlang_async_tls_client_ctx"
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn SSL_CTX::server() -> SSL_CTX = "moonbitlang_async_tls_server_ctx"
+fn SSL_CTX::client(load_default_verify_path~ : Bool) -> SSL_CTX {
+  load_openssl()
+  SSL_CTX::client_ffi(load_default_verify_path~)
+}
+
+///|
+#cfg(not(platform="windows"))
+extern "C" fn SSL_CTX::server_ffi() -> SSL_CTX = "moonbitlang_async_tls_server_ctx"
+
+///|
+#cfg(not(platform="windows"))
+fn SSL_CTX::server() -> SSL_CTX {
+  load_openssl()
+  SSL_CTX::server_ffi()
+}
 
 ///|
 #cfg(not(platform="windows"))
@@ -38,28 +52,56 @@ extern "C" fn SSL_CTX::free_ffi(self : SSL_CTX) = "moonbitlang_async_tls_ssl_ctx
 #borrow(der)
 extern "C" fn SSL_CTX::add_root_certificate(self : SSL_CTX, der : Bytes) -> Int = "moonbitlang_async_tls_ssl_ctx_add_root_certificate"
 
+// Lazy singletons: the shared client/server contexts (and the system CA read
+// they trigger) are built on first use, not before a TLS connection is made.
+
 ///|
 #cfg(not(platform="windows"))
-let client_ctx : SSL_CTX = {
-  load_openssl()
-  let ctx = SSL_CTX::client(load_default_verify_path=true)
-  guard !ctx.is_null() else { abort("failed to initialize SSL client context") }
-  ctx
+let client_ctx_cell : Ref[SSL_CTX?] = Ref(None)
+
+///|
+#cfg(not(platform="windows"))
+fn client_ctx() -> SSL_CTX {
+  match client_ctx_cell.val {
+    Some(ctx) => ctx
+    None => {
+      let ctx = SSL_CTX::client(load_default_verify_path=true)
+      guard !ctx.is_null() else {
+        abort("failed to initialize SSL client context")
+      }
+      client_ctx_cell.val = Some(ctx)
+      ctx
+    }
+  }
 }
 
 ///|
 #cfg(not(platform="windows"))
-let server_ctx : SSL_CTX = {
-  load_openssl()
-  let ctx = SSL_CTX::server()
-  guard !ctx.is_null() else { abort("failed to initialize SSL server context") }
-  ctx
+let server_ctx_cell : Ref[SSL_CTX?] = Ref(None)
+
+///|
+#cfg(not(platform="windows"))
+fn server_ctx() -> SSL_CTX {
+  match server_ctx_cell.val {
+    Some(ctx) => ctx
+    None => {
+      let ctx = SSL_CTX::server()
+      guard !ctx.is_null() else {
+        abort("failed to initialize SSL server context")
+      }
+      server_ctx_cell.val = Some(ctx)
+      ctx
+    }
+  }
 }
 
 ///|
 #cfg(not(platform="windows"))
 fn SSL_CTX::free(self : SSL_CTX) -> Unit {
-  if physical_equal(self, client_ctx) || physical_equal(self, server_ctx) {
+  // Never free the shared singletons. Compare against the CACHED contexts without
+  // forcing their creation (a `free` must not lazily spin up a context just to check).
+  if (client_ctx_cell.val is Some(c) && physical_equal(self, c)) ||
+    (server_ctx_cell.val is Some(s) && physical_equal(self, s)) {
     return
   }
   self.free_ffi()
@@ -258,7 +300,15 @@ extern "C" fn BIO::set_flags(bio : BIO, flags : Int) = "moonbitlang_async_tls_bi
 ///|
 #cfg(not(platform="windows"))
 #owned(data)
-extern "C" fn create_bio(data : Transport) -> BIO = "moonbitlang_async_tls_create_bio"
+extern "C" fn create_bio_ffi(data : Transport) -> BIO = "moonbitlang_async_tls_create_bio"
+
+///|
+// Also the sole consumer of the BIO method table `load_openssl` registers.
+#cfg(not(platform="windows"))
+fn create_bio(data : Transport) -> BIO {
+  load_openssl()
+  create_bio_ffi(data)
+}
 
 ///|
 #cfg(not(platform="windows"))
@@ -419,7 +469,7 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::client_from_pair(
     None => if verify { SystemRoot } else { NoVerification }
   }
   let ctx = match trust {
-    NoVerification | SystemRoot => client_ctx
+    NoVerification | SystemRoot => client_ctx()
     CustomPemFile(root_cert) => SSL_CTX::client_with_custom_root(root_cert)
   }
   let self = Tls::from_pair(ctx, r, w, is_client=true, host~)
@@ -472,7 +522,7 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::server_from_pair(
 ) -> Tls {
   let private_key_file = @utf8.encode(private_key_file)
   let certificate_file = @utf8.encode(certificate_file)
-  let self = Tls::from_pair(server_ctx, r, w, is_client=false, host=None)
+  let self = Tls::from_pair(server_ctx(), r, w, is_client=false, host=None)
   try {
     if self.ssl.use_certificate_file(certificate_file, certificate_type) != 1 {
       raise TlsError(err_get_error())

--- a/src/tls/openssl_loader.mbt
+++ b/src/tls/openssl_loader.mbt
@@ -29,30 +29,51 @@ extern "C" fn init_bio_method(
 ) = "moonbitlang_async_init_bio_method"
 
 ///|
+/// `None` until the first load attempt; afterwards caches the outcome so a
+/// failed load fails fast on every subsequent call instead of retrying.
 #cfg(not(platform="windows"))
-let openssl_loaded : Ref[Bool] = Ref(false)
+let openssl_loaded : Ref[Result[Unit, Error]?] = Ref(None)
 
 ///|
 /// Lazily load OpenSSL on first use, so a program that never touches TLS pays
 /// nothing. Every raw-symbol FFI wrapper calls this first; all other FFI runs on
-/// handles those produce, so it is transitively covered. Guarded → repeat calls
-/// are free.
+/// handles those produce, so it is transitively covered. The outcome is cached →
+/// success makes repeat calls free, failure re-raises the same error immediately.
 #cfg(not(platform="windows"))
-fn load_openssl() -> Unit {
-  if openssl_loaded.val {
-    return
+fn load_openssl() -> Unit raise {
+  match openssl_loaded.val {
+    Some(Ok(_)) => return
+    Some(Err(err)) => raise err
+    None => ()
   }
-  openssl_loaded.val = true
+  let result = try {
+    load_openssl_unchecked()
+    Ok(())
+  } catch {
+    err => Err(err)
+  }
+  openssl_loaded.val = Some(result)
+  match result {
+    Ok(_) => ()
+    Err(err) => raise err
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+fn load_openssl_unchecked() -> Unit raise {
   let major = Ref(0)
   let minor = Ref(0)
   let fix = Ref(0)
   match load_openssl_ffi(major, minor, fix) {
     0 => ()
-    1 => abort("failed to load OpenSSL")
-    2 => abort("failed to get OpenSSL version")
+    1 => raise TlsError("failed to load OpenSSL")
+    2 => raise TlsError("failed to get OpenSSL version")
     3 =>
-      abort("unsupported OpenSSL version \{major.val}.\{minor.val}.\{fix.val}")
-    4 => abort("failed to load some OpenSSL function")
+      raise TlsError(
+        "unsupported OpenSSL version \{major.val}.\{minor.val}.\{fix.val}",
+      )
+    4 => raise TlsError("failed to load some OpenSSL function")
     _ => panic()
   }
   init_bio_method((bio, dst, len) => bio.read(dst, len)) <| ((bio, src, len) => {

--- a/src/tls/openssl_loader.mbt
+++ b/src/tls/openssl_loader.mbt
@@ -42,8 +42,7 @@ let openssl_loaded : Ref[Result[Unit, Error]?] = Ref(None)
 #cfg(not(platform="windows"))
 fn load_openssl() -> Unit raise {
   match openssl_loaded.val {
-    Some(Ok(_)) => return
-    Some(Err(err)) => raise err
+    Some(cached) => return cached.unwrap_or_error()
     None => ()
   }
   let result = try {
@@ -53,10 +52,7 @@ fn load_openssl() -> Unit raise {
     err => Err(err)
   }
   openssl_loaded.val = Some(result)
-  match result {
-    Ok(_) => ()
-    Err(err) => raise err
-  }
+  result.unwrap_or_error()
 }
 
 ///|

--- a/src/tls/openssl_loader.mbt
+++ b/src/tls/openssl_loader.mbt
@@ -33,6 +33,10 @@ extern "C" fn init_bio_method(
 let openssl_loaded : Ref[Bool] = Ref(false)
 
 ///|
+/// Lazily load OpenSSL on first use, so a program that never touches TLS pays
+/// nothing. Every raw-symbol FFI wrapper calls this first; all other FFI runs on
+/// handles those produce, so it is transitively covered. Guarded → repeat calls
+/// are free.
 #cfg(not(platform="windows"))
 fn load_openssl() -> Unit {
   if openssl_loaded.val {
@@ -51,12 +55,6 @@ fn load_openssl() -> Unit {
     4 => abort("failed to load some OpenSSL function")
     _ => panic()
   }
-}
-
-///|
-#cfg(not(platform="windows"))
-fn init {
-  load_openssl()
   init_bio_method((bio, dst, len) => bio.read(dst, len)) <| ((bio, src, len) => {
     bio.write(src, len)
   })

--- a/src/tls/pkg.generated.mbti
+++ b/src/tls/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 // Values
 pub fn rand_bytes(Int) -> Bytes raise
 
-pub fn sha1(Bytes) -> Bytes
+pub fn sha1(Bytes) -> Bytes raise
 
 // Errors
 pub suberror ConnectionClosed derive(ToJson, @debug.Debug)


### PR DESCRIPTION
The OpenSSL backend resolved its symbols in a package `init {}` and built the
shared client/server `SSL_CTX` in top-level `let`s — both evaluated at process
startup. So merely linking this package made every program `dlopen` libssl, run
~50 `dlsym`, and read the system CA store before `main`, even commands that never
touch TLS (e.g. a build tool's `--help`). That cost showed up on otherwise
trivial invocations.

This makes loading lazy: a single guarded `load_openssl()` does the work on first
use, the shared contexts are memoized in `Ref[SSL_CTX?]` cells, and every
raw-symbol FFI wrapper (`SSL_CTX::client`/`server`, `create_bio`, `rand_bytes`,
`sha1`) calls it first — so the standalone crypto entry points used by the
WebSocket handshake (`rand_bytes` / `sha1`) still load OpenSSL even with no TLS
connection, instead of dereferencing NULL `dlsym`'d pointers on the lazy path.
A TLS-free run now pays nothing.
