### PR TITLE
align signal handling code for native/wasm

### DIFF
--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -9,15 +9,9 @@ import {
 }
 
 // Values
-pub let _SIGBREAK : Int
-
-pub let _SIGHUP : Int
-
-pub let _SIGINT : Int
-
-pub let _SIGTERM : Int
-
 pub async fn access(StringView, Access, context~ : String) -> Int
+
+pub let all_signals : ReadOnlyArray[Int]
 
 pub let check_fd_leak : @ref.Ref[Bool]
 

--- a/src/internal/event_loop/signal.c
+++ b/src/internal/event_loop/signal.c
@@ -28,18 +28,22 @@
 
 #endif
 
+enum SignalCode {
+  SIGINT_CODE = 0,
+  SIGTERM_CODE = 1,
+  SIGHUP_CODE = 2,
+  SIGBREAK_CODE = 3
+};
+
 #ifdef _WIN32
 
 MOONBIT_FFI_EXPORT
-int moonbitlang_async_get_signal_by_name(const char *name) {
-  if (0 == strcmp(name, "SIGINT")) {
-    return CTRL_C_EVENT;
-  } else if (0 == strcmp(name, "SIGBREAK")) {
-    return CTRL_BREAK_EVENT;
-  } else if (0 == strcmp(name, "SIGHUP")) {
-    return CTRL_CLOSE_EVENT;
-  } else {
-    return -1;
+int moonbitlang_async_get_signal_by_index(int32_t code) {
+  switch (code) {
+    case SIGINT_CODE: return CTRL_C_EVENT;
+    case SIGBREAK_CODE: return CTRL_BREAK_EVENT;
+    case SIGHUP_CODE: return CTRL_CLOSE_EVENT;
+    default: return -1;
   }
 }
 
@@ -54,9 +58,14 @@ extern int interested_console_ctrl_event;
 BOOL WINAPI moonbitlang_async_console_control_handler(DWORD ctrl_type);
 
 MOONBIT_FFI_EXPORT
-void moonbitlang_async_set_global_cancellation_signals(int *all_signals, int *signals) {
+void moonbitlang_async_set_global_cancellation_signals(
+  int32_t *all_signals,
+  int32_t all_signals_length,
+  int32_t *signals,
+  int32_t signals_length
+) {
   int new_mask = 0;
-  for (int i = 0; i < Moonbit_array_length(signals); ++i) {
+  for (int i = 0; i < signals_length; ++i) {
     if (signals[i] < 0) continue;
     new_mask |= 1 << signals[i];
   }
@@ -71,27 +80,29 @@ int moonbitlang_async_set_console_control_handler(int32_t add) {
 #else // #ifdef _WIN32
 
 MOONBIT_FFI_EXPORT
-int moonbitlang_async_get_signal_by_name(const char *name) {
-  if (0 == strcmp(name, "SIGINT")) {
-    return SIGINT;
-  } else if (0 == strcmp(name, "SIGTERM")) {
-    return SIGTERM;
-  } else if (0 == strcmp(name, "SIGHUP")) {
-    return SIGHUP;
-  } else {
-    return -1;
+int moonbitlang_async_get_signal_by_index(int32_t code) {
+  switch (code) {
+    case SIGINT_CODE: return SIGINT;
+    case SIGTERM_CODE: return SIGTERM;
+    case SIGHUP_CODE: return SIGHUP;
+    default: return -1;
   }
 }
 
 MOONBIT_FFI_EXPORT
-void moonbitlang_async_set_global_cancellation_signals(int *all_signals, int *signals) {
+void moonbitlang_async_set_global_cancellation_signals(
+  int32_t *all_signals,
+  int32_t all_signals_length,
+  int32_t *signals,
+  int32_t signals_length
+) {
   sigset_t set;
   pthread_sigmask(SIG_SETMASK, 0, &set);
-  for (int i = 0; i < Moonbit_array_length(all_signals); ++i) {
+  for (int i = 0; i < all_signals_length; ++i) {
     if (all_signals[i] < 0) continue;
     sigdelset(&set, all_signals[i]);
   }
-  for (int i = 0; i < Moonbit_array_length(signals); ++i) {
+  for (int i = 0; i < signals_length; ++i) {
     if (signals[i] < 0) continue;
     sigaddset(&set, signals[i]);
   }

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -14,8 +14,7 @@
 
 ///|
 #cfg(target="native")
-#borrow(name)
-extern "C" fn get_signal_by_name(name : Bytes) -> Int = "moonbitlang_async_get_signal_by_name"
+extern "C" fn get_signal_by_index(index : Int) -> Int = "moonbitlang_async_get_signal_by_index"
 
 ///|
 #cfg(target="wasm")
@@ -23,55 +22,9 @@ extern "C" fn get_signal_by_name(name : Bytes) -> Int = "moonbitlang_async_get_s
 fn get_signal_by_index(index : Int) -> Int = "moonbitlang/async" "signal/get_signal_by_index"
 
 ///|
-#cfg(target="wasm")
-let sigint_index : Int = 0
-
-///|
-#cfg(target="wasm")
-let sigterm_index : Int = 1
-
-///|
-#cfg(target="wasm")
-let sighup_index : Int = 2
-
-///|
-#cfg(target="wasm")
-let sigbreak_index : Int = 3
-
-///|
-#cfg(target="native")
-pub let _SIGINT : Int = get_signal_by_name(b"SIGINT")
-
-///|
-#cfg(target="wasm")
-pub let _SIGINT : Int = get_signal_by_index(sigint_index)
-
-///|
-#cfg(target="native")
-pub let _SIGTERM : Int = get_signal_by_name(b"SIGTERM")
-
-///|
-#cfg(target="wasm")
-pub let _SIGTERM : Int = get_signal_by_index(sigterm_index)
-
-///|
-#cfg(target="native")
-pub let _SIGHUP : Int = get_signal_by_name(b"SIGHUP")
-
-///|
-#cfg(target="wasm")
-pub let _SIGHUP : Int = get_signal_by_index(sighup_index)
-
-///|
-#cfg(target="native")
-pub let _SIGBREAK : Int = get_signal_by_name(b"SIGBREAK")
-
-///|
-#cfg(target="wasm")
-pub let _SIGBREAK : Int = get_signal_by_index(sigbreak_index)
-
-///|
-let all_signals : ReadOnlyArray[Int] = [_SIGINT, _SIGTERM, _SIGHUP, _SIGBREAK]
+pub let all_signals : ReadOnlyArray[Int] = ReadOnlyArray::makei(
+  4, get_signal_by_index,
+)
 
 ///|
 pub suberror KilledBySignal {
@@ -83,7 +36,9 @@ pub suberror KilledBySignal {
 #borrow(all_signals, signals)
 extern "C" fn set_global_cancellation_signals_ffi(
   all_signals : ReadOnlyArray[Int],
+  all_signals_len : Int,
   signals : ReadOnlyArray[Int],
+  signals_len : Int,
 ) -> Unit = "moonbitlang_async_set_global_cancellation_signals"
 
 ///|
@@ -101,14 +56,6 @@ fn set_global_cancellation_signals_ffi(
 let global_signal_handler_initialized : Ref[Bool] = Ref(false)
 
 ///|
-#cfg(target="native")
-pub fn set_global_cancellation_signals(signals : ReadOnlyArray[Int]) -> Unit {
-  global_signal_handler_initialized.val = true
-  set_global_cancellation_signals_ffi(all_signals, signals)
-}
-
-///|
-#cfg(target="wasm")
 pub fn set_global_cancellation_signals(signals : ReadOnlyArray[Int]) -> Unit {
   global_signal_handler_initialized.val = true
   set_global_cancellation_signals_ffi(
@@ -120,8 +67,15 @@ pub fn set_global_cancellation_signals(signals : ReadOnlyArray[Int]) -> Unit {
 }
 
 ///|
+#warnings("-unused_constructor")
+priv enum SignalHandler {
+  SigwaitHandler(@coroutine.Coroutine)
+  ConsoleControlHandler
+}
+
+///|
 #cfg(not(platform="windows"))
-fn setup_sigwait_signal_handler() -> @coroutine.Coroutine {
+fn setup_signal_handler_unix() -> @coroutine.Coroutine {
   if !global_signal_handler_initialized.val {
     set_global_cancellation_signals(all_signals)
   }
@@ -139,7 +93,7 @@ fn setup_sigwait_signal_handler() -> @coroutine.Coroutine {
 
 ///|
 #cfg(not(platform="windows"))
-async fn EventLoop::terminate_sigwait_signal_handler(
+async fn EventLoop::terminate_signal_handler_unix(
   evloop : EventLoop,
   sigwait_task : @coroutine.Coroutine,
 ) -> Unit {
@@ -164,7 +118,7 @@ fn set_console_control_handler(add : Int) -> Int = "moonbitlang/async" "signal/s
 
 ///|
 #cfg(any(target="wasm", platform="windows"))
-fn setup_console_control_signal_handler() -> Unit raise {
+fn setup_signal_handler_windows() -> Unit raise {
   if !global_signal_handler_initialized.val {
     set_global_cancellation_signals(all_signals)
   }
@@ -175,7 +129,7 @@ fn setup_console_control_signal_handler() -> Unit raise {
 
 ///|
 #cfg(any(target="wasm", platform="windows"))
-fn EventLoop::terminate_console_control_signal_handler(
+fn EventLoop::terminate_signal_handler_windows(
   evloop : EventLoop,
 ) -> Unit raise {
   if set_console_control_handler(0) is 0 {
@@ -188,49 +142,45 @@ fn EventLoop::terminate_console_control_signal_handler(
 
 ///|
 #cfg(all(target="native", not(platform="windows")))
-fn setup_signal_handler() -> @coroutine.Coroutine {
-  setup_sigwait_signal_handler()
+fn setup_signal_handler() -> SignalHandler {
+  SigwaitHandler(setup_signal_handler_unix())
 }
 
 ///|
 #cfg(all(target="native", not(platform="windows")))
 async fn EventLoop::terminate_signal_handler(
   evloop : EventLoop,
-  sigwait_task : @coroutine.Coroutine,
+  handler : SignalHandler,
 ) -> Unit {
-  evloop.terminate_sigwait_signal_handler(sigwait_task)
+  guard handler is SigwaitHandler(sigwait_task)
+  evloop.terminate_signal_handler_unix(sigwait_task)
 }
 
 ///|
 #cfg(platform="windows")
-fn setup_signal_handler() -> Unit raise {
-  setup_console_control_signal_handler()
+fn setup_signal_handler() -> SignalHandler raise {
+  setup_signal_handler_windows()
+  ConsoleControlHandler
 }
 
 ///|
 #cfg(platform="windows")
 fn EventLoop::terminate_signal_handler(
   evloop : EventLoop,
-  _ : Unit,
+  handler : SignalHandler,
 ) -> Unit raise {
-  evloop.terminate_console_control_signal_handler()
-}
-
-///|
-#cfg(target="wasm")
-priv enum SignalHandler {
-  Sigwait(@coroutine.Coroutine)
-  ConsoleControl
+  guard handler is ConsoleControlHandler
+  evloop.terminate_signal_handler_windows()
 }
 
 ///|
 #cfg(target="wasm")
 fn setup_signal_handler() -> SignalHandler raise {
   if platform is Windows {
-    setup_console_control_signal_handler()
-    ConsoleControl
+    setup_signal_handler_windows()
+    ConsoleControlHandler
   } else {
-    Sigwait(setup_sigwait_signal_handler())
+    SigwaitHandler(setup_signal_handler_unix())
   }
 }
 
@@ -241,8 +191,8 @@ async fn EventLoop::terminate_signal_handler(
   signal_handler : SignalHandler,
 ) -> Unit {
   match signal_handler {
-    Sigwait(sigwait_task) =>
-      evloop.terminate_sigwait_signal_handler(sigwait_task)
-    ConsoleControl => evloop.terminate_console_control_signal_handler()
+    SigwaitHandler(sigwait_task) =>
+      evloop.terminate_signal_handler_unix(sigwait_task)
+    ConsoleControlHandler => evloop.terminate_signal_handler_windows()
   }
 }

--- a/src/signal/signal.mbt
+++ b/src/signal/signal.mbt
@@ -26,15 +26,13 @@ pub(all) enum Signal {
 } derive(Debug)
 
 ///|
+fn Signal::index(sig : Signal) -> Int = "%identity"
+
+///|
 /// Convert a signal to its underlying signal code in the OS.
 /// The result of this function is platform-dependent.
 pub fn Signal::to_int(signal : Signal) -> Int {
-  match signal {
-    SIGINT => @event_loop._SIGINT
-    SIGTERM => @event_loop._SIGTERM
-    SIGHUP => @event_loop._SIGHUP
-    SIGBREAK => @event_loop._SIGBREAK
-  }
+  @event_loop.all_signals[signal.index()]
 }
 
 ///|


### PR DESCRIPTION
Also eliminate the dirty trick of the signal handler value implicitly having different types on different platforms. All platforms now use `enum SignalHandler` consistently.