### PR TITLE
fix `/dev/null` handling, allow failure when registering fd

### DIFF
--- a/src/internal/event_loop/dev_null_test.mbt
+++ b/src/internal/event_loop/dev_null_test.mbt
@@ -1,0 +1,26 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(target="native")
+async test "/dev/null" {
+  if @event_loop.platform is Windows {
+    return
+  }
+  let file = @fs.open("/dev/null", mode=ReadWrite)
+  defer file.close()
+  assert_eq(file.kind(), CharDevice)
+  file.write(Bytes::make(1024, 0))
+  assert_eq(file.read_all().text(), "")
+}

--- a/src/internal/event_loop/epoll.c
+++ b/src/internal/event_loop/epoll.c
@@ -17,11 +17,10 @@
 #ifdef __linux__
 
 #include <unistd.h>
+#include <errno.h>
 #include <fcntl.h>
-#include <sys/syscall.h>
 #include <sys/epoll.h>
 #include <sys/wait.h>
-#include <linux/version.h>
 
 _Noreturn void moonbit_panic();
 
@@ -40,7 +39,12 @@ static const int ev_masks[] = {
   EPOLLIN | EPOLLOUT,
 };
 
-int moonbitlang_async_event_bus_register(int epfd, int fd, int32_t read_only) {
+/* return value:
+   `-1` => failure
+   `0` => fd not supported
+   `1` => successfully registered
+ */
+int32_t moonbitlang_async_event_bus_register(int epfd, int fd, int32_t read_only) {
   // File descriptors registered with the event bus
   // should always be used in a non-blocking manner, due to our use of `EPOLLET`.
   // Error is intentionally omitted here, because some special file descriptors,
@@ -56,7 +60,13 @@ int moonbitlang_async_event_bus_register(int epfd, int fd, int32_t read_only) {
   epoll_data_t data;
   data.u64 = fd;
   struct epoll_event event = { events, data };
-  return epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event);
+  int ret = epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event);
+  if (ret >= 0)
+    return 1;
+  else if (errno == EPERM)
+    return 0;
+  else
+    return -1;
 }
 
 int moonbitlang_async_event_bus_register_pid(int epfd, pid_t pid) {

--- a/src/internal/event_loop/event_bus.mbt
+++ b/src/internal/event_loop/event_bus.mbt
@@ -46,14 +46,19 @@ extern "C" fn EventBus::register_ffi(
 ) -> Int = "moonbitlang_async_event_bus_register"
 
 ///|
+/// Try to register the file descriptor with the event bus,
+/// return `true` if the file descriptor is succesfully registered,
+/// `false` if the fd is not supported.
 fn EventBus::register(
   self : EventBus,
   fd : @fd_util.Fd,
   read_only~ : Bool,
-) -> Unit raise {
-  if self.register_ffi(fd, read_only) < 0 {
+) -> Bool raise {
+  let ret = self.register_ffi(fd, read_only)
+  if ret < 0 {
     @os_error.check_errno("runtime internal: @event_loop.EventBus::register()")
   }
+  ret > 0
 }
 
 ///|

--- a/src/internal/event_loop/event_bus.wasm.mbt
+++ b/src/internal/event_loop/event_bus.wasm.mbt
@@ -47,10 +47,12 @@ fn EventBus::register(
   self : EventBus,
   fd : @fd_util.Fd,
   read_only~ : Bool,
-) -> Unit raise {
+) -> Bool raise {
   if self.register_ffi(fd, read_only) < 0 {
     @os_error.check_errno("runtime internal: @event_loop.EventBus::register()")
   }
+  // TODO: support try-register in Wasm runtime
+  true
 }
 
 ///|

--- a/src/internal/event_loop/io.mbt
+++ b/src/internal/event_loop/io.mbt
@@ -100,12 +100,10 @@ pub fn IoHandle::from_fd(
   let context = "@event_loop.IoHandle::from_fd()"
   guard! curr_loop.val is Some(evloop)
   guard! evloop.fds.get(fd) is None
-  if is_async {
-    evloop.bus.register(fd, read_only~) catch {
-      err => {
-        @fd_util.close(fd, kind~, context~)
-        raise err
-      }
+  let is_async = (is_async && evloop.bus.register(fd, read_only~)) catch {
+    err => {
+      @fd_util.close(fd, kind~, context~)
+      raise err
     }
   }
   let handle = {

--- a/src/internal/event_loop/iocp.c
+++ b/src/internal/event_loop/iocp.c
@@ -33,7 +33,7 @@ MOONBIT_FFI_EXPORT
 int moonbitlang_async_event_bus_register(HANDLE iocp, HANDLE fd, int32_t read_only) {
   if (!SetFileCompletionNotificationModes(fd, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS))
     return -1;
-  return CreateIoCompletionPort(fd, iocp, (ULONG_PTR)fd, 0) == NULL ? -1 : 0;
+  return CreateIoCompletionPort(fd, iocp, (ULONG_PTR)fd, 0) == NULL ? -1 : 1;
 }
 
 #define EVENT_BUFFER_SIZE 1024

--- a/src/internal/event_loop/kqueue.c
+++ b/src/internal/event_loop/kqueue.c
@@ -46,7 +46,12 @@ void moonbitlang_async_event_bus_destroy(int kqfd) {
   close(kqfd);
 }
 
-int moonbitlang_async_event_bus_register(int kqfd, int fd, int32_t read_only) {
+/* return value:
+   `-1` => failure
+   `0` => fd not supported
+   `1` => successfully registered
+ */
+int32_t moonbitlang_async_event_bus_register(int kqfd, int fd, int32_t read_only) {
   // File descriptors registered with the event bus
   // should always be used in a non-blocking manner, due to our use of `EV_CLEAR`.
   // Error is intentionally omitted here, because some special file descriptors,
@@ -55,14 +60,27 @@ int moonbitlang_async_event_bus_register(int kqfd, int fd, int32_t read_only) {
   if (fd_flags >= 0 && !(fd_flags & O_NONBLOCK))
     fcntl(fd, F_SETFL, fd_flags | O_NONBLOCK);
 
-  int flags = EV_ADD | EV_CLEAR;
+  int flags = EV_ADD | EV_CLEAR | EV_RECEIPT;
 
-  struct kevent events[2];
+  struct kevent events[2], receipts[2];
   EV_SET(&events[0], fd, EVFILT_READ, flags, 0, 0, 0);
   if (!read_only)
     EV_SET(&events[1], fd, EVFILT_WRITE, flags, 0, 0, 0);
 
-  return kevent(kqfd, events, read_only ? 1 : 2, 0, 0, 0);
+  int ret = kevent(kqfd, events, read_only ? 1 : 2, receipts, 2, 0);
+  if (ret < 0)
+    return ret;
+
+  /* If any of the filter (`EVFILT_READ`/`EVFILT_WRITE`) is registered,
+     treat the fd as "pollable".
+     Note that `kqueue` support registering regular file with `EVFILT_READ`,
+     but the semantic is not very useful.
+     So we still rely on `st_mode` to do filtering before `event_bus_register` */
+  for (int i = 0; i < ret; ++i)
+    if (receipts[i].data == 0)
+      return 1;
+
+  return 0;
 }
 
 // return value:


### PR DESCRIPTION
closes #533 

Note:

- we still rely on `st_mode` for pre-register filtering, because `kqueue` support `EVFILT_READ` on regular files with a not-very-useful semantic
- `kqueue` reports availability of read/write filters separately. Here we treat the fd as pollable if any of the filter is available