### PR TITLE
fix timer overflow bug & prevent direct use of `@env.now()`

### DIFF
--- a/src/all_any_test.mbt
+++ b/src/all_any_test.mbt
@@ -14,7 +14,7 @@
 
 ///|
 async test "all basic" {
-  let start = @env.now()
+  let start = @async.now()
   let results = @async.all([
     () => {
       @async.sleep(400)
@@ -26,7 +26,7 @@ async test "all basic" {
     },
     () => 3,
   ])
-  let duration = (@env.now() - start).to_int()
+  let duration = (@async.now() - start).to_int()
   json_inspect(results, content=[1, 2, 3])
   inspect((duration + 50) / 200, content="2")
 }
@@ -160,7 +160,7 @@ async test "all cancelled" {
 
 ///|
 async test "any basic" {
-  let start = @env.now()
+  let start = @async.now()
   let result = @async.any([
     () => {
       @async.sleep(600)
@@ -175,7 +175,7 @@ async test "any basic" {
       3
     },
   ])
-  let duration = (@env.now() - start).to_int()
+  let duration = (@async.now() - start).to_int()
   json_inspect(result, content=2)
   inspect((duration + 50) / 200, content="1")
 }

--- a/src/aqueue/close_test.mbt
+++ b/src/aqueue/close_test.mbt
@@ -77,7 +77,7 @@ async test "close with blocking put" {
   let q = @async.Queue(kind=Blocking(1))
   q.put(1)
   @async.with_task_group() <| group => {
-    let start = @env.now()
+    let start = @async.now()
     group.spawn_bg() <| () => {
       @async.sleep(300)
       q.close()
@@ -86,7 +86,7 @@ async test "close with blocking put" {
       @test_util.expect_error_async(() => q.put(2)),
       content="QueueAlreadyClosed",
     )
-    let now = @env.now()
+    let now = @async.now()
     let duration = (now + 50 - start) / 300
     inspect(duration, content="1")
   }
@@ -96,7 +96,7 @@ async test "close with blocking put" {
 async test "close zero buffered with blocking put" {
   let q = @async.Queue(kind=Blocking(0))
   @async.with_task_group() <| group => {
-    let start = @env.now()
+    let start = @async.now()
     group.spawn_bg() <| () => {
       @async.sleep(300)
       q.close()
@@ -105,7 +105,7 @@ async test "close zero buffered with blocking put" {
       @test_util.expect_error_async(() => q.put(2)),
       content="QueueAlreadyClosed",
     )
-    let now = @env.now()
+    let now = @async.now()
     let duration = (now + 50 - start) / 300
     inspect(duration, content="1")
   }
@@ -115,7 +115,7 @@ async test "close zero buffered with blocking put" {
 async test "close with blocking get" {
   let q : @aqueue.Queue[Int] = Queue(kind=Unbounded)
   @async.with_task_group() <| group => {
-    let start = @env.now()
+    let start = @async.now()
     group.spawn_bg() <| () => {
       @async.sleep(300)
       q.close()
@@ -124,7 +124,7 @@ async test "close with blocking get" {
       @test_util.expect_error_async(() => q.get()),
       content="QueueAlreadyClosed",
     )
-    let now = @env.now()
+    let now = @async.now()
     let duration = (now + 50 - start) / 300
     inspect(duration, content="1")
   }

--- a/src/aqueue/moon.pkg
+++ b/src/aqueue/moon.pkg
@@ -5,7 +5,6 @@ import {
 
 import {
   "moonbitlang/core/debug",
-  "moonbitlang/core/env",
   "moonbitlang/async",
   "moonbitlang/async/internal/test_util",
 } for "test"

--- a/src/async.mbt
+++ b/src/async.mbt
@@ -107,34 +107,13 @@ pub async fn[X] with_timeout_opt(time : Int, f : async () -> X) -> X? {
 pub using @coroutine {protect_from_cancel}
 
 ///|
-#cfg(target="wasm")
-fn ms_since_epoch() -> UInt64 = "moonbitlang/async" "time/get_ms_since_epoch"
-
-///|
 /// Get current time, measured in milliseconds.
 /// `now` uses the same clock as timers in `moonbitlang/async`.
 ///
 /// `now` can be used to measure elapsed time, such as benchmarking,
 /// but the meaning of the absolute time value returned by `now`
 /// is undefined, and should not be depended on.
-#cfg(any(target="native", target="js", target="wasm-gc"))
-#deprecated("use `@env.now()` from `moonbitlang/core/env` instead")
-pub fn now() -> Int64 {
-  @env.now().reinterpret_as_int64()
-}
-
-///|
-/// Get current time, measured in milliseconds.
-/// `now` uses the same clock as timers in `moonbitlang/async`.
-///
-/// `now` can be used to measure elapsed time, such as benchmarking,
-/// but the meaning of the absolute time value returned by `now`
-/// is undefined, and should not be depended on.
-#cfg(target="wasm")
-#deprecated("use `@env.now()` from `moonbitlang/core/env` instead")
-pub fn now() -> Int64 {
-  ms_since_epoch().reinterpret_as_int64()
-}
+pub using @event_loop {now}
 
 ///|
 pub using @aqueue {type Queue}

--- a/src/fs/moon.pkg
+++ b/src/fs/moon.pkg
@@ -5,7 +5,6 @@ import {
   "moonbitlang/core/cmp",
   "moonbitlang/core/deque",
   "moonbitlang/core/sorted_set",
-  "moonbitlang/core/env",
   "moonbitlang/async/os_error",
   "moonbitlang/async/io",
   "moonbitlang/async/internal/event_loop",
@@ -21,6 +20,7 @@ import {
 import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/debug",
+  "moonbitlang/core/env",
   "moonbitlang/async/process",
   "moonbitlang/async/internal/test_util",
 } for "test"

--- a/src/fs/tmpdir.mbt
+++ b/src/fs/tmpdir.mbt
@@ -15,9 +15,9 @@
 ///|
 let tmpdir_seed : @random.Rand = {
   let seed = Buffer()
-  let now = @env.now()
+  let now = @event_loop.now()
   for _ in 0..<4 {
-    seed.write_uint64_le(now)
+    seed.write_int64_le(now)
   }
   @random.Rand::chacha8(seed=seed.contents())
 }
@@ -54,7 +54,7 @@ pub async fn tmpdir(prefix~ : StringView) -> String {
   for _ in 0..<@int.MAX_VALUE {
     let hasher = Hasher()
     hasher.combine_uint64(tmpdir_seed.uint64())
-    hasher.combine_uint64(@env.now())
+    hasher.combine_int64(@event_loop.now())
     let h = hasher.finalize().reinterpret_as_uint()
     let path = StringBuilder::new()
     path.write_string(tmp_base_path)

--- a/src/fs/watch_kqueue.mbt
+++ b/src/fs/watch_kqueue.mbt
@@ -158,10 +158,10 @@ impl WatcherBackend for KqueueWatcher with fn wait(self) {
   while root.is_clean() {
     self.process_events(timeout=None, context~)
   }
-  let debounce_deadline = @env.now() + self.max_debounce_delay.to_uint64()
+  let debounce_deadline = @event_loop.now() + self.max_debounce_delay.to_int64()
   for ;; {
     let t = @cmp.minimum(
-      (debounce_deadline - @env.now()).to_int(),
+      (debounce_deadline - @event_loop.now()).to_int(),
       self.debounce_timeout,
     )
     guard t > 0 else { break }

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -26,13 +26,13 @@ async test "http request" {
 
 ///|
 async test "request cancel" {
-  let start = @env.now()
+  let start = @async.now()
   let result = @async.with_timeout_opt(300, () => {
     @http.get(
       "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz",
     )
   })
-  let end = @env.now()
+  let end = @async.now()
   assert_true(result is None)
   if @env.get_env_var("MOONBIT_ASYNC_TEST_SANITIZER_ENABLED") is None {
     let delta = end - start

--- a/src/internal/event_loop/event_loop.js.mbt
+++ b/src/internal/event_loop/event_loop.js.mbt
@@ -21,6 +21,11 @@ let _ignore_unused_import : Unit = {
 }
 
 ///|
+pub fn now() -> Int64 {
+  @env.now().reinterpret_as_int64()
+}
+
+///|
 pub fn reschedule() -> Unit {
   guard !@coroutine.all_coroutines().is_empty() else {  }
   @coroutine.reschedule()

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -160,12 +160,14 @@ async fn EventLoop::suspend(evloop : EventLoop) -> Unit {
 
 ///|
 #cfg(target="native")
-using @env {now}
+pub fn now() -> Int64 {
+  @env.now().reinterpret_as_int64()
+}
 
 ///|
 #cfg(target="wasm")
 #unsafe_skip_stub_check
-fn now() -> UInt64 = "moonbitlang/async" "time/get_ms_since_epoch"
+pub fn now() -> Int64 = "moonbitlang/async" "time/get_ms_since_epoch"
 
 ///|
 fn EventLoop::wait_for_event(self : EventLoop) -> Int raise {

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -33,6 +33,8 @@ pub async fn kind_of_fd(Int, context~ : String) -> @fd_util.FileKind
 
 pub async fn mkdir(StringView, mode~ : Int, context~ : String) -> Unit
 
+pub fn now() -> Int64
+
 pub async fn open(StringView, Int, create~ : Int, append~ : Bool, sync~ : Int, mode~ : Int, context~ : String) -> (IoHandle, FileIdentity)
 
 pub let platform : Platform

--- a/src/internal/event_loop/starvation_test.mbt
+++ b/src/internal/event_loop/starvation_test.mbt
@@ -21,8 +21,8 @@ async test "starvation" {
       log.push("sleep completed")
     }
     group.spawn_bg() <| () => {
-      let start = @env.now()
-      while @env.now() - start < 100 {
+      let start = @async.now()
+      while @async.now() - start < 100 {
         @async.pause()
       }
       log.push("busy wait completed")

--- a/src/internal/event_loop/timer.mbt
+++ b/src/internal/event_loop/timer.mbt
@@ -15,7 +15,7 @@
 ///|
 struct Timer {
   timer_id : Int
-  expire_time : UInt64
+  expire_time : Int64
   callback : () -> Unit
 }
 
@@ -25,7 +25,7 @@ let timer_id : Ref[Int] = { val: 0 }
 ///|
 pub fn Timer::new(duration : Int, callback : () -> Unit) -> Timer {
   guard curr_loop.val is Some(evloop)
-  let expire_time = @env.now() + duration.to_uint64()
+  let expire_time = now() + duration.to_int64()
   timer_id.val += 1
   let timer = { timer_id: timer_id.val, expire_time, callback }
   evloop.timers.add(timer)

--- a/src/internal/event_loop/unimplemented.mbt
+++ b/src/internal/event_loop/unimplemented.mbt
@@ -23,6 +23,11 @@ let _ignore_unused_import : Unit = {
 }
 
 ///|
+pub fn now() -> Int64 {
+  @env.now().reinterpret_as_int64()
+}
+
+///|
 type Timer
 
 ///|

--- a/src/js_async/moon.pkg
+++ b/src/js_async/moon.pkg
@@ -6,7 +6,6 @@ import {
 
 import {
   "moonbitlang/core/debug",
-  "moonbitlang/core/env",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/async",
   "moonbitlang/async/internal/test_util",

--- a/src/js_async/readable_stream_test.mbt
+++ b/src/js_async/readable_stream_test.mbt
@@ -18,9 +18,9 @@ async test "ReadableStream roundtrip" {
   let (r, w) = @js_async.JsReadableStream::new_pipe()
   let r = @js_async.ReadableStream::from_js(r)
   @async.with_task_group() <| group => {
-    let start = @env.now()
+    let start = @async.now()
     fn tick() {
-      ((@env.now() - start).to_int() + 50) / 200
+      ((@async.now() - start).to_int() + 50) / 200
     }
     group.spawn_bg() <| () => {
       defer w.close()

--- a/src/lazy_init_test.mbt
+++ b/src/lazy_init_test.mbt
@@ -15,9 +15,9 @@
 ///|
 async test "lazy init basic" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn current_tick() -> Int {
-    (@env.now() - start + 20).to_int() / 200
+    (@async.now() - start + 20).to_int() / 200
   }
 
   let x = @async.Lazy(() => {
@@ -42,9 +42,9 @@ async test "lazy init failure" {
     @async.sleep(200)
     raise Failure::Failure("msg")
   })
-  let start = @env.now()
+  let start = @async.now()
   fn current_tick() -> Int {
-    (@env.now() - start + 20).to_int() / 200
+    (@async.now() - start + 20).to_int() / 200
   }
 
   let result = @test_util.expect_error_async(() => x.wait())
@@ -68,9 +68,9 @@ async test "lazy init failure" {
 ///|
 async test "lazy init cancelled" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn current_tick() -> Int {
-    (@env.now() - start + 20).to_int() / 200
+    (@async.now() - start + 20).to_int() / 200
   }
 
   let x = @async.Lazy(() => {
@@ -97,9 +97,9 @@ async test "lazy init cancelled" {
 ///|
 async test "lazy init multiple waiters 1" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn current_tick() -> Int {
-    (@env.now() - start + 20).to_int() / 200
+    (@async.now() - start + 20).to_int() / 200
   }
 
   let x = @async.Lazy(() => {
@@ -128,9 +128,9 @@ async test "lazy init multiple waiters 1" {
 ///|
 async test "lazy init multiple waiters 2" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn current_tick() -> Int {
-    (@env.now() - start + 20).to_int() / 200
+    (@async.now() - start + 20).to_int() / 200
   }
 
   let x = @async.Lazy(() => {

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "moonbitlang/core/set",
   "moonbitlang/core/cmp",
-  "moonbitlang/core/env",
   "moonbitlang/async/internal/coroutine",
   "moonbitlang/async/internal/event_loop",
   "moonbitlang/async/aqueue",

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -18,7 +18,6 @@ pub fn is_being_cancelled() -> Bool
 
 pub fn is_cancellation_error(Error) -> Bool
 
-#deprecated
 pub fn now() -> Int64
 
 pub async fn pause() -> Unit

--- a/src/process/cancel_test.mbt
+++ b/src/process/cancel_test.mbt
@@ -62,18 +62,18 @@ async test "cancel process timeout" {
       defer r.close()
       guard r.read_some() is Some(data)
       let data = @utf8.decode(data).trim_end(chars="\r\n")
-      let t = @env.now()
+      let t = @async.now()
       inspect(data, content="received termination signal")
       t
     })
     @async.sleep(500)
-    let t_cancel = @env.now()
+    let t_cancel = @async.now()
     task.cancel()
     debug_inspect(
       @test_util.expect_error_async(() => task.wait()),
       content="Cancelled",
     )
-    let t_process_terminates = @env.now()
+    let t_process_terminates = @async.now()
     let t1 = t_receive_graceful_termination.wait() - t_cancel
     let t2 = t_process_terminates - t_cancel
     inspect(t1 / 250, content="0")
@@ -99,13 +99,13 @@ async test "cancel process hard" {
       inspect(r.read_all().text(), content="")
     }
     @async.sleep(500)
-    let t0 = @env.now()
+    let t0 = @async.now()
     task.cancel()
     debug_inspect(
       @test_util.expect_error_async(() => task.wait()),
       content="Cancelled",
     )
-    let t1 = @env.now()
+    let t1 = @async.now()
     inspect((t1 - t0) / 250, content="0")
   }
 }

--- a/src/process/spawn_in_group_test.mbt
+++ b/src/process/spawn_in_group_test.mbt
@@ -16,14 +16,14 @@
 async test "spawn_in_group wait" {
   let log = []
   let sleep = sleep_prog.wait()
-  let t0 = @env.now()
+  let t0 = @async.now()
   @async.with_task_group() <| group => {
     let _ = @process.spawn(group, sleep, ["500"])
     @async.sleep(250)
-    let t = (@env.now() - t0).to_int() / 250
+    let t = (@async.now() - t0).to_int() / 250
     log.push("main task completed at tick #\{t}")
   }
-  let t = (@env.now() - t0).to_int() / 250
+  let t = (@async.now() - t0).to_int() / 250
   log.push("`with_task_group` completed at tick #\{t}")
   json_inspect(log, content=[
     "main task completed at tick #1", "`with_task_group` completed at tick #2",
@@ -49,12 +49,12 @@ async test "spawn_in_group cancel" {
 ///|
 async test "Process::wait" {
   let sleep = sleep_prog.wait()
-  let mut t0 = 0UL
+  let mut t0 = 0L
   @async.with_task_group() <| group => {
     let child = @process.spawn(group, sleep, ["500", "-exit-code", "42"])
-    t0 = @env.now()
+    t0 = @async.now()
     let result = child.wait()
-    let t = (@env.now() - t0).to_int() / 250
+    let t = (@async.now() - t0).to_int() / 250
     inspect(t, content="2")
     inspect(result, content="42")
     // `.wait()` should be idempotent
@@ -77,7 +77,7 @@ async test "Process::try_wait" {
 ///|
 async test "Process:cancel" {
   let sleep = sleep_prog.wait()
-  let mut t0 = 0UL
+  let mut t0 = 0L
   @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
     group.spawn_bg() <| () => {
@@ -85,10 +85,10 @@ async test "Process:cancel" {
       inspect(r.read_all().text().trim(), content="received termination signal")
     }
     let child = @process.spawn(group, sleep, ["10000"], stdout=w)
-    t0 = @env.now()
+    t0 = @async.now()
     @async.sleep(500)
     child.cancel()
   }
-  let t = (@env.now() - t0).to_int() / 500
+  let t = (@async.now() - t0).to_int() / 500
   inspect(t, content="1")
 }

--- a/src/retry_test.mbt
+++ b/src/retry_test.mbt
@@ -37,9 +37,9 @@ async test "retry immediate" {
 ///|
 async test "retry fixed" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn tick() {
-    (@env.now() - start + 50).to_int() / 200
+    (@async.now() - start + 50).to_int() / 200
   }
   let mut i = 0
   @async.retry(FixedDelay(200)) <| () => {
@@ -58,9 +58,9 @@ async test "retry fixed" {
 ///|
 async test "retry exponential" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn tick() {
-    (@env.now() - start + 50).to_int() / 200
+    (@async.now() - start + 50).to_int() / 200
   }
   let mut i = 0
   @async.retry(ExponentialDelay(initial=200, factor=2, maximum=600)) <| () => {

--- a/src/spawn_loop_test.mbt
+++ b/src/spawn_loop_test.mbt
@@ -68,9 +68,9 @@ async test "spawn_loop retry-exponential" {
   let log = []
   @async.with_task_group() <| group => {
     let mut i = 0
-    let start = @env.now()
+    let start = @async.now()
     fn tick() {
-      (@env.now() - start + 50).to_int() / 200
+      (@async.now() - start + 50).to_int() / 200
     }
     group.spawn_loop(
       retry=ExponentialDelay(initial=200, factor=2, maximum=600),

--- a/src/timer.mbt
+++ b/src/timer.mbt
@@ -43,7 +43,7 @@ priv enum TimerState {
 pub struct Timer {
   duration : Int
   priv mut state : TimerState
-  priv mut expire_time : UInt64
+  priv mut expire_time : Int64
   // invariant: `waiters` is non-empty iff `state` is `Running`
   priv waiters : Set[@coroutine.Coroutine]
 }
@@ -53,7 +53,7 @@ pub struct Timer {
 /// The timer will start immediately, and expire after the duration elapsed.
 #alias(new, deprecated)
 pub fn Timer::Timer(duration : Int) -> Timer {
-  let expire_time = @env.now() + duration.to_uint64()
+  let expire_time = now() + duration.to_int64()
   { state: Detached, duration, expire_time, waiters: Set([]) }
 }
 
@@ -92,7 +92,7 @@ pub async fn Timer::wait(timer : Timer) -> Unit {
   match timer.state {
     Running(_) => ()
     Detached => {
-      let duration = timer.expire_time - @env.now()
+      let duration = timer.expire_time - now()
       guard duration > 0 else { return }
       timer.state = Running(
         @event_loop.Timer::new(duration.to_int()) <| () => {
@@ -126,7 +126,7 @@ pub fn Timer::refresh(timer : Timer) -> Unit {
     Detached | Terminated => ()
     Cancelled(_) => return
   }
-  timer.expire_time = @env.now() + timer.duration.to_uint64()
+  timer.expire_time = now() + timer.duration.to_int64()
   if timer.waiters.is_empty() {
     timer.state = Detached
   } else {

--- a/src/timer_test.mbt
+++ b/src/timer_test.mbt
@@ -116,9 +116,9 @@ async test "Timer waiter cancelled 2" {
 ///|
 async test "Timer::cancel" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn tick() {
-    (@env.now() - start + 50).to_int() / 150
+    (@async.now() - start + 50).to_int() / 150
   }
   let timer = @async.Timer(450)
   @async.with_task_group() <| group => {
@@ -146,9 +146,9 @@ async test "Timer::cancel" {
 ///|
 async test "Timer::refresh has waiter" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn tick() -> Int {
-    (@env.now() - start + 50).to_int() / 150
+    (@async.now() - start + 50).to_int() / 150
   }
 
   let timer = @async.Timer(300)
@@ -176,9 +176,9 @@ async test "Timer::refresh has waiter" {
 ///|
 async test "Timer::refresh no waiter" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn tick() -> Int {
-    (@env.now() - start + 50).to_int() / 150
+    (@async.now() - start + 50).to_int() / 150
   }
 
   let timer = @async.Timer(300)
@@ -195,9 +195,9 @@ async test "Timer::refresh no waiter" {
 ///|
 async test "Timer::refresh already terminated" {
   let log = []
-  let start = @env.now()
+  let start = @async.now()
   fn tick() -> Int {
-    (@env.now() - start + 50).to_int() / 150
+    (@async.now() - start + 50).to_int() / 150
   }
 
   let timer = @async.Timer(300)


### PR DESCRIPTION
#433 replaced the manual `@time.ms_since_epoch` helper with `@env.now`. However, there is one difference between `@time.ms_since_epoch` and `@env.now`: the former returns `Int64` while the latter returns `UInt64`. For the `now` API itself this difference is minor, both `Int64` and `UInt64` are capable of holding all valid return value. However, for the caller of `now` this difference matters: for `Int64`, the `now()` value can be used to calculate a (potentially negative) range by subtraction without problems. For `UInt64`, a negative range will overflow. In fact there is already bug about this in current code. On JS backend the `now()` value is (deliberately) imprecise, so it is very easy to trigger the negative range overflow bug.

This PR fixes the issue, making `@event_loop.now()` return `Int64` instead (but still calls `@env.now()` under the hood), and eliminate all direct usage of `@env.now()` elsewhere. Since users of `moonbitlang/async` may face the same issue, the previously deprecated `@async.now()` was revived as well, which returns `Int64`.