### PR TITLE
use builder style API for process spawning in event loop

### DIFF
--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -53,7 +53,7 @@ pub fn set_global_cancellation_signals(ReadOnlyArray[Int]) -> Unit
 
 pub async fn sleep(Int) -> Unit
 
-pub async fn spawn_unix(@os_string.OsString, @c_buffer.Buffer, env~ : @c_buffer.Buffer, stdin~ : Int, stdout~ : Int, stderr~ : Int, cwd~ : @os_string.OsString?, context~ : String) -> Process
+pub async fn spawn_unix(@os_string.OsString, @c_buffer.Buffer, env~ : @c_buffer.Buffer, stdin~ : Int, stdout~ : Int, stderr~ : Int, is_orphan~ : Bool, cwd~ : @os_string.OsString?, context~ : String) -> Process
 
 pub let stderr : Result[IoHandle, Error]
 

--- a/src/internal/event_loop/process_unix.mbt
+++ b/src/internal/event_loop/process_unix.mbt
@@ -21,13 +21,10 @@ pub async fn spawn_unix(
   stdin~ : @fd_util.Fd,
   stdout~ : @fd_util.Fd,
   stderr~ : @fd_util.Fd,
+  is_orphan~ : Bool,
   cwd~ : @os_string.OsString?,
   context~ : String,
 ) -> Process {
-  let (cwd, has_cwd) = match cwd {
-    None => (@os_string.empty, false)
-    Some(cwd) => (cwd, true)
-  }
   let job = Job::spawn_unix(
     path,
     args,
@@ -36,7 +33,7 @@ pub async fn spawn_unix(
     stdout~,
     stderr~,
     cwd~,
-    has_cwd~,
+    is_orphan~,
   )
   defer job.0.free()
   let pid = perform_job_in_worker(job.0, context~)

--- a/src/internal/event_loop/process_windows.mbt
+++ b/src/internal/event_loop/process_windows.mbt
@@ -25,10 +25,6 @@ pub async fn spawn_windows(
   is_orphan~ : Bool,
   context~ : String,
 ) -> Process {
-  let (cwd, has_cwd) = match cwd {
-    None => (@os_string.empty, false)
-    Some(cwd) => (cwd, true)
-  }
   let job = Job::spawn_windows(
     command_line,
     env~,
@@ -36,7 +32,6 @@ pub async fn spawn_windows(
     stdout~,
     stderr~,
     cwd~,
-    has_cwd~,
     no_console_window~,
     is_orphan~,
   )

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -2292,9 +2292,6 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   HANDLE stdin_handle,
   HANDLE stdout_handle,
   HANDLE stderr_handle,
-  LPWSTR cwd,
-  int32_t has_cwd,
-  int32_t no_console_window,
   int32_t is_orphan
 ) {
   struct spawn_job *job = MAKE_JOB(spawn);
@@ -2303,8 +2300,8 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   job->stdio[0] = stdin_handle;
   job->stdio[1] = stdout_handle;
   job->stdio[2] = stderr_handle;
-  job->cwd = has_cwd ? cwd : 0;
-  job->no_console_window = no_console_window;
+  job->cwd = NULL;
+  job->no_console_window = FALSE;
   job->is_orphan = is_orphan;
   job->result = INVALID_HANDLE_VALUE;
 
@@ -2321,6 +2318,14 @@ HANDLE moonbitlang_async_get_spawn_job_result_handle(struct spawn_job *job) {
   HANDLE result = job->result;
   job->result = INVALID_HANDLE_VALUE;
   return result;
+}
+
+void moonbitlang_async_spawn_job_set_cwd(struct spawn_job *job, LPWSTR cwd) {
+  job->cwd = cwd;
+}
+
+void moonbitlang_async_spawn_job_set_no_console_window(struct spawn_job *job) {
+  job->no_console_window = TRUE;
 }
 
 // For windows, waiting for process is done via one dedicated thread per process,
@@ -2490,8 +2495,7 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   int stdin_fd,
   int stdout_fd,
   int stderr_fd,
-  char *cwd,
-  int32_t has_cwd
+  int32_t is_orphan
 ) {
   struct spawn_job *job = MAKE_JOB(spawn);
   job->path = path;
@@ -2500,9 +2504,13 @@ struct spawn_job *moonbitlang_async_make_spawn_job(
   job->stdio[0] = stdin_fd;
   job->stdio[1] = stdout_fd;
   job->stdio[2] = stderr_fd;
-  job->cwd = has_cwd ? cwd : 0;
+  job->cwd = 0;
   job->pidfd = -1;
   return job;
+}
+
+void moonbitlang_async_spawn_job_set_cwd(struct spawn_job *job, char *cwd) {
+  job->cwd = cwd;
 }
 
 // Unix wait_for_process: blocking waitpid in worker thread

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -230,35 +230,97 @@ priv struct SpawnJob(Job)
 
 ///|
 #cfg(not(platform="windows"))
-#owned(path, args, env, cwd)
-extern "C" fn Job::spawn_unix(
+#owned(path, args, env)
+extern "C" fn Job::spawn_unix_ffi(
   path : @os_string.OsString,
   args : @c_buffer.Buffer,
   env~ : @c_buffer.Buffer,
   stdin~ : @fd_util.Fd,
   stdout~ : @fd_util.Fd,
   stderr~ : @fd_util.Fd,
-  cwd~ : @os_string.OsString,
-  has_cwd~ : Bool,
+  is_orphan~ : Bool,
 ) -> SpawnJob = "moonbitlang_async_make_spawn_job"
 
 ///|
 #cfg(platform="windows")
-#owned(command_line, env, cwd)
-extern "C" fn Job::spawn_windows(
+#owned(command_line, env)
+extern "C" fn Job::spawn_windows_ffi(
   command_line : @os_string.OsString,
   env~ : @c_buffer.Buffer,
   stdin~ : @fd_util.Fd,
   stdout~ : @fd_util.Fd,
   stderr~ : @fd_util.Fd,
-  cwd~ : @os_string.OsString,
-  has_cwd~ : Bool,
-  no_console_window~ : Bool,
   is_orphan~ : Bool,
 ) -> SpawnJob = "moonbitlang_async_make_spawn_job"
 
 ///|
+#borrow(job)
+#owned(cwd)
+extern "C" fn SpawnJob::set_cwd(job : SpawnJob, cwd : @os_string.OsString) = "moonbitlang_async_spawn_job_set_cwd"
+
+///|
+#cfg(platform="windows")
+#borrow(job)
+extern "C" fn SpawnJob::set_no_console_window(job : SpawnJob) = "moonbitlang_async_spawn_job_set_no_console_window"
+
+///|
 extern "C" fn SpawnJob::result_handle(job : SpawnJob) -> @fd_util.Fd = "moonbitlang_async_get_spawn_job_result_handle"
+
+///|
+#cfg(not(platform="windows"))
+fn Job::spawn_unix(
+  path : @os_string.OsString,
+  args : @c_buffer.Buffer,
+  env~ : @c_buffer.Buffer,
+  stdin~ : @fd_util.Fd,
+  stdout~ : @fd_util.Fd,
+  stderr~ : @fd_util.Fd,
+  is_orphan~ : Bool,
+  cwd~ : @os_string.OsString?,
+) -> SpawnJob {
+  let job = Job::spawn_unix_ffi(
+    path,
+    args,
+    env~,
+    stdin~,
+    stdout~,
+    stderr~,
+    is_orphan~,
+  )
+  if cwd is Some(cwd) {
+    job.set_cwd(cwd)
+  }
+  job
+}
+
+///|
+#cfg(platform="windows")
+fn Job::spawn_windows(
+  command_line : @os_string.OsString,
+  env~ : @c_buffer.Buffer,
+  stdin~ : @fd_util.Fd,
+  stdout~ : @fd_util.Fd,
+  stderr~ : @fd_util.Fd,
+  is_orphan~ : Bool,
+  cwd~ : @os_string.OsString?,
+  no_console_window~ : Bool,
+) -> SpawnJob {
+  let job = Job::spawn_windows_ffi(
+    command_line,
+    env~,
+    stdin~,
+    stdout~,
+    stderr~,
+    is_orphan~,
+  )
+  if cwd is Some(cwd) {
+    job.set_cwd(cwd)
+  }
+  if no_console_window {
+    job.set_no_console_window()
+  }
+  job
+}
 
 ///|
 // `handle` is used by Windows, `pid` is used by Linux

--- a/src/internal/event_loop/thread_pool.wasm.mbt
+++ b/src/internal/event_loop/thread_pool.wasm.mbt
@@ -572,9 +572,14 @@ fn Job::spawn_unix(
   stdin~ : @fd_util.Fd,
   stdout~ : @fd_util.Fd,
   stderr~ : @fd_util.Fd,
-  cwd~ : @os_string.OsString,
-  has_cwd~ : Bool,
+  is_orphan~ : Bool,
+  cwd~ : @os_string.OsString?,
 ) -> SpawnJob {
+  let (cwd, has_cwd) = match cwd {
+    None => (@os_string.empty, false)
+    Some(cwd) => (cwd, true)
+  }
+  ignore(is_orphan)
   SpawnJob(
     Job(
       JobHandle::spawn_unix(
@@ -617,11 +622,14 @@ fn Job::spawn_windows(
   stdin~ : @fd_util.Fd,
   stdout~ : @fd_util.Fd,
   stderr~ : @fd_util.Fd,
-  cwd~ : @os_string.OsString,
-  has_cwd~ : Bool,
+  cwd~ : @os_string.OsString?,
   no_console_window~ : Bool,
   is_orphan~ : Bool,
 ) -> SpawnJob {
+  let (cwd, has_cwd) = match cwd {
+    None => (@os_string.empty, false)
+    Some(cwd) => (cwd, true)
+  }
   SpawnJob(
     Job(
       JobHandle::spawn_windows(

--- a/src/process/unix.mbt
+++ b/src/process/unix.mbt
@@ -162,6 +162,7 @@ async fn raw_spawn_unix(
     stdin~,
     stdout~,
     stderr~,
+    is_orphan~,
     cwd~,
     context~,
   )


### PR DESCRIPTION
Use builder style API for creation of process spawning job, so that we can more easily add more options in the future. Also reserve an `is_orphan` flag for the process spawning API for potential future use.

Since #518 would require changing the API interface, I think we may also adapt the change here to Wasm as well for cleaner FFI shape? cc @peter-jerry-ye 