### PR TITLE
refactor event loop & add deadlock detection

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -64,3 +64,7 @@ You can learn about the basic structure of a UDP server in MoonBit from this exa
 A simple toy program that exit automatically if the user have not type anything in the terminal for 5 seconds.
 
 You can learn about the pattern of setting up a idle timeout system in MoonBit from this example.
+
+## `dead_lock`
+An example program with dead lock. This example demonstrates the dead lock detection feature of `moonbitlang/async`.
+Instead of hanging forever, the dead lock program will abort with meaningful message when it enter dead lock state.

--- a/examples/dead_lock/main.mbt
+++ b/examples/dead_lock/main.mbt
@@ -1,0 +1,40 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async fn main {
+  let mutex1 = @async.Mutex()
+  let mutex2 = @async.Mutex()
+  @async.with_task_group <| group => {
+    group.spawn_bg() <| () => {
+      mutex1.acquire()
+      defer mutex1.release()
+      println("task 1 acquired mutex 1")
+      @async.pause()
+      mutex2.acquire()
+      defer mutex2.release()
+      println("task 1 acquired mutex 2")
+    }
+    group.spawn_bg() <| () => {
+      mutex2.acquire()
+      defer mutex2.release()
+      println("task 2 acquired mutex 2")
+      @async.pause()
+      mutex1.acquire()
+      defer mutex1.release()
+      println("task 1 acquired mutex 1")
+    }
+  }
+  println("program completed")
+}

--- a/examples/dead_lock/moon.pkg
+++ b/examples/dead_lock/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "moonbitlang/async",
+}
+
+supported_targets = "+native"
+
+pkgtype(kind: "executable")

--- a/examples/dead_lock/pkg.generated.mbti
+++ b/examples/dead_lock/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/async_examples/dead_lock"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -93,10 +93,6 @@ pub async fn suspend() -> Unit {
   if coro.cancelled && !coro.shielded {
     raise Cancelled
   }
-  scheduler.blocking += 1
-  defer {
-    scheduler.blocking -= 1
-  }
   async_suspend() <| fn(ok_cont, err_cont) {
     guard coro.state is Running
     coro.state = Suspend(ok_cont~, err_cont~)

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -21,13 +21,14 @@ priv enum State {
 }
 
 ///|
-struct Coroutine {
-  coro_id : Int
-  mut state : State
-  mut shielded : Bool
-  mut cancelled : Bool
-  mut ready : Bool
-  downstream : Set[Coroutine]
+pub struct Coroutine {
+  priv coro_id : Int
+  priv mut state : State
+  priv mut shielded : Bool
+  priv mut cancelled : Bool
+  priv mut ready : Bool
+  priv downstream : Set[Coroutine]
+  loc : SourceLoc
 }
 
 ///|
@@ -103,7 +104,8 @@ pub async fn suspend() -> Unit {
 }
 
 ///|
-pub fn spawn(f : async () -> Unit) -> Coroutine {
+#callsite(autofill(loc))
+pub fn spawn(f : async () -> Unit, loc~ : SourceLoc) -> Coroutine {
   scheduler.coro_id += 1
   let coro = {
     state: Running,
@@ -112,6 +114,7 @@ pub fn spawn(f : async () -> Unit) -> Coroutine {
     downstream: Set([]),
     coro_id: scheduler.coro_id,
     cancelled: false,
+    loc,
   }
   fn run(_) {
     run_async() <| () => {

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -128,11 +128,13 @@ pub fn spawn(f : async () -> Unit, loc~ : SourceLoc) -> Coroutine {
         coro.wake()
       }
       coro.downstream.clear()
+      scheduler.all_coros.remove(coro)
     }
   }
 
   coro.state = Suspend(ok_cont=run, err_cont=_ => ())
   scheduler.run_later.push_back(coro)
+  scheduler.all_coros.add(coro)
   coro
 }
 

--- a/src/internal/coroutine/pause_test.mbt
+++ b/src/internal/coroutine/pause_test.mbt
@@ -33,7 +33,7 @@ test "coroutine ping-pong" {
       }
     })
   })
-  while !@coroutine.no_more_work() {
+  while @coroutine.has_immediately_ready_task() {
     @coroutine.reschedule()
   }
   coro.unwrap()

--- a/src/internal/coroutine/pkg.generated.mbti
+++ b/src/internal/coroutine/pkg.generated.mbti
@@ -3,9 +3,12 @@ package "moonbitlang/async/internal/coroutine"
 
 import {
   "moonbitlang/core/debug",
+  "moonbitlang/core/set",
 }
 
 // Values
+pub fn all_coroutines() -> @set.Set[Coroutine]
+
 pub fn check_cancellation() -> Unit raise
 
 pub fn current_coroutine() -> Coroutine

--- a/src/internal/coroutine/pkg.generated.mbti
+++ b/src/internal/coroutine/pkg.generated.mbti
@@ -22,7 +22,8 @@ pub async fn[X] protect_from_cancel(async () -> X, resume_on_cancel? : Bool) -> 
 
 pub fn reschedule() -> Unit
 
-pub fn spawn(async () -> Unit) -> Coroutine
+#callsite(autofill(loc))
+pub fn spawn(async () -> Unit, loc~ : SourceLoc) -> Coroutine
 
 pub async fn suspend() -> Unit
 
@@ -32,7 +33,10 @@ pub(all) suberror Cancelled derive(@debug.Debug)
 pub impl Show for Cancelled
 
 // Types and methods
-type Coroutine
+pub struct Coroutine {
+  loc : SourceLoc
+  // private fields
+}
 pub fn Coroutine::cancel(Self) -> Unit
 pub fn Coroutine::check_error(Self) -> Unit raise
 pub fn Coroutine::unwrap(Self) -> Unit raise

--- a/src/internal/coroutine/pkg.generated.mbti
+++ b/src/internal/coroutine/pkg.generated.mbti
@@ -17,8 +17,6 @@ pub fn has_immediately_ready_task() -> Bool
 
 pub fn is_being_cancelled() -> Bool
 
-pub fn no_more_work() -> Bool
-
 pub async fn pause() -> Unit
 
 pub async fn[X] protect_from_cancel(async () -> X, resume_on_cancel? : Bool) -> X

--- a/src/internal/coroutine/scheduler.mbt
+++ b/src/internal/coroutine/scheduler.mbt
@@ -16,7 +16,6 @@
 priv struct Scheduler {
   mut coro_id : Int
   mut curr_coro : Coroutine?
-  mut blocking : Int
   run_later : @deque.Deque[Coroutine]
   all_coros : Set[Coroutine]
 }
@@ -25,7 +24,6 @@ priv struct Scheduler {
 let scheduler : Scheduler = {
   coro_id: 0,
   curr_coro: None,
-  blocking: 0,
   run_later: Deque([]),
   all_coros: Set([]),
 }
@@ -38,11 +36,6 @@ pub fn current_coroutine() -> Coroutine {
 ///|
 pub fn has_immediately_ready_task() -> Bool {
   !scheduler.run_later.is_empty()
-}
-
-///|
-pub fn no_more_work() -> Bool {
-  scheduler.blocking == 0 && scheduler.run_later.is_empty()
 }
 
 ///|

--- a/src/internal/coroutine/scheduler.mbt
+++ b/src/internal/coroutine/scheduler.mbt
@@ -18,6 +18,7 @@ priv struct Scheduler {
   mut curr_coro : Coroutine?
   mut blocking : Int
   run_later : @deque.Deque[Coroutine]
+  all_coros : Set[Coroutine]
 }
 
 ///|
@@ -26,6 +27,7 @@ let scheduler : Scheduler = {
   curr_coro: None,
   blocking: 0,
   run_later: Deque([]),
+  all_coros: Set([]),
 }
 
 ///|
@@ -65,4 +67,9 @@ pub fn reschedule() -> Unit {
     }
     scheduler.curr_coro = last_coro
   }
+}
+
+///|
+pub fn all_coroutines() -> Set[Coroutine] {
+  scheduler.all_coros
 }

--- a/src/internal/event_loop/event_loop.js.mbt
+++ b/src/internal/event_loop/event_loop.js.mbt
@@ -22,7 +22,7 @@ let _ignore_unused_import : Unit = {
 
 ///|
 pub fn reschedule() -> Unit {
-  guard !@coroutine.no_more_work() else {  }
+  guard !@coroutine.all_coroutines().is_empty() else {  }
   @coroutine.reschedule()
   // Instead of looping blockingly until there is no ready task,
   // we only perform one round of scheduling here

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -46,7 +46,9 @@ priv struct EventLoop {
   jobs : Map[Int, @coroutine.Coroutine]
   timers : @sorted_set.SortedSet[Timer]
   mut main : @coroutine.Coroutine?
+  mut signal_handler : SignalHandler?
   mut killed_by_signal : Int?
+  mut blocked_tasks : Int
 }
 
 ///|
@@ -97,7 +99,9 @@ fn EventLoop::new() -> EventLoop raise {
       jobs: Map([]),
       timers: SortedSet([]),
       main: None,
+      signal_handler: None,
       killed_by_signal: None,
+      blocked_tasks: 0,
     }
   } catch {
     err => {
@@ -129,6 +133,7 @@ pub fn with_event_loop(f : async () -> Unit) -> Unit raise {
     }
   }
   let signal_handler = setup_signal_handler()
+  evloop.signal_handler = Some(signal_handler)
   let main = @coroutine.spawn(() => {
     try f() catch {
       err => {
@@ -142,6 +147,15 @@ pub fn with_event_loop(f : async () -> Unit) -> Unit raise {
   evloop.main = Some(main)
   evloop.run_forever()
   main.unwrap()
+}
+
+///|
+async fn EventLoop::suspend(evloop : EventLoop) -> Unit {
+  evloop.blocked_tasks += 1
+  defer {
+    evloop.blocked_tasks -= 1
+  }
+  @coroutine.suspend()
 }
 
 ///|
@@ -261,12 +275,25 @@ fn EventLoop::cleanup(self : Self) -> Unit raise {
 ///|
 fn EventLoop::run_forever(self : Self) -> Unit raise {
   try {
-    while !(@coroutine.no_more_work() && self.running_workers.is_empty()) {
+    while @coroutine.has_immediately_ready_task() || self.blocked_tasks > 0 {
       self.extra.poll(self) catch {
         @os_error.OSError(_) as err if err.is_EINTR() => continue
         err => raise err
       }
       @coroutine.reschedule()
+    }
+    let all_coros = @coroutine.all_coroutines().iter()
+    let all_coros = match self.signal_handler {
+      Some(SigwaitHandler(sigwait_task)) =>
+        all_coros.filter(coro => coro != sigwait_task)
+      None | Some(ConsoleControlHandler) => all_coros
+    }
+    let all_coros = all_coros.map(coro => coro.loc.to_string()).collect()
+    if all_coros.length() > 0 {
+      println(
+        "Dead lock detected. Tasks spawned at the following locations are still alive: \{to_repr(all_coros)}",
+      )
+      panic()
     }
   } catch {
     err => {
@@ -299,11 +326,15 @@ priv enum CancellationStatus {
 async fn wait_for_cancellation(
   cancel_func : () -> CancellationStatus raise,
 ) -> Unit {
+  guard curr_loop.val is Some(evloop)
   try cancel_func() catch {
     err => {
       // The cancellation operation itself failed.
       // Give up the cancellation and wait for completion normally.
-      @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
+      @coroutine.protect_from_cancel(
+        () => evloop.suspend(),
+        resume_on_cancel=true,
+      )
       raise err
     }
   } noraise {
@@ -311,7 +342,10 @@ async fn wait_for_cancellation(
       // The cancellation operation has succeeded,
       // but the thread pool or OS may need some more time to finish all the cleanup.
       // So wait for the completion of the cleanup process here.
-      @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
+      @coroutine.protect_from_cancel(
+        () => evloop.suspend(),
+        resume_on_cancel=true,
+      )
     NoWait =>
       // The cancellation operation has succeeded,
       // and the cancelled operation has already terminated.
@@ -336,9 +370,12 @@ async fn EventLoop::wait_for_job(
   defer evloop.jobs.remove(job_id)
   match cancel {
     None =>
-      @coroutine.protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
+      @coroutine.protect_from_cancel(
+        () => evloop.suspend(),
+        resume_on_cancel=true,
+      )
     Some(cancel_func) =>
-      @coroutine.suspend() catch {
+      evloop.suspend() catch {
         _ =>
           // The cancellation error is swallowed here,
           // because in case the operation completed before cancellation,

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -300,7 +300,7 @@ fn EventLoop::run_forever(self : Self) -> Unit raise {
       Ref::protect(check_fd_leak, false, () => self.cleanup())
       // In case the event loop has encountered some fatal error,
       // propagate the error to relevant coroutines.
-      while !@coroutine.no_more_work() {
+      while @coroutine.has_immediately_ready_task() || self.blocked_tasks > 0 {
         @coroutine.reschedule()
       }
       raise err

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -15,6 +15,7 @@
 ///|
 #cfg(not(platform="windows"))
 pub async fn IoHandle::wait_read(handle : IoHandle) -> Unit {
+  guard curr_loop.val is Some(evloop)
   guard @fd_util.fd_is_valid(handle.fd) else {
     abort("file descriptor already closed")
   }
@@ -23,12 +24,13 @@ pub async fn IoHandle::wait_read(handle : IoHandle) -> Unit {
   defer {
     handle.read = Idle
   }
-  @coroutine.suspend()
+  evloop.suspend()
 }
 
 ///|
 #cfg(not(platform="windows"))
 async fn IoHandle::wait_write(handle : IoHandle) -> Unit {
+  guard curr_loop.val is Some(evloop)
   guard @fd_util.fd_is_valid(handle.fd) else {
     abort("file descriptor already closed")
   }
@@ -38,7 +40,7 @@ async fn IoHandle::wait_write(handle : IoHandle) -> Unit {
   defer {
     handle.write = Idle
   }
-  @coroutine.suspend()
+  evloop.suspend()
 }
 
 ///|

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -55,12 +55,13 @@ async fn IoHandle::wait_read_result(
   io_result : IoResult,
   context~ : String,
 ) -> Unit {
+  guard curr_loop.val is Some(evloop)
   guard handle.read is Idle
   handle.read = Waiting(@coroutine.current_coroutine())
   defer {
     handle.read = Idle
   }
-  @coroutine.suspend() catch {
+  evloop.suspend() catch {
     _ => wait_for_cancellation(() => io_result.cancel(handle.fd, context~))
   }
 }
@@ -72,12 +73,13 @@ async fn IoHandle::wait_write_result(
   io_result : IoResult,
   context~ : String,
 ) -> Unit {
+  guard curr_loop.val is Some(evloop)
   guard handle.write is Idle
   handle.write = Waiting(@coroutine.current_coroutine())
   defer {
     handle.write = Idle
   }
-  @coroutine.suspend() catch {
+  evloop.suspend() catch {
     _ => wait_for_cancellation(() => io_result.cancel(handle.fd, context~))
   }
 }

--- a/src/internal/event_loop/process.wasm.mbt
+++ b/src/internal/event_loop/process.wasm.mbt
@@ -132,7 +132,7 @@ pub async fn Process::wait_pid(self : Process, context~ : String) -> Int {
         guard extra.pids.get(self.pid) is None
         extra.pids[self.pid] = @coroutine.current_coroutine()
         defer extra.pids.remove(self.pid)
-        @coroutine.suspend()
+        evloop.suspend()
       }
     Windows => {
       guard self.handle is Some(io)

--- a/src/internal/event_loop/process_unix.mbt
+++ b/src/internal/event_loop/process_unix.mbt
@@ -62,7 +62,7 @@ pub async fn Process::wait_pid(self : Process, context~ : String) -> Int {
       guard evloop.extra.pids.get(self.pid) is None
       evloop.extra.pids[self.pid] = @coroutine.current_coroutine()
       defer evloop.extra.pids.remove(self.pid)
-      @coroutine.suspend()
+      evloop.suspend()
     }
   } else {
     // Linux systems where pidfd is not available.

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -76,17 +76,23 @@ priv enum SignalHandler {
 ///|
 #cfg(not(platform="windows"))
 fn setup_signal_handler_unix() -> @coroutine.Coroutine {
+  guard curr_loop.val is Some(evloop)
   if !global_signal_handler_initialized.val {
     set_global_cancellation_signals(all_signals)
   }
   @coroutine.spawn() <| () => {
     let context = "sigwait thread"
     fn cancel(job_id) raise {
-      guard curr_loop.val is Some(evloop)
       evloop.cancel_job_in_worker(job_id, context~)
     }
     let job = Job::sigwait(all_signals)
     defer job.free()
+    // We want to exclude the signal waiting task from dead lock detection.
+    // Since we do not execute coroutines with nested call stack,
+    // when the main loop is running, the sigwait task must be suspended,
+    // so whenever `blocked_task` is read, the `-= 1` here
+    // will cancel a `+= 1` caused by `evloop.suspend()` in the sigwait task.
+    evloop.blocked_tasks -= 1
     ignore <| perform_job_in_worker(job, context~, cancel~)
   }
 }
@@ -98,6 +104,8 @@ async fn EventLoop::terminate_signal_handler_unix(
   sigwait_task : @coroutine.Coroutine,
 ) -> Unit {
   sigwait_task.cancel()
+  // Undo the `-= 1` in `setup_sigwait_signal_handler`.
+  evloop.blocked_tasks += 1
   @coroutine.protect_from_cancel(() => sigwait_task.wait()) catch {
     @coroutine.Cancelled => ()
     err => raise err

--- a/src/internal/event_loop/timer.mbt
+++ b/src/internal/event_loop/timer.mbt
@@ -53,8 +53,9 @@ impl Compare for Timer with fn compare(t1, t2) {
 
 ///|
 pub async fn sleep(duration : Int) -> Unit {
+  guard curr_loop.val is Some(evloop)
   let coro = @coroutine.current_coroutine()
   let timer = Timer::new(duration, () => coro.wake())
   defer timer.cancel()
-  @coroutine.suspend()
+  evloop.suspend()
 }

--- a/src/io/memory_reader.mbt
+++ b/src/io/memory_reader.mbt
@@ -33,9 +33,13 @@ struct MemoryReader {
 ///
 /// If the reader is closed before the callback completes,
 /// the callback will be cancelled automatically.
-pub fn MemoryReader::MemoryReader(f : async (&Writer) -> Unit) -> MemoryReader {
+#callsite(autofill(loc))
+pub fn MemoryReader::MemoryReader(
+  f : async (&Writer) -> Unit,
+  loc~ : SourceLoc,
+) -> MemoryReader {
   let (r, w) = pipe()
-  let writer = @coroutine.spawn() <| () => {
+  let writer = @coroutine.spawn(loc~) <| () => {
     defer w.close()
     f(w)
   }

--- a/src/io/pkg.generated.mbti
+++ b/src/io/pkg.generated.mbti
@@ -29,7 +29,8 @@ pub(all) enum Encoding {
 }
 
 type MemoryReader
-pub fn MemoryReader::MemoryReader(async (&Writer) -> Unit) -> Self
+#callsite(autofill(loc))
+pub fn MemoryReader::MemoryReader(async (&Writer) -> Unit, loc~ : SourceLoc) -> Self
 pub fn MemoryReader::close(Self) -> Unit
 pub impl Reader for MemoryReader
 

--- a/src/js_async/unimplemented.mbt
+++ b/src/js_async/unimplemented.mbt
@@ -15,7 +15,7 @@
 ///|
 #coverage.skip
 let _ignore_unused_import : Unit = {
-  ignore(@coroutine.spawn)
+  ignore(@coroutine.Coroutine::wake)
   ignore(@event_loop.Timer::new)
 }
 

--- a/src/lazy_init.mbt
+++ b/src/lazy_init.mbt
@@ -30,6 +30,7 @@ struct Lazy[X] {
   worker : async () -> X
   waiters : Set[@coroutine.Coroutine]
   mut state : LazyValueState[X]
+  loc : SourceLoc
 }
 
 ///|
@@ -46,7 +47,7 @@ pub async fn[X] Lazy::wait(self : Lazy[X]) -> X {
     Fail(err) => raise err
     Running(_) => ()
     Uninitialized => {
-      let coro = @coroutine.spawn(() => {
+      let coro = @coroutine.spawn(loc=self.loc, () => {
         try (self.worker)() catch {
           err =>
             if err is @coroutine.Cancelled && is_being_cancelled() {
@@ -97,6 +98,7 @@ pub async fn[X] Lazy::wait(self : Lazy[X]) -> X {
 /// always complete immediately.
 #as_free_fn(lazy_init, deprecated="use `@async.Lazy(..)` instead")
 #alias(new, deprecated)
-pub fn[X] Lazy::Lazy(f : async () -> X) -> Lazy[X] {
-  { worker: f, waiters: Set([]), state: Uninitialized }
+#callsite(autofill(loc))
+pub fn[X] Lazy::Lazy(f : async () -> X, loc~ : SourceLoc) -> Lazy[X] {
+  { worker: f, waiters: Set([]), state: Uninitialized, loc }
 }

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -29,7 +29,8 @@ pub async fn[X] retry(RetryMethod, max_retry? : Int, fatal_error? : (Error) -> B
 
 pub async fn sleep(Int) -> Unit
 
-pub async fn[X] with_task_group(async (TaskGroup[X]) -> X) -> X
+#callsite(autofill(loc))
+pub async fn[X] with_task_group(async (TaskGroup[X]) -> X, loc~ : SourceLoc) -> X
 
 pub async fn[X] with_timeout(Int, async () -> X, error? : Error) -> X
 
@@ -50,7 +51,8 @@ pub impl Show for TimerCancelled
 type Lazy[X]
 #alias(new, deprecated)
 #as_free_fn(lazy_init, deprecated)
-pub fn[X] Lazy::Lazy(async () -> X) -> Self[X]
+#callsite(autofill(loc))
+pub fn[X] Lazy::Lazy(async () -> X, loc~ : SourceLoc) -> Self[X]
 pub async fn[X] Lazy::wait(Self[X]) -> X
 
 type Mutex
@@ -73,8 +75,10 @@ pub async fn[X] Task::wait(Self[X]) -> X
 type TaskGroup[X]
 pub fn[X] TaskGroup::add_defer(Self[X], async () -> Unit) -> Unit
 pub fn[X] TaskGroup::return_immediately(Self[X], X) -> Unit raise
-pub fn[G, X] TaskGroup::spawn(Self[G], async () -> X, no_wait? : Bool, allow_failure? : Bool) -> Task[X]
-pub fn[X] TaskGroup::spawn_bg(Self[X], async () -> Unit, no_wait? : Bool, allow_failure? : Bool) -> Unit
+#callsite(autofill(loc))
+pub fn[G, X] TaskGroup::spawn(Self[G], async () -> X, no_wait? : Bool, allow_failure? : Bool, loc~ : SourceLoc) -> Task[X]
+#callsite(autofill(loc))
+pub fn[X] TaskGroup::spawn_bg(Self[X], async () -> Unit, no_wait? : Bool, allow_failure? : Bool, loc~ : SourceLoc) -> Unit
 pub fn[X] TaskGroup::spawn_loop(Self[X], async () -> Unit, no_wait? : Bool, allow_failure? : Bool, retry? : RetryMethod, max_retry? : Int, fatal_error? : (Error) -> Bool) -> Unit
 
 pub struct Timer {

--- a/src/process/unimplemented.mbt
+++ b/src/process/unimplemented.mbt
@@ -20,7 +20,7 @@ pub let unimplemented : Unit = {
   ignore(@io.pipe)
   ignore(@async.sleep)
   ignore(@event_loop.Timer::new)
-  ignore(@coroutine.spawn)
+  ignore(@coroutine.Coroutine::wake)
   ignore(@stdio.unimplemented)
   ignore(@fd_util.unimplemented)
   ignore(@os_string.unimplemented)

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -46,6 +46,7 @@ fn[X] TaskGroup::spawn_coroutine(
   f : async () -> Unit,
   no_wait~ : Bool,
   allow_failure~ : Bool,
+  loc~ : SourceLoc,
 ) -> @coroutine.Coroutine {
   guard self.state is Running || !self.children.is_empty() else {
     abort("trying to spawn from a terminated task group")
@@ -88,7 +89,7 @@ fn[X] TaskGroup::spawn_coroutine(
     }
   }
 
-  let coro = @coroutine.spawn(worker)
+  let coro = @coroutine.spawn(worker, loc~)
   self.children.add(coro)
   if !(self.state is Running) {
     coro.cancel()
@@ -128,13 +129,15 @@ fn[X] TaskGroup::spawn_coroutine(
 ///
 /// It is undefined whether the child task will start running immediately
 /// before `spawn_bg` returns.
+#callsite(autofill(loc))
 pub fn[X] TaskGroup::spawn_bg(
   self : TaskGroup[X],
   f : async () -> Unit,
   no_wait? : Bool = false,
   allow_failure? : Bool = false,
+  loc~ : SourceLoc,
 ) -> Unit {
-  ignore(self.spawn_coroutine(f, no_wait~, allow_failure~))
+  ignore(self.spawn_coroutine(f, no_wait~, allow_failure~, loc~))
 }
 
 ///|
@@ -171,17 +174,20 @@ pub fn[X] TaskGroup::spawn_bg(
 ///
 /// It is undefined whether the child task will start running immediately
 /// before `spawn` returns.
+#callsite(autofill(loc))
 pub fn[G, X] TaskGroup::spawn(
   self : TaskGroup[G],
   f : async () -> X,
   no_wait? : Bool = false,
   allow_failure? : Bool = false,
+  loc~ : SourceLoc,
 ) -> Task[X] {
   let value = Ref(None)
   let coro = self.spawn_coroutine(
     () => value.val = Some(f()),
     no_wait~,
     allow_failure~,
+    loc~,
   )
   { value, coro }
 }
@@ -220,7 +226,11 @@ pub fn[X] TaskGroup::add_defer(
 ///
 /// If all children task terminate successfully,
 /// `with_task_group` will return the result of `f`.
-pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X) -> X {
+#callsite(autofill(loc))
+pub async fn[X] with_task_group(
+  f : async (TaskGroup[X]) -> X,
+  loc~ : SourceLoc,
+) -> X {
   let tg = {
     children: Set([]),
     parent: @coroutine.current_coroutine(),
@@ -229,7 +239,7 @@ pub async fn[X] with_task_group(f : async (TaskGroup[X]) -> X) -> X {
     result: None,
     group_defer: [],
   }
-  tg.spawn_bg() <| () => {
+  tg.spawn_bg(loc~) <| () => {
     let value = f(tg)
     if tg.result is None {
       tg.result = Some(value)

--- a/src/websocket/unimplemented.mbt
+++ b/src/websocket/unimplemented.mbt
@@ -21,7 +21,7 @@ pub let unimplemented : Unit = {
   ignore(@semaphore.Semaphore::release)
   ignore(@tls.unimplemented)
   ignore(@http.unimplemented)
-  ignore(@coroutine.spawn)
+  ignore(@coroutine.Coroutine::wake)
   ignore(@utf8.encode(""))
 }
 
@@ -33,6 +33,6 @@ pub let unimplemented : Unit = {
   ignore(@tls.SystemRoot)
   ignore(@http.Get)
   ignore(@semaphore.Semaphore::release)
-  ignore(@coroutine.spawn)
+  ignore(@coroutine.Coroutine::cancel)
   ignore(@utf8.encode(""))
 }


### PR DESCRIPTION
When a coroutine is suspended, there are two possibilities:

1. a coroutine is suspended, waiting for some foreign condition such as timer, IO etc.
2. a coroutine is suspended, waiting for another coroutine, mutex, queue etc.

Previously, the event loop will iterate until both kinds of suspended coroutine disappear. But in case of a dead lock, the program will loop forever. This PR refactors the main event loop and let it keep track of case (1) only. When there is no more type (1) coroutine, the remaining coroutines, if any, must be in a deadlock state. The event loop will now detect such dead lock and abort the program with proper message.

In order to report good error message on dead lock, the location for the body of every coroutine spawned is recorded, and the set of all alive coroutines is maintained globally. Local benchmarking reveals that this extra book keeping does not introduce any performance penalty.

One thing that need special treatment here is the special sigwait task on Linux/MacOS. That task wait for external signal, so it is technically type (1). But since we do not allow custom signal handler, user program never contain logic waiting for a signal. Hence the special sigwait task should be excluded from dead lock detection logic (i.e. we report dead lock even if the sigwait task is still actively waiting for some "foreign condition").