### PR TITLE
fix(wasm): port process environment and spawn builders

### DIFF
--- a/src/internal/event_loop/thread_pool.wasm.mbt
+++ b/src/internal/event_loop/thread_pool.wasm.mbt
@@ -544,20 +544,32 @@ priv struct SpawnJob(Job)
 
 ///|
 #unsafe_skip_stub_check
-#borrow(path, cwd)
-fn JobHandle::spawn_unix(
+#borrow(path)
+fn JobHandle::spawn_unix_ffi(
   path : @os_string.OsString,
   path_len? : Int = path.to_string().length(),
   args : UInt64,
   env~ : UInt64,
-  inherited_env_entry_count~ : Int,
   stdin~ : @fd_util.Fd,
   stdout~ : @fd_util.Fd,
   stderr~ : @fd_util.Fd,
-  cwd~ : @os_string.OsString,
+) -> JobHandle = "moonbitlang/async" "thread_pool/spawn_job/unix"
+
+///|
+// Use JobHandle at the Wasm boundary so the private fields nested in Job are
+// not lowered as additional import parameters.
+#unsafe_skip_stub_check
+#borrow(cwd)
+fn JobHandle::spawn_job_set_cwd(
+  job : JobHandle,
+  cwd : @os_string.OsString,
   cwd_len? : Int = cwd.to_string().length(),
-  has_cwd~ : Bool,
-) -> JobHandle = "moonbitlang/async" "thread_pool/make_spawn_job/unix"
+) -> Unit = "moonbitlang/async" "thread_pool/spawn_job/set_cwd"
+
+///|
+fn SpawnJob::set_cwd(job : SpawnJob, cwd : @os_string.OsString) -> Unit {
+  job.0.handle.spawn_job_set_cwd(cwd)
+}
 
 ///|
 fn Job::spawn_unix(
@@ -570,45 +582,40 @@ fn Job::spawn_unix(
   is_orphan~ : Bool,
   cwd~ : @os_string.OsString?,
 ) -> SpawnJob {
-  let (cwd, has_cwd) = match cwd {
-    None => (@os_string.empty, false)
-    Some(cwd) => (cwd, true)
-  }
+  // Match native Unix: hard-termination child cleanup is not supported, so
+  // orphan status does not change the spawn job.
   ignore(is_orphan)
-  SpawnJob(
-    Job(
-      JobHandle::spawn_unix(
-        path,
-        args,
-        env~,
-        // unused on Wasm1, should be removed later
-        inherited_env_entry_count=0,
-        stdin~,
-        stdout~,
-        stderr~,
-        cwd~,
-        has_cwd~,
-      ),
-    ),
+  let job = SpawnJob(
+    Job(JobHandle::spawn_unix_ffi(path, args, env~, stdin~, stdout~, stderr~)),
   )
+  if cwd is Some(cwd) {
+    job.set_cwd(cwd)
+  }
+  job
 }
 
 ///|
 #unsafe_skip_stub_check
-#borrow(command_line, cwd)
-fn JobHandle::spawn_windows(
+#borrow(command_line)
+fn JobHandle::spawn_windows_ffi(
   command_line : @os_string.OsString,
   command_line_len? : Int = command_line.to_string().length(),
   env~ : UInt64,
   stdin~ : @fd_util.Fd,
   stdout~ : @fd_util.Fd,
   stderr~ : @fd_util.Fd,
-  cwd~ : @os_string.OsString,
-  cwd_len? : Int = cwd.to_string().length(),
-  has_cwd~ : Bool,
-  no_console_window~ : Bool,
   is_orphan~ : Bool,
-) -> JobHandle = "moonbitlang/async" "thread_pool/make_spawn_job/windows"
+) -> JobHandle = "moonbitlang/async" "thread_pool/spawn_job/windows"
+
+///|
+// Keep the setter on JobHandle for the same aggregate-lowering reason as cwd.
+#unsafe_skip_stub_check
+fn JobHandle::spawn_job_set_no_console_window(job : JobHandle) -> Unit = "moonbitlang/async" "thread_pool/spawn_job/set_no_console_window"
+
+///|
+fn SpawnJob::set_no_console_window(job : SpawnJob) -> Unit {
+  job.0.handle.spawn_job_set_no_console_window()
+}
 
 ///|
 fn Job::spawn_windows(
@@ -621,31 +628,35 @@ fn Job::spawn_windows(
   no_console_window~ : Bool,
   is_orphan~ : Bool,
 ) -> SpawnJob {
-  let (cwd, has_cwd) = match cwd {
-    None => (@os_string.empty, false)
-    Some(cwd) => (cwd, true)
-  }
-  SpawnJob(
+  let job = SpawnJob(
     Job(
-      JobHandle::spawn_windows(
+      JobHandle::spawn_windows_ffi(
         command_line,
         env~,
         stdin~,
         stdout~,
         stderr~,
-        cwd~,
-        has_cwd~,
-        no_console_window~,
         is_orphan~,
       ),
     ),
   )
+  if cwd is Some(cwd) {
+    job.set_cwd(cwd)
+  }
+  if no_console_window {
+    job.set_no_console_window()
+  }
+  job
 }
 
 ///|
 #unsafe_skip_stub_check
-#borrow(job)
-fn SpawnJob::result_handle(job : SpawnJob) -> @fd_util.Fd = "moonbitlang/async" "thread_pool/get_spawn_job_result_handle"
+fn JobHandle::spawn_job_result_handle(job : JobHandle) -> @fd_util.Fd = "moonbitlang/async" "thread_pool/spawn_job_get_result_handle"
+
+///|
+fn SpawnJob::result_handle(job : SpawnJob) -> @fd_util.Fd {
+  job.0.handle.spawn_job_result_handle()
+}
 
 ///|
 #unsafe_skip_stub_check

--- a/src/process/env_test.mbt
+++ b/src/process/env_test.mbt
@@ -63,8 +63,6 @@ async test "set_env no inherit" {
 }
 
 ///|
-// TODO: port to Wasm1
-#cfg(target="native")
 async test "set_env override" {
   let name = "VAR_TO_OVERRIDE"
   @env.set_env_var(name, "old_value")
@@ -84,8 +82,6 @@ async test "set_env override" {
 }
 
 ///|
-// Currently the Wasm1 runtime has its own NUL check
-#cfg(target="native")
 async test "set_env injection key" {
   let env_var = if is_windows { "$env:MAGIC_VAR" } else { "$MAGIC_VAR" }
   let (_, output) = @process.collect_stdout(
@@ -104,8 +100,6 @@ async test "set_env injection key" {
 }
 
 ///|
-/// Currently the Wasm1 runtime has its own NUL check
-#cfg(target="native")
 async test "set_env injection value" {
   let env_var = if is_windows { "$env:MAGIC_VAR2" } else { "$MAGIC_VAR2" }
   let (_, output) = @process.collect_stdout(

--- a/src/process/wasm.mbt
+++ b/src/process/wasm.mbt
@@ -20,74 +20,28 @@ priv struct OsEnv(UInt64)
 
 ///|
 #unsafe_skip_stub_check
-fn get_curr_env() -> OsEnv = "moonbitlang/async" "process/get_curr_env"
-
-///|
-#unsafe_skip_stub_check
-fn OsEnv::length(self : OsEnv) -> Int = "moonbitlang/async" "process/env_block_length"
-
-///|
-#unsafe_skip_stub_check
-fn OsEnv::new(size : Int) -> OsEnv = "moonbitlang/async" "process/allocate_env_block"
-
-///|
-#unsafe_skip_stub_check
-fn OsEnv::write_env_block(dst : OsEnv, block : OsEnv) -> Unit = "moonbitlang/async" "process/write_env_block"
+fn OsEnv::new(inherit_env : Bool) -> OsEnv = "moonbitlang/async" "process/make_env"
 
 ///|
 #unsafe_skip_stub_check
 #borrow(key, value)
 fn OsEnv::add_entry(
   dst : OsEnv,
-  index_or_offset : Int,
   key~ : String,
   key_len~ : Int,
   value~ : String,
   value_len~ : Int,
-) -> Unit = "moonbitlang/async" "process/env_block_add_entry"
+) -> Unit = "moonbitlang/async" "process/env_add_entry"
 
 ///|
 fn OsEnv::make(extra_env : Map[String, String], inherit_env~ : Bool) -> OsEnv {
-  if @event_loop.platform is Windows {
-    let extra_env_len = for k, v in extra_env; acc = 0 {
-      continue acc + k.length() + v.length() + 2
-    } nobreak {
-      acc
-    }
-    let (env, extra_env_offset) = if inherit_env {
-      let curr_env = get_curr_env()
-      let curr_env_len = curr_env.length()
-      let env = OsEnv::new(curr_env_len + extra_env_len)
-      env.write_env_block(curr_env)
-      (env, curr_env_len)
-    } else {
-      (OsEnv::new(extra_env_len), 0)
-    }
-    for k, v in extra_env; offset = extra_env_offset {
-      let key_len = k.length()
-      let value_len = v.length()
-      env.add_entry(offset, key=k, key_len~, value=v, value_len~)
-      continue offset + key_len + value_len + 2
-    }
-    env
-  } else {
-    let extra_count = extra_env.length()
-    let (env, inherited_env_entry_count) = if inherit_env {
-      let curr_env = get_curr_env()
-      let curr_env_len = curr_env.length()
-      let env = OsEnv::new(curr_env_len + extra_count)
-      env.write_env_block(curr_env)
-      (env, curr_env_len)
-    } else {
-      (OsEnv::new(extra_count), 0)
-    }
-    for k, v in extra_env; i = inherited_env_entry_count; i = i + 1 {
-      let key_len = k.length()
-      let value_len = v.length()
-      env.add_entry(i, key=k, key_len~, value=v, value_len~)
-    }
-    env
+  let env = OsEnv::new(inherit_env)
+  for k, v in extra_env {
+    let key_len = k.length()
+    let value_len = v.length()
+    env.add_entry(key=k, key_len~, value=v, value_len~)
   }
+  env
 }
 
 ///|


### PR DESCRIPTION
## Why

PR #518 fixed environment overrides, inherited-environment snapshotting, and NUL handling in the native backend, but the Wasm guest still uses the old inherited-first buffer protocol. That leaves the Wasm runtime unable to implement the same behavior without relying on an incompatible offset/index contract.

PR #523 moved native process spawning to the builder-style `SpawnJob` API, while the Wasm guest retained the historical monolithic spawn imports. Porting only the environment change would therefore leave Wasm on a second, obsolete construction interface.

The old Wasm spawn-result wrapper also passed the aggregate `SpawnJob` representation into an import. MoonBit aggregate lowering adds its nested copy-output field to the ABI, even though this operation only needs the underlying `JobHandle`.

## Why this is correct

The Wasm guest now gives the host an explicit environment builder: it records whether the current environment should be inherited and sends extra entries in map order. The host can then apply the native extra-first merge and platform-specific duplicate rules before spawning. The previously native-only override and NUL tests are enabled for Wasm coverage.

Spawn construction now matches #523's native interface: the platform import creates a base `SpawnJob`, then cwd and the Windows no-console option are applied through setters before the job is submitted. The imports pass `JobHandle` rather than the aggregate `SpawnJob` representation, avoiding hidden lowered fields. The obsolete Unix inherited-entry-count parameter is gone.

The strict spawn-result `JobHandle` import formerly proposed in #545 is folded into this migration, so there is no separate intermediate guest ABI to retain.

## Scope

This is the coordinated Wasm guest port of both #518's process-environment changes and #523's `SpawnJob` builder. It includes the related spawn-result ABI correction.

The prerequisite signal-termination PR #541 and matching Moon runtime PR moonbitlang/moon#2029 have merged, so this guest change can now land.
