### PR TITLE
fix & enforce empty body for `HEAD` response

### DIFF
--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -377,7 +377,10 @@ async fn Sender::send_response(
     cookie.write_to(self)
     self.write(b"\r\n")
   }
-  if content_length is Some(len) {
+  if request_method is Head {
+    self.write("\r\n")
+    self.mode = SendingFixed(remaining=0)
+  } else if content_length is Some(len) {
     self.write(b"\r\n")
     self.mode = SendingFixed(remaining=len)
   } else {

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -868,3 +868,58 @@ async test "sender persistent header" {
     )
   }
 }
+
+///|
+async test "HEAD response with Content-Length" {
+  @async.with_task_group() <| root => {
+    let (r, w) = @io.pipe()
+    root.spawn_bg() <| () => {
+      defer w.close()
+      let sender = Sender::new(w, headers={
+        "Host": "x.y.org",
+        "User-Agent": "MoonBit",
+      })
+      let _ = sender.send_response(200, "Ok", cookies=[], request_method=Head, extra_headers={
+        "Content-Length": "42",
+      })
+      sender.end_body()
+    }
+    defer r.close()
+    inspect(
+      r.read_all().binary() |> @bytes_util.ascii_to_string,
+      content=(
+        #|HTTP/1.1 200 Ok\r
+        #|Host: x.y.org\r
+        #|User-Agent: MoonBit\r
+        #|Content-Length: 42\r
+        #|\r
+        #|
+      ),
+    )
+  }
+}
+
+///|
+async test "HEAD response with non-empty body" {
+  @async.with_task_group() <| root => {
+    let (r, w) = @io.pipe()
+    root.spawn_bg() <| () => {
+      defer w.close()
+      let sender = Sender::new(w, headers={
+        "Host": "x.y.org",
+        "User-Agent": "MoonBit",
+      })
+      let _ = sender.send_response(200, "Ok", cookies=[], request_method=Head, extra_headers={
+        "Content-Length": "4",
+      })
+      debug_inspect(
+        @test_util.expect_error_async(() => sender..write("abcd").end_body()),
+        content=(
+          #|IncorrectBodyLength
+        ),
+      )
+    }
+    defer r.close()
+    ignore(r.read_all().binary())
+  }
+}


### PR DESCRIPTION
closes #551

Let the HTTP sender support & enforce empty message body for response to `HEAD` request.