### PR TITLE
do not rely on `P_PIDFD` constant in glibc

### DIFF
--- a/src/internal/event_loop/process.c
+++ b/src/internal/event_loop/process.c
@@ -27,8 +27,14 @@
 typedef int HANDLE;
 
 #ifdef __linux__
+
 #include <linux/version.h>
 #include <sys/syscall.h>
+
+#ifndef P_PIDFD
+#define P_PIDFD 3
+#endif
+
 #endif
 
 #endif


### PR DESCRIPTION
Definition of the constant `P_PIDFD` requires a rather new version of glibc (2.36). If we manually define the constant when it is missing, a much older version of glibc (2.x with `waitid`) can be used.