### PR TITLE
refactor & fix IO cancellation

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -431,6 +431,42 @@ priv enum CancellationStatus {
 }
 
 ///|
+/// Generic function for performing cancellation on an IO operation.
+/// `cancel_func` performs the cancellation work under the hood.
+/// For Windows IOCP/thread pool operations, the OS/thread pool hold references to user objects.
+/// We must wait for the completion of the operation before dropping those user objects,
+/// even in case of cancellation.
+async fn wait_for_cancellation(
+  cancel_func : () -> CancellationStatus raise,
+) -> Unit {
+  try cancel_func() catch {
+    err => {
+      // The cancellation operation itself failed.
+      // Give up the cancellation and wait for completion normally.
+      @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
+      raise err
+    }
+  } noraise {
+    NeedWait =>
+      // The cancellation operation has succeeded,
+      // but the thread pool or OS may need some more time to finish all the cleanup.
+      // So wait for the completion of the cleanup process here.
+      @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
+    NoWait =>
+      // The cancellation operation has succeeded,
+      // and the cancelled operation has already terminated.
+      // Return immediately here.
+      ()
+    RetryLater => {
+      // Due to some inherent race condition, the cancellaion attempt did not succeed.
+      // Retry again after a small timeout.
+      @coroutine.protect_from_cancel(() => sleep(10), resume_on_cancel=true)
+      wait_for_cancellation(cancel_func)
+    }
+  }
+}
+
+///|
 async fn EventLoop::wait_for_job(
   evloop : EventLoop,
   job_id : Int,
@@ -443,35 +479,15 @@ async fn EventLoop::wait_for_job(
       @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
     Some(cancel_func) =>
       @coroutine.suspend() catch {
-        err =>
-          for ;; {
-            let status = cancel_func(job_id) catch {
-              err =>
-                @coroutine.protect_from_cancel() <| () => {
-                  @coroutine.suspend()
-                  raise err
-                }
-            }
-            match status {
-              NeedWait => {
-                @coroutine.protect_from_cancel(
-                  @coroutine.suspend,
-                  resume_on_cancel=true,
-                )
-                break
-              }
-              NoWait => raise err
-              RetryLater => {
-                @coroutine.protect_from_cancel(
-                  @coroutine.pause,
-                  resume_on_cancel=true,
-                )
-                if evloop.jobs.get(job_id) is None {
-                  break
-                }
-              }
-            }
-          }
+        _ =>
+          // The cancellation error is swallowed here,
+          // because in case the operation completed before cancellation,
+          // we need to return the result normally to retain cancellation safety
+          // and avoid data loss.
+          // In case the cancellation succeeded,
+          // the underlying operation itself should report cancelled status properly
+          // via error code (`EINTR` or `ERROR_OPERATION_ABORTED`)
+          wait_for_cancellation(() => cancel_func(job_id))
       }
   }
 }
@@ -503,7 +519,7 @@ async fn perform_job_in_worker(
   }
   evloop.wait_for_job(job_id, cancel?)
   if job.err() is err && err > 0 {
-    if errno_is_cancelled(err) {
+    if @coroutine.is_being_cancelled() && errno_is_cancelled(err) {
       raise @coroutine.Cancelled
     } else {
       raise @os_error.OSError(err, context~)

--- a/src/internal/event_loop/event_loop.wasm.mbt
+++ b/src/internal/event_loop/event_loop.wasm.mbt
@@ -286,6 +286,42 @@ priv enum CancellationStatus {
 }
 
 ///|
+/// Generic function for performing cancellation on an IO operation.
+/// `cancel_func` performs the cancellation work under the hood.
+/// For Windows IOCP/thread pool operations, the OS/thread pool hold references to user objects.
+/// We must wait for the completion of the operation before dropping those user objects,
+/// even in case of cancellation.
+async fn wait_for_cancellation(
+  cancel_func : () -> CancellationStatus raise,
+) -> Unit {
+  try cancel_func() catch {
+    err => {
+      // The cancellation operation itself failed.
+      // Give up the cancellation and wait for completion normally.
+      @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
+      raise err
+    }
+  } noraise {
+    NeedWait =>
+      // The cancellation operation has succeeded,
+      // but the thread pool or OS may need some more time to finish all the cleanup.
+      // So wait for the completion of the cleanup process here.
+      @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
+    NoWait =>
+      // The cancellation operation has succeeded,
+      // and the cancelled operation has already terminated.
+      // Return immediately here.
+      ()
+    RetryLater => {
+      // Due to some inherent race condition, the cancellaion attempt did not succeed.
+      // Retry again after a small timeout.
+      @coroutine.protect_from_cancel(() => sleep(10), resume_on_cancel=true)
+      wait_for_cancellation(cancel_func)
+    }
+  }
+}
+
+///|
 async fn EventLoop::wait_for_job(
   evloop : EventLoop,
   job_id : Int,
@@ -298,35 +334,15 @@ async fn EventLoop::wait_for_job(
       @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
     Some(cancel_func) =>
       @coroutine.suspend() catch {
-        err =>
-          for ;; {
-            let status = cancel_func(job_id) catch {
-              err =>
-                @coroutine.protect_from_cancel() <| () => {
-                  @coroutine.suspend()
-                  raise err
-                }
-            }
-            match status {
-              NeedWait => {
-                @coroutine.protect_from_cancel(
-                  @coroutine.suspend,
-                  resume_on_cancel=true,
-                )
-                break
-              }
-              NoWait => raise err
-              RetryLater => {
-                @coroutine.protect_from_cancel(
-                  @coroutine.pause,
-                  resume_on_cancel=true,
-                )
-                if evloop.jobs.get(job_id) is None {
-                  break
-                }
-              }
-            }
-          }
+        _ =>
+          // The cancellation error is swallowed here,
+          // because in case the operation completed before cancellation,
+          // we need to return the result normally to retain cancellation safety
+          // and avoid data loss.
+          // In case the cancellation succeeded,
+          // the underlying operation itself should report cancelled status properly
+          // via error code (`EINTR` or `ERROR_OPERATION_ABORTED`)
+          wait_for_cancellation(() => cancel_func(job_id))
       }
   }
 }
@@ -359,7 +375,7 @@ async fn perform_job_in_worker(
   }
   evloop.wait_for_job(job_id, cancel?)
   if job.err() is err && err > 0 {
-    if errno_is_cancelled(err) {
+    if @coroutine.is_being_cancelled() && errno_is_cancelled(err) {
       raise @coroutine.Cancelled
     } else {
       raise @os_error.OSError(err, context~)

--- a/src/internal/event_loop/io_windows.c
+++ b/src/internal/event_loop/io_windows.c
@@ -252,11 +252,17 @@ int32_t moonbitlang_async_io_result_get_status(
 MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_cancel_io_result(LPOVERLAPPED overlapped, HANDLE handle) {
   int32_t result = CancelIoEx(handle, overlapped);
-  // cancellation failure, wait for completion packet
-  if (!result)
-    return GetLastError() == ERROR_NOT_FOUND ? 0 : -1;
+  // The cancellation operation itself failed for some reason.
+  // The caller should give up cancellation and wait for completion in this case.
+  // 
+  // `ERROR_NOT_FOUND` is an exception here,
+  // because it indicates the operation has already completed.
+  if (!result && GetLastError() != ERROR_NOT_FOUND)
+    return -1;
 
-  // no need to wait if the operation already completed
+  // The operation may have already completed before cancellation (`ERROR_NOT_FOUND`),
+  // or `CancelIoEx` may have taken effect immediately.
+  // So we should check the status of the operation immediately here.
   DWORD bytes_transferred;
   if (GetOverlappedResult(handle, overlapped, &bytes_transferred, FALSE))
     return 0;

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -138,12 +138,7 @@ async fn IoHandle::wait_read(
     handle.read = Idle
   }
   @coroutine.suspend() catch {
-    err => {
-      if io_result.cancel(handle.fd, context~) is NeedWait {
-        @coroutine.protect_from_cancel(@coroutine.suspend)
-      }
-      raise err
-    }
+    _ => wait_for_cancellation(() => io_result.cancel(handle.fd, context~))
   }
 }
 
@@ -160,12 +155,7 @@ async fn IoHandle::wait_write(
     handle.write = Idle
   }
   @coroutine.suspend() catch {
-    err => {
-      if io_result.cancel(handle.fd, context~) is NeedWait {
-        @coroutine.protect_from_cancel(@coroutine.suspend)
-      }
-      raise err
-    }
+    _ => wait_for_cancellation(() => io_result.cancel(handle.fd, context~))
   }
 }
 

--- a/src/internal/event_loop/network_windows.mbt
+++ b/src/internal/event_loop/network_windows.mbt
@@ -115,21 +115,20 @@ extern "C" fn setup_accepted_socket_ffi(
 #cfg(platform="windows")
 pub async fn IoHandle::accept(
   handle : IoHandle,
-  conn_sock : @fd_util.Fd,
+  conn_sock : IoHandle,
   context~ : String,
-) -> IoHandle {
+) -> Unit {
   @coroutine.check_cancellation()
   let result = IoResult::for_accept()
   defer result.free()
-  if 0 == accept_ffi(handle.fd, conn_sock, result) {
+  if 0 == accept_ffi(handle.fd, conn_sock.fd, result) {
     if !@os_error.is_nonblocking_io_error() {
       @os_error.check_errno(context)
     }
     handle.wait_read(result, context~)
     ignore(result.status(handle.fd, context~))
   }
-  if setup_accepted_socket_ffi(handle.fd, conn_sock) < 0 {
+  if setup_accepted_socket_ffi(handle.fd, conn_sock.fd) < 0 {
     @os_error.check_errno(context)
   }
-  IoHandle::from_fd(conn_sock, kind=Socket)
 }

--- a/src/socket/happy_eyeball.mbt
+++ b/src/socket/happy_eyeball.mbt
@@ -57,7 +57,11 @@ pub async fn Tcp::connect_to_host(
               raise err
             }
           }
-          result = Some(conn)
+          if result is None {
+            result = Some(conn)
+          } else {
+            conn.close()
+          }
           group.return_immediately(())
         }
         @async.sleep(250)

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -202,8 +202,9 @@ pub async fn TcpServer::accept(self : TcpServer) -> (Tcp, Addr) {
   let context = "@socket.TcpServer::accept()"
   let family = self.addr.family()
   let conn_sock = make_tcp_socket(family, context~)
-  let conn = self.io.accept(conn_sock, context~)
+  let conn = @event_loop.IoHandle::from_fd(conn_sock, kind=Socket)
   try {
+    self.io.accept(conn, context~)
     if disable_nagle(conn_sock) < 0 {
       @os_error.check_errno("@socket.TcpServer::accept(): set TCP_NODELAY")
     }


### PR DESCRIPTION
This PR refactors IO cancellation handling for IOCP/thread pool operations and fix some potential bugs. For IOCP/thread pool operations, certain resource, in particular buffers, are submitted to the OS/worker thread. So these resources must not be freed until the OS/worker thread no longer hold reference to them, **even in case of cancellation**. The previous implementation failed to confront to this constraint in certain corner cases. When cancelling an IOCP/thread pool operation, there are four cases:

- the operation has already completed after the cancellation attempt. In this case, we can safely return and free the resources
- the cancellation request succeeded, but the operation is still on the way of cleanup. In this case, we **must** wait for the operation to complete before dropping any resource. If the cancellation indeed succeeded, the underlying operation should fail with `EINTR`/`ERROR_OPERATION_ABORTED`, and that error will be translated to cancellation error
- the cancellation attempt itself failed. Previously, the implementation will fail immediately here, triggering resource dropping logic incorrectly. In this PR, the event loop will give up cancellation and wait for the operation to complete normally in this case. This case should be extremely rare though
- the cancellation need to be retried later. This is mainly for cancelling thread pool job via signal on Unix platforms, where we have no way to tell if the signal successfully interrupted the target syscall, and can only blindly retry. Previously the retry will be performed immediately on the next scheduler round, which is a bit too eager and can waste CPU resource. In this PR, the retry is adjusted to perform a 10ms timeout in the middle.

There is one more problem here is "what to do after successful cancellation". Previously, all event loop operations fail with the cancellation error unconditionally on cancellation. But if the underlying operation completed successfully before the cancellation is fired, this will break cancellation safety (i.e. cancelled = no side effect) and may result in data loss. After this PR, IO operation cancellation always swallow the cancellation error, and rely on return status of the underlying operation to determine the status of cancellation.