### PR TITLE
Split wasm IO result buffer ownership

### DIFF
--- a/src/internal/event_loop/io.wasm.mbt
+++ b/src/internal/event_loop/io.wasm.mbt
@@ -376,33 +376,17 @@ priv struct IoResult(UInt64)
 
 ///|
 #unsafe_skip_stub_check
-#borrow(buf)
-fn IoResult::for_file(
-  events : Int,
-  buf : Bytes,
-  offset~ : Int,
-  len~ : Int,
-  position~ : Int64,
-) -> IoResult = "moonbitlang/async" "io/make_file_io_result/windows"
+fn IoResult::for_file(events : Int, len~ : Int, position~ : Int64) -> IoResult = "moonbitlang/async" "io/make_file_io_result/windows"
 
 ///|
 #unsafe_skip_stub_check
-#borrow(buf)
-fn IoResult::for_socket(
-  events : Int,
-  buf : Bytes,
-  offset~ : Int,
-  len~ : Int,
-  flags~ : Int,
-) -> IoResult = "moonbitlang/async" "io/make_socket_io_result/windows"
+fn IoResult::for_socket(events : Int, len~ : Int, flags~ : Int) -> IoResult = "moonbitlang/async" "io/make_socket_io_result/windows"
 
 ///|
 #unsafe_skip_stub_check
-#borrow(buf, addr)
+#borrow(addr)
 fn IoResult::for_socket_with_addr(
   events : Int,
-  buf : Bytes,
-  offset~ : Int,
   len~ : Int,
   flags~ : Int,
   addr~ : Bytes,
@@ -462,6 +446,18 @@ fn IoResult::cancel(
 ///|
 #unsafe_skip_stub_check
 fn IoResult::status_ffi(result : IoResult, handle : @fd_util.Fd) -> Int = "moonbitlang/async" "io/io_result_get_status/windows"
+
+///|
+#unsafe_skip_stub_check
+#borrow(dst, addr)
+fn IoResult::copy_read(
+  result : IoResult,
+  dst : FixedArray[Byte],
+  offset~ : Int,
+  len~ : Int,
+  addr~ : Bytes,
+  addr_len? : Int = addr.length(),
+) -> Unit = "moonbitlang/async" "io/io_result_copy_read/windows"
 
 ///|
 fn IoResult::status(
@@ -534,10 +530,13 @@ fn errno_is_read_eof(errno : Int) -> Bool = "moonbitlang/async" "io/errno_is_rea
 async fn IoHandle::generic_read_windows(
   handle : IoHandle,
   result : IoResult,
+  buf : FixedArray[Byte],
+  offset~ : Int,
+  addr~ : Bytes,
   context~ : String,
 ) -> Int {
   let n = read_io_result_ffi(handle.fd, result)
-  if n >= 0 {
+  let n = if n >= 0 {
     // The `pause` here prevent a busy read loop from exhausting the whole program,
     // and give chance for other tasks to execute.
     @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
@@ -554,6 +553,8 @@ async fn IoHandle::generic_read_windows(
     @os_error.check_errno(context)
     panic()
   }
+  result.copy_read(buf, offset~, len=n, addr~)
+  n
 }
 
 ///|
@@ -566,25 +567,11 @@ async fn IoHandle::read_via_event_bus_windows(
 ) -> Int {
   let result = match handle.kind {
     Regular => panic()
-    Socket =>
-      IoResult::for_socket(
-        ReadEvent,
-        buf.unsafe_reinterpret_as_bytes(),
-        offset~,
-        len~,
-        flags=0,
-      )
-    _ =>
-      IoResult::for_file(
-        ReadEvent,
-        buf.unsafe_reinterpret_as_bytes(),
-        offset~,
-        len~,
-        position=0,
-      )
+    Socket => IoResult::for_socket(ReadEvent, len~, flags=0)
+    _ => IoResult::for_file(ReadEvent, len~, position=0)
   }
   defer result.free()
-  handle.generic_read_windows(result, context~)
+  handle.generic_read_windows(result, buf, offset~, addr=b"", context~)
 }
 
 ///|
@@ -604,15 +591,25 @@ async fn IoHandle::read_via_event_bus(
 
 ///|
 #unsafe_skip_stub_check
-fn write_io_result_ffi(fd : @fd_util.Fd, result : IoResult) -> Int = "moonbitlang/async" "io/write/windows"
+#borrow(buf)
+fn write_io_result_ffi(
+  fd : @fd_util.Fd,
+  result : IoResult,
+  buf : Bytes,
+  offset~ : Int,
+  len~ : Int,
+) -> Int = "moonbitlang/async" "io/write/windows"
 
 ///|
 async fn IoHandle::generic_write_windows(
   handle : IoHandle,
   result : IoResult,
+  buf : Bytes,
+  offset~ : Int,
+  len~ : Int,
   context~ : String,
 ) -> Int {
-  let n = write_io_result_ffi(handle.fd, result)
+  let n = write_io_result_ffi(handle.fd, result, buf, offset~, len~)
   if n >= 0 {
     // The `pause` here prevent a busy write loop from exhausting the whole program,
     // and give chance for other tasks to execute.
@@ -637,11 +634,11 @@ async fn IoHandle::write_via_event_bus_windows(
 ) -> Int {
   let result = match handle.kind {
     Regular => panic()
-    Socket => IoResult::for_socket(WriteEvent, buf, offset~, len~, flags=0)
-    _ => IoResult::for_file(WriteEvent, buf, offset~, len~, position=0)
+    Socket => IoResult::for_socket(WriteEvent, len~, flags=0)
+    _ => IoResult::for_file(WriteEvent, len~, position=0)
   }
   defer result.free()
-  handle.generic_write_windows(result, context~)
+  handle.generic_write_windows(result, buf, offset~, len~, context~)
 }
 
 ///|

--- a/src/internal/event_loop/io.wasm.mbt
+++ b/src/internal/event_loop/io.wasm.mbt
@@ -376,22 +376,53 @@ priv struct IoResult(UInt64)
 
 ///|
 #unsafe_skip_stub_check
-fn IoResult::for_file(events : Int, len~ : Int, position~ : Int64) -> IoResult = "moonbitlang/async" "io/make_file_io_result/windows"
+fn IoResult::for_file_read(len~ : Int, position~ : Int64) -> IoResult = "moonbitlang/async" "io/make_file_read_io_result/windows"
 
 ///|
 #unsafe_skip_stub_check
-fn IoResult::for_socket(events : Int, len~ : Int, flags~ : Int) -> IoResult = "moonbitlang/async" "io/make_socket_io_result/windows"
+#borrow(buf)
+fn IoResult::for_file_write(
+  buf : Bytes,
+  offset~ : Int,
+  len~ : Int,
+  position~ : Int64,
+) -> IoResult = "moonbitlang/async" "io/make_file_write_io_result/windows"
+
+///|
+#unsafe_skip_stub_check
+fn IoResult::for_socket_read(len~ : Int, flags~ : Int) -> IoResult = "moonbitlang/async" "io/make_socket_read_io_result/windows"
+
+///|
+#unsafe_skip_stub_check
+#borrow(buf)
+fn IoResult::for_socket_write(
+  buf : Bytes,
+  offset~ : Int,
+  len~ : Int,
+  flags~ : Int,
+) -> IoResult = "moonbitlang/async" "io/make_socket_write_io_result/windows"
 
 ///|
 #unsafe_skip_stub_check
 #borrow(addr)
-fn IoResult::for_socket_with_addr(
-  events : Int,
+fn IoResult::for_socket_with_addr_read(
   len~ : Int,
   flags~ : Int,
   addr~ : Bytes,
   addr_len? : Int = addr.length(),
-) -> IoResult = "moonbitlang/async" "io/make_socket_with_addr_io_result/windows"
+) -> IoResult = "moonbitlang/async" "io/make_socket_with_addr_read_io_result/windows"
+
+///|
+#unsafe_skip_stub_check
+#borrow(buf, addr)
+fn IoResult::for_socket_with_addr_write(
+  buf : Bytes,
+  offset~ : Int,
+  len~ : Int,
+  flags~ : Int,
+  addr~ : Bytes,
+  addr_len? : Int = addr.length(),
+) -> IoResult = "moonbitlang/async" "io/make_socket_with_addr_write_io_result/windows"
 
 ///|
 #unsafe_skip_stub_check
@@ -449,15 +480,25 @@ fn IoResult::status_ffi(result : IoResult, handle : @fd_util.Fd) -> Int = "moonb
 
 ///|
 #unsafe_skip_stub_check
-#borrow(dst, addr)
+#borrow(dst)
 fn IoResult::copy_read(
+  result : IoResult,
+  dst : FixedArray[Byte],
+  offset~ : Int,
+  len~ : Int,
+) -> Unit = "moonbitlang/async" "io/io_result_copy_read/windows"
+
+///|
+#unsafe_skip_stub_check
+#borrow(dst, addr)
+fn IoResult::copy_read_with_addr(
   result : IoResult,
   dst : FixedArray[Byte],
   offset~ : Int,
   len~ : Int,
   addr~ : Bytes,
   addr_len? : Int = addr.length(),
-) -> Unit = "moonbitlang/async" "io/io_result_copy_read/windows"
+) -> Unit = "moonbitlang/async" "io/io_result_copy_read_with_addr/windows"
 
 ///|
 fn IoResult::status(
@@ -527,16 +568,13 @@ fn read_io_result_ffi(fd : @fd_util.Fd, result : IoResult) -> Int = "moonbitlang
 fn errno_is_read_eof(errno : Int) -> Bool = "moonbitlang/async" "io/errno_is_read_EOF/windows"
 
 ///|
-async fn IoHandle::generic_read_windows(
+async fn IoHandle::read_io_result_windows(
   handle : IoHandle,
   result : IoResult,
-  buf : FixedArray[Byte],
-  offset~ : Int,
-  addr~ : Bytes,
   context~ : String,
 ) -> Int {
   let n = read_io_result_ffi(handle.fd, result)
-  let n = if n >= 0 {
+  if n >= 0 {
     // The `pause` here prevent a busy read loop from exhausting the whole program,
     // and give chance for other tasks to execute.
     @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
@@ -553,7 +591,32 @@ async fn IoHandle::generic_read_windows(
     @os_error.check_errno(context)
     panic()
   }
-  result.copy_read(buf, offset~, len=n, addr~)
+}
+
+///|
+async fn IoHandle::generic_read_windows(
+  handle : IoHandle,
+  result : IoResult,
+  buf : FixedArray[Byte],
+  offset~ : Int,
+  context~ : String,
+) -> Int {
+  let n = handle.read_io_result_windows(result, context~)
+  result.copy_read(buf, offset~, len=n)
+  n
+}
+
+///|
+async fn IoHandle::generic_read_with_addr_windows(
+  handle : IoHandle,
+  result : IoResult,
+  buf : FixedArray[Byte],
+  offset~ : Int,
+  addr~ : Bytes,
+  context~ : String,
+) -> Int {
+  let n = handle.read_io_result_windows(result, context~)
+  result.copy_read_with_addr(buf, offset~, len=n, addr~)
   n
 }
 
@@ -567,11 +630,11 @@ async fn IoHandle::read_via_event_bus_windows(
 ) -> Int {
   let result = match handle.kind {
     Regular => panic()
-    Socket => IoResult::for_socket(ReadEvent, len~, flags=0)
-    _ => IoResult::for_file(ReadEvent, len~, position=0)
+    Socket => IoResult::for_socket_read(len~, flags=0)
+    _ => IoResult::for_file_read(len~, position=0)
   }
   defer result.free()
-  handle.generic_read_windows(result, buf, offset~, addr=b"", context~)
+  handle.generic_read_windows(result, buf, offset~, context~)
 }
 
 ///|
@@ -591,25 +654,15 @@ async fn IoHandle::read_via_event_bus(
 
 ///|
 #unsafe_skip_stub_check
-#borrow(buf)
-fn write_io_result_ffi(
-  fd : @fd_util.Fd,
-  result : IoResult,
-  buf : Bytes,
-  offset~ : Int,
-  len~ : Int,
-) -> Int = "moonbitlang/async" "io/write/windows"
+fn write_io_result_ffi(fd : @fd_util.Fd, result : IoResult) -> Int = "moonbitlang/async" "io/write/windows"
 
 ///|
 async fn IoHandle::generic_write_windows(
   handle : IoHandle,
   result : IoResult,
-  buf : Bytes,
-  offset~ : Int,
-  len~ : Int,
   context~ : String,
 ) -> Int {
-  let n = write_io_result_ffi(handle.fd, result, buf, offset~, len~)
+  let n = write_io_result_ffi(handle.fd, result)
   if n >= 0 {
     // The `pause` here prevent a busy write loop from exhausting the whole program,
     // and give chance for other tasks to execute.
@@ -634,11 +687,11 @@ async fn IoHandle::write_via_event_bus_windows(
 ) -> Int {
   let result = match handle.kind {
     Regular => panic()
-    Socket => IoResult::for_socket(WriteEvent, len~, flags=0)
-    _ => IoResult::for_file(WriteEvent, len~, position=0)
+    Socket => IoResult::for_socket_write(buf, offset~, len~, flags=0)
+    _ => IoResult::for_file_write(buf, offset~, len~, position=0)
   }
   defer result.free()
-  handle.generic_write_windows(result, buf, offset~, len~, context~)
+  handle.generic_write_windows(result, context~)
 }
 
 ///|

--- a/src/internal/event_loop/network.wasm.mbt
+++ b/src/internal/event_loop/network.wasm.mbt
@@ -125,9 +125,9 @@ async fn IoHandle::recvfrom_windows(
   addr~ : Bytes,
   context~ : String,
 ) -> Int {
-  let result = IoResult::for_socket_with_addr(ReadEvent, len~, flags=0, addr~)
+  let result = IoResult::for_socket_with_addr_read(len~, flags=0, addr~)
   defer result.free()
-  handle.generic_read_windows(result, buf, offset~, addr~, context~)
+  handle.generic_read_with_addr_windows(result, buf, offset~, addr~, context~)
 }
 
 ///|
@@ -194,9 +194,15 @@ async fn IoHandle::sendto_windows(
   addr~ : Bytes,
   context~ : String,
 ) -> Int {
-  let result = IoResult::for_socket_with_addr(WriteEvent, len~, flags=0, addr~)
+  let result = IoResult::for_socket_with_addr_write(
+    buf,
+    offset~,
+    len~,
+    flags=0,
+    addr~,
+  )
   defer result.free()
-  handle.generic_write_windows(result, buf, offset~, len~, context~)
+  handle.generic_write_windows(result, context~)
 }
 
 ///|

--- a/src/internal/event_loop/network.wasm.mbt
+++ b/src/internal/event_loop/network.wasm.mbt
@@ -125,16 +125,9 @@ async fn IoHandle::recvfrom_windows(
   addr~ : Bytes,
   context~ : String,
 ) -> Int {
-  let result = IoResult::for_socket_with_addr(
-    ReadEvent,
-    buf.unsafe_reinterpret_as_bytes(),
-    offset~,
-    len~,
-    flags=0,
-    addr~,
-  )
+  let result = IoResult::for_socket_with_addr(ReadEvent, len~, flags=0, addr~)
   defer result.free()
-  handle.generic_read_windows(result, context~)
+  handle.generic_read_windows(result, buf, offset~, addr~, context~)
 }
 
 ///|
@@ -201,16 +194,9 @@ async fn IoHandle::sendto_windows(
   addr~ : Bytes,
   context~ : String,
 ) -> Int {
-  let result = IoResult::for_socket_with_addr(
-    WriteEvent,
-    buf,
-    offset~,
-    len~,
-    flags=0,
-    addr~,
-  )
+  let result = IoResult::for_socket_with_addr(WriteEvent, len~, flags=0, addr~)
   defer result.free()
-  handle.generic_write_windows(result, context~)
+  handle.generic_write_windows(result, buf, offset~, len~, context~)
 }
 
 ///|


### PR DESCRIPTION
## Why

The wasm IOResult path should not retain MoonBit buffer pointers across asynchronous Windows operations. Native Windows IOResults bind the operation data when the result is created and retain the MoonBit objects until `free_io_result`; the wasm adapter needs the same lifetime boundary using host-owned data instead of guest pointers.

## What changed

- Split wasm IOResult creation into read and write constructors for file, socket, and socket-with-address operations.
- Keep read constructors buffer-only; completed plain-read data is copied back through the payload-only copy-out import.
- Use a separate recvfrom copy-out import for completed data plus the peer address buffer.
- Copy write payloads, and socket addresses when present, into host-owned IOResult storage during result creation.
- Restore `io/write/windows` to the native-shaped `(fd, result)` submission import.

## Correctness

Read results never receive a MoonBit destination array at creation or submission. Plain reads do not pass any address buffer during copy-out; recvfrom is the only read path that carries an address buffer. Write constructors borrow MoonBit buffers only for the import call and the host owns the copied bytes for the entire pending operation. Unix read/write remains the immediate borrowed-slice syscall path and does not create IOResults.