### PR TITLE
refactor Windows `AcceptEx` handling, fix buffer size

### DIFF
--- a/src/internal/event_loop/io_windows.c
+++ b/src/internal/event_loop/io_windows.c
@@ -108,7 +108,8 @@ struct AcceptIoResult {
 
   // output buffer used for `AcceptEx`
   DWORD bytes_received;
-  char accept_buffer[sizeof(struct sockaddr_storage) * 2];
+  int32_t addr_len;
+  char accept_buffer[0];
 };
 
 struct ReadDirChangesIoResult {
@@ -193,8 +194,15 @@ struct ConnectIoResult *moonbitlang_async_make_connect_io_result(struct sockaddr
 }
 
 MOONBIT_FFI_EXPORT
-struct AcceptIoResult *moonbitlang_async_make_accept_io_result() {
-  return MAKE_IO_RESULT(IO_RESULT_READ_EVENT, Accept);
+struct AcceptIoResult *moonbitlang_async_make_accept_io_result(int32_t addr_len) {
+  struct AcceptIoResult *result = (struct AcceptIoResult*)make_io_result(
+    IO_RESULT_READ_EVENT,
+    Accept,
+    // `AcceptEx` requires 16 extra bytes per address for internal use in the buffer.
+    sizeof(struct AcceptIoResult) + (addr_len + 16) * 2
+  );
+  result->addr_len = addr_len;
+  return result;
 }
 
 MOONBIT_FFI_EXPORT
@@ -478,10 +486,10 @@ int32_t moonbitlang_async_accept(
   return AcceptEx(
     (SOCKET)handle,
     (SOCKET)conn_sock,
-    &(result->accept_buffer),
+    result->accept_buffer,
     0,
-    sizeof(struct sockaddr_storage),
-    sizeof(struct sockaddr_storage),
+    result->addr_len + 16,
+    result->addr_len + 16,
     &(result->bytes_received),
     (LPOVERLAPPED)result
   );
@@ -504,6 +512,11 @@ int32_t moonbitlang_async_setup_accepted_socket(HANDLE listen_sock, HANDLE accep
     (char*)&listen_sock,
     sizeof(UINT_PTR)
   );
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_get_accept_peer_addr(struct AcceptIoResult *result, struct sockaddr *dst) {
+  memcpy(dst, result->accept_buffer + result->addr_len + 16, result->addr_len);
 }
 
 MOONBIT_FFI_EXPORT

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -58,7 +58,7 @@ extern "C" fn IoResult::for_connect(addr : Bytes) -> IoResult = "moonbitlang_asy
 
 ///|
 #cfg(platform="windows")
-extern "C" fn IoResult::for_accept() -> IoResult = "moonbitlang_async_make_accept_io_result"
+extern "C" fn IoResult::for_accept(addr_len : Int) -> IoResult = "moonbitlang_async_make_accept_io_result"
 
 ///|
 #cfg(platform="windows")

--- a/src/internal/event_loop/network_windows.mbt
+++ b/src/internal/event_loop/network_windows.mbt
@@ -106,6 +106,14 @@ extern "C" fn accept_ffi(
 
 ///|
 #cfg(platform="windows")
+#borrow(dst)
+extern "C" fn IoResult::get_accept_peer_addr(
+  result : IoResult,
+  dst : Bytes,
+) -> Unit = "moonbitlang_async_get_accept_peer_addr"
+
+///|
+#cfg(platform="windows")
 extern "C" fn setup_accepted_socket_ffi(
   listen_sock : @fd_util.Fd,
   accept_sock : @fd_util.Fd,
@@ -116,10 +124,11 @@ extern "C" fn setup_accepted_socket_ffi(
 pub async fn IoHandle::accept(
   handle : IoHandle,
   conn_sock : IoHandle,
+  addr : Bytes,
   context~ : String,
 ) -> Unit {
   @coroutine.check_cancellation()
-  let result = IoResult::for_accept()
+  let result = IoResult::for_accept(addr.length())
   defer result.free()
   if 0 == accept_ffi(handle.fd, conn_sock.fd, result) {
     if !@os_error.is_nonblocking_io_error() {
@@ -128,6 +137,7 @@ pub async fn IoHandle::accept(
     handle.wait_read(result, context~)
     ignore(result.status(handle.fd, context~))
   }
+  result.get_accept_peer_addr(addr)
   if setup_accepted_socket_ffi(handle.fd, conn_sock.fd) < 0 {
     @os_error.check_errno(context)
   }

--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -224,22 +224,3 @@ fn getsockname(
   }
   addr
 }
-
-///|
-#cfg(platform="windows")
-#borrow(addr_out)
-extern "C" fn getpeername_ffi(sock : @fd_util.Fd, addr_out : Addr) -> Int = "moonbitlang_async_getpeername"
-
-///|
-#cfg(platform="windows")
-fn getpeername(
-  sock : @fd_util.Fd,
-  family : AddrFamily,
-  context~ : String,
-) -> Addr raise {
-  let addr = Addr::empty(family)
-  if getpeername_ffi(sock, addr) != 0 {
-    @os_error.check_errno(context)
-  }
-  addr
-}

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -506,12 +506,6 @@ int moonbitlang_async_getsockname(HANDLE sock, struct sockaddr *addr_out) {
 }
 
 MOONBIT_FFI_EXPORT
-int moonbitlang_async_getpeername(HANDLE sock, struct sockaddr *addr_out) {
-  socklen_t len = Moonbit_array_length(addr_out);
-  return getpeername((SOCKET)sock, addr_out, &len);
-}
-
-MOONBIT_FFI_EXPORT
 uint32_t moonbitlang_async_if_nametoindex(HANDLE sock, const char *name) {
 #ifdef _WIN32
 

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -204,11 +204,11 @@ pub async fn TcpServer::accept(self : TcpServer) -> (Tcp, Addr) {
   let conn_sock = make_tcp_socket(family, context~)
   let conn = @event_loop.IoHandle::from_fd(conn_sock, kind=Socket)
   try {
-    self.io.accept(conn, context~)
+    let addr = Addr::empty(family)
+    self.io.accept(conn, addr.0, context~)
     if disable_nagle(conn_sock) < 0 {
       @os_error.check_errno("@socket.TcpServer::accept(): set TCP_NODELAY")
     }
-    let addr = getpeername(conn_sock, self.addr.family(), context~)
     // The local address of a server connection is the same as the listen address
     ({ io: conn, addr: self.addr, read_buf: @io.ReaderBuffer::new() }, addr)
   } catch {


### PR DESCRIPTION
- fix the issue in https://github.com/moonbitlang/async/issues/442#issuecomment-4828673595
    - previously the bug did not cause any issue, probably because `struct(sockaddr_storage) > sizeof(struct sockaddr_in6) + 16`
- dynamically allocate `AcceptIoResult` object based on actual address family
- retrieve the address of remote peer from result of `AcceptEx` directly, instead of relying on an extra call to `getpeername`