### PR TITLE
feat(wasm): use generic stat job ABI

### DIFF
--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -20,7 +20,6 @@ pub(all) struct FileIdentity {
 } derive(Eq, Hash)
 
 ///|
-#cfg(target="native")
 pub async fn open(
   path : StringView,
   // 0 => read only, 1 => write only, 2 => read write, 3 => directory listing
@@ -82,49 +81,6 @@ pub async fn open(
 }
 
 ///|
-#cfg(target="wasm")
-pub async fn open(
-  path : StringView,
-  // 0 => read only, 1 => write only, 2 => read write, 3 => directory listing
-  access : Int,
-  // See `@fs.CreateMode` for more details
-  create~ : Int,
-  append~ : Bool,
-  // 0 => no sync, 1 => data sync, 2 => full sync
-  sync~ : Int,
-  // permission for file when new file is created
-  mode~ : Int,
-  context~ : String,
-) -> (IoHandle, FileIdentity) {
-  let path_bytes = @os_string.encode(path)
-  let job = Job::open(path_bytes, access, create~, append~, sync~, mode~)
-  defer job.0.free()
-  try perform_job_in_worker(job.0, context~, cancellable=true) catch {
-    @os_error.OSError(errno, context~) =>
-      raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
-    err => raise err
-  } noraise {
-    _ => {
-      let fd = job.fd()
-      let kind = job.kind()
-      let io = IoHandle::from_fd(
-        fd,
-        kind~,
-        is_async=access is 3 || (!(platform is Windows) && kind.can_poll()),
-        read_only=access is 0,
-      )
-      if append {
-        // For append mode file descriptor, let the OS do the work.
-        // Reading is unaffected by `append`.
-        io.write_offset = -1
-      }
-      (io, { dev_id: job.dev_id(), file_id: job.file_id() })
-    }
-  }
-}
-
-///|
-#cfg(target="native")
 pub async fn fstatx(
   fd : @fd_util.Fd,
   request : UInt,
@@ -138,7 +94,6 @@ pub async fn fstatx(
 }
 
 ///|
-#cfg(target="native")
 async fn fstatx_single(
   fd : @fd_util.Fd,
   request : UInt,
@@ -155,7 +110,6 @@ async fn fstatx_single(
 }
 
 ///|
-#cfg(target="native")
 pub async fn statx(
   path : StringView,
   parent~ : @fd_util.Fd,
@@ -185,7 +139,6 @@ pub async fn statx(
 }
 
 ///|
-#cfg(target="native")
 async fn statx_single(
   path : StringView,
   parent~ : @fd_util.Fd,
@@ -204,7 +157,6 @@ async fn statx_single(
 }
 
 ///|
-#cfg(target="native")
 pub async fn kind_of_fd(
   fd : @fd_util.Fd,
   context~ : String,
@@ -218,7 +170,6 @@ pub async fn kind_of_fd(
 /// `path` will be interpreted relative to the directory pointed by `parent`,
 /// see `fstatat` for more details.
 /// `parent` is not supported on Windows.
-#cfg(target="native")
 pub async fn file_kind_by_path(
   path : StringView,
   parent~ : @fd_util.Fd,
@@ -238,43 +189,12 @@ pub async fn file_kind_by_path(
 }
 
 ///|
-#cfg(target="wasm")
-pub async fn file_kind_by_path(
-  path : StringView,
-  parent~ : @fd_util.Fd,
-  follow_symlink~ : Bool,
-  context~ : String,
-) -> @fd_util.FileKind {
-  let path_bytes = @os_string.encode(path)
-  let job = Job::file_kind_by_path(parent, path_bytes, follow_symlink~)
-  defer job.free()
-  try perform_job_in_worker(job, context~) catch {
-    @os_error.OSError(errno, context~) =>
-      raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
-    err => raise err
-  } noraise {
-    result => @fd_util.FileKind::unsafe_from_int(result)
-  }
-}
-
-///|
-#cfg(target="native")
 pub async fn file_size(fd : @fd_util.Fd, context~ : String) -> Int64 {
   guard! fstatx_single(fd, STAT_FILE_SIZE, 1, context~) is [i64le(size)]
   size
 }
 
 ///|
-#cfg(target="wasm")
-pub async fn file_size(fd : @fd_util.Fd, context~ : String) -> Int64 {
-  let job = Job::file_size(fd)
-  defer job.free()
-  let _ = perform_job_in_worker(job, context~)
-  job.get_file_size_result()
-}
-
-///|
-#cfg(target="native")
 pub async fn mtime(fd : @fd_util.Fd, context~ : String) -> (Int64, Int) {
   guard! fstatx_single(fd, STAT_MODIFY_TIME, 2, context~)
     is [i64le(sec), i64le(nsec)]
@@ -282,7 +202,6 @@ pub async fn mtime(fd : @fd_util.Fd, context~ : String) -> (Int64, Int) {
 }
 
 ///|
-#cfg(target="native")
 pub async fn atime(fd : @fd_util.Fd, context~ : String) -> (Int64, Int) {
   guard! fstatx_single(fd, STAT_ACCESS_TIME, 2, context~)
     is [i64le(sec), i64le(nsec)]
@@ -290,7 +209,6 @@ pub async fn atime(fd : @fd_util.Fd, context~ : String) -> (Int64, Int) {
 }
 
 ///|
-#cfg(target="native")
 pub async fn ctime(fd : @fd_util.Fd, context~ : String) -> (Int64, Int) {
   guard! fstatx_single(fd, STAT_CHANGE_TIME, 2, context~)
     is [i64le(sec), i64le(nsec)]
@@ -298,7 +216,6 @@ pub async fn ctime(fd : @fd_util.Fd, context~ : String) -> (Int64, Int) {
 }
 
 ///|
-#cfg(target="native")
 pub async fn mtime_by_path(
   path : StringView,
   follow_symlink~ : Bool,
@@ -317,7 +234,6 @@ pub async fn mtime_by_path(
 }
 
 ///|
-#cfg(target="native")
 pub async fn atime_by_path(
   path : StringView,
   follow_symlink~ : Bool,
@@ -336,7 +252,6 @@ pub async fn atime_by_path(
 }
 
 ///|
-#cfg(target="native")
 pub async fn ctime_by_path(
   path : StringView,
   follow_symlink~ : Bool,
@@ -352,85 +267,6 @@ pub async fn ctime_by_path(
     )
     is [i64le(sec), i64le(nsec)]
   (sec, nsec.to_int())
-}
-
-///|
-#cfg(target="wasm")
-async fn file_time(fd : @fd_util.Fd, context~ : String) -> @fd_util.FileTime {
-  let result = @fd_util.FileTime::new()
-  let job = Job::file_time(fd, result)
-  defer job.free()
-  let _ = perform_job_in_worker(job, context~)
-  result
-}
-
-///|
-#cfg(target="wasm")
-async fn file_time_by_path(
-  path : StringView,
-  follow_symlink~ : Bool,
-  context~ : String,
-) -> @fd_util.FileTime {
-  let path_bytes = @os_string.encode(path)
-  let result = @fd_util.FileTime::new()
-  let job = Job::file_time_by_path(path_bytes, result, follow_symlink~)
-  defer job.free()
-  try perform_job_in_worker(job, context~) catch {
-    @os_error.OSError(errno, context~) =>
-      raise @os_error.OSError(errno, context="\{context}: \{path.escape()}")
-    err => raise err
-  } noraise {
-    _ => ()
-  }
-  result
-}
-
-///|
-#cfg(target="wasm")
-pub async fn mtime(fd : @fd_util.Fd, context~ : String) -> (Int64, Int) {
-  file_time(fd, context~).mtime()
-}
-
-///|
-#cfg(target="wasm")
-pub async fn atime(fd : @fd_util.Fd, context~ : String) -> (Int64, Int) {
-  file_time(fd, context~).atime()
-}
-
-///|
-#cfg(target="wasm")
-pub async fn ctime(fd : @fd_util.Fd, context~ : String) -> (Int64, Int) {
-  file_time(fd, context~).ctime()
-}
-
-///|
-#cfg(target="wasm")
-pub async fn mtime_by_path(
-  path : StringView,
-  follow_symlink~ : Bool,
-  context~ : String,
-) -> (Int64, Int) {
-  file_time_by_path(path, follow_symlink~, context~).mtime()
-}
-
-///|
-#cfg(target="wasm")
-pub async fn atime_by_path(
-  path : StringView,
-  follow_symlink~ : Bool,
-  context~ : String,
-) -> (Int64, Int) {
-  file_time_by_path(path, follow_symlink~, context~).atime()
-}
-
-///|
-#cfg(target="wasm")
-pub async fn ctime_by_path(
-  path : StringView,
-  follow_symlink~ : Bool,
-  context~ : String,
-) -> (Int64, Int) {
-  file_time_by_path(path, follow_symlink~, context~).ctime()
 }
 
 ///|

--- a/src/internal/event_loop/thread_pool.wasm.mbt
+++ b/src/internal/event_loop/thread_pool.wasm.mbt
@@ -201,7 +201,9 @@ fn JobHandle::open(
   sync~ : Int,
   // permission for file when new file is created
   mode~ : Int,
-) -> JobHandle = "moonbitlang/async" "thread_pool/make_open_job"
+  stat_request~ : UInt,
+  stat_buf_len~ : Int,
+) -> JobHandle = "moonbitlang/async" "thread_pool/make_open_stat_job"
 
 ///|
 priv struct OpenJob(Job)
@@ -218,8 +220,23 @@ fn Job::open(
   sync~ : Int,
   // permission for file when new file is created
   mode~ : Int,
+  stat_request~ : UInt,
+  stat_buf~ : FixedArray[Byte],
+  stat_buf_len~ : Int,
 ) -> OpenJob {
-  Job(JobHandle::open(filename, access, create~, append~, sync~, mode~))
+  Job(
+    JobHandle::open(
+      filename,
+      access,
+      create~,
+      append~,
+      sync~,
+      mode~,
+      stat_request~,
+      stat_buf_len~,
+    ),
+    copy_output=job => job.get_stat_result(stat_buf, stat_buf_len),
+  )
 }
 
 ///|
@@ -233,104 +250,82 @@ fn OpenJob::fd(job : OpenJob) -> @fd_util.Fd {
 
 ///|
 #unsafe_skip_stub_check
-fn OpenJob::kind_ffi(job : JobHandle) -> @fd_util.FileKind = "moonbitlang/async" "thread_pool/open_job_get_kind"
+#borrow(buf)
+fn JobHandle::get_stat_result(
+  self : JobHandle,
+  buf : FixedArray[Byte],
+  buf_len : Int,
+) -> Unit = "moonbitlang/async" "thread_pool/get_stat_result"
 
 ///|
-fn OpenJob::kind(job : OpenJob) -> @fd_util.FileKind {
-  OpenJob::kind_ffi(job.0.handle)
-}
+pub const STAT_FILE_KIND : UInt = 0x0001
+
+///|
+pub const STAT_FILE_SIZE : UInt = 0x0002
+
+///|
+pub const STAT_DEVICE_ID : UInt = 0x0004
+
+///|
+pub const STAT_FILE_ID : UInt = 0x0008
+
+///|
+pub const STAT_ACCESS_TIME : UInt = 0x0010
+
+///|
+pub const STAT_MODIFY_TIME : UInt = 0x0020
+
+///|
+pub const STAT_CHANGE_TIME : UInt = 0x0040
+
+///|
+pub const STAT_CREATE_TIME : UInt = 0x0080
 
 ///|
 #unsafe_skip_stub_check
-fn OpenJob::dev_id_ffi(job : JobHandle) -> UInt64 = "moonbitlang/async" "thread_pool/open_job_get_dev_id"
+fn JobHandle::fstatx(
+  fd : @fd_util.Fd,
+  request : UInt,
+  buf_len : Int,
+) -> JobHandle = "moonbitlang/async" "thread_pool/make_fstatx_job"
 
 ///|
-fn OpenJob::dev_id(job : OpenJob) -> UInt64 {
-  OpenJob::dev_id_ffi(job.0.handle)
-}
-
-///|
-#unsafe_skip_stub_check
-fn OpenJob::file_id_ffi(job : JobHandle) -> UInt64 = "moonbitlang/async" "thread_pool/open_job_get_file_id"
-
-///|
-fn OpenJob::file_id(job : OpenJob) -> UInt64 {
-  OpenJob::file_id_ffi(job.0.handle)
-}
-
-///|
-#unsafe_skip_stub_check
-#borrow(path)
-fn JobHandle::file_kind_by_path(
-  parent : @fd_util.Fd,
-  path : @os_string.OsString,
-  path_len? : Int = path.to_string().length(),
-  follow_symlink~ : Bool,
-) -> JobHandle = "moonbitlang/async" "thread_pool/make_file_kind_by_path_job"
-
-///|
-fn Job::file_kind_by_path(
-  parent : @fd_util.Fd,
-  path : @os_string.OsString,
-  follow_symlink~ : Bool,
+fn Job::fstatx(
+  fd : @fd_util.Fd,
+  request : UInt,
+  buf : FixedArray[Byte],
+  buf_len : Int,
 ) -> Job {
-  Job(JobHandle::file_kind_by_path(parent, path, follow_symlink~))
-}
-
-///|
-#unsafe_skip_stub_check
-fn JobHandle::file_size(fd : @fd_util.Fd) -> JobHandle = "moonbitlang/async" "thread_pool/make_file_size_job"
-
-///|
-fn Job::file_size(fd : @fd_util.Fd) -> Job {
-  Job(JobHandle::file_size(fd))
-}
-
-///|
-#unsafe_skip_stub_check
-fn JobHandle::get_file_size_result(job : JobHandle) -> Int64 = "moonbitlang/async" "thread_pool/get_file_size_result"
-
-///|
-fn Job::get_file_size_result(job : Job) -> Int64 {
-  job.handle.get_file_size_result()
-}
-
-///|
-#unsafe_skip_stub_check
-fn JobHandle::file_time(fd : @fd_util.Fd) -> JobHandle = "moonbitlang/async" "thread_pool/make_file_time_job"
-
-///|
-fn Job::file_time(fd : @fd_util.Fd, out : @fd_util.FileTime) -> Job {
-  Job(JobHandle::file_time(fd), copy_output=job => job.get_file_time_result(out))
-}
-
-///|
-#unsafe_skip_stub_check
-#borrow(path)
-fn JobHandle::file_time_by_path(
-  path : @os_string.OsString,
-  path_len? : Int = path.to_string().length(),
-  follow_symlink~ : Bool,
-) -> JobHandle = "moonbitlang/async" "thread_pool/make_file_time_by_path_job"
-
-///|
-fn Job::file_time_by_path(
-  path : @os_string.OsString,
-  out : @fd_util.FileTime,
-  follow_symlink~ : Bool,
-) -> Job {
-  Job(JobHandle::file_time_by_path(path, follow_symlink~), copy_output=job => {
-    job.get_file_time_result(out)
+  Job(JobHandle::fstatx(fd, request, buf_len), copy_output=job => {
+    job.get_stat_result(buf, buf_len)
   })
 }
 
 ///|
 #unsafe_skip_stub_check
-#borrow(out)
-fn JobHandle::get_file_time_result(
-  self : JobHandle,
-  out : @fd_util.FileTime,
-) -> Unit = "moonbitlang/async" "thread_pool/get_file_time_result"
+#borrow(path)
+fn JobHandle::statx(
+  path : @os_string.OsString,
+  path_len? : Int = path.to_string().length(),
+  request : UInt,
+  buf_len : Int,
+  parent~ : @fd_util.Fd,
+  follow_symlink~ : Bool,
+) -> JobHandle = "moonbitlang/async" "thread_pool/make_statx_job"
+
+///|
+fn Job::statx(
+  path : @os_string.OsString,
+  request : UInt,
+  buf : FixedArray[Byte],
+  buf_len : Int,
+  parent~ : @fd_util.Fd,
+  follow_symlink~ : Bool,
+) -> Job {
+  Job(JobHandle::statx(path, request, buf_len, parent~, follow_symlink~), copy_output=job => {
+    job.get_stat_result(buf, buf_len)
+  })
+}
 
 ///|
 pub(all) enum Access {

--- a/src/os_error/error.wasm.mbt
+++ b/src/os_error/error.wasm.mbt
@@ -140,3 +140,10 @@ pub fn OSError::is_ENOTDIR(err : OSError) -> Bool {
   let OSError(errno, ..) = err
   errno == errno_ENOTDIR
 }
+
+///|
+#unsafe_skip_stub_check
+fn get_ENOTSUP() -> Int = "moonbitlang/async" "os_error/get_ENOTSUP"
+
+///|
+pub let errno_ENOTSUP : Int = get_ENOTSUP()


### PR DESCRIPTION
## Why

PR #527 moved the native event loop to the generic stat API, but the Wasm adapter still used the legacy file-kind, file-size, file-time, and open-result imports. That left the Wasm runtime contract on the old ABI and prevented the generic implementation from being exercised end to end.

## What changed

- Use the generic `open`, `fstatx`, and `statx` job builders from Wasm.
- Keep result storage in the runtime and copy it into guest memory only after job completion through `get_stat_result`, preserving the existing `memory.grow` safety invariant.
- Share the native generic-stat parsing and error handling with Wasm instead of maintaining a parallel implementation.
- Expose `ENOTSUP` to the Wasm path because the shared generic result parser uses it for unsupported requested fields.

## Pairing and merge order

moonbitlang/moon#2018 has landed the generic stat builders, exact Wasm signatures, compatibility imports, and host-owned result copy-out. moonbitlang/moon#2021 adds the `os_error/get_ENOTSUP` import introduced here and pins this commit so the existing upstream filesystem tests exercise the real guest → Wasm import → Moonrun path.

The runtime must accept the new guest before the guest change is published. Merge moonbitlang/moon#2021 first, then merge this PR.

The split is intentional: this PR contains only the guest-side ABI migration, while the runtime implementation remains in Moon.