### PR TITLE
refactor external loop integration, retrieve event in main thread

### DIFF
--- a/src/external_loop_integration/external_loop_test.mbt
+++ b/src/external_loop_integration/external_loop_test.mbt
@@ -112,3 +112,56 @@ test "external loop blocked on async only" {
     "main loop received 0 at #1", "main loop received 1 at #2", "terminate main loop",
   ])
 }
+
+///|
+#cfg(target="native")
+test "non-blocking read & external waiter race" {
+  let main_loop = @external_loop_test.MainLoop()
+  @event_loop.with_event_loop <| () => {
+    @async.set_external_event_loop(main_loop)
+    let (r, w) = @pipe.pipe()
+    defer r.close()
+    @async.with_task_group <| group => {
+      // The following three tasks will start running at the same scheduler slice
+      group.spawn_bg() <| () => {
+        defer w.close()
+        // The `write` here will generate a read-readiness event for the pipe
+        w.write("abcd")
+        @async.sleep(150)
+        w.write("xyzw")
+      }
+      group.spawn_bg() <| () => {
+        // do some spinning here to ensure the waiter thread has generated
+        // the read readiness event before we drain the pipe
+        let start = @async.now()
+        while @async.now() - start < 10 {
+
+        }
+        // The `read` here will execute after the `write` above,
+        // so it would immediately succeed and drain all data in the pipe.
+        // At this point, the read readiness event for the pipe
+        // is still in the event bus and not yet consumed.
+        guard r.read_some() is Some(data) else {
+          fail("expected data, no data found")
+        }
+        inspect(@utf8.decode(data), content="abcd")
+      }
+      group.spawn_bg() <| () => {
+        // The `read` here has no data to read, because the pipe
+        // is already drained by the first `read` above.
+        // The first non-blocking `read` attempt here will fail with `EAGAIN`,
+        // and the task will start waiting for read readiness of the pipe.
+        //
+        // Now, the event loop will enter the next slice.
+        // The main loop will get waken by the event from the waiter thread,
+        // and the stale read readiness event will wake this task up.
+        // But at this point, there is still no data in the pipe,
+        // so the second `read` attempt still fail with `EAGAIN`, failing the whole test
+        guard r.read_some() is Some(data) else {
+          fail("expected data, no data found")
+        }
+        inspect(@utf8.decode(data), content="xyzw")
+      }
+    }
+  }
+}

--- a/src/external_loop_integration/moon.pkg
+++ b/src/external_loop_integration/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/async",
   "moonbitlang/async/socket",
   "moonbitlang/async/internal/event_loop",

--- a/src/internal/event_loop/event_bus.c
+++ b/src/internal/event_loop/event_bus.c
@@ -60,6 +60,7 @@ int32_t cond_wait(cond_t *cond, mutex_t *mutex) {
 #include <pthread.h>
 #include <signal.h>
 #include <errno.h>
+#include <poll.h>
 
 typedef _Atomic int32_t atomic_int32_t;
 
@@ -106,7 +107,6 @@ int32_t cond_wait(cond_t *cond, mutex_t *mutex) {
 
 // defined in `epoll.c`/`kqueue.c`/`iocp.c`
 int32_t moonbitlang_async_event_bus_wait(HANDLE bus, int32_t timeout);
-int32_t moonbitlang_async_event_bus_register(HANDLE bus, HANDLE fd, int32_t read_only);
 
 struct EventBusWaiter {
   thread_id_t thread_id;
@@ -123,10 +123,33 @@ struct EventBusWaiter {
   mutex_t lock;
   cond_t waker;
 
-  // The following fields, together with the static event buffer
-  // in `epoll.c`/`kqueue.c`/`iocp.c`, should be protected by
-  // `lock` above.
-  atomic_int32_t number_of_events;
+  /* `status` should be protected by `lock` above.
+   
+     On Unix systems, instead of doing `epoll_wait`/`kevent` in the waiter thread directly,
+     we only wait for the readiness of the underlying `epoll`/`kqueue` in the waiter.
+     The actual retrieval of events are still performed in the main thread,
+     via a zero-timeout `epoll_wait`/`kevent` call.
+
+     The reason for this is that performing wait in an alternative thread introduce
+     various kinds of race condition. For example, registering a unconnected socket
+     may produce stale `EPOLLOUT | EPOLLHUP` event. Usually, a subsequent `connect`
+     call will remove that stale event, and the final `epoll_wait` will not see it.
+     However, if `epoll_wait` is performed in a dedicated thread, this kind of stale
+     event may accidentally get captured.
+
+     Hence, on Unix systems, `status` is merely a boolean hint
+     indicating whether there is any event.
+     while the static `epoll`/`kqueue` event buffer is exclusively owned by the main thread.
+
+     On Windows, we perform `GetQueuedCompletionStatusEx` in the waiter thread directly,
+     because IOCP completion packets are associated with invidual IO operations,
+     and hence has no stale event issue. Another reason is IOCP does not support peeking,
+     so we cannot use the same approach as Unix-like systems.
+
+     On Windows, `status` is the number of event is retrieved,
+     and the static buffer should also be protected by `lock` above.
+   */
+  atomic_int32_t status;
 };
 
 static
@@ -138,24 +161,40 @@ thread_worker_result_t THREAD_PROC_CALLING_CONVENTION waiter_loop(void *data) {
   while (!waiter->cancelled) {
     // When control flow reaches here:
     // - `waiter->lock` should have been acquired
-    // - `waiter->number_of_events` must be zero
-    // - `waiter->state` must be `SUSPENDED`
-    waiter->number_of_events = moonbitlang_async_event_bus_wait(waiter->event_bus, -1); 
+    // - `waiter->status` must be zero
+#ifdef _WIN32
+    waiter->status = moonbitlang_async_event_bus_wait(waiter->event_bus, -1); 
 
-    if (waiter->number_of_events == 0)
+    if (waiter->status == 0)
       continue;
 
-    if (waiter->number_of_events < 0) {
+    if (waiter->status < 0) {
       waiter->error = GetLastError();
       goto exit;
     }
+#else
+    struct pollfd pfds[] = {
+      { waiter->event_bus, POLLIN, 0 },
+      { waiter->cancel_pipe[0], POLLIN, 0 }
+    };
+    int ret = poll(pfds, 2, -1);
 
-    // `waiter->number_of_events > 0` must hold here,
+    if (ret < 0) {
+      waiter->error = errno;
+      goto exit;
+    }
+
+    waiter->status = pfds[0].revents & POLLIN;
+    if (!waiter->status)
+      continue;
+#endif
+
+    // `waiter->status` must be non-zero here,
     // when we wake the main thread and suspend the waiter
 
     waiter->wakeup_callback();
 
-    while (waiter->number_of_events > 0 && !waiter->cancelled) {
+    while (waiter->status && !waiter->cancelled) {
       if (cond_wait(&waiter->waker, &waiter->lock) < 0) {
         waiter->error = GetLastError();
         goto exit;
@@ -191,15 +230,12 @@ struct EventBusWaiter *moonbitlang_async_spawn_event_bus_waiter(
     if (!(flags & FD_CLOEXEC) && fcntl(fd, F_SETFD, flags | FD_CLOEXEC) < 0)
       goto error_with_pipe;
   }
-
-  if (moonbitlang_async_event_bus_register(bus, waiter->cancel_pipe[0], 1) < 0)
-    goto error_with_pipe;
 #endif
 
   mutex_init(&waiter->lock);
   cond_init(&waiter->waker);
 
-  waiter->number_of_events = 0;
+  waiter->status = 0;
   waiter->cancelled = 0;
   waiter->error = 0;
 
@@ -245,12 +281,12 @@ error:
 MOONBIT_FFI_EXPORT
 void moonbitlang_async_terminate_event_bus_waiter(struct EventBusWaiter *waiter) {
   waiter->cancelled = 1;
-  if (!waiter->number_of_events) {
+  if (!waiter->status) {
     /* If the waiter is currently blocked, try to wake it up.
        Note that the code here is not atomic, so the following sequence is possible:
       
-       - main thread see `waiter->number_of_events == 0`
-       - waiter woken and set `waiter->number_of_events` to a non-zero value
+       - main thread see `waiter->status == 0`
+       - waiter woken and set `waiter->status` to a non-zero value
        - main thread perform cancellation operation below
 
        But this sequence is fine, because the cancellation operation below
@@ -290,12 +326,20 @@ void moonbitlang_async_terminate_event_bus_waiter(struct EventBusWaiter *waiter)
 }
 
 MOONBIT_FFI_EXPORT
+void moonbitlang_async_wake_event_bus_waiter(struct EventBusWaiter *waiter) {
+  // `waiter->lock` should be acquired here
+  waiter->status = 0;
+  cond_signal(&waiter->waker);
+  mutex_unlock(&waiter->lock);
+}
+
+MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_event_bus_waiter_get_events(struct EventBusWaiter *waiter) {
-  if (!waiter->number_of_events)
+  if (!waiter->status)
     return 0;
 
-  // Only the main thread will turn `number_of_events` from non-zero to zero,
-  // So `waiter->number_of_events != 0` will not get violated
+  // Only the main thread will turn `status` from non-zero to zero,
+  // So `waiter->status!= 0` will not get violated
   // in the window after the previous check and before acquiring the lock.
   mutex_lock(&waiter->lock);
 
@@ -305,13 +349,22 @@ int32_t moonbitlang_async_event_bus_waiter_get_events(struct EventBusWaiter *wai
     return -1;
   }
 
-  return waiter->number_of_events;
-}
+#ifdef _WIN32
+  return waiter->status;
+#else
+  int32_t ret = moonbitlang_async_event_bus_wait(waiter->event_bus, 0);
 
-MOONBIT_FFI_EXPORT
-void moonbitlang_async_wake_event_bus_waiter(struct EventBusWaiter *waiter) {
-  // `waiter->lock` should be acquired here
-  waiter->number_of_events = 0;
-  cond_signal(&waiter->waker);
-  mutex_unlock(&waiter->lock);
+  // This may happen when there is stale event that appeared and then disappeared
+  // or some extra error happened after the waiter is woken.
+  // Our contract for `waiter_get_events` is that if it return zero or negative value,
+  // `waiter->lock` should be unlocked in the main thread,
+  // and the wait thread should keep going.
+  if (ret <= 0)
+    moonbitlang_async_wake_event_bus_waiter(waiter); 
+
+  if (ret < 0 && errno == EINTR)
+    ret = 0;
+
+  return ret;
+#endif
 }


### PR DESCRIPTION
closes #538

This PR fixes the same issue as #538, but using a different approach. Current external loop integration perform `epoll_wait`/`kevent` in the dedicated waiter thread, which creates a whole class of new race condition not present when using `moonbitlang/async`'s own loop. In addition to the one in #538, registering a new fd with `epoll`/`kqueue` may also wake up the waiter thread with a stale/spurious event.

Instead of trying to live with the race by retrying as in #538, this PR changes the way external loop integration is implemented. The implementation in this PR no longer perform `epoll_wait`/`kevent` call in the waiter thread. Instead, the waiter thread only watches for whether the main event bus contain any event to fetch via `poll`, actual event retrieval is still performed in the main thread, via a `epoll_wait`/`kevent` call with zero timeout. This way, the lifetime of event retrieval become the same in external loop mode and normal mode, eliminating the race completely.

On Windows, IOCP does not support waiting for presence of event nor peeking. Meanwhile, IOCP completion packets are associated to individual IO operations, so there is no stale event issue here as well. So the IOCP path is unchanged (i.e. we still do `GetQueuedCompletionStatusEx` in the waiter thread in external loop mode).