### PR TITLE
block `SIGUSR2` in `sigwait_job_worker`

### DIFF
--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -2661,24 +2661,34 @@ static
 void sigwait_job_worker(struct job *job) {
   struct sigwait_job *sigwait_job = (struct sigwait_job*)job;
 
+  // Block all signals for the `sigwait` job.
+  // Cancellation is performed via `SIGUSR2`, which is in the wait set.
+  sigset_t all_signals, prev_mask;
+  sigfillset(&all_signals);
+  pthread_sigmask(SIG_SETMASK, &all_signals, &prev_mask);
+
   siginfo_t info;
   while (1) {
     int sig;
     int err = sigwait(&sigwait_job->signals, &sig);
     if (err > 0) {
       job->err = err;
-      return;
+      goto cleanup;
     }
 
     if (sig == SIGUSR2)
-      break;
+      goto cleanup;
 
     sig |= 1 << 31;
     do {
       if (write(pool.notify_send, &sig, sizeof(int)) > 0)
-        break;
+        goto cleanup;
     } while (errno == EINTR);
   }
+
+cleanup:
+  // Restore the mask of the worker thread, in case it get reused
+  pthread_sigmask(SIG_SETMASK, &prev_mask, 0);
 }
 
 MOONBIT_FFI_EXPORT


### PR DESCRIPTION
`sigwait_job_worker` forgot to block `SIGUSR2`, which is used for cancellation of the sigwait job itself. Cancellation should be performed by adding `SIGUSR2` into the wait set for `sigwait_job`, unlike most other jobs. So `SIGUSR2` should be blocked in the worker thread while running `sigwait_job`.