### PR TITLE
Enable stdio on wasm

### DIFF
--- a/src/internal/event_loop/moon.pkg
+++ b/src/internal/event_loop/moon.pkg
@@ -61,7 +61,7 @@ options(
     "process_unix.mbt": [ "native" ],
     "process_windows.mbt": [ "native" ],
     "signal.mbt": [ "native", "wasm" ],
-    "stdio.mbt": [ "native" ],
+    "stdio.mbt": [ "native", "wasm" ],
     "thread_pool.mbt": [ "native" ],
     "timer.mbt": [ "native", "wasm" ],
     "io.wasm.mbt": [ "wasm" ],

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -13,7 +13,13 @@
 // limitations under the License.
 
 ///|
+#cfg(target="native")
 extern "C" fn kind_of_fd_sync_ffi(fd : @fd_util.Fd) -> Int = "moonbitlang_async_kind_of_fd"
+
+///|
+#cfg(target="wasm")
+#unsafe_skip_stub_check
+fn kind_of_fd_sync_ffi(fd : @fd_util.Fd) -> Int = "moonbitlang/async" "fd_util/kind_of_fd"
 
 ///|
 fn kind_of_fd_sync(
@@ -28,7 +34,13 @@ fn kind_of_fd_sync(
 }
 
 ///|
+#cfg(target="native")
 extern "C" fn get_stdio_handle(id : Int) -> @fd_util.Fd = "moonbitlang_async_get_stdio_handle"
+
+///|
+#cfg(target="wasm")
+#unsafe_skip_stub_check
+fn get_stdio_handle(id : Int) -> @fd_util.Fd = "moonbitlang/async" "stdio/get_stdio_handle"
 
 ///|
 let stdio_handles : Map[@fd_util.Fd, IoHandle] = {}

--- a/src/stdio/moon.pkg
+++ b/src/stdio/moon.pkg
@@ -11,5 +11,8 @@ import {
 } for "test"
 
 options(
-  targets: { "stdio.mbt": [ "native" ], "stdio_test.mbt": [ "native" ] },
+  targets: {
+    "stdio.mbt": [ "native", "wasm" ],
+    "stdio_test.mbt": [ "native", "wasm" ],
+  },
 )

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 ///|
+#cfg(target="native")
 let cat : @async.Lazy[String] = @async.Lazy(() => {
   // Note: the `cat` example program lies in another MoonBit module.
   // Currently, dependencies of a module is built locally in that module,
@@ -27,6 +28,7 @@ let cat : @async.Lazy[String] = @async.Lazy(() => {
 })
 
 ///|
+#cfg(target="native")
 async test "redirect_file" {
   let cat = cat.wait()
   let out_file = "_build/stdio_file_test"
@@ -41,6 +43,7 @@ async test "redirect_file" {
 }
 
 ///|
+#cfg(target="native")
 async test "redirect pipe" {
   @async.with_task_group() <| root => {
     let cat = cat.wait()
@@ -69,6 +72,7 @@ async test "redirect pipe" {
 }
 
 ///|
+#cfg(target="native")
 async test "stdio cancel" {
   let cat = cat.wait()
   @async.with_task_group() <| group => {
@@ -101,6 +105,7 @@ async test "stdio cancel" {
 }
 
 ///|
+#cfg(target="native")
 async test "stdout and stderr are the same" {
   let cat = cat.wait()
   let (cat_read, we_write) = @process.write_to_process()
@@ -120,4 +125,12 @@ async test "stdout and stderr are the same" {
       ),
     )
   }
+}
+
+///|
+#cfg(target="wasm")
+async test "stdio handles are available on wasm" {
+  ignore(@stdio.stdin.fd())
+  ignore(@stdio.stdout.fd())
+  ignore(@stdio.stderr.fd())
 }


### PR DESCRIPTION
## Why

`moonbitlang/async/stdio` was still native-only, so wasm users could not access standard input, output, or error through the async IO abstractions.

## What

This enables the internal stdio event-loop setup and public `stdio` package on wasm, then adds a small handle-availability regression test.

## Why This Is Correct

The public `stdio` API stays unchanged. The shared stdio setup still takes logical standard stream ids (`0`, `1`, `2`) like the native implementation. Upstream now always routes stdio through the thread pool, so wasm only needs a target-specific `get_stdio_handle(id)` import and the existing fd-kind import.

## Scope

This is limited to wasm stdio package support. Native stdio behavior is unchanged.