### PR TITLE
simplify code using `Lazy` from `moonbitlang/core`

### DIFF
--- a/src/socket/addr.mbt
+++ b/src/socket/addr.mbt
@@ -188,10 +188,10 @@ fn Addr::family(self : Addr) -> AddrFamily {
 }
 
 ///|
-let ipv4_any : @lazy.Lazy[Addr] = @lazy.Lazy(() => Addr::new(0, 0))
+let ipv4_any : Lazy[Addr] = Lazy(() => Addr::new(0, 0))
 
 ///|
-let ipv6_any : @lazy.Lazy[Addr] = @lazy.Lazy(() => {
+let ipv6_any : Lazy[Addr] = Lazy(() => {
   Addr::new_ipv6(FixedArray::make(16, 0), 0, scope_id=0)
 })
 

--- a/src/socket/moon.pkg
+++ b/src/socket/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "moonbitlang/core/string",
   "moonbitlang/core/encoding/utf8",
-  "moonbitlang/core/lazy",
   "moonbitlang/async/os_error",
   "moonbitlang/async/internal/event_loop",
   "moonbitlang/async/internal/fd_util",

--- a/src/tls/openssl.mbt
+++ b/src/tls/openssl.mbt
@@ -23,25 +23,11 @@ extern "C" fn SSL_CTX::is_null(self : SSL_CTX) -> Bool = "moonbitlang_async_tls_
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn SSL_CTX::client_ffi(load_default_verify_path~ : Bool) -> SSL_CTX = "moonbitlang_async_tls_client_ctx"
+extern "C" fn SSL_CTX::client(load_default_verify_path~ : Bool) -> SSL_CTX = "moonbitlang_async_tls_client_ctx"
 
 ///|
 #cfg(not(platform="windows"))
-fn SSL_CTX::client(load_default_verify_path~ : Bool) -> SSL_CTX raise {
-  load_openssl()
-  SSL_CTX::client_ffi(load_default_verify_path~)
-}
-
-///|
-#cfg(not(platform="windows"))
-extern "C" fn SSL_CTX::server_ffi() -> SSL_CTX = "moonbitlang_async_tls_server_ctx"
-
-///|
-#cfg(not(platform="windows"))
-fn SSL_CTX::server() -> SSL_CTX raise {
-  load_openssl()
-  SSL_CTX::server_ffi()
-}
+extern "C" fn SSL_CTX::server() -> SSL_CTX = "moonbitlang_async_tls_server_ctx"
 
 ///|
 #cfg(not(platform="windows"))
@@ -57,51 +43,23 @@ extern "C" fn SSL_CTX::add_root_certificate(self : SSL_CTX, der : Bytes) -> Int 
 
 ///|
 #cfg(not(platform="windows"))
-let client_ctx_cell : Ref[SSL_CTX?] = Ref(None)
+let client_ctx : Lazy[SSL_CTX] = Lazy(() => {
+  SSL_CTX::client(load_default_verify_path=true)
+})
 
 ///|
 #cfg(not(platform="windows"))
-fn client_ctx() -> SSL_CTX raise {
-  match client_ctx_cell.val {
-    Some(ctx) => ctx
-    None => {
-      let ctx = SSL_CTX::client(load_default_verify_path=true)
-      guard !ctx.is_null() else {
-        raise TlsError("failed to initialize SSL client context")
-      }
-      client_ctx_cell.val = Some(ctx)
-      ctx
-    }
-  }
-}
-
-///|
-#cfg(not(platform="windows"))
-let server_ctx_cell : Ref[SSL_CTX?] = Ref(None)
-
-///|
-#cfg(not(platform="windows"))
-fn server_ctx() -> SSL_CTX raise {
-  match server_ctx_cell.val {
-    Some(ctx) => ctx
-    None => {
-      let ctx = SSL_CTX::server()
-      guard !ctx.is_null() else {
-        raise TlsError("failed to initialize SSL server context")
-      }
-      server_ctx_cell.val = Some(ctx)
-      ctx
-    }
-  }
-}
+let server_ctx : Lazy[SSL_CTX] = Lazy(() => SSL_CTX::server())
 
 ///|
 #cfg(not(platform="windows"))
 fn SSL_CTX::free(self : SSL_CTX) -> Unit {
   // Never free the shared singletons. Compare against the CACHED contexts without
   // forcing their creation (a `free` must not lazily spin up a context just to check).
-  if (client_ctx_cell.val is Some(c) && physical_equal(self, c)) ||
-    (server_ctx_cell.val is Some(s) && physical_equal(self, s)) {
+  if client_ctx.peek() is Some(c) && physical_equal(self, c) {
+    return
+  }
+  if server_ctx.peek() is Some(s) && physical_equal(self, s) {
     return
   }
   self.free_ffi()
@@ -298,17 +256,10 @@ extern "C" fn BIO::get_endpoint(bio : BIO) -> Transport = "moonbitlang_async_tls
 extern "C" fn BIO::set_flags(bio : BIO, flags : Int) = "moonbitlang_async_tls_bio_set_flags"
 
 ///|
-#cfg(not(platform="windows"))
-#owned(data)
-extern "C" fn create_bio_ffi(data : Transport) -> BIO = "moonbitlang_async_tls_create_bio"
-
-///|
 // Also the sole consumer of the BIO method table `load_openssl` registers.
 #cfg(not(platform="windows"))
-fn create_bio(data : Transport) -> BIO raise {
-  load_openssl()
-  create_bio_ffi(data)
-}
+#owned(data)
+extern "C" fn create_bio(data : Transport) -> BIO = "moonbitlang_async_tls_create_bio"
 
 ///|
 #cfg(not(platform="windows"))
@@ -385,7 +336,7 @@ fn[R : @io.Reader, W : @io.Writer] Tls::from_pair(
   w : W,
   is_client~ : Bool,
   host~ : String?,
-) -> Tls raise {
+) -> Tls {
   let transport = Transport::new(r, w)
   let rbio = create_bio(transport)
   let wbio = create_bio(transport)
@@ -406,8 +357,8 @@ fn[R : @io.Reader, W : @io.Writer] Tls::from_pair(
 #cfg(not(platform="windows"))
 async fn SSL_CTX::client_with_custom_root(root_cert : String) -> SSL_CTX {
   let ctx = SSL_CTX::client(load_default_verify_path=false)
-  guard !ctx.is_null() else {
-    raise TlsError("failed to initialize SSL client context")
+  if ctx.is_null() {
+    return ctx
   }
   try {
     let pem = @fs.read_file(root_cert).text()
@@ -464,13 +415,17 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::client_from_pair(
   sni? : Bool = true,
   trust? : TrustedRoot,
 ) -> Tls {
+  load_openssl()
   let trust = match trust {
     Some(trust) => trust
     None => if verify { SystemRoot } else { NoVerification }
   }
   let ctx = match trust {
-    NoVerification | SystemRoot => client_ctx()
+    NoVerification | SystemRoot => client_ctx.force()
     CustomPemFile(root_cert) => SSL_CTX::client_with_custom_root(root_cert)
+  }
+  guard !ctx.is_null() else {
+    raise TlsError("failed to initialize SSL client context")
   }
   let self = Tls::from_pair(ctx, r, w, is_client=true, host~)
   try {
@@ -520,9 +475,14 @@ pub async fn[R : @io.Reader, W : @io.Writer] Tls::server_from_pair(
   certificate_file~ : String,
   certificate_type~ : X509FileType,
 ) -> Tls {
+  load_openssl()
   let private_key_file = @utf8.encode(private_key_file)
   let certificate_file = @utf8.encode(certificate_file)
-  let self = Tls::from_pair(server_ctx(), r, w, is_client=false, host=None)
+  let ctx = server_ctx.force()
+  guard !ctx.is_null() else {
+    raise TlsError("failed to initialize SSL server context")
+  }
+  let self = Tls::from_pair(ctx, r, w, is_client=false, host=None)
   try {
     if self.ssl.use_certificate_file(certificate_file, certificate_type) != 1 {
       raise TlsError(err_get_error())

--- a/src/tls/openssl_loader.mbt
+++ b/src/tls/openssl_loader.mbt
@@ -29,50 +29,36 @@ extern "C" fn init_bio_method(
 ) = "moonbitlang_async_init_bio_method"
 
 ///|
-/// `None` until the first load attempt; afterwards caches the outcome so a
-/// failed load fails fast on every subsequent call instead of retrying.
-#cfg(not(platform="windows"))
-let openssl_loaded : Ref[Result[Unit, Error]?] = Ref(None)
-
-///|
 /// Lazily load OpenSSL on first use, so a program that never touches TLS pays
 /// nothing. Every raw-symbol FFI wrapper calls this first; all other FFI runs on
 /// handles those produce, so it is transitively covered. The outcome is cached →
 /// success makes repeat calls free, failure re-raises the same error immediately.
 #cfg(not(platform="windows"))
-fn load_openssl() -> Unit raise {
-  match openssl_loaded.val {
-    Some(cached) => return cached.unwrap_or_error()
-    None => ()
-  }
-  let result = try {
-    load_openssl_unchecked()
-    Ok(())
-  } catch {
-    err => Err(err)
-  }
-  openssl_loaded.val = Some(result)
-  result.unwrap_or_error()
-}
-
-///|
-#cfg(not(platform="windows"))
-fn load_openssl_unchecked() -> Unit raise {
+let load_openssl_result : Lazy[Result[Unit, Error]] = Lazy(() => {
   let major = Ref(0)
   let minor = Ref(0)
   let fix = Ref(0)
   match load_openssl_ffi(major, minor, fix) {
     0 => ()
-    1 => raise TlsError("failed to load OpenSSL")
-    2 => raise TlsError("failed to get OpenSSL version")
+    1 => return Err(TlsError("failed to load OpenSSL"))
+    2 => return Err(TlsError("failed to get OpenSSL version"))
     3 =>
-      raise TlsError(
-        "unsupported OpenSSL version \{major.val}.\{minor.val}.\{fix.val}",
+      return Err(
+        TlsError(
+          "unsupported OpenSSL version \{major.val}.\{minor.val}.\{fix.val}",
+        ),
       )
-    4 => raise TlsError("failed to load some OpenSSL function")
+    4 => return Err(TlsError("failed to load some OpenSSL function"))
     _ => panic()
   }
   init_bio_method((bio, dst, len) => bio.read(dst, len)) <| ((bio, src, len) => {
     bio.write(src, len)
   })
+  Ok(())
+})
+
+///|
+#cfg(not(platform="windows"))
+fn load_openssl() -> Unit raise {
+  load_openssl_result.force().unwrap_or_error()
 }


### PR DESCRIPTION
Some time ago `moonbitlang/core` introduced a new type `Lazy` for lazily evaluated value, several places in `moonbitlang/async` can be simplified with this new type.