### PR TITLE
fix MacOS false signal report

### DIFF
--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -2669,7 +2669,8 @@ void sigwait_job_worker(struct job *job) {
 
   siginfo_t info;
   while (1) {
-    int sig;
+    int sig = 0;
+    errno = 0;
     int err = sigwait(&sigwait_job->signals, &sig);
     if (err > 0) {
       job->err = err;
@@ -2678,6 +2679,19 @@ void sigwait_job_worker(struct job *job) {
 
     if (sig == SIGUSR2)
       goto cleanup;
+
+    // It seems that on MacOS, it is possible for `sigwait` to
+    // silently return `0` without returning a signal,
+    // and set `errno` to `EINTR`.
+    // Handle this case here by retrying.
+    if (sig == 0) {
+      if (errno == EINTR || !errno) {
+        continue;
+      } else {
+        job->err = errno;
+        goto cleanup;
+      }
+    }
 
     sig |= 1 << 31;
     do {


### PR DESCRIPTION
It seems that on MacOS, `sigwait` may silently return `0` (success) without setting the signal value, while setting `errno` to `EINTR`. This is obviously not compliant behavior, but it happens. This PR let the `sigwait` job detect this case and retry automatically.