### PR TITLE
fix(js): keep scheduling rounds after Promise::from_async

### DIFF
--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -215,6 +215,6 @@ pub fn[X] Promise::from_async(
       signal.on_abort(() => coro.cancel())
     }
   })
-  @coroutine.reschedule()
+  @event_loop.reschedule()
   promise.cast()
 }


### PR DESCRIPTION
## Problem

`Promise::from_async` ends with `@coroutine.reschedule()`, which runs one round of the coroutines that are ready at entry and never schedules a follow-up. When `from_async` is the only thing driving the event loop (e.g. MoonBit async code exported to a JS host such as Cloudflare Workers), coroutines that become ready during that round are stranded in `run_later` and the returned promise never settles. Every other JS entry point into the scheduler (`Promise::wait` resolve/reject callbacks, timers) goes through `@event_loop.reschedule()`, which chains a `set_timeout(0, reschedule)` round while immediately-ready tasks remain.

## Fix

Replace the `@coroutine.reschedule()` call at the end of `from_async` with `@event_loop.reschedule()`, so it re-enters the scheduler the same way the other JS entry points do. `js_async` already imports `internal/event_loop`.

## Testing

Verified on workerd (`wrangler dev`) with a Cloudflare Worker that dispatches Discord interactions through `from_async`: previously requests deterministically alternated between hanging (cancelled by workerd with "code had hung and would never generate a response") and succeeding, because each request's leftover coroutines were driven to completion by the next request's scheduler entry. With this fix every request succeeds. `moon test --target js` passes 263/263, and the changed file is `js`-target-only, so other backends are unaffected.

I wasn't able to reproduce this inside `moon test`, where the test runner already drives the event loop. If there's a good way to write a regression test for this, I'd be happy to add one.
