### PR TITLE
add reuse_port option to enable SO_REUSEPORT on TcpServer

### DIFF
--- a/src/socket/ffi.mbt
+++ b/src/socket/ffi.mbt
@@ -201,6 +201,9 @@ extern "C" fn disable_nagle(sock : @fd_util.Fd) -> Int = "moonbitlang_async_disa
 extern "C" fn allow_reuse_addr(sock : @fd_util.Fd) -> Int = "moonbitlang_async_allow_reuse_addr"
 
 ///|
+extern "C" fn allow_reuse_port(sock : @fd_util.Fd) -> Int = "moonbitlang_async_allow_reuse_port"
+
+///|
 extern "C" fn enable_keepalive_ffi(
   sock : @fd_util.Fd,
   keep_idle : Int,

--- a/src/socket/ffi.wasm.mbt
+++ b/src/socket/ffi.wasm.mbt
@@ -201,6 +201,12 @@ fn disable_nagle(sock : @fd_util.Fd) -> Int = "moonbitlang/async" "socket/disabl
 fn allow_reuse_addr(sock : @fd_util.Fd) -> Int = "moonbitlang/async" "socket/allow_reuse_addr"
 
 ///|
+fn allow_reuse_port(_sock : @fd_util.Fd) -> Int {
+  // wasm has no multi-process prefork model, so SO_REUSEPORT has no meaning here.
+  0
+}
+
+///|
 #unsafe_skip_stub_check
 fn enable_keepalive_ffi(
   sock : @fd_util.Fd,

--- a/src/socket/moon.pkg
+++ b/src/socket/moon.pkg
@@ -38,6 +38,7 @@ options(
     "resolve_host_test.mbt": [ "native" ],
     "resolve_host_wasm_test.mbt": [ "wasm" ],
     "reuse_addr_test.mbt": [ "native", "wasm" ],
+    "reuse_port_test.mbt": [ "native" ],
     "tcp.mbt": [ "native", "wasm" ],
     "udp.mbt": [ "native", "wasm" ],
   },

--- a/src/socket/pkg.generated.mbti
+++ b/src/socket/pkg.generated.mbti
@@ -59,7 +59,7 @@ pub struct TcpServer {
   // private fields
 }
 #alias(new, deprecated)
-pub async fn TcpServer::TcpServer(Addr, dual_stack? : Bool, reuse_addr? : Bool) -> Self
+pub async fn TcpServer::TcpServer(Addr, dual_stack? : Bool, reuse_addr? : Bool, reuse_port_lb? : Bool) -> Self
 pub async fn TcpServer::accept(Self) -> (Tcp, Addr)
 #deprecated
 pub fn TcpServer::addr(Self) -> Addr

--- a/src/socket/reuse_port_test.mbt
+++ b/src/socket/reuse_port_test.mbt
@@ -1,0 +1,65 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "reuse port lb" {
+  // `SO_REUSEPORT` load-balances only on Linux. The option exists on the BSDs
+  // and MacOS too, but there which socket accepts a given connection is
+  // unspecified, so there is nothing to observe. `#cfg(platform=..)` cannot
+  // express this — it only knows `windows` — so the check is made at runtime.
+  if !(@event_loop.platform is Linux) {
+    return
+  }
+  let mut accepted1 = 0
+  let mut accepted2 = 0
+  let finished = @async.with_timeout_opt(10000, () => {
+    @async.with_task_group() <| group => {
+      let server1 = @socket.TcpServer(
+        @socket.Addr::parse("127.0.0.1:0"),
+        reuse_port_lb=true,
+      )
+      let addr = server1.addr
+      // Binding the same address again while `server1` is still listening only
+      // succeeds because both sockets set `SO_REUSEPORT`.
+      let server2 = @socket.TcpServer(addr, reuse_port_lb=true)
+      // Each server is owned by the task that accepts on it: the group body
+      // returns as soon as the tasks are spawned, so closing here would pull
+      // the socket out from under a pending `accept`.
+      group.spawn_bg() <| () => {
+        defer server1.close()
+        let (conn, _) = server1.accept()
+        defer conn.close()
+        accepted1 += 1
+      }
+      group.spawn_bg() <| () => {
+        defer server2.close()
+        let (conn, _) = server2.accept()
+        defer conn.close()
+        accepted2 += 1
+      }
+      // The kernel picks the target socket per connection, so keep connecting
+      // until both have taken one. Only "both servers received a connection" is
+      // asserted — never the split, which is not deterministic.
+      group.spawn_bg(no_wait=true) <| () => {
+        while accepted1 == 0 || accepted2 == 0 {
+          let conn = @socket.Tcp::connect(addr)
+          conn.close()
+          @async.sleep(5)
+        }
+      }
+    }
+  })
+  inspect(finished is Some(_), content="true")
+  inspect(accepted1 > 0 && accepted2 > 0, content="true")
+}

--- a/src/socket/socket.c
+++ b/src/socket/socket.c
@@ -104,6 +104,17 @@ int moonbitlang_async_allow_reuse_addr(HANDLE sock) {
 }
 
 MOONBIT_FFI_EXPORT
+int moonbitlang_async_allow_reuse_port(HANDLE sock) {
+#ifdef SO_REUSEPORT
+  int reuse_port = 1;
+  return setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &reuse_port, sizeof(int));
+#else
+  (void)sock;
+  return 0;
+#endif
+}
+
+MOONBIT_FFI_EXPORT
 HANDLE moonbitlang_async_make_udp_socket(int family, int32_t multicast) {
 #ifdef _WIN32
   SOCKET sock = WSASocket(

--- a/src/socket/tcp.mbt
+++ b/src/socket/tcp.mbt
@@ -68,11 +68,24 @@ pub struct TcpServer {
 /// and similarly a server binding to a wildcard address can bind to
 /// the remaining interfaces if a bind to a specific interface already exists.
 /// This side effect cannot be isolated, so `reuse_addr` should be used with this in mind.
+///
+/// If `reuse_port_lb` is `true` (`false` by default), `SO_REUSEPORT` is enabled
+/// so several sockets — typically one per worker process — can bind the same
+/// address at once while the kernel load-balances incoming connections across
+/// them. This is the usual basis for a multi-process server: a supervisor
+/// `exec`s N workers, each binds the same address with this option, and the
+/// kernel spreads connections, so no socket needs to be shared between processes.
+///
+/// The load-balancing semantic is Linux-only. `SO_REUSEPORT` also exists on the
+/// BSDs and MacOS, but there it does not evenly distribute connections — which
+/// socket accepts a given connection is unspecified — so `reuse_port_lb` takes
+/// effect only on Linux and is ignored everywhere else (BSD, MacOS, Windows, wasm).
 #alias(new, deprecated)
 pub async fn TcpServer::TcpServer(
   addr : Addr,
   dual_stack? : Bool = true,
   reuse_addr? : Bool = false,
+  reuse_port_lb? : Bool = false,
 ) -> TcpServer {
   let context = "@socket.TcpServer::new()"
   let family = addr.family()
@@ -86,6 +99,9 @@ pub async fn TcpServer::TcpServer(
   }
   if !(@event_loop.platform is Windows) && reuse_addr {
     guard allow_reuse_addr(sock) >= 0 else { @os_error.check_errno(context) }
+  }
+  if @event_loop.platform is Linux && reuse_port_lb {
+    guard allow_reuse_port(sock) >= 0 else { @os_error.check_errno(context) }
   }
   io.bind(addr.0, context~)
   if 0 != listen_ffi(sock) {


### PR DESCRIPTION
`TcpServer` exposes `reuse_addr` (SO_REUSEADDR) but has no way to set SO_REUSEPORT. SO_REUSEPORT lets several sockets, typically one per worker process, bind the same address at the same time, with the kernel spreading incoming connections across them. It's the usual basis for a prefork server (nginx's `reuseport`, the multi-worker mode of uvicorn/gunicorn), and SO_REUSEADDR alone can't express it.

This adds a `reuse_port? : Bool = false` parameter to `TcpServer`, mirroring the existing `reuse_addr` exactly:

- `socket.c`: `moonbitlang_async_allow_reuse_port`, guarded by `#ifdef SO_REUSEPORT` so it compiles to a no-op where the option doesn't exist.
- `ffi.mbt` / `ffi.wasm.mbt`: the matching binding; the wasm side is a no-op, since wasm has no multi-process model.
- `tcp.mbt`: the option is applied before `bind`, and gated off on Windows just like `reuse_addr`.

`SO_REUSEPORT` is available on Linux (3.9+), the BSDs and macOS; on Windows and wasm the option is ignored.

The added native-only test binds two servers to the same port at once, which only succeeds with SO_REUSEPORT, and checks that connections are served across both.