### PR TITLE
make suffix detection on Windows case insensitive

### DIFF
--- a/src/process/windows.mbt
+++ b/src/process/windows.mbt
@@ -116,7 +116,8 @@ async fn raw_spawn(
   context~ : String,
 ) -> @event_loop.Process {
   let cmd = match cmd {
-    [.., .. ".exe"] | [.., .. ".com"] => cmd
+    [.., '.', 'e' | 'E', 'x' | 'X', 'e' | 'E']
+    | [.., '.', 'c' | 'C', 'o' | 'O', 'm' | 'M'] => cmd
     _ => cmd + ".exe"
   }
   let command_line = StringBuilder::new()


### PR DESCRIPTION
On Windows, we only allow execution of `.exe` or `.com` files. If the files does not already contain a `.exe.` or `.com` suffix, we append an `.exe` suffix to reject unsafe execution of `.bat` files (due to command line escaping issue). However, the detection of `.exe`/`.com` suffix was case sensitive, which does not confront general Windows practice. This PR makes the suffix detection case insensitive.