### PR TITLE
fix(io): preserve ownership of read_some chunks

### DIFF
--- a/src/io/read_some_test.mbt
+++ b/src/io/read_some_test.mbt
@@ -117,3 +117,26 @@ async test "read_some length limit 3" {
     ),
   )
 }
+
+///|
+async test "read_some returned chunks remain stable" {
+  @async.with_task_group() <| root => {
+    let first_expected = Bytes::make(1024, b'a')
+    let second_expected = Bytes::make(1024, b'b')
+    let (r, w) = @io.pipe()
+    defer r.close()
+    root.spawn_bg() <| () => {
+      defer w.close()
+      w.write(first_expected)
+      w.write(second_expected)
+    }
+    guard r.read_some(max_len=1024) is Some(first) else {
+      fail("missing first chunk")
+    }
+    guard r.read_some(max_len=1024) is Some(second) else {
+      fail("missing second chunk")
+    }
+    assert_eq(first, first_expected)
+    assert_eq(second, second_expected)
+  }
+}

--- a/src/io/reader.mbt
+++ b/src/io/reader.mbt
@@ -99,6 +99,21 @@ impl Reader with fn read_exactly(self, len) {
 }
 
 ///|
+fn ReaderBuffer::take_owned(
+  self : ReaderBuffer,
+  start : Int,
+  len : Int,
+) -> Bytes {
+  if start == 0 && len == self.buf.length() {
+    let buf = self.buf
+    self.buf = FixedArray::make(len, b'\x00')
+    buf.unsafe_reinterpret_as_bytes()
+  } else {
+    self.buf.unsafe_reinterpret_as_bytes()[start:start + len].to_owned()
+  }
+}
+
+///|
 /// `reader.read_some(max_len?)` fetch and return a chunk of data from the reader.
 /// It will return as fast as possible when new data become available.
 /// If EOF is reached, `None` is returned.
@@ -110,14 +125,13 @@ impl Reader with fn read_exactly(self, len) {
 impl Reader with fn read_some(self, max_len?) {
   let buf = self._get_internal_buffer()
   if buf.len > 0 {
-    let buf_bytes = buf.buf.unsafe_reinterpret_as_bytes()
     if max_len is Some(max_len) && max_len < buf.len {
-      let data = buf_bytes[buf.start:buf.start + max_len].to_owned()
+      let data = buf.take_owned(buf.start, max_len)
       buf.start += max_len
       buf.len -= max_len
       return Some(data)
     } else {
-      let data = buf_bytes[buf.start:buf.start + buf.len].to_owned()
+      let data = buf.take_owned(buf.start, buf.len)
       buf.start = 0
       buf.len = 0
       return Some(data)
@@ -131,11 +145,11 @@ impl Reader with fn read_some(self, max_len?) {
   if max_len is Some(max_len) && max_len < n {
     buf.start = max_len
     buf.len = n - max_len
-    Some(buf.buf.unsafe_reinterpret_as_bytes()[:max_len].to_owned())
+    Some(buf.take_owned(0, max_len))
   } else {
     buf.start = 0
     buf.len = 0
-    Some(buf.buf.unsafe_reinterpret_as_bytes()[:n].to_owned())
+    Some(buf.take_owned(0, n))
   }
 }
 


### PR DESCRIPTION
`Reader::read_some` could return a `Bytes` value backed by its reusable internal read buffer. When a returned view covered the entire buffer, `BytesView::to_owned()` reused the backing `Bytes` instead of copying it. A later read then overwrote data that had already been returned to the caller.

This is observable outside HTTP as a general `Reader` ownership bug. On the JavaScript backend it corrupts streamed fetch request bodies: `JsReadableStream::new_pipe` enqueues a chunk, the next pipe read reuses the same 1024-byte buffer, and fetch later observes the overwritten bytes.

## Problem

Before writing to @http.Client, the serialized UTF-8 body was captured. A local Node HTTP server captured the exact bytes received on the wire.

expected bytes: 2654

received bytes: 2654

chunks: 1024 + 1024 + 606

expected SHA-256: 2cafae89bff675c6fb8e6a49e904356c598f52f0743de9506578c5a9d2e23368

received SHA-256: dd4fee7cc2820e53922b5304b83d61984638f97568a0b6f50072776f3411a8d6

first differing offset: 0

server-side JSON.parse: failed

The received stream was not simply truncated. Its layout showed buffer reuse:

received[0..1630]    == expected[1024..2654]
received[1630..2654] == expected[1630..2654]

At chunk boundaries this was:

received chunk 1 = expected chunk 2
received chunk 2 = expected final 606 bytes + stale 418-byte tail
received chunk 3 = expected final 606 bytes