### PR TITLE
add default user agent for HTTP client on native/wasm1

### DIFF
--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -63,6 +63,10 @@ async fn Client::connect(
     Plain(@socket.Tcp::connect_to_host(hostname, port~))
   }
   headers["Host"] = host.to_owned()
+  // TODO: case insensitive check
+  if !headers.contains("User-Agent") {
+    headers["User-Agent"] = "moonbit-http-client/1.1"
+  }
   let (tls, reader, sender) = match (protocol, transport) {
     (Http, Plain(conn)) =>
       (None, Reader::new(conn), Sender::new(conn, headers~))
@@ -241,6 +245,11 @@ pub async fn Client::end_request(self : Client) -> Response {
 ///
 /// - Host
 /// - Transfer-Encoding
+///
+/// The following headers can only be set globally for each client on initialization,
+/// and must not be set on a per-request basis:
+///
+/// - User-Agent
 ///
 /// If `Content-Length` is present in `extra_headers`,
 /// it should be the total length of the request body.

--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -185,3 +185,42 @@ async test "multiple request" {
   inspect(response2.code, content="200")
   assert_true(client.read_all().text().has_prefix("<!doctype html>"))
 }
+
+///|
+#cfg(any(target="native", target="wasm"))
+async test "user agent" {
+  let log = StringBuilder::new()
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
+    let port = server.addr.port()
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever() <| ((request, _body, conn) => {
+        let meth = @debug.to_string(request.meth).to_upper()
+        log <+ "server received request: \{meth} \{request.path}\n"
+        let ua = request.headers.get("user-agent").unwrap_or("none")
+        log <+ "User-Agent: \{ua}\n"
+        conn.send_response(200, "OK")
+      })
+    }
+    {
+      let (response, client) = @http.get_stream("http://localhost:\{port}")
+      defer client.close()
+      inspect(response.code, content="200")
+    }
+    let (response, client) = @http.get_stream("http://localhost:\{port}", headers={
+      "User-Agent": "my-custom-UA/4.2",
+    })
+    defer client.close()
+    inspect(response.code, content="200")
+  }
+  inspect(
+    log.to_string(),
+    content=(
+      #|server received request: GET /
+      #|User-Agent: moonbit-http-client/1.1
+      #|server received request: GET /
+      #|User-Agent: my-custom-UA/4.2
+      #|
+    ),
+  )
+}

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -186,8 +186,8 @@ pub async fn put_stream(
   proxy? : Client,
 ) -> Client {
   let (protocol, host, path) = resolve_url(uri)
-  let client = Client::connect(host, protocol~, proxy?)
-  try client.request(Put, path, extra_headers=headers) catch {
+  let client = Client::connect(host, protocol~, headers~, proxy?)
+  try client.request(Put, path) catch {
     err => {
       client.close()
       raise err
@@ -216,8 +216,8 @@ pub async fn post_stream(
   proxy? : Client,
 ) -> Client {
   let (protocol, host, path) = resolve_url(uri)
-  let client = Client::connect(host, protocol~, proxy?)
-  try client.request(Post, path, extra_headers=headers) catch {
+  let client = Client::connect(host, protocol~, headers~, proxy?)
+  try client.request(Post, path) catch {
     err => {
       client.close()
       raise err


### PR DESCRIPTION
closes #550

Add default user agent for `@http.Client`. The default for native/wasm1 is `moonbit-http-client/1.1`. For JS backend, the underlying fetch API implementation already has its own user agent, so no default user agent is set for JS backend.