### PR TITLE
[breaking] JS HTTP client: buffer request body

### DIFF
--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -56,9 +56,10 @@ extern "js" fn JsResponse::body(
 
 ///|
 priv struct OngoingRequest {
-  body_writer : @io.PipeWrite
-  abort_controller : @js_async.AbortController
-  response : @js_async.Promise[JsResponse]
+  meth : String
+  uri : String
+  body : @buffer.Buffer
+  headers : JsHeaders
 }
 
 ///|
@@ -72,10 +73,7 @@ struct Client {
 
 ///|
 pub fn Client::close(self : Client) -> Unit {
-  if self.request is Some(request) {
-    request.body_writer.close()
-    self.request = None
-  }
+  self.request = None
   if self.response_body is Some(response_body) {
     response_body.close()
   }
@@ -129,7 +127,8 @@ pub async fn Client::Client(
 ///|
 pub impl @io.Writer for Client with fn write_once(self, buf, offset~, len~) {
   guard! self.request is Some(request)
-  request.body_writer.write_once(buf, offset~, len~)
+  request.body.write_bytes(buf[offset:offset + len])
+  len
 }
 
 ///|
@@ -160,10 +159,14 @@ pub impl @io.Reader for Client with fn _direct_read(
 pub async fn Client::end_request(self : Client) -> Response {
   guard! self.request is Some(request)
   self.request = None
-  request.body_writer.close()
-  let js_response : JsResponse = request.response.wait(
-    abort_controller=request.abort_controller,
-  )
+  let abort_controller = @js_async.AbortController::new()
+  let js_response = Client::request_ffi(
+    request.uri,
+    request.meth,
+    headers=request.headers,
+    body=request.body.contents(),
+    signal=abort_controller.signal(),
+  ).wait(abort_controller~)
   self.response_body = Some(
     @js_async.ReadableStream::from_js(js_response.body()),
   )
@@ -184,7 +187,7 @@ extern "js" fn Client::request_ffi(
   uri : String,
   meth : String,
   headers~ : JsHeaders,
-  body~ : @js_async.JsReadableStream,
+  body~ : Bytes,
   signal~ : @js_async.AbortSignal,
 ) -> @js_async.Promise[JsResponse] =
   #| (uri, method, headers, body, signal) => {
@@ -196,7 +199,6 @@ extern "js" fn Client::request_ffi(
   #|       method: method,
   #|       headers: headers,
   #|       signal: signal,
-  #|       duplex: 'half',
   #|     },
   #|   )
   #| }
@@ -248,20 +250,7 @@ pub async fn Client::request(
   for k, v in extra_headers {
     headers.append(k, v)
   }
-  let abort_controller = @js_async.AbortController::new()
-  let (body, we_write) = @js_async.JsReadableStream::new_pipe()
-  let response_promise = Client::request_ffi(
-    uri,
-    meth,
-    headers~,
-    body~,
-    signal=abort_controller.signal(),
-  )
-  let request : OngoingRequest = {
-    abort_controller,
-    body_writer: we_write,
-    response: response_promise,
-  }
+  let request : OngoingRequest = { meth, uri, headers, body: @buffer.Buffer() }
   self.request = Some(request)
 }
 

--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -90,6 +90,14 @@ async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
 }
 
 ///|
+#cfg(not(target="js"))
+let is_js : Bool = false
+
+///|
+#cfg(target="js")
+let is_js : Bool = true
+
+///|
 async test "request streaming" {
   let log = StringBuilder::new()
   @async.with_task_group() <| group => {
@@ -140,38 +148,76 @@ async test "request streaming" {
     // so that the port occupied by the server can be reused immediately.
     @async.sleep(200)
   }
-  inspect(
-    log,
-    content=(
-      #|client sending GET request
-      #|server received request: GET /get
-      #|server: sending GET response part 1
-      #|client received: GET response part 1
-      #|server: sending GET response part 2
-      #|client received: GET response part 2
-      #|client sending PUT request
-      #|client: sending PUT data part 1
-      #|server received request: PUT /put
-      #|server received: PUT data part 1
-      #|client: sending PUT data part 2
-      #|server received: PUT data part 2
-      #|server: sending PUT response part 1
-      #|client received: PUT response part 1
-      #|server: sending PUT response part 2
-      #|client received: PUT response part 2
-      #|client sending POST request
-      #|client: sending POST data part 1
-      #|server received request: POST /post
-      #|server received: POST data part 1
-      #|client: sending POST data part 2
-      #|server received: POST data part 2
-      #|server: sending POST response part 1
-      #|client received: POST response part 1
-      #|server: sending POST response part 2
-      #|client received: POST response part 2
-      #|
-    ),
-  )
+  if is_js {
+    // On JS backend, streaming request body is not supported,
+    // so we can only buffer the whole request body before sending.
+    // This will result is different evaluation order behavior here.
+    inspect(
+      log,
+      content=(
+        #|client sending GET request
+        #|server received request: GET /get
+        #|server: sending GET response part 1
+        #|client received: GET response part 1
+        #|server: sending GET response part 2
+        #|client received: GET response part 2
+        #|client sending PUT request
+        #|client: sending PUT data part 1
+        #|client: sending PUT data part 2
+        #|server received request: PUT /put
+        #|server received: PUT data part 1
+        #|PUT data part 2
+        #|server: sending PUT response part 1
+        #|client received: PUT response part 1
+        #|server: sending PUT response part 2
+        #|client received: PUT response part 2
+        #|client sending POST request
+        #|client: sending POST data part 1
+        #|client: sending POST data part 2
+        #|server received request: POST /post
+        #|server received: POST data part 1
+        #|POST data part 2
+        #|server: sending POST response part 1
+        #|client received: POST response part 1
+        #|server: sending POST response part 2
+        #|client received: POST response part 2
+        #|
+      ),
+    )
+  } else {
+    inspect(
+      log,
+      content=(
+        #|client sending GET request
+        #|server received request: GET /get
+        #|server: sending GET response part 1
+        #|client received: GET response part 1
+        #|server: sending GET response part 2
+        #|client received: GET response part 2
+        #|client sending PUT request
+        #|client: sending PUT data part 1
+        #|server received request: PUT /put
+        #|server received: PUT data part 1
+        #|client: sending PUT data part 2
+        #|server received: PUT data part 2
+        #|server: sending PUT response part 1
+        #|client received: PUT response part 1
+        #|server: sending PUT response part 2
+        #|client received: PUT response part 2
+        #|client sending POST request
+        #|client: sending POST data part 1
+        #|server received request: POST /post
+        #|server received: POST data part 1
+        #|client: sending POST data part 2
+        #|server received: POST data part 2
+        #|server: sending POST response part 1
+        #|client received: POST response part 1
+        #|server: sending POST response part 2
+        #|client received: POST response part 2
+        #|
+      ),
+    )
+  }
 }
 
 ///|


### PR DESCRIPTION
closes #552

Previously, the HTTP client API use a readable stream as request body on JS backend. However, streaming request body is not a universally available fetch API feature. Firefox does not support it, while Chrome [only support streaming body for HTTP/2 and HTTP/3](https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests). This PR fixes this compatibility problem by buffering the whole request body before sending. As a consequence, the performance and laziness characteristic of HTTP request sending may get affected.