### PR TITLE
always use thread pool for stdio channels

### DIFF
--- a/src/internal/event_loop/stdio.c
+++ b/src/internal/event_loop/stdio.c
@@ -28,20 +28,14 @@ typedef int HANDLE;
 #include <moonbit.h>
 
 MOONBIT_FFI_EXPORT
-HANDLE moonbitlang_async_get_stdio_handle(int32_t id, int32_t *is_async) {
+HANDLE moonbitlang_async_get_stdio_handle(int32_t id) {
 #ifdef _WIN32
 
-  *is_async = 0;
   // The value comes from https://learn.microsoft.com/en-us/windows/console/getstdhandle
   return GetStdHandle(-10 - id);
 
 #else // #ifdef _WIN32
 
-  int flags = fcntl(id, F_GETFL);
-  if (flags < 0)
-    return -1;
-
-  *is_async = (flags & O_NONBLOCK) != 0;
   return id;
 
 #endif // #ifndef _WIN32

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -28,16 +28,14 @@ fn kind_of_fd_sync(
 }
 
 ///|
-#borrow(is_async)
-extern "C" fn get_stdio_handle(id : Int, is_async~ : Ref[Bool]) -> @fd_util.Fd = "moonbitlang_async_get_stdio_handle"
+extern "C" fn get_stdio_handle(id : Int) -> @fd_util.Fd = "moonbitlang_async_get_stdio_handle"
 
 ///|
 let stdio_handles : Map[@fd_util.Fd, IoHandle] = {}
 
 ///|
 fn setup_stdio(id : Int, context~ : String) -> IoHandle raise {
-  let is_async = Ref(false)
-  let fd = get_stdio_handle(id, is_async~)
+  let fd = get_stdio_handle(id)
   if !@fd_util.fd_is_valid(fd) {
     @os_error.check_errno(context)
   }
@@ -51,7 +49,13 @@ fn setup_stdio(id : Int, context~ : String) -> IoHandle raise {
   let handle = {
     fd,
     kind,
-    is_async: is_async.val,
+    // Stdio channels may be shared between many different processes,
+    // and some (argubly misbehaving ones) of them may
+    // change the blocking/non-blocking status of stdio channels.
+    // So we play safe here and always use the thread pool for stdio channels.
+    // As a consequence, the thread pool need to handle non blocking fd as well,
+    // see the code for `read_job_worker`/`write_job_worker` in `thread_pool.c` for more details.
+    is_async: false,
     read: Idle,
     read_offset: if kind is Regular {
       0

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -49,6 +49,7 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 #include <sys/wait.h>
+#include <poll.h>
 
 #ifdef __linux__
 #include <sys/syscall.h>
@@ -620,7 +621,18 @@ void read_job_worker(struct job *job) {
 #else
 
   if (read_job->position < 0) {
-    job->ret = read(read_job->fd, read_job->buf + read_job->offset, read_job->len);
+    while (1) {
+      job->ret = read(read_job->fd, read_job->buf + read_job->offset, read_job->len);
+      if (job->ret >= 0)
+        break;
+
+      if (errno != EAGAIN && errno != EWOULDBLOCK)
+        break;
+
+      struct pollfd pfd = { read_job->fd, POLL_IN, 0 };
+      if (poll(&pfd, 1, -1) < 0)
+        break;
+    }
   } else {
     job->ret = pread(
       read_job->fd,
@@ -697,11 +709,22 @@ void write_job_worker(struct job *job) {
 #else
 
   if (write_job->position < 0) {
-    job->ret = write(
-      write_job->fd,
-      write_job->buf + write_job->offset,
-      write_job->len
-    );
+    while (1) {
+      job->ret = write(
+        write_job->fd,
+        write_job->buf + write_job->offset,
+        write_job->len
+      );
+      if (job->ret >= 0)
+        break;
+
+      if (errno != EAGAIN && errno != EWOULDBLOCK)
+        break;
+
+      struct pollfd pfd = { write_job->fd, POLL_OUT, 0 };
+      if (poll(&pfd, 1, -1) < 0)
+        break;
+    }
   } else {
     job->ret = pwrite(
       write_job->fd,


### PR DESCRIPTION
This PR refactors stdio handling on Linux/MacOS. Previously, the code detect if each stdio channel is non blocking on program startup, and use `epoll`/`kqueue` for stdio channels that are non blocking. However, since stdio channels are often shared by multiple processes, it is possible for the blocking/non-blocking status of stdio channels to change while the program is running. If a stdio channels unfortunately turned from non-blocking to blocking after the program started, handling it with `epoll`/`kqueue` will block the main thread and is hence unsafe.

In this PR, stdio channels are now unconditionally dispatched to the thread pool. `read_job_worker`/`write_job_worker` are modified so that they can handle non-blocking file descriptors as well: when `read`/`write` returns `EAGAIN` or `EWOULDBLOCK`, the thread pool job automatically use `poll` to wait for read/write readiness and retry again.