### PR TITLE
simplify thread pool job cancellation API

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -390,28 +390,30 @@ async fn wait_for_cancellation(
 async fn EventLoop::wait_for_job(
   evloop : EventLoop,
   job_id : Int,
-  cancel? : (Int) -> CancellationStatus raise,
+  cancellable~ : Bool,
+  context~ : String,
 ) -> Unit {
   evloop.jobs[job_id] = @coroutine.current_coroutine()
   defer evloop.jobs.remove(job_id)
-  match cancel {
-    None =>
-      @coroutine.protect_from_cancel(
-        () => evloop.suspend(),
-        resume_on_cancel=true,
-      )
-    Some(cancel_func) =>
-      evloop.suspend() catch {
-        _ =>
-          // The cancellation error is swallowed here,
-          // because in case the operation completed before cancellation,
-          // we need to return the result normally to retain cancellation safety
-          // and avoid data loss.
-          // In case the cancellation succeeded,
-          // the underlying operation itself should report cancelled status properly
-          // via error code (`EINTR` or `ERROR_OPERATION_ABORTED`)
-          wait_for_cancellation(() => cancel_func(job_id))
-      }
+  if cancellable {
+    evloop.suspend() catch {
+      _ =>
+        // The cancellation error is swallowed here,
+        // because in case the operation completed before cancellation,
+        // we need to return the result normally to retain cancellation safety
+        // and avoid data loss.
+        // In case the cancellation succeeded,
+        // the underlying operation itself should report cancelled status properly
+        // via error code (`EINTR` or `ERROR_OPERATION_ABORTED`)
+        wait_for_cancellation(() => {
+          evloop.cancel_job_in_worker(job_id, context~)
+        })
+    }
+  } else {
+    @coroutine.protect_from_cancel(
+      () => evloop.suspend(),
+      resume_on_cancel=true,
+    )
   }
 }
 
@@ -428,7 +430,7 @@ fn errno_is_cancelled(errno : Int) -> Bool = "moonbitlang/async" "thread_pool/er
 async fn perform_job_in_worker(
   job : Job,
   context~ : String,
-  cancel? : (Int) -> CancellationStatus raise,
+  cancellable? : Bool = false,
 ) -> Int {
   @coroutine.check_cancellation()
   guard curr_loop.val is Some(evloop)
@@ -459,7 +461,7 @@ async fn perform_job_in_worker(
       worker.wake(job_id, job)
     }
   }
-  evloop.wait_for_job(job_id, cancel?)
+  evloop.wait_for_job(job_id, cancellable~, context~)
   if job.err() is err && err > 0 {
     if @coroutine.is_being_cancelled() && errno_is_cancelled(err) {
       raise @coroutine.Cancelled

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -36,12 +36,7 @@ pub async fn open(
   let path_bytes = @os_string.encode(path)
   let job = Job::open(path_bytes, access, create~, append~, sync~, mode~)
   defer job.0.free()
-  fn cancel(job_id) raise {
-    guard curr_loop.val is Some(evloop)
-    evloop.cancel_job_in_worker(job_id, context~)
-  }
-
-  try perform_job_in_worker(job.0, context~, cancel~) catch {
+  try perform_job_in_worker(job.0, context~, cancellable=true) catch {
     @os_error.OSError(errno, context~) =>
       raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
     err => raise err
@@ -182,15 +177,9 @@ pub async fn IoHandle::lock(
   exclusive~ : Bool,
   context~ : String,
 ) -> Unit {
-  guard curr_loop.val is Some(evloop)
   let job = Job::flock(handle.fd, exclusive)
   defer job.free()
-  perform_job_in_worker(
-    job,
-    cancel=job_id => evloop.cancel_job_in_worker(job_id, context~),
-    context~,
-  )
-  |> ignore
+  perform_job_in_worker(job, cancellable=true, context~) |> ignore
 }
 
 ///|

--- a/src/internal/event_loop/io.mbt
+++ b/src/internal/event_loop/io.mbt
@@ -139,7 +139,6 @@ async fn IoHandle::read_via_worker(
   len~ : Int,
   context~ : String,
 ) -> Int {
-  guard curr_loop.val is Some(evloop)
   guard handle.read is Idle
   handle.read = Submitted
   defer {
@@ -147,12 +146,11 @@ async fn IoHandle::read_via_worker(
   }
   let job = Job::read(handle.fd, buf, offset, len, position=handle.read_offset)
   defer job.free()
-  let cancel = if platform is Windows || handle.kind.can_poll() {
-    Some(job_id => evloop.cancel_job_in_worker(job_id, context~))
-  } else {
-    None
-  }
-  perform_job_in_worker(job, context~, cancel?)
+  perform_job_in_worker(
+    job,
+    context~,
+    cancellable=platform is Windows || handle.kind.can_poll(),
+  )
 }
 
 ///|
@@ -187,7 +185,6 @@ async fn IoHandle::write_via_worker(
   len~ : Int,
   context~ : String,
 ) -> Int {
-  guard curr_loop.val is Some(evloop)
   guard handle.write is Idle
   handle.write = Submitted
   defer {
@@ -201,12 +198,11 @@ async fn IoHandle::write_via_worker(
     position=handle.write_offset,
   )
   defer job.free()
-  let cancel = if platform is Windows || handle.kind.can_poll() {
-    Some(job_id => evloop.cancel_job_in_worker(job_id, context~))
-  } else {
-    None
-  }
-  perform_job_in_worker(job, context~, cancel?)
+  perform_job_in_worker(
+    job,
+    context~,
+    cancellable=platform is Windows || handle.kind.can_poll(),
+  )
 }
 
 ///|
@@ -244,16 +240,10 @@ pub async fn IoHandle::read_at(
   context~ : String,
 ) -> Int {
   @coroutine.check_cancellation()
-  guard curr_loop.val is Some(evloop)
   guard !handle.is_async
   let job = Job::read(handle.fd, buf, offset, len, position~)
   defer job.free()
-  let cancel = if platform is Windows {
-    Some(job_id => evloop.cancel_job_in_worker(job_id, context~))
-  } else {
-    None
-  }
-  perform_job_in_worker(job, context~, cancel?)
+  perform_job_in_worker(job, context~, cancellable=platform is Windows)
 }
 
 ///|
@@ -269,7 +259,6 @@ pub async fn IoHandle::write_at(
   context~ : String,
 ) -> Unit {
   @coroutine.check_cancellation()
-  guard curr_loop.val is Some(evloop)
   guard !handle.is_async
   guard handle.write_offset >= 0 else {
     raise Failure::Failure(
@@ -278,10 +267,5 @@ pub async fn IoHandle::write_at(
   }
   let job = Job::write(handle.fd, buf, offset, len, position~)
   defer job.free()
-  let cancel = if platform is Windows {
-    Some(job_id => evloop.cancel_job_in_worker(job_id, context~))
-  } else {
-    None
-  }
-  ignore(perform_job_in_worker(job, context~, cancel?))
+  ignore(perform_job_in_worker(job, context~, cancellable=platform is Windows))
 }

--- a/src/internal/event_loop/process_unix.mbt
+++ b/src/internal/event_loop/process_unix.mbt
@@ -77,9 +77,7 @@ pub async fn Process::wait_pid_unix(self : Process, context~ : String) -> Int {
     // The thread pool job will obain the exit code and reap the process.
     let job = Job::wait_for_process(handle, pid=self.pid)
     defer job.free()
-    return perform_job_in_worker(job, context~, cancel=job_id => {
-      evloop.cancel_job_in_worker(job_id, context~)
-    })
+    return perform_job_in_worker(job, context~, cancellable=true)
   }
 
   let ret = get_process_result(handle, self.pid, out)

--- a/src/internal/event_loop/process_windows.mbt
+++ b/src/internal/event_loop/process_windows.mbt
@@ -56,14 +56,10 @@ pub async fn Process::wait_pid_windows(
   self : Process,
   context~ : String,
 ) -> Int {
-  guard curr_loop.val is Some(evloop)
   guard self.handle is Some(io)
   let job = Job::wait_for_process(io.fd, pid=self.pid)
   defer job.free()
-  let _ = perform_job_in_worker(job, context~, cancel=job_id => {
-    evloop.cancel_job_in_worker(job_id, context~)
-  })
-
+  let _ = perform_job_in_worker(job, context~, cancellable=true)
   let out = Ref(0)
   let ret = get_process_result(io.fd, self.pid, out)
   if ret < 0 {

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -82,9 +82,6 @@ fn setup_signal_handler_unix() -> @coroutine.Coroutine {
   }
   @coroutine.spawn() <| () => {
     let context = "sigwait thread"
-    fn cancel(job_id) raise {
-      evloop.cancel_job_in_worker(job_id, context~)
-    }
     let job = Job::sigwait(all_signals)
     defer job.free()
     // We want to exclude the signal waiting task from dead lock detection.
@@ -93,7 +90,7 @@ fn setup_signal_handler_unix() -> @coroutine.Coroutine {
     // so whenever `blocked_task` is read, the `-= 1` here
     // will cancel a `+= 1` caused by `evloop.suspend()` in the sigwait task.
     evloop.blocked_tasks -= 1
-    ignore <| perform_job_in_worker(job, context~, cancel~)
+    ignore <| perform_job_in_worker(job, context~, cancellable=true)
   }
 }
 


### PR DESCRIPTION
After several previous refactors, all cancellation operations on thread pool jobs now go through the standard `cancel_job_in_worker` process. So there is no need to allow arbitrary callback in the internal API anymore.