### PR TITLE
fix several process bugs

### DIFF
--- a/src/internal/event_loop/process.c
+++ b/src/internal/event_loop/process.c
@@ -46,11 +46,8 @@ MOONBIT_FFI_EXPORT
 int moonbitlang_async_get_process_result(HANDLE handle, int32_t pid, int32_t *out) {
 #ifdef _WIN32
 
+  // On Windows, `get_process_result` should only be called when the process has exited.
   BOOL ret = GetExitCodeProcess(handle, out);
-  if (ret && *out == STILL_ACTIVE) {
-    SetLastError(ERROR_IO_PENDING);
-    return -1;
-  }
   return ret ? 0 : - 1;
 
 #else

--- a/src/internal/event_loop/process.c
+++ b/src/internal/event_loop/process.c
@@ -61,7 +61,7 @@ int moonbitlang_async_get_process_result(HANDLE handle, int32_t pid, int32_t *ou
   if (handle >= 0) {
     siginfo_t info;
     info.si_pid = 0;
-    int ret = waitid(P_PIDFD, handle, &info, WEXITED | WSTOPPED | WNOHANG);
+    int ret = waitid(P_PIDFD, handle, &info, WEXITED | WNOHANG);
 
     if (ret < 0)
       return -1;

--- a/src/process/wait_test.mbt
+++ b/src/process/wait_test.mbt
@@ -68,3 +68,18 @@ async test "wait_pid" {
     ),
   )
 }
+
+///|
+async test "wait exitcode STILL_ACTIVE" {
+  guard @event_loop.platform is Windows else {  }
+  // `259` is the special value for `STILL_ACTIVE`,
+  // wihch is returned by `GetExitCodeProcess` when the process is still running on Windows.
+  // However, 259 can also be a valid exit code,
+  // so we should not use it to determine whether the process has exited or not.
+  inspect(
+    @process.run(shell, ["-c", "exit 259"]),
+    content=(
+      #|259
+    ),
+  )
+}

--- a/src/process/windows.mbt
+++ b/src/process/windows.mbt
@@ -57,6 +57,10 @@ fn StringBuilder::write_arg_with_windows_escape(
   builder : StringBuilder,
   arg : StringView,
 ) -> Unit {
+  if arg is "" {
+    builder.write("\"\"")
+    return
+  }
   // Do not add double quotes if it is unnecessary to do so.
   // This help with simple cases when the program is not using C argv syntax,
   // such as `rundll32.exe`.
@@ -80,8 +84,8 @@ fn StringBuilder::write_arg_with_windows_escape(
       if trailing_backslash > 0 {
         builder.write_string(String::make(trailing_backslash * 2, '\\'))
       }
-      segment_start = index + skip
     }
+    segment_start = index + skip
   }
 
   builder.write_char('"')

--- a/src/process/windows_escape_wbtest.mbt
+++ b/src/process/windows_escape_wbtest.mbt
@@ -70,3 +70,28 @@ test "windows command line arg escape" {
     ),
   )
 }
+
+///|
+#cfg(platform="windows")
+test "windows command line arg escape empty" {
+  let test_str = ""
+  inspect(
+    test_arg(test_str),
+    content=(
+      #|""
+    ),
+  )
+}
+
+///|
+#cfg(platform="windows")
+test "windows command line arg escape leading quote" {
+  let test_str =
+    #|"abcd
+  inspect(
+    test_arg(test_str),
+    content=(
+      #|"\"abcd"
+    ),
+  )
+}


### PR DESCRIPTION
Fix several process related bugs discovered in #442:

- should not pass `WSTOPPED` to `waitid`
- two incorrect cases in Windows command line argument escaping
- should not treat `STILL_ACTIVE` output specially with `GetExitCodeProcess`. The Windows path already guarantee the process has terminated before calling `get_process_result`