### PR TITLE
output fatal message to `stderr` & support custom deadlock detection

### DIFF
--- a/src/async.mbt
+++ b/src/async.mbt
@@ -116,6 +116,25 @@ pub using @coroutine {protect_from_cancel}
 pub using @event_loop {now}
 
 ///|
+/// When `moonbitlang/async` detects a a deadlock situation
+/// (i.e. all remaining tasks are mutually blocked on each other,
+/// no one is waiting for any timer or IO),
+/// the runtime automatically panic and report error to `stderr`
+/// to avoid stucking forever.
+///
+/// This behavior can be altered by `set_deadlock_handler`.
+/// The handler will receive the source location of remaining tasks as input,
+/// the user may choose to output log via a file or other means and panic,
+/// or simply ignore the deadlock situation by setting a custom callback.
+///
+/// If the deadlock handler return normally without aborting the program,
+/// the runtime will ignore the deadlock and continue execution,
+/// disabling deadlock detection in effect.
+/// Note that the program will likely hang forever in this case.
+#cfg(any(target="native", target="wasm"))
+pub using @event_loop {set_deadlock_handler}
+
+///|
 pub using @aqueue {type Queue}
 
 ///|

--- a/src/integration.mbt
+++ b/src/integration.mbt
@@ -23,8 +23,7 @@ pub fn run_async_main(main : async () -> Unit) -> Unit {
     @event_loop.KilledBySignal(signal) =>
       @event_loop.terminate_process_by_signal(signal)
     err => {
-      // TODO: output the error to stderr
-      println(err)
+      @env_util.eprintln(err.to_string())
       exit(1)
     }
   }
@@ -63,6 +62,7 @@ extern "C" fn exit(code : Int) = "exit"
 #cfg(target="js")
 #doc(hidden)
 pub fn run_async_main(main : async () -> Unit) -> Unit {
+  ignore(@env_util.eprintln)
   let _ = @coroutine.spawn(main)
   @event_loop.reschedule()
 }

--- a/src/integration.wasm.mbt
+++ b/src/integration.wasm.mbt
@@ -18,7 +18,7 @@
 pub fn run_async_main(main : async () -> Unit) -> Unit {
   @event_loop.with_event_loop(() => main()) catch {
     err => {
-      println(err)
+      @env_util.eprintln(err.to_string())
       exit(1)
     }
   }

--- a/src/internal/env_util/env_util.mbt
+++ b/src/internal/env_util/env_util.mbt
@@ -22,4 +22,16 @@ extern "C" fn get_pid() -> UInt = "moonbitlang_async_getpid"
 fn get_pid() -> UInt = "moonbitlang/async" "env_util/getpid"
 
 ///|
+#cfg(any(target="native", target="wasm"))
 pub let current_process : UInt = get_pid()
+
+///|
+#cfg(target="native")
+#borrow(msg)
+pub extern "C" fn eprintln(msg : String) -> Unit = "moonbitlang_async_eprintln"
+
+///|
+#cfg(not(target="native"))
+pub fn eprintln(msg : String) -> Unit {
+  println(msg)
+}

--- a/src/internal/env_util/moon.pkg
+++ b/src/internal/env_util/moon.pkg
@@ -1,4 +1,3 @@
 options(
   "native-stub": [ "stub.c" ],
-  targets: { "env_util.mbt": [ "native", "wasm" ] },
 )

--- a/src/internal/env_util/pkg.generated.mbti
+++ b/src/internal/env_util/pkg.generated.mbti
@@ -4,6 +4,8 @@ package "moonbitlang/async/internal/env_util"
 // Values
 pub let current_process : UInt
 
+pub fn eprintln(String) -> Unit
+
 // Errors
 
 // Types and methods

--- a/src/internal/env_util/stub.c
+++ b/src/internal/env_util/stub.c
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
+#include <stdio.h>
+#include <moonbit.h>
+
 #ifdef _WIN32
 
 #include <windows.h>
-#include <moonbit.h>
 
 #else
 
 #include <unistd.h>
-#include <moonbit.h>
 
 #endif
 
@@ -32,4 +33,85 @@ uint32_t moonbitlang_async_getpid() {
 #else
   return getpid();
 #endif
+}
+
+void moonbitlang_async_eprintln(moonbit_string_t msg) {
+#ifdef _WIN32
+  static HANDLE stderr_handle = INVALID_HANDLE_VALUE;
+  static BOOL stderr_is_console = 0;
+  static const DWORD max_chunk_size = 1 << 14; // 16K
+
+  if (stderr_handle == INVALID_HANDLE_VALUE) {
+    stderr_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+
+    if (stderr_handle == INVALID_HANDLE_VALUE) {
+      // There is no stderr. Simply ignore the message
+      return;
+    }
+
+    DWORD mode;
+    stderr_is_console = GetConsoleMode(stderr_handle, &mode);
+  }
+
+  if (stderr_is_console) {
+    // When stderr is a real console,
+    // use `WriteConsoleW` to errput with current code page of the console.
+    DWORD len = Moonbit_array_length(msg);
+    DWORD written = 0, total_written = 0;
+    while (total_written < len) {
+      DWORD chars_to_write = len - total_written;
+      if (chars_to_write > max_chunk_size)
+        chars_to_write = max_chunk_size;
+
+      BOOL ret = WriteConsoleW(
+        stderr_handle,
+        ((WCHAR*)msg) + total_written,
+        chars_to_write,
+        &written,
+        NULL
+      );
+
+      if (!ret) return;
+      total_written += written;
+    }
+    WriteConsoleW(stderr_handle, L"\n", 1, NULL, NULL);
+    return;
+  }
+#endif
+
+  char window[1024];
+  int32_t const len = Moonbit_array_length(msg);
+  int32_t window_len = 0;
+  for (int32_t i = 0; i < len; ++i) {
+    // always reserve one bit for the newline character
+    if (window_len + 4 >= sizeof(window) - 1) {
+      fwrite(window, 1, window_len, stderr);
+      window_len = 0;
+    }
+    uint32_t c = msg[i];
+    if (0xD800 <= c && c <= 0xDBFF) {
+      c -= 0xD800;
+      i = i + 1;
+      uint32_t l = msg[i] - 0xDC00;
+      c = ((c << 10) + l) + 0x10000;
+    }
+    // stdout accepts UTF-8, so convert the stream to UTF-8 first
+    if (c < 0x80) {
+      window[window_len++] = c;
+    } else if (c < 0x800) {
+      window[window_len++] = 0xc0 + (c >> 6);
+      window[window_len++] = 0x80 + (c & 0x3f);
+    } else if (c < 0x10000) {
+      window[window_len++] = 0xe0 + (c >> 12);
+      window[window_len++] = 0x80 + ((c >> 6) & 0x3f);
+      window[window_len++] = 0x80 + (c & 0x3f);
+    } else {
+      window[window_len++] = 0xf0 + (c >> 18);
+      window[window_len++] = 0x80 + ((c >> 12) & 0x3f);
+      window[window_len++] = 0x80 + ((c >> 6) & 0x3f);
+      window[window_len++] = 0x80 + (c & 0x3f);
+    }
+  }
+  window[window_len++] = '\n';
+  fwrite(window, 1, window_len, stderr);
 }

--- a/src/internal/event_loop/event_loop.js.mbt
+++ b/src/internal/event_loop/event_loop.js.mbt
@@ -19,6 +19,7 @@ let _ignore_unused_import : Unit = {
   ignore(@os_string.unimplemented)
   ignore(@os_error.unimplemented)
   let _ : (&@external_loop_integration.ExternalEventLoop) -> Unit = ignore
+  ignore(@env_util.eprintln)
 }
 
 ///|

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -310,17 +310,15 @@ fn EventLoop::cleanup(self : Self) -> Unit raise {
 }
 
 ///|
-fn EventLoop::get_next_timeout(self : Self) -> Int? {
+fn EventLoop::get_next_timeout(self : Self) -> Int {
   if @coroutine.has_immediately_ready_task() {
-    Some(0)
+    0
   } else if !self.timers.is_empty() {
     guard! self.timers.iter().head() is Some(first_timer)
     let timeout = first_timer.expire_time - now()
-    Some(@cmp.maximum(0, timeout.to_int()))
-  } else if self.blocked_tasks > 0 {
-    Some(-1)
+    @cmp.maximum(0, timeout.to_int())
   } else {
-    None
+    -1
   }
 }
 
@@ -337,6 +335,20 @@ fn EventLoop::handle_timers(self : Self) -> Unit {
 }
 
 ///|
+let deadlock_handler : Ref[(Array[SourceLoc]) -> Unit] = Ref(locs => {
+  let locs = locs.map(loc => loc.to_string())
+  @env_util.eprintln(
+    "Dead lock detected. Tasks spawned at the following locations are still alive: \{Repr(locs)}",
+  )
+  panic()
+})
+
+///|
+pub fn set_deadlock_handler(f : (Array[SourceLoc]) -> Unit) -> Unit {
+  deadlock_handler.val = f
+}
+
+///|
 fn EventLoop::check_dead_lock(self : Self) -> Unit {
   let all_coros = @coroutine.all_coroutines().iter()
   let all_coros = match self.signal_handler {
@@ -344,19 +356,24 @@ fn EventLoop::check_dead_lock(self : Self) -> Unit {
       all_coros.filter(coro => coro != sigwait_task)
     None | Some(ConsoleControlHandler) => all_coros
   }
-  let all_coros = all_coros.map(coro => coro.loc.to_string()).collect()
+  let all_coros = all_coros.map(coro => coro.loc).collect()
   if all_coros.length() > 0 {
-    @env_util.eprintln(
-      "Dead lock detected. Tasks spawned at the following locations are still alive: \{Repr(all_coros)}",
-    )
-    panic()
+    (deadlock_handler.val)(all_coros)
   }
 }
 
 ///|
 fn EventLoop::run_forever(self : Self) -> Unit raise {
   try {
-    while self.get_next_timeout() is Some(timeout) {
+    let mut checked_deadlock = false
+    while !@coroutine.all_coroutines().is_empty() {
+      let timeout = self.get_next_timeout()
+      if timeout < 0 && self.blocked_tasks is 0 && !checked_deadlock {
+        // The user may decide to ignore deadlock situation,
+        // in this case we only perform the deadlock check once.
+        checked_deadlock = true
+        self.check_dead_lock()
+      }
       let n = self.wait_for_event(timeout~)
       if timeout >= 0 {
         self.handle_timers()
@@ -399,8 +416,8 @@ fn EventLoop::run_with_external_loop(
   try {
     while !@coroutine.all_coroutines().is_empty() {
       let timeout = match self.get_next_timeout() {
-        Some(_..<0) | None => None
-        Some(timeout) => Some(timeout)
+        _..<0 => None
+        timeout => Some(timeout)
       }
       extloop.poll(timeout?)
       if !self.timers.is_empty() {

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -273,7 +273,8 @@ fn EventLoop::check_fd_leak(self : Self) -> Unit {
     let leaked_handles = [
       for handle in self.fds.values() => @debug.to_string(handle.kind)
     ].join(", ")
-    abort("file descriptor leak detected: \{leaked_handles}")
+    @env_util.eprintln("file descriptor leak detected: \{leaked_handles}")
+    panic()
   }
 }
 
@@ -345,7 +346,7 @@ fn EventLoop::check_dead_lock(self : Self) -> Unit {
   }
   let all_coros = all_coros.map(coro => coro.loc.to_string()).collect()
   if all_coros.length() > 0 {
-    println(
+    @env_util.eprintln(
       "Dead lock detected. Tasks spawned at the following locations are still alive: \{Repr(all_coros)}",
     )
     panic()

--- a/src/internal/event_loop/moon.pkg
+++ b/src/internal/event_loop/moon.pkg
@@ -10,6 +10,7 @@ import {
   "moonbitlang/async/internal/fd_util",
   "moonbitlang/async/internal/c_buffer",
   "moonbitlang/async/internal/os_string",
+  "moonbitlang/async/internal/env_util",
   "moonbitlang/async/external_loop_integration",
 }
 

--- a/src/internal/event_loop/pkg.generated.mbti
+++ b/src/internal/event_loop/pkg.generated.mbti
@@ -76,6 +76,8 @@ pub async fn rename(StringView, StringView, replace~ : Bool, context~ : String) 
 
 pub async fn rmdir(StringView, context~ : String) -> Unit
 
+pub fn set_deadlock_handler((Array[SourceLoc]) -> Unit) -> Unit
+
 pub fn set_external_event_loop(&@external_loop_integration.ExternalEventLoop) -> Unit
 
 pub fn set_global_cancellation_signals(ReadOnlyArray[Int]) -> Unit

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/async/aqueue",
   "moonbitlang/async/semaphore",
   "moonbitlang/async/cond_var",
+  "moonbitlang/async/internal/env_util",
 }
 
 import {

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -27,6 +27,8 @@ pub async fn[X] protect_from_cancel(async () -> X, resume_on_cancel? : Bool) -> 
 
 pub async fn[X] retry(RetryMethod, max_retry? : Int, fatal_error? : (Error) -> Bool, async () -> X) -> X
 
+pub fn set_deadlock_handler((Array[SourceLoc]) -> Unit) -> Unit
+
 pub fn set_external_event_loop(&@external_loop_integration.ExternalEventLoop) -> Unit
 
 pub async fn sleep(Int) -> Unit

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -78,17 +78,20 @@ async test "stdio cancel" {
   @async.with_task_group() <| group => {
     let (cat_read, we_write) = @process.write_to_process()
     let (we_read, cat_write) = @process.read_from_process()
+    let (we_read_err, cat_write_err) = @process.read_from_process()
     group.spawn_bg() <| () => {
       let code = @process.run(
         cat,
         ["-timeout", "500"],
         stdin=cat_read,
         stdout=cat_write,
+        stderr=cat_write_err,
       )
       inspect(code, content="1")
     }
     defer we_write.close()
     defer we_read.close()
+    defer we_read_err.close()
     we_write.write("abcd")
     debug_inspect(
       we_read.read_some(),
@@ -97,8 +100,9 @@ async test "stdio cancel" {
       ),
     )
     @async.sleep(750)
+    assert_eq(we_read.read_all().text(), "")
     inspect(
-      we_read.read_all().text().trim(chars="\r\n"),
+      we_read_err.read_all().text().trim(chars="\r\n"),
       content="TimeoutError",
     )
   }


### PR DESCRIPTION
- previously, on fatal condition such as unhandled error, deadlock and fd leak (if enabled), the runtime will output error message to `stdout`, which is a bad choice. This PR let the runtime output those fatal error message to `stderr` instead
- add `@async.set_deadlock_handler` for setting a custom deadlock handler. The user may choose to log the deadlock information to an alternative channel or a log file. If the handler return normally, the deadlock situation will be ignored. So the new API can be used to disable deadlock detection as well