### PR TITLE
handle killed-by-signal process state properly

### DIFF
--- a/src/integration.mbt
+++ b/src/integration.mbt
@@ -20,7 +20,8 @@
 #doc(hidden)
 pub fn run_async_main(main : async () -> Unit) -> Unit {
   @event_loop.with_event_loop(() => main()) catch {
-    @event_loop.KilledBySignal(signal) => exit(128 + signal)
+    @event_loop.KilledBySignal(signal) =>
+      @event_loop.terminate_process_by_signal(signal)
     err => {
       // TODO: output the error to stderr
       println(err)

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -63,6 +63,8 @@ pub let stdout : Result[IoHandle, Error]
 
 pub async fn symlink(StringView, StringView, force_symlink~ : Bool, context~ : String) -> Unit
 
+pub fn terminate_process_by_signal(Int) -> Unit
+
 pub fn with_event_loop(async () -> Unit) -> Unit raise
 
 // Errors

--- a/src/internal/event_loop/process.c
+++ b/src/internal/event_loop/process.c
@@ -68,7 +68,12 @@ int moonbitlang_async_get_process_result(HANDLE handle, int32_t pid, int32_t *ou
       return -1;
     }
 
-    *out = info.si_status;
+    if (info.si_code == CLD_EXITED) {
+      *out = info.si_status;
+    } else {
+      // killed by signal
+      *out = -info.si_status;
+    }
     return 0;
   }
 
@@ -89,7 +94,11 @@ int moonbitlang_async_get_process_result(HANDLE handle, int32_t pid, int32_t *ou
     return -1;
   }
 
-  *out = WEXITSTATUS(wstatus);
+  if WIFEXITED(wstatus) {
+    *out = WEXITSTATUS(wstatus);
+  } else {
+    *out = -WTERMSIG(wstatus);
+  }
   return 0;
 
 #endif // #ifdef _WIN32

--- a/src/internal/event_loop/signal.c
+++ b/src/internal/event_loop/signal.c
@@ -19,12 +19,12 @@
 #ifdef _WIN32
 
 #include <windows.h>
-#include <string.h>
+#include <stdio.h>
 
 #else
 
 #include <signal.h>
-#include <string.h>
+#include <stdio.h>
 
 #endif
 
@@ -77,6 +77,14 @@ int moonbitlang_async_set_console_control_handler(int32_t add) {
   return SetConsoleCtrlHandler(moonbitlang_async_console_control_handler, add);
 }
 
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_terminate_process_by_signal(int32_t sig) {
+  // flush stdio buffers used by `println` etc.
+  fflush(0);
+
+  ExitProcess(STATUS_CONTROL_C_EXIT);
+}
+
 #else // #ifdef _WIN32
 
 MOONBIT_FFI_EXPORT
@@ -107,6 +115,19 @@ void moonbitlang_async_set_global_cancellation_signals(
     sigaddset(&set, signals[i]);
   }
   pthread_sigmask(SIG_SETMASK, &set, 0);
+}
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_terminate_process_by_signal(int32_t sig) {
+  sigset_t sigset;
+  sigemptyset(&sigset);
+  sigaddset(&sigset, sig);
+  pthread_sigmask(SIG_UNBLOCK, &sigset, 0);
+
+  // flush stdio buffers used by `println` etc.
+  fflush(0);
+
+  raise(sig);
 }
 
 #endif // #ifndef _WIN32

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -204,3 +204,7 @@ async fn EventLoop::terminate_signal_handler(
     ConsoleControlHandler => evloop.terminate_signal_handler_windows()
   }
 }
+
+///|
+#cfg(target="native")
+pub extern "C" fn terminate_process_by_signal(sig : Int) -> Unit = "moonbitlang_async_terminate_process_by_signal"

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -62,6 +62,7 @@ pub async fn spawn_orphan(
 ///|
 /// Wait for the process with specfic ID to terminate,
 /// and return the exit code of the process.
+/// If the process is killed by a signal, the result would be `-signal_number`.
 pub async fn wait_pid(pid : Int) -> Int {
   let context = "@process.wait_pid()"
   let process = @event_loop.Process::from_pid(pid, context~)
@@ -77,6 +78,7 @@ pub async fn wait_pid(pid : Int) -> Int {
 /// `run` will block until the new process terminates,
 /// and returns the exit status of the process.
 /// To run the process in background, use `@async.spawn` or `@async.spawn_bg`.
+/// If the process is killed by a signal, the result would be `-signal_number`.
 ///
 /// If `inherit_env` is `true` (`true` by default),
 /// the new process will inherit environment variables of current process.
@@ -167,12 +169,14 @@ pub struct Process {
 
 ///|
 /// Wait for a process to terminate, return the exit code of the process
+/// If the process is killed by a signal, the result would be `-signal_number`.
 pub async fn Process::wait(self : Process) -> Int {
   self.result.wait()
 }
 
 ///|
 /// If the process already terminated, return its exit code.
+/// If the process is killed by a signal, the result would be `-signal_number`.
 /// If the process is still running, return `None`.
 pub fn Process::try_wait(self : Process) -> Int? raise {
   self.result.try_wait()

--- a/src/process/wait_test.mbt
+++ b/src/process/wait_test.mbt
@@ -83,3 +83,18 @@ async test "wait exitcode STILL_ACTIVE" {
     ),
   )
 }
+
+///|
+#cfg(all(target="native", not(platform="windows")))
+async test "signal exit code" {
+  let sleep = sleep_prog.wait()
+  let exit_code = @async.with_task_group <| group => {
+    let proc = @process.spawn(group, sleep, ["1000", "-use-default-handler"])
+    group.spawn_bg(no_wait=true) <| () => {
+      @async.sleep(100)
+      @process.graceful_cancel(timeout=1000, signal=SIGINT)(proc.pid)
+    }
+    proc.wait()
+  }
+  assert_eq(exit_code, -@signal.SIGINT.to_int())
+}


### PR DESCRIPTION
On Unix-like systems, when a process is killed by a signal, the process would have a special return status, differing from any normal exit code. Previously:

- when a process running `async fn main` is cancelled gracefully by signal, it return `128 + signal_number` *normally*. This is the convention used by `bash`/`zsh`, but ambiguous and not faithful (the process is actually killed by signal)
- when a child process spawned by `@process.run` etc. is killed by signal, the returned exit status is simply corrupted

This PR fixes these two problems:

- when `async fn main` is gracefully cancelled via a signal, the program will kill itself with the same signal after finishing all the cleanup, creating an actual killed-by-signal exit status
    - on Windows, when the process is terminated gracefully via a console control event, `async fn main` will exit with `CONTROL_C_EXIT_STATUS` following Windows convention.
- when a child process spawned by `@process` API is killed by a signal, the returned exit status of `run`, `.wait_pid` and `Process::wait` would be `-signal_number`. Using negative number is unambiguous on Unix-like systems and can avoid breaking existing API. This is also the convention used by Python's `subprocess` API