### PR TITLE
fix cancellation of queued job in thread pool

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -40,7 +40,7 @@ priv struct EventLoop {
   notify_recv : @fd_util.Fd
   max_worker_count : Int
   mut job_id : Int
-  job_queue : @deque.Deque[QueuedJob]
+  job_queue : Set[QueuedJob]
   idle_workers : @deque.Deque[Worker]
   running_workers : Map[Int, Worker]
   jobs : Map[Int, @coroutine.Coroutine]
@@ -55,6 +55,17 @@ priv struct EventLoop {
 priv struct QueuedJob {
   job_id : Int
   job : Job
+  waiter : @coroutine.Coroutine
+}
+
+///|
+impl Eq for QueuedJob with fn equal(x, y) {
+  x.job_id == y.job_id
+}
+
+///|
+impl Hash for QueuedJob with fn hash_combine(job, hasher) {
+  Hash::hash_combine(job.job_id, hasher)
 }
 
 ///|
@@ -99,7 +110,7 @@ fn EventLoop::new(max_worker_count~ : Int) -> EventLoop raise {
       notify_recv,
       max_worker_count,
       job_id: 0,
-      job_queue: Deque([]),
+      job_queue: Set([]),
       idle_workers: Deque([]),
       running_workers: Map([]),
       jobs: Map([]),
@@ -222,7 +233,7 @@ fn EventLoop::handle_completed_job(self : Self, job_id : Int) -> Unit {
   }
   guard self.running_workers.get(job_id) is Some(worker)
   self.running_workers.remove(job_id)
-  match self.job_queue.pop_front() {
+  match self.job_queue.iter().next() {
     None => {
       worker.enter_idle()
       self.idle_workers.push_back(worker)
@@ -230,6 +241,8 @@ fn EventLoop::handle_completed_job(self : Self, job_id : Int) -> Unit {
     Some(job) => {
       self.running_workers[job.job_id] = worker
       worker.wake(job.job_id, job.job)
+      self.job_queue.remove(job)
+      job.waiter.wake()
     }
   }
   if self.jobs.get(job_id) is Some(coro) {
@@ -422,8 +435,21 @@ async fn perform_job_in_worker(
   let job_id = evloop.job_id
   evloop.job_id += 1
   match evloop.idle_workers.pop_front() {
-    None if evloop.running_workers.length() >= evloop.max_worker_count =>
-      evloop.job_queue.push_back({ job_id, job })
+    None if evloop.running_workers.length() >= evloop.max_worker_count => {
+      let waiter = @coroutine.current_coroutine()
+      let queued_job = { job_id, job, waiter }
+      evloop.job_queue.add(queued_job)
+      @coroutine.suspend() catch {
+        err =>
+          // If `queued_job` is already removed, the job must have been submitted already,
+          // within the same tick as the cancellation request.
+          // In this case, swallow the cancellation to avoid problems. 
+          if evloop.job_queue.contains(queued_job) {
+            evloop.job_queue.remove(queued_job)
+            raise err
+          }
+      }
+    }
     None => {
       let worker = Worker::spawn(job_id, job)
       evloop.running_workers[job_id] = worker

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -78,7 +78,7 @@ pub fn register_hook(
 }
 
 ///|
-fn EventLoop::new() -> EventLoop raise {
+fn EventLoop::new(max_worker_count~ : Int) -> EventLoop raise {
   let bus = EventBus::new()
   try {
     let notify_recv = init_thread_pool_ffi(bus)
@@ -86,12 +86,18 @@ fn EventLoop::new() -> EventLoop raise {
       @os_error.check_errno("initialize thread pool")
     }
     let extra = PlatformEventLoopExtra::new()
+    let max_worker_count = match platform {
+      Linux | MacOS =>
+        // reserve one extra worker for the global `sigwait` job
+        max_worker_count + 1
+      Windows => max_worker_count
+    }
     {
       bus,
       fds: Map([]),
       extra,
       notify_recv,
-      max_worker_count: 1024,
+      max_worker_count,
       job_id: 0,
       job_queue: Deque([]),
       idle_workers: Deque([]),
@@ -119,9 +125,12 @@ fn EventLoop::destroy(evloop : EventLoop) -> Unit {
 }
 
 ///|
-pub fn with_event_loop(f : async () -> Unit) -> Unit raise {
+pub fn with_event_loop(
+  f : async () -> Unit,
+  max_worker_count? : Int = 1024,
+) -> Unit raise {
   guard curr_loop.val is None
-  let evloop = EventLoop::new()
+  let evloop = EventLoop::new(max_worker_count~)
   defer evloop.destroy()
   curr_loop.val = Some(evloop)
   defer {

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -65,7 +65,7 @@ pub async fn symlink(StringView, StringView, force_symlink~ : Bool, context~ : S
 
 pub fn terminate_process_by_signal(Int) -> Unit
 
-pub fn with_event_loop(async () -> Unit) -> Unit raise
+pub fn with_event_loop(async () -> Unit, max_worker_count? : Int) -> Unit raise
 
 // Errors
 pub suberror KilledBySignal {

--- a/src/internal/event_loop/worker_wbtest.mbt
+++ b/src/internal/event_loop/worker_wbtest.mbt
@@ -158,3 +158,61 @@ async test "worker cancel2" {
     ),
   )
 }
+
+///|
+#cfg(any(target="native", target="wasm"))
+test "max worker limit" {
+  let log = []
+  with_event_loop(max_worker_count=2, () => {
+    @async.with_task_group <| group => {
+      let start = @async.now()
+      for i in 0..<4 {
+        group.spawn_bg() <| () => {
+          let t = (@async.now() - start).to_int() / 200
+          log.push("job #\{i} starting at tick #\{t}")
+          perform_sleep_job(200)
+          let t = (@async.now() - start).to_int() / 200
+          log.push("job #\{i} completed at tick #\{t}")
+        }
+        @async.sleep(50)
+      }
+    }
+  })
+  json_inspect(log, content=[
+    "job #0 starting at tick #0", "job #1 starting at tick #0", "job #2 starting at tick #0",
+    "job #3 starting at tick #0", "job #0 completed at tick #1", "job #1 completed at tick #1",
+    "job #2 completed at tick #2", "job #3 completed at tick #2",
+  ])
+}
+
+///|
+#cfg(any(target="native", target="wasm"))
+test "cancel queued job" {
+  let log = []
+  with_event_loop(max_worker_count=1, () => {
+    @async.with_task_group <| group => {
+      let start = @async.now()
+      fn tick() {
+        (@async.now() - start + 50).to_int() / 100
+      }
+      group.spawn_bg() <| () => {
+        log.push("main job starting at tick #\{tick()}")
+        perform_sleep_job(300)
+        log.push("main job completed at tick #\{tick()}")
+      }
+      @async.sleep(100)
+      log.push("queued job starting at tick #\{tick()}")
+      // The job here is not cancellable once it start running.
+      // But all jobs are cancellable while they are queued.
+      try @async.with_timeout(100, () => perform_sleep_job(200)) catch {
+        _ => log.push("queued job cancelled at tick #\{tick()}")
+      } noraise {
+        _ => log.push("queued job completed at tick #\{tick()}")
+      }
+    }
+  })
+  json_inspect(log, content=[
+    "main job starting at tick #0", "queued job starting at tick #1", "queued job cancelled at tick #2",
+    "main job completed at tick #3",
+  ])
+}


### PR DESCRIPTION
https://github.com/moonbitlang/async/issues/442#issuecomment-4840815407

When the thread pool run out of worker, new jobs will be queued. Previous implementation failed to handle cancellation of such queued job correctly. This PR fixes the problem. The queued case of `perform_job_in_worker` is refactored into a two phase wait:

- a new, dedicated wait is added for the job being actually submitted to a worker. This wait is always cancellable
    - callers can always wrap the whole thing in `protect_from_cancel` though
- after the job is actually submitted, a second wait will be performed for the completion of the job. This wait is the same as the non-queued path

The max worker count is 1024 by default, and highly parallel operations such as socket IO does not go through the thread pool, so this bug was previously hard to reproduce. For testing purpose, the max worker count is made configurable internally.