### PR TITLE
remove unnecessary `set_blocking` call

### DIFF
--- a/src/internal/fd_util/fd_util.mbt
+++ b/src/internal/fd_util/fd_util.mbt
@@ -31,18 +31,6 @@ pub fn fd_is_nonblocking(fd : Fd, context~ : String) -> Bool raise {
 
 ///|
 #cfg(not(platform="windows"))
-extern "C" fn set_blocking_ffi(fd : Fd) -> Int = "moonbitlang_async_set_blocking"
-
-///|
-#cfg(not(platform="windows"))
-pub fn set_blocking(fd : Fd, context~ : String) -> Unit raise {
-  if set_blocking_ffi(fd) < 0 {
-    @os_error.check_errno(context)
-  }
-}
-
-///|
-#cfg(not(platform="windows"))
 extern "C" fn set_nonblocking_ffi(fd : Fd) -> Int = "moonbitlang_async_set_nonblocking"
 
 ///|

--- a/src/internal/fd_util/pkg.generated.mbti
+++ b/src/internal/fd_util/pkg.generated.mbti
@@ -16,8 +16,6 @@ pub let invalid_fd : Int
 
 pub fn pipe(read_end_is_async~ : Bool, write_end_is_async~ : Bool, context~ : String) -> (Int, Int) raise
 
-pub fn set_blocking(Int, context~ : String) -> Unit raise
-
 pub fn set_cloexec(Int, context~ : String) -> Unit raise
 
 pub fn set_nonblocking(Int, context~ : String) -> Unit raise

--- a/src/process/unix.mbt
+++ b/src/process/unix.mbt
@@ -112,24 +112,15 @@ async fn raw_spawn(
     }
   }
   let stdin = match stdin {
-    Some(pipe) => {
-      @fd_util.set_blocking(pipe.fd(), context~)
-      pipe.fd()
-    }
+    Some(pipe) => pipe.fd()
     None => -1
   }
   let stdout = match stdout {
-    Some(pipe) => {
-      @fd_util.set_blocking(pipe.fd(), context~)
-      pipe.fd()
-    }
+    Some(pipe) => pipe.fd()
     None => -1
   }
   let stderr = match stderr {
-    Some(pipe) => {
-      @fd_util.set_blocking(pipe.fd(), context~)
-      pipe.fd()
-    }
+    Some(pipe) => pipe.fd()
     None => -1
   }
   let extra_count = extra_env.length()


### PR DESCRIPTION
Back in the old days, the main way to redirect process output is `@pipe.pipe()`. To avoid downstream child process from failing on a non-blocking fd, the process spawning code manually set every redirected channel to blocking mode before spawning. However, we have already shifted to more explicit redirection API, such as `read_from_process()` and `read_from_file` now. Fds created by these API are always blocking, so the manual set blocking is no longer necessary. When `@stdio.xxx` is passed to a process, the set blocking call is actually undesirable: we try to be nice and avoid touching state of stdio channels whenever possible. If the parent indeed give us a non blocking stdio channel and that crashes a child process, it is not our fault anyway.

This PR removes the `set_blocking` call for redirected stdio channels in Unix code for `@process`. After this, the whole `set_blocking` API become useless and can be removed.

One remaining case is using `@pipe.pipe()` for redirection, which is problematic on its own for various reasons, and will be deprecated soon-ish.