### PR TITLE
perf(fs): read regular files using a size hint

### DIFF
--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -466,6 +466,92 @@ pub async fn File::ctime(self : File) -> (Int64, Int) {
 }
 
 ///|
+/// Read a regular file using its current size as an allocation hint.
+///
+/// The size is not treated as EOF: pseudo files such as procfs entries may
+/// report a size of zero, and a regular file may grow while it is being read.
+/// Once the hinted region is full, keep reading in larger chunks until the
+/// underlying file actually reports EOF.
+async fn[R : @io.Reader] read_all_with_size_hint(
+  reader : R,
+  hinted_size : Int,
+) -> &@io.Data {
+  let hinted = FixedArray::make(hinted_size, b'0')
+  let mut hinted_len = 0
+  while hinted_len < hinted_size {
+    let n = reader.read(
+      hinted,
+      offset=hinted_len,
+      max_len=hinted_size - hinted_len,
+    )
+    if n == 0 {
+      return hinted.unsafe_reinterpret_as_bytes()[:hinted_len].to_owned()
+    }
+    hinted_len += n
+  }
+
+  // The size returned by stat is only a hint. Probe for a real EOF without
+  // allocating a large tail buffer in the common case.
+  let probe = FixedArray::make(1, b'0')
+  let probe_len = reader.read(probe, offset=0, max_len=1)
+  if probe_len == 0 {
+    return hinted.unsafe_reinterpret_as_bytes()
+  }
+
+  // Retain data appended after the stat call, as well as data from zero-sized
+  // pseudo files such as entries in procfs.
+  let chunk_size = 64 * 1024
+  let chunks = []
+  let mut chunk = FixedArray::make(chunk_size, b'0')
+  chunk.unsafe_blit(0, probe, 0, probe_len)
+  let mut chunk_len = probe_len
+  while reader.read(chunk, offset=chunk_len, max_len=chunk.length() - chunk_len)
+        is n &&
+        n > 0 {
+    chunk_len += n
+    if chunk_len == chunk.length() {
+      chunks.push(chunk)
+      chunk = FixedArray::make(chunk_size, b'0')
+      chunk_len = 0
+    }
+  }
+  let tail_size = chunks.length().to_int64() * chunk_size.to_int64() +
+    chunk_len.to_int64()
+  guard hinted_size.to_int64() <= @int.MAX_VALUE.to_int64() - tail_size else {
+    raise Failure::Failure("@fs.read_file(): file is too large")
+  }
+  let total_size = hinted_size + tail_size.to_int()
+  let result = FixedArray::make(total_size, b'0')
+  result.unsafe_blit(0, hinted, 0, hinted_size)
+  for i, buf in chunks {
+    result.unsafe_blit(hinted_size + i * chunk_size, buf, 0, chunk_size)
+  }
+  result.unsafe_blit(
+    hinted_size + chunks.length() * chunk_size,
+    chunk,
+    0,
+    chunk_len,
+  )
+  result.unsafe_reinterpret_as_bytes()
+}
+
+///|
+async fn File::read_regular_to_end(self : File) -> &@io.Data {
+  let size = self.size() catch {
+    err if @async.is_being_cancelled() => raise err
+    // A size is only an optimization hint. Some handles may be classified as
+    // regular but not support querying a size, so preserve the streaming path.
+    @os_error.OSError(_) => return self.read_all()
+    err => raise err
+  }
+  guard size >= 0L && size <= @int.MAX_VALUE.to_int64() else {
+    return self.read_all()
+  }
+  @coroutine.check_cancellation()
+  read_all_with_size_hint(self, size.to_int())
+}
+
+///|
 /// Read the contents of the file located at `path`.
 /// If `sync_timestamp` is `true` (`false` by default),
 /// `read_file` will block until timestamp change is written to the file system.
@@ -475,7 +561,11 @@ pub async fn read_file(
 ) -> &@io.Data {
   let file = open(path, mode=ReadOnly)
   defer file.close()
-  let result = file.read_all()
+  let result = if file.kind() is Regular {
+    file.read_regular_to_end()
+  } else {
+    file.read_all()
+  }
   if sync_timestamp {
     file.io.fsync(only_data=false, context="@fs.read_file(sync_timestamp=true)")
   }

--- a/src/fs/moon.pkg
+++ b/src/fs/moon.pkg
@@ -51,6 +51,7 @@ options(
     "pkg.generated.mbti": [ "native" ],
     "random_access_test.mbt": [ "native", "wasm" ],
     "read_all_test.mbt": [ "native", "wasm" ],
+    "read_file_wbtest.mbt": [ "native", "wasm" ],
     "realpath_test.mbt": [ "native" ],
     "rename_test.mbt": [ "native", "wasm" ],
     "stat_test.mbt": [ "native" ],

--- a/src/fs/read_file_wbtest.mbt
+++ b/src/fs/read_file_wbtest.mbt
@@ -1,0 +1,156 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+struct ChunkedReader {
+  data : FixedArray[Byte]
+  chunks : Array[Int]
+  buffer : @io.ReaderBuffer
+  mut offset : Int
+  mut chunk_index : Int
+}
+
+///|
+fn ChunkedReader::new(size : Int, chunks : Array[Int]) -> ChunkedReader {
+  {
+    data: FixedArray::make(size, b'x'),
+    chunks,
+    buffer: @io.ReaderBuffer::new(),
+    offset: 0,
+    chunk_index: 0,
+  }
+}
+
+///|
+impl @io.Reader for ChunkedReader with fn _get_internal_buffer(self) {
+  self.buffer
+}
+
+///|
+impl @io.Reader for ChunkedReader with fn _direct_read(
+  self,
+  dst,
+  offset~,
+  max_len~,
+) {
+  guard self.offset < self.data.length() else { return 0 }
+  let requested = if self.chunk_index < self.chunks.length() {
+    let requested = self.chunks[self.chunk_index]
+    self.chunk_index += 1
+    requested
+  } else {
+    max_len
+  }
+  let n = @cmp.minimum(
+    max_len,
+    @cmp.minimum(requested, self.data.length() - self.offset),
+  )
+  dst.unsafe_blit(offset, self.data, self.offset, n)
+  self.offset += n
+  n
+}
+
+///|
+async test "read_file size hint handles short reads" {
+  let reader = ChunkedReader::new(10, [1, 2, 3, 4])
+  assert_eq(read_all_with_size_hint(reader, 10).binary(), Bytes::make(10, b'x'))
+}
+
+///|
+async test "read_file size hint handles an early EOF" {
+  let reader = ChunkedReader::new(5, [2, 2, 1])
+  assert_eq(read_all_with_size_hint(reader, 10).binary(), Bytes::make(5, b'x'))
+}
+
+///|
+async test "read_file size hint retains data beyond the hint" {
+  let reader = ChunkedReader::new(10, [2, 2, 3, 3])
+  assert_eq(read_all_with_size_hint(reader, 4).binary(), Bytes::make(10, b'x'))
+}
+
+///|
+async test "read_file size hint of zero still reads to EOF" {
+  let reader = ChunkedReader::new(10, [3, 3, 4])
+  assert_eq(read_all_with_size_hint(reader, 0).binary(), Bytes::make(10, b'x'))
+}
+
+///|
+async test "read_file regular file size boundaries" {
+  for size in [0, 1, 1023, 1024, 1025, 64 * 1024 + 1] {
+    let path = "_build/read_file_regular_\{size}"
+    let expected = Bytes::make(size, b'x')
+    write_file(path, expected, create_mode=CreateOrTruncate, sync=NoSync)
+    let actual = read_file(path).binary()
+    remove(path)
+    assert_eq(actual, expected)
+  }
+}
+
+///|
+#cfg(all(target="native", platform="linux"))
+async test "read_file reads a zero-sized procfs regular file" {
+  let path = "/proc/self/cmdline"
+  let file = open(path, mode=ReadOnly)
+  assert_eq(file.kind(), Regular)
+  assert_eq(file.size(), 0L)
+  file.close()
+  assert_true(read_file(path).binary().length() > 0)
+}
+
+///|
+#cfg(all(target="native", not(platform="windows")))
+#borrow(path)
+extern "C" fn make_read_file_fifo(
+  path : @os_string.OsString,
+  mode : Int,
+) -> Int = "mkfifo"
+
+///|
+#cfg(all(target="native", not(platform="windows")))
+async test "read_file falls back for a fifo" {
+  @async.with_task_group() <| group => {
+    let path = "_build/read_file_fifo"
+    if make_read_file_fifo(@os_string.encode(path), 0o600) < 0 {
+      @os_error.check_errno("read_file fifo test")
+    }
+    group.add_defer(() => remove(path))
+    let read_task = group.spawn(() => read_file(path).binary())
+    let writer = open(path, mode=WriteOnly)
+    writer.write(b"abcd")
+    writer.close()
+    assert_eq(read_task.wait(), b"abcd")
+  }
+}
+
+///|
+#cfg(all(target="native", platform="windows"))
+async test "read_file falls back for a Windows named pipe" {
+  @async.with_task_group() <| group => {
+    let context = "read_file named pipe test"
+    let path = "\\\\.\\pipe\\moonbitlang_async_read_file_test"
+    let server = @fd_util.create_named_pipe_server(
+      @os_string.encode(path),
+      is_async=true,
+    )
+    if !@fd_util.fd_is_valid(server) {
+      @os_error.check_errno(context)
+    }
+    let read_task = group.spawn(() => read_file(path).binary())
+    @async.sleep(200)
+    let writer = @event_loop.IoHandle::from_fd(server, kind=@fd_util.Pipe)
+    ignore(writer.write(b"abcd", offset=0, len=4, context~))
+    writer.close()
+    assert_eq(read_task.wait(), b"abcd")
+  }
+}


### PR DESCRIPTION
## Motivation

`@fs.read_file` currently delegates to the generic `Reader::read_all`, which reads into fixed 1 KiB buffers. Regular files use worker-backed `pread`/`ReadFile`, so a 16 KiB file needs 16 data jobs plus an EOF job, with a coroutine suspend/resume and worker wakeup for every chunk.

This restores a regular-file fast path at the narrower `read_file` boundary, where the file is newly opened, its reader buffer is empty, and its cursor is known to be zero.

## Implementation

- Query `File::size()` only for handles classified as `Regular`.
- Treat the size as an allocation hint, not as EOF.
- Fill the hinted buffer in a loop so positive short reads are handled correctly.
- Return the actual prefix if the file shrinks before it is read.
- Perform a one-byte EOF probe after filling the hint.
- If the file grew, or a pseudo file reports size zero, retain the probe and continue in 64 KiB chunks until real EOF.
- Fall back to the existing streaming `read_all` path for non-regular files, out-of-range sizes, and handles that do not support size queries.
- Check sticky cancellation before allocating the size-derived buffer.

No public API or thread-pool ownership model changes.

## Benchmark

Linux x86_64, native debug test executable, warm page cache and warm builds. The test reads the same 16 KiB regular file 1,000 times; hyperfine used 2 warmups and 10 measured runs.

| implementation | mean |
| --- | ---: |
| current `main` | 208.4 ms ± 4.2 ms |
| this PR | 69.9 ms ± 2.2 ms |

This is **2.98× faster** in the microbenchmark. For a stable 16 KiB file the worker-job count falls from 18 (`open + 16 reads + EOF`) to 4 (`open + size + bulk read + EOF probe`).

## Notes

This PR intentionally keeps the extra `File::size()` worker job. The open job already obtains stat data, but exposing that size would require expanding the native and Wasm host interfaces. If the constant extra job remains material after integration profiling, that can be a separate follow-up.
