### PR TITLE
fix dead lock detection

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -277,7 +277,9 @@ fn EventLoop::cleanup(self : Self) -> Unit raise {
 ///|
 fn EventLoop::run_forever(self : Self) -> Unit raise {
   try {
-    while @coroutine.has_immediately_ready_task() || self.blocked_tasks > 0 {
+    while @coroutine.has_immediately_ready_task() ||
+          self.blocked_tasks > 0 ||
+          !self.timers.is_empty() {
       self.extra.poll(self) catch {
         @os_error.OSError(_) as err if err.is_EINTR() => continue
         err => raise err

--- a/src/internal/event_loop/timer.mbt
+++ b/src/internal/event_loop/timer.mbt
@@ -53,9 +53,8 @@ impl Compare for Timer with fn compare(t1, t2) {
 
 ///|
 pub async fn sleep(duration : Int) -> Unit {
-  guard curr_loop.val is Some(evloop)
   let coro = @coroutine.current_coroutine()
   let timer = Timer::new(duration, () => coro.wake())
   defer timer.cancel()
-  evloop.suspend()
+  @coroutine.suspend()
 }


### PR DESCRIPTION
Previous version of dead lock detection did not handle timer correctly. Not all timer's waiter go through `EventLoop::suspend`, so if all remaining tasks in a program is waiting for timers, previously the dead lock detector will wrongly terminate the program. This PR fixes the problem, avoid dead lock report whenever there is active timer.