### PR TITLE
fix(wasm): align poll fallback and TLS peer certificates

### DIFF
--- a/src/internal/event_loop/dev_null_test.mbt
+++ b/src/internal/event_loop/dev_null_test.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-#cfg(target="native")
+#cfg(any(target="native", target="wasm"))
 async test "/dev/null" {
   if @event_loop.platform is Windows {
     return

--- a/src/internal/event_loop/event_bus.wasm.mbt
+++ b/src/internal/event_loop/event_bus.wasm.mbt
@@ -36,11 +36,11 @@ fn EventBus::destroy(self : EventBus) -> Unit = "moonbitlang/async" "event_bus/d
 
 ///|
 #unsafe_skip_stub_check
-fn EventBus::register_ffi(
+fn EventBus::try_register_ffi(
   self : EventBus,
   fd : @fd_util.Fd,
   read_only : Bool,
-) -> Int = "moonbitlang/async" "event_bus/register"
+) -> Int = "moonbitlang/async" "event_bus/try_register"
 
 ///|
 fn EventBus::register(
@@ -48,11 +48,11 @@ fn EventBus::register(
   fd : @fd_util.Fd,
   read_only~ : Bool,
 ) -> Bool raise {
-  if self.register_ffi(fd, read_only) < 0 {
+  let ret = self.try_register_ffi(fd, read_only)
+  if ret < 0 {
     @os_error.check_errno("runtime internal: @event_loop.EventBus::register()")
   }
-  // TODO: support try-register in Wasm runtime
-  true
+  ret > 0
 }
 
 ///|

--- a/src/tls/moon.pkg
+++ b/src/tls/moon.pkg
@@ -23,7 +23,7 @@ import {
 options(
   "native-stub": [ "openssl.c", "schannel.c" ],
   targets: {
-    "certificate_test.mbt": [ "native" ],
+    "certificate_test.mbt": [ "native", "wasm" ],
     "channel_binding_test.mbt": [ "native", "wasm" ],
     "crypto_util.mbt": [ "native" ],
     "crypto_util.wasm.mbt": [ "wasm" ],

--- a/src/tls/tls.wasm.mbt
+++ b/src/tls/tls.wasm.mbt
@@ -654,11 +654,12 @@ pub async fn Tls::shutdown(self : Tls) -> Unit {
 
 ///|
 pub fn Tls::get_peer_certificate(self : Tls) -> Bytes? raise {
+  guard self.is_client else { None }
   let cert = self.conn.peer_certificate()
   guard !cert.is_null() else { raise TlsError(self.conn.take_error_message()) }
   defer cert.free()
   let len = tls_buffer_length(cert)
-  guard! len > 0
+  guard len > 0 else { return None }
   let result = FixedArray::make(len, b'\x00')
   cert.blit_to_bytes(dst=result, len~)
   Some(result.unsafe_reinterpret_as_bytes())


### PR DESCRIPTION
## Why

The Wasm event-bus wrapper still hardcoded successful registration, even though native async now uses a tri-state result so valid non-pollable descriptors can fall back to the thread pool. The Wasm TLS wrapper also treated an absent peer certificate as an error and did not mirror native server behavior.

The existing `event_bus/register` import has a historical `0 = success` contract and therefore cannot safely be reused for the new `0 = unsupported` result.

## What

- Use a separately named `event_bus/try_register` import and return `false` when the runtime reports a valid but unsupported descriptor.
- Mirror native `get_peer_certificate`: servers return `None`, and a valid zero-length certificate buffer means no peer certificate.
- Enable the existing `/dev/null` and peer-certificate tests on Wasm.

## Correctness and compatibility

The runtime-side companion moonbitlang/moon#2046 has merged. It provides the new tri-state import while retaining `event_bus/register` with its old ABI and semantics for existing Wasm modules. Separating the names prevents either generation from silently interpreting `0` under the other generation's contract. TLS absence remains distinct from runtime errors and is compatible with the previous zero-length-to-`None` guest behavior.

#546 has also merged. This branch is rebased onto the resulting `main` and now contains only this guest-side parity fix.