### PR TITLE
Move pipe nonblocking setup to runtime

### DIFF
--- a/src/internal/fd_util/fd_util.wasm.mbt
+++ b/src/internal/fd_util/fd_util.wasm.mbt
@@ -17,17 +17,6 @@ pub type Fd = @types.Fd
 
 ///|
 #unsafe_skip_stub_check
-fn set_nonblocking_ffi(fd : Fd) -> Int = "moonbitlang/async" "fd_util/set_nonblocking/unix"
-
-///|
-pub fn set_nonblocking(fd : Fd, context~ : String) -> Unit raise {
-  if set_nonblocking_ffi(fd) < 0 {
-    @os_error.check_errno(context)
-  }
-}
-
-///|
-#unsafe_skip_stub_check
 fn set_cloexec_ffi(fd : Fd) -> Int = "moonbitlang/async" "fd_util/set_cloexec"
 
 ///|

--- a/src/internal/fd_util/pipe.wasm.mbt
+++ b/src/internal/fd_util/pipe.wasm.mbt
@@ -13,20 +13,6 @@
 // limitations under the License.
 
 ///|
-priv enum Platform {
-  Linux = 0
-  MacOS = 1
-  Windows = 2
-}
-
-///|
-#unsafe_skip_stub_check
-fn get_platform() -> Platform = "moonbitlang/async" "runtime/get_platform"
-
-///|
-let platform : Platform = get_platform()
-
-///|
 #unsafe_skip_stub_check
 #borrow(fds)
 fn pipe_ffi(
@@ -45,22 +31,6 @@ pub fn pipe(
   let fds = FixedArray::make(2, invalid_fd)
   if pipe_ffi(fds, fds.length(), read_end_is_async, write_end_is_async) < 0 {
     @os_error.check_errno(context)
-  }
-  if !(platform is Windows) {
-    try {
-      if read_end_is_async {
-        set_nonblocking(fds[0], context~)
-      }
-      if write_end_is_async {
-        set_nonblocking(fds[1], context~)
-      }
-    } catch {
-      err => {
-        close(fds[0], kind=Pipe, context~)
-        close(fds[1], kind=Pipe, context~)
-        raise err
-      }
-    }
   }
   (fds[0], fds[1])
 }


### PR DESCRIPTION
## Why

Pipe async-end flags should be handled by the runtime side that creates the descriptors. Keeping the old MoonBit-side nonblocking path duplicates responsibility and keeps wasm pipe setup coupled to a platform check.

## What

- Remove the wasm `fd_util/set_nonblocking/unix` import and MoonBit helper from `fd_util`.
- Stop calling the old setter from `fd_util/pipe`.
- Keep passing read/write async flags to the runtime pipe import.

## Correctness

The runtime pipe import already receives both async-end flags before returning descriptors, so it can set descriptor mode at creation time. This leaves the wasm MoonBit code as a thin caller and avoids changing native async code.

## Scope

This branch is based on `main` and only changes the wasm fd-util pipe path. The moonrun counterpart keeps the old wasm import ABI as a no-op for older guests until the compatibility shim is removed later.
