### PR TITLE
fix(process): preserve signal termination on Wasm

### DIFF
--- a/src/integration.wasm.mbt
+++ b/src/integration.wasm.mbt
@@ -17,6 +17,7 @@
 #doc(hidden)
 pub fn run_async_main(main : async () -> Unit) -> Unit {
   @event_loop.with_event_loop(() => main()) catch {
+    @event_loop.KilledBySignal(signal) => terminate_process_by_signal(signal)
     err => {
       @env_util.eprintln(err.to_string())
       exit(1)
@@ -27,3 +28,7 @@ pub fn run_async_main(main : async () -> Unit) -> Unit {
 ///|
 #unsafe_skip_stub_check
 fn exit(code : Int) = "moonbitlang/async" "runtime/exit"
+
+///|
+#unsafe_skip_stub_check
+fn terminate_process_by_signal(signal : Int) = "moonbitlang/async" "runtime/terminate_process_by_signal"

--- a/src/process/wait_test.mbt
+++ b/src/process/wait_test.mbt
@@ -85,8 +85,8 @@ async test "wait exitcode STILL_ACTIVE" {
 }
 
 ///|
-#cfg(all(target="native", not(platform="windows")))
 async test "signal exit code" {
+  guard !(@event_loop.platform is Windows) else {  }
   let sleep = sleep_prog.wait()
   let exit_code = @async.with_task_group <| group => {
     let proc = @process.spawn(group, sleep, ["1000", "-use-default-handler"])


### PR DESCRIPTION
## Why

The behavior introduced by #512 is not complete on the Wasm backend. A signal-killed child is only tested on native, and the Wasm async-main wrapper currently treats `KilledBySignal` as a generic error and exits with code 1.

## What

- Catch `KilledBySignal` in the Wasm async-main wrapper and request signal termination through a strict `runtime/terminate_process_by_signal(i32) -> Unit` import.
- Run the existing signal-killed child exit-status test on Wasm Unix. Because one Wasm artifact runs on both Unix and Windows hosts, the test selects Unix at runtime through `@event_loop.platform` rather than compile-time `#cfg(platform=...)`.

## Why this is correct

The child-process result follows the existing #512 contract: normal exits return the exit code, while signal termination returns the negative signal number on Unix-like systems. The async-main wrapper now preserves the same terminal condition on Wasm instead of collapsing it to exit code 1.

The paired Moonrun change records the termination as per-Wasm-run state and interrupts guest execution. Only the outer standalone runner applies the OS signal after guest and host teardown, so the import never terminates an embedding runner directly.

The native thread-pool fallback discrepancy is tracked separately in #442. This coordinating PR intentionally does not modify native C code.

## Merge order

Paired Moon PR: moonbitlang/moon#2023.

Do not merge this PR before the paired Moon PR. The Moon host must land first; this async PR lands second. This coordinating PR intentionally has no `wasm-runtime-port-required` label.