### PR TITLE
improve `read_all` performance

### DIFF
--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -208,6 +208,36 @@ pub impl @io.Reader for File with fn _get_internal_buffer(self) {
 }
 
 ///|
+pub impl @io.Reader for File with fn read_all(self) {
+  guard self.io.kind() is Regular else { @io.read_all(self) }
+  let size = (self.size() - self.io.read_offset) catch {
+    _ => return @io.read_all(self)
+  }
+  guard size > 0 && size < @int.MAX_VALUE.to_int64() else { @io.read_all(self) }
+  let size_hint = size.to_int()
+  let buf = FixedArray::make(size_hint, b'\x00')
+  let n = self.read(buf, offset=0, max_len=size_hint)
+  if n is 0 {
+    return b""
+  }
+  // The only reliable way to detect EOF is `read` returning `0`,
+  // even for regular files. So do a simple EOF probe here.
+  let eof_probe = FixedArray::make(1, b'\x00')
+  if self.read(eof_probe, offset=0, max_len=1) is 0 {
+    // happy path, the file size is accurate
+    return buf.unsafe_reinterpret_as_bytes()[:n].to_owned()
+  }
+  @io.read_all(
+    self,
+    prefix_list=[
+      buf.unsafe_reinterpret_as_bytes()[:n],
+      eof_probe.unsafe_reinterpret_as_bytes(),
+    ],
+    chunk_size=1 << 16, // 64k
+  )
+}
+
+///|
 /// Read from a file at the offset given by `position`.
 /// Only seekable files (e.g. regular files and block devices) support this operation,
 /// calling `read_at` on unsupported file, such as pipe or socket, result in error.

--- a/src/internal/event_loop/io.mbt
+++ b/src/internal/event_loop/io.mbt
@@ -24,14 +24,14 @@ priv enum IoStatus {
 ///|
 /// A managed file descriptor/`HANDLE`,
 /// capable of performing async IO operations.
-struct IoHandle {
-  mut fd : @fd_util.Fd
-  kind : @fd_util.FileKind
+pub struct IoHandle {
+  priv mut fd : @fd_util.Fd
+  priv kind : @fd_util.FileKind
   /// - `is_async=true`: support native async operations through the event bus.
   ///   This usually means the fd is non blocking (Unix) or overlapped (Windows)
   /// - `is_async=false`: all operations are blocking and go through the thread pool
-  is_async : Bool
-  mut read : IoStatus
+  priv is_async : Bool
+  priv mut read : IoStatus
   /// The current offset for reading.
   /// A negative value indicates that the underlying object does not support random access.
   ///
@@ -41,7 +41,7 @@ struct IoHandle {
   /// - On Unix-like systems, read/write share the same file pointer.
   /// - On Windows, random access read/write will change the file pointer for synchronous handle.
   mut read_offset : Int64
-  mut write : IoStatus
+  priv mut write : IoStatus
   /// Similar to `read_offset`, but for the write end of the object.
   mut write_offset : Int64
 }

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -90,7 +90,11 @@ pub(all) struct FileIdentity {
   file_id : UInt64
 } derive(Eq, Hash)
 
-type IoHandle
+pub struct IoHandle {
+  mut read_offset : Int64
+  mut write_offset : Int64
+  // private fields
+}
 pub async fn IoHandle::accept_unix(Self, Bytes, context~ : String) -> Self
 pub async fn IoHandle::bind(Self, Bytes, context~ : String) -> Unit
 pub fn IoHandle::close(Self) -> Unit

--- a/src/io/moon.pkg
+++ b/src/io/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/int",
   "moonbitlang/async/internal/coroutine",
   "moonbitlang/async/internal/io_buffer",
 }

--- a/src/io/reader.mbt
+++ b/src/io/reader.mbt
@@ -144,6 +144,7 @@ impl Reader with fn read_some(self, max_len?) {
 #doc(hidden)
 pub async fn[R : Reader] read_all(
   reader : R,
+  prefix_list? : FixedArray[BytesView] = [],
   chunk_size? : Int = 4096,
 ) -> Bytes {
   let buffer_list = []
@@ -158,15 +159,28 @@ pub async fn[R : Reader] read_all(
       offset = 0
     }
   }
-  if buffer_list.length() >= (@int.MAX_VALUE - offset) / chunk_size {
+  let prefix_len = for prefix in prefix_list; len = 0 {
+    continue len + prefix.length()
+  } nobreak {
+    len
+  }
+  if buffer_list.length() >= (@int.MAX_VALUE - offset - prefix_len) / chunk_size {
     raise Failure::Failure("@io.read_all(): data length exceed range of `Int`")
   }
-  let total_size = buffer_list.length() * chunk_size + offset
+  let total_size = prefix_len + buffer_list.length() * chunk_size + offset
   let result = FixedArray::make(total_size, b'0')
-  for i, buf in buffer_list {
-    result.unsafe_blit(i * chunk_size, buf, 0, chunk_size)
+  for prefix in prefix_list; len = 0; len = len + prefix.length() {
+    result.blit_from_bytesview(0, prefix)
   }
-  result.unsafe_blit(buffer_list.length() * chunk_size, buffer, 0, offset)
+  for i, buf in buffer_list {
+    result.unsafe_blit(prefix_len + i * chunk_size, buf, 0, chunk_size)
+  }
+  result.unsafe_blit(
+    prefix_len + buffer_list.length() * chunk_size,
+    buffer,
+    0,
+    offset,
+  )
   result.unsafe_reinterpret_as_bytes()
 }
 

--- a/src/io/reader.mbt
+++ b/src/io/reader.mbt
@@ -158,6 +158,9 @@ pub async fn[R : Reader] read_all(
       offset = 0
     }
   }
+  if buffer_list.length() >= (@int.MAX_VALUE - offset) / chunk_size {
+    raise Failure::Failure("@io.read_all(): data length exceed range of `Int`")
+  }
   let total_size = buffer_list.length() * chunk_size + offset
   let result = FixedArray::make(total_size, b'0')
   for i, buf in buffer_list {

--- a/src/io/reader.mbt
+++ b/src/io/reader.mbt
@@ -140,29 +140,39 @@ impl Reader with fn read_some(self, max_len?) {
 }
 
 ///|
-/// Read all remaining content from the reader.
-/// The return value is a `&io.Data` object, which can be converted to different formats
-/// using `.binary()`, `.text()` or `.json()`.
-impl Reader with fn read_all(self) {
+#internal(internal, "for internal use only")
+#doc(hidden)
+pub async fn[R : Reader] read_all(
+  reader : R,
+  chunk_size? : Int = 4096,
+) -> Bytes {
   let buffer_list = []
-  let mut buffer = FixedArray::make(1024, b'0')
+  let mut buffer = FixedArray::make(chunk_size, b'\x00')
   let mut offset = 0
-  while self.read(buffer, offset~, max_len=buffer.length() - offset) is n &&
+  while reader.read(buffer, offset~, max_len=buffer.length() - offset) is n &&
         n > 0 {
     offset += n
     if offset == buffer.length() {
       buffer_list.push(buffer)
-      buffer = FixedArray::make(1024, b'0')
+      buffer = FixedArray::make(chunk_size, b'0')
       offset = 0
     }
   }
-  let total_size = buffer_list.length() * 1024 + offset
+  let total_size = buffer_list.length() * chunk_size + offset
   let result = FixedArray::make(total_size, b'0')
   for i, buf in buffer_list {
-    result.unsafe_blit(i * 1024, buf, 0, 1024)
+    result.unsafe_blit(i * chunk_size, buf, 0, chunk_size)
   }
-  result.unsafe_blit(buffer_list.length() * 1024, buffer, 0, offset)
+  result.unsafe_blit(buffer_list.length() * chunk_size, buffer, 0, offset)
   result.unsafe_reinterpret_as_bytes()
+}
+
+///|
+/// Read all remaining content from the reader.
+/// The return value is a `&io.Data` object, which can be converted to different formats
+/// using `.binary()`, `.text()` or `.json()`.
+impl Reader with fn read_all(self) {
+  read_all(self)
 }
 
 ///|


### PR DESCRIPTION
This PR is a slight refactor of #495. Compared to #495:

- instead of repeating the logic for chunked `read_all`, a separated helper `@io.read_all` is introduced, with configurable chunk size and a optional list of prefix to be prepended to the result
- add size overflow check for the generic `@io.read_all`
- the default chunk size for all readers is increased to 4k
- for `@fs.File`, the optimization in #495 is performed on `@fs.File::read_all` directly, instead of only for `@fs.read_file`. Note that `.read_all()` may be called at somewhere middle in the file, so the current read offset of the file need to be subtracted