### PR TITLE
fix race condition on read/write readiness event when using external loop

### DIFF
--- a/src/external_loop_integration/external_loop_test.mbt
+++ b/src/external_loop_integration/external_loop_test.mbt
@@ -156,7 +156,9 @@ test "non-blocking read & external waiter race" {
         // The main loop will get waken by the event from the waiter thread,
         // and the stale read readiness event will wake this task up.
         // But at this point, there is still no data in the pipe,
-        // so the second `read` attempt still fail with `EAGAIN`, failing the whole test
+        // so the second `read` attempt still fail with `EAGAIN`.
+        // If we do not tolerate `EAGAIN` on the second non-blocking `read` attempt,
+        // the test will (wrongly) fail with error.
         guard r.read_some() is Some(data) else {
           fail("expected data, no data found")
         }

--- a/src/external_loop_integration/external_loop_test.mbt
+++ b/src/external_loop_integration/external_loop_test.mbt
@@ -112,3 +112,56 @@ test "external loop blocked on async only" {
     "main loop received 0 at #1", "main loop received 1 at #2", "terminate main loop",
   ])
 }
+
+///|
+#cfg(target="native")
+test "non-blocking read & external waiter race" {
+  let main_loop = @external_loop_test.MainLoop()
+  @event_loop.with_event_loop <| () => {
+    @async.set_external_event_loop(main_loop)
+    let (r, w) = @pipe.pipe()
+    defer r.close()
+    @async.with_task_group <| group => {
+      // The following three tasks will start running at the same scheduler slice
+      group.spawn_bg() <| () => {
+        defer w.close()
+        // The `write` here will generate a read-readiness event for the pipe
+        w.write("abcd")
+        @async.sleep(150)
+        w.write("xyzw")
+      }
+      group.spawn_bg() <| () => {
+        // do some spinning here to ensure the waiter thread has generated
+        // the read readiness event before we drain the pipe
+        let start = @async.now()
+        while @async.now() - start < 10 {
+
+        }
+        // The `read` here will execute after the `write` above,
+        // so it would immediately succeed and drain all data in the pipe.
+        // At this point, the read readiness event for the pipe
+        // is still in the event bus and not yet consumed.
+        guard r.read_some() is Some(data) else {
+          fail("expected data, no data found")
+        }
+        inspect(@utf8.decode(data), content="abcd")
+      }
+      group.spawn_bg() <| () => {
+        // The `read` here has no data to read, because the pipe
+        // is already drained by the first `read` above.
+        // The first non-blocking `read` attempt here will fail with `EAGAIN`,
+        // and the task will start waiting for read readiness of the pipe.
+        //
+        // Now, the event loop will enter the next slice.
+        // The main loop will get waken by the event from the waiter thread,
+        // and the stale read readiness event will wake this task up.
+        // But at this point, there is still no data in the pipe,
+        // so the second `read` attempt still fail with `EAGAIN`, failing the whole test
+        guard r.read_some() is Some(data) else {
+          fail("expected data, no data found")
+        }
+        inspect(@utf8.decode(data), content="xyzw")
+      }
+    }
+  }
+}

--- a/src/external_loop_integration/moon.pkg
+++ b/src/external_loop_integration/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/async",
   "moonbitlang/async/socket",
   "moonbitlang/async/internal/event_loop",

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -80,16 +80,22 @@ async fn IoHandle::read_via_event_bus_unix(
     @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
-  let ret = if @os_error.is_nonblocking_io_error() {
+  // Usually, the retry loop here should execute at most once.
+  // Because `wait_read` only get woken by a read-readiness event,
+  // and the subsequent `read_unix_ffi` attempt should always succeed.
+  // However, when an external loop is used,
+  // the read readiness event that wake `wait_read` up may be stale,
+  // because the event bus waiter thread is not in-sync with the main thread.
+  while @os_error.is_nonblocking_io_error() {
     handle.wait_read()
-    read_unix_ffi(handle.fd, buf, offset~, len~)
-  } else {
-    ret
-  }
-  if ret < 0 {
+    let ret = read_unix_ffi(handle.fd, buf, offset~, len~)
+    if ret >= 0 {
+      return ret
+    }
+  } nobreak {
     @os_error.check_errno(context)
+    -1
   }
-  ret
 }
 
 ///|
@@ -141,16 +147,22 @@ async fn IoHandle::write_via_event_bus_unix(
     @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
-  let ret = if @os_error.is_nonblocking_io_error() {
+  // Usually, the retry loop here should execute at most once.
+  // Because `wait_read` only get woken by a read-readiness event,
+  // and the subsequent `read_unix_ffi` attempt should always succeed.
+  // However, when an external loop is used,
+  // the read readiness event that wake `wait_read` up may be stale,
+  // because the event bus waiter thread is not in-sync with the main thread.
+  while @os_error.is_nonblocking_io_error() {
     handle.wait_write()
-    write_unix_ffi(handle.fd, buf, offset~, len~)
-  } else {
-    ret
-  }
-  if ret < 0 {
+    let ret = write_unix_ffi(handle.fd, buf, offset~, len~)
+    if ret >= 0 {
+      return ret
+    }
+  } nobreak {
     @os_error.check_errno(context)
+    -1
   }
-  ret
 }
 
 ///|

--- a/src/internal/event_loop/network_unix.mbt
+++ b/src/internal/event_loop/network_unix.mbt
@@ -63,16 +63,16 @@ async fn IoHandle::recvfrom_unix(
     @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
-  let ret = if @os_error.is_nonblocking_io_error() {
+  while @os_error.is_nonblocking_io_error() {
     handle.wait_read()
-    recvfrom_unix_ffi(handle.fd, buf, offset~, len~, addr~)
-  } else {
-    ret
-  }
-  if ret < 0 {
+    let ret = recvfrom_unix_ffi(handle.fd, buf, offset~, len~, addr~)
+    if ret >= 0 {
+      return ret
+    }
+  } nobreak {
     @os_error.check_errno(context)
+    -1
   }
-  ret
 }
 
 ///|
@@ -128,16 +128,16 @@ async fn IoHandle::sendto_unix(
     @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     return ret
   }
-  let ret = if @os_error.is_nonblocking_io_error() {
+  while @os_error.is_nonblocking_io_error() {
     handle.wait_write()
-    sendto_unix_ffi(handle.fd, buf, offset~, len~, addr~)
-  } else {
-    ret
-  }
-  if ret < 0 {
+    let ret = sendto_unix_ffi(handle.fd, buf, offset~, len~, addr~)
+    if ret >= 0 {
+      return ret
+    }
+  } nobreak {
     @os_error.check_errno(context)
+    -1
   }
-  ret
 }
 
 ///|
@@ -244,11 +244,16 @@ pub async fn IoHandle::accept_unix(
     // and give chance for other tasks to execute.
     @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
     conn
-  } else if @os_error.is_nonblocking_io_error() {
-    handle.wait_read()
-    accept_unix_ffi(handle.fd, addr)
   } else {
-    conn
+    while @os_error.is_nonblocking_io_error() {
+      handle.wait_read()
+      let conn = accept_unix_ffi(handle.fd, addr)
+      if @fd_util.fd_is_valid(conn) {
+        break conn
+      }
+    } nobreak {
+      @fd_util.invalid_fd
+    }
   }
   if !@fd_util.fd_is_valid(conn) {
     @os_error.check_errno(context)


### PR DESCRIPTION
When using external event loop, the following race condition may happen on Unix systems:

- a fd become readable because new data have arrived, a read readiness event is generated on the separated waiter thread
- the data is drained before the read readiness event is processed
- a `read` operation is requested, and the initial non-blocking attempt fail with `EAGAIN`
- the `read` operation start waiting for read readiness event
- the main event loop receives notification from the waiter thread, and the (stale) read readiness event is processed, waking the `read` operation
- the second non-blocking `read` attempt still fail with `EAGAIN`

currently, `EAGAIN` is not handled for the second non-blocking `read` attempt, so the program will (incorrectly) fail in this case. This PR add a retry loop for `read`/`write` etc. on Unix systems to solve this problem.

