### PR TITLE
fix(wasm): use spawn job handle result import

### DIFF
--- a/src/internal/event_loop/thread_pool.wasm.mbt
+++ b/src/internal/event_loop/thread_pool.wasm.mbt
@@ -644,8 +644,12 @@ fn Job::spawn_windows(
 
 ///|
 #unsafe_skip_stub_check
-#borrow(job)
-fn SpawnJob::result_handle(job : SpawnJob) -> @fd_util.Fd = "moonbitlang/async" "thread_pool/get_spawn_job_result_handle"
+fn JobHandle::spawn_job_result_handle(job : JobHandle) -> @fd_util.Fd = "moonbitlang/async" "thread_pool/spawn_job_get_result_handle"
+
+///|
+fn SpawnJob::result_handle(job : SpawnJob) -> @fd_util.Fd {
+  job.0.handle.spawn_job_result_handle()
+}
 
 ///|
 #unsafe_skip_stub_check


### PR DESCRIPTION
The Wasm wrapper currently passes `SpawnJob` directly to `thread_pool/get_spawn_job_result_handle`. Because `SpawnJob` contains the two-field `Job` valtype, MoonBit lowers that call to both the job handle and the optional copy-output closure. This accidentally relies on a permissive JavaScript callback accepting the wrong function arity and will not link against a strict Wasm engine.

Call the canonical `thread_pool/spawn_job_get_result_handle` import with the nested `JobHandle` instead. The private `SpawnJob::result_handle` API remains unchanged, while the Wasm boundary is now exactly `(i64) -> i64` and matches the native operation.

This PR is stacked on #541. Merge order: moonbitlang/moon#2023, then #541, then this PR. The Moon runtime retains the old aggregate-shaped import as a compatibility adapter for already-built guests.