### PR TITLE
[breaking] make HTTP headers case insensitive

### DIFF
--- a/examples/http_file_server/server_wbtest.mbt
+++ b/examples/http_file_server/server_wbtest.mbt
@@ -101,8 +101,8 @@ async test "basic" {
     content=(
       #|client: GET /http_file_server
       #|HTTP/1.1 200 OK
-      #|content-type: text/html
-      #|transfer-encoding: chunked
+      #|Content-Type: text/html
+      #|Transfer-Encoding: chunked
       #|<!DOCTYPE html><html><head></head><body>
       #|<h1>/http_file_server</h1>
       #|<div style="margin: 1em; font-size: 15pt">
@@ -115,8 +115,8 @@ async test "basic" {
       #|
       #|client: GET /moon.mod
       #|HTTP/1.1 200 OK
-      #|content-type: appliaction/octet-stream
-      #|content-length: 304
+      #|Content-Type: appliaction/octet-stream
+      #|Content-Length: 304
       #|name = "moonbitlang/async_examples"
       #|
       #|version = "0.3.0"
@@ -141,9 +141,9 @@ async test "basic" {
       #|
       #|
       #|HTTP/1.1 200 OK
-      #|content-type: application/octet-stream
-      #|content-disposition: filename=http_file_server.zip
-      #|transfer-encoding: chunked
+      #|Content-Type: application/octet-stream
+      #|Content-Disposition: filename=http_file_server.zip
+      #|Transfer-Encoding: chunked
       #|http_file_server/
       #|http_file_server/main.mbt
       #|http_file_server/moon.pkg

--- a/src/http/case_insensitive_string.mbt
+++ b/src/http/case_insensitive_string.mbt
@@ -1,0 +1,49 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// String type with case insensitive comparison (in the ASCII sense).
+/// This type is implicitly convertible from `String` & string literal.
+pub(all) struct CaseInsensitiveString(String) derive(ToJson)
+
+///|
+pub impl Eq for CaseInsensitiveString with fn equal(x, y) {
+  Compare::compare(x, y) == 0
+}
+
+///|
+pub impl Compare for CaseInsensitiveString with fn compare(x, y) {
+  x.0.compare_ignore_ascii_case(y.0)
+}
+
+///|
+pub impl Debug for CaseInsensitiveString with fn to_repr(self) {
+  Debug::to_repr(self.0)
+}
+
+///|
+pub impl Show for CaseInsensitiveString with fn to_string(self) {
+  self.0
+}
+
+///|
+pub impl Hash for CaseInsensitiveString with fn hash_combine(self, hasher) {
+  for code in self.0.code_units() {
+    let code = match code {
+      'A'..='Z' => code + ('a' - 'A')
+      _ => code
+    }
+    hasher.combine_uint(code.to_uint())
+  }
+}

--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -66,7 +66,7 @@ priv struct OngoingRequest {
 struct Client {
   host : String
   protocol : Protocol
-  headers : Map[String, String]
+  headers : Headers
   mut request : OngoingRequest?
   mut response_body : @js_async.ReadableStream?
 }
@@ -82,7 +82,7 @@ pub fn Client::close(self : Client) -> Unit {
 ///|
 fn Client::connect(
   host : String,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   protocol? : Protocol = Https,
   proxy? : Client,
 ) -> Client {
@@ -113,7 +113,7 @@ fn Client::connect(
 #label_migration(verify, fill=false, msg="verify is unsupported on Windows")
 pub async fn Client::Client(
   uri : String,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   proxy? : Client,
   verify? : Bool = true,
 ) -> Client {
@@ -170,9 +170,9 @@ pub async fn Client::end_request(self : Client) -> Response {
   self.response_body = Some(
     @js_async.ReadableStream::from_js(js_response.body()),
   )
-  let headers = Map([])
+  let headers : Headers = Map([])
   for entry in js_response.headers().to_array() {
-    headers[entry[0].to_lower()] = entry[1]
+    headers[entry[0]] = entry[1]
   }
   {
     code: js_response.status(),
@@ -223,7 +223,7 @@ pub async fn Client::request(
   self : Client,
   meth : RequestMethod,
   path : StringView,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : Headers = Map([]),
 ) -> Unit {
   guard! self.request is None
   let protocol = match self.protocol {
@@ -245,10 +245,10 @@ pub async fn Client::request(
   }
   let headers = JsHeaders::new()
   for k, v in self.headers {
-    headers.append(k, v)
+    headers.append(k.0, v)
   }
   for k, v in extra_headers {
-    headers.append(k, v)
+    headers.append(k.0, v)
   }
   let request : OngoingRequest = { meth, uri, headers, body: @buffer.Buffer() }
   self.request = Some(request)
@@ -260,7 +260,7 @@ pub async fn Client::request(
 pub async fn Client::get(
   self : Client,
   path : String,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : Headers = Map([]),
   body? : &@io.Data,
 ) -> Response {
   self.request(Get, path, extra_headers~)
@@ -276,7 +276,7 @@ pub async fn Client::put(
   self : Client,
   path : String,
   body : &@io.Data,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : Headers = Map([]),
 ) -> Response {
   self..request(Put, path, extra_headers~)..write(body).end_request()
 }
@@ -287,7 +287,7 @@ pub async fn Client::post(
   self : Client,
   path : String,
   body : &@io.Data,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : Headers = Map([]),
 ) -> Response {
   self..request(Post, path, extra_headers~)..write(body).end_request()
 }

--- a/src/http/client.mbt
+++ b/src/http/client.mbt
@@ -39,7 +39,7 @@ pub suberror ProxyError {
 ///|
 async fn Client::connect(
   host : StringView,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   protocol? : Protocol = Https,
   proxy? : Client,
   trust? : @tls.TrustedRoot = SystemRoot,
@@ -133,7 +133,7 @@ async fn Client::connect(
 #label_migration(verify, fill=false, msg="use `trust` instead")
 pub async fn Client::Client(
   uri : String,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   proxy? : Client,
   verify? : Bool = true,
   trust? : @tls.TrustedRoot,
@@ -260,7 +260,7 @@ pub async fn Client::request(
   self : Client,
   meth : RequestMethod,
   path : StringView,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : Headers = Map([]),
 ) -> Unit {
   self.auto_decompress = self.sender.send_request(meth, path, extra_headers~)
   self.request_method = Some(meth)
@@ -279,7 +279,7 @@ pub async fn Client::skip_response_body(self : Client) -> Unit {
 pub async fn Client::get(
   self : Client,
   path : String,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : Headers = Map([]),
   body? : &@io.Data,
 ) -> Response {
   self.request(Get, path, extra_headers~)
@@ -295,7 +295,7 @@ pub async fn Client::put(
   self : Client,
   path : String,
   body : &@io.Data,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : Headers = Map([]),
 ) -> Response {
   self..request(Put, path, extra_headers~)..write(body).end_request()
 }
@@ -306,7 +306,7 @@ pub async fn Client::post(
   self : Client,
   path : String,
   body : &@io.Data,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : Headers = Map([]),
 ) -> Response {
   self..request(Post, path, extra_headers~)..write(body).end_request()
 }

--- a/src/http/deprecated.mbt
+++ b/src/http/deprecated.mbt
@@ -36,7 +36,7 @@ fn Protocol::write_show(self : Protocol, logger : &Logger) -> Unit {
 }
 
 ///|
-fn write_headers_show(headers : Map[String, String], logger : &Logger) -> Unit {
+fn write_headers_show(headers : Headers, logger : &Logger) -> Unit {
   logger <+ "{"
   let mut first = true
   for key, value in headers {
@@ -45,7 +45,7 @@ fn write_headers_show(headers : Map[String, String], logger : &Logger) -> Unit {
     } else {
       logger <+ ", "
     }
-    logger <+ "\{key.escape()}: \{value.escape()}"
+    logger <+ "\{key.0.escape()}: \{value.escape()}"
   }
   logger <+ "}"
 }

--- a/src/http/parser.mbt
+++ b/src/http/parser.mbt
@@ -229,10 +229,8 @@ impl @io.Reader for Reader with fn _get_internal_buffer(self) {
 extend Reader with @io.Reader::{_direct_read, _get_internal_buffer, drop}
 
 ///|
-async fn Reader::read_headers(
-  self : Reader,
-) -> (Map[String, String], Array[Cookie]) {
-  let headers = Map([])
+async fn Reader::read_headers(self : Reader) -> (Headers, Array[Cookie]) {
+  let headers : Headers = Map([])
   let cookies = []
   for ;; {
     guard self.transport.read_until("\r\n") is Some(header_line) else {
@@ -243,7 +241,7 @@ async fn Reader::read_headers(
       break
     }
     guard header_line.find(":") is Some(colon_index) else { raise BadRequest }
-    let key = header_line[:colon_index].to_lower().to_owned()
+    let key = CaseInsensitiveString(header_line[:colon_index].to_owned())
     guard colon_index + 1 < header_line.length() else { raise BadRequest }
     let value_start = if header_line.code_unit_at(colon_index + 1) == ' ' {
       colon_index + 2
@@ -251,36 +249,32 @@ async fn Reader::read_headers(
       colon_index + 1
     }
     let value = header_line[value_start:].to_owned()
-    match key {
-      "content-length" => {
-        guard !(self.body is Fixed(_)) else { raise BadRequest }
-        let len = @string.parse_int(value, base=10)
-        if self.body is Empty && len > 0 {
-          self.body = Fixed(len)
-        }
-        // if automatic decompression is enabled, avoid reporting a wrong content-length value
-        if self.gzip is Some(_) {
-          continue
-        }
+    if key == "Content-Length" {
+      guard !(self.body is Fixed(_)) else { raise BadRequest }
+      let len = @string.parse_int(value, base=10)
+      if self.body is Empty && len > 0 {
+        self.body = Fixed(len)
       }
-      "transfer-encoding" => {
-        guard !(self.body is Chunked(_)) else { raise BadRequest }
-        guard value.to_lower() is "chunked" else { raise NotImplemented }
-        self.body = Chunked(0)
-      }
-      "content-encoding" if self.auto_decompress => {
-        guard self.gzip is None else { raise BadRequest }
-        guard value.to_lower() is "gzip" else { raise NotImplemented }
-        self.gzip = Some(@gzip.Decoder())
-        // if automatic decompression is enabled, avoid reporting a wrong content-length value
-        headers.remove("content-length")
+      // if automatic decompression is enabled, avoid reporting a wrong content-length value
+      if self.gzip is Some(_) {
         continue
       }
-      "set-cookie" => {
-        cookies.push(Cookie::parse(value))
-        continue
+    } else if key == "Transfer-Encoding" {
+      guard !(self.body is Chunked(_)) else { raise BadRequest }
+      guard CaseInsensitiveString(value) == "chunked" else {
+        raise NotImplemented
       }
-      _ => ()
+      self.body = Chunked(0)
+    } else if key == "Content-Encoding" && self.auto_decompress {
+      guard self.gzip is None else { raise BadRequest }
+      guard CaseInsensitiveString(value) == "gzip" else { raise NotImplemented }
+      self.gzip = Some(@gzip.Decoder())
+      // if automatic decompression is enabled, avoid reporting a wrong content-length value
+      headers.remove("Content-Length")
+      continue
+    } else if key == "Set-Cookie" {
+      cookies.push(Cookie::parse(value))
+      continue
     }
     match headers.get(key) {
       None => headers[key] = value
@@ -298,9 +292,6 @@ async fn Reader::read_headers(
 ///
 /// After `read_request` successfully returned,
 /// the HTTP reader itself can be used to extract the body of the request.
-///
-/// HTTP header fields are case insensitive.
-/// In the result of `read_request`, all header fields will be in lower case.
 async fn Reader::read_request(self : Reader) -> Request {
   guard! self.body is Empty
   guard self.transport.read_until("\r\n") is Some(request_line) else {
@@ -341,7 +332,7 @@ async fn Reader::read_request(self : Reader) -> Request {
 /// - Not a response to a HEAD request (which never has a message body)
 fn should_read_body_until_close(
   code : Int,
-  headers : Map[String, String],
+  headers : Headers,
   current_body : BodyKind,
   request_method : RequestMethod?,
 ) -> Bool {
@@ -355,8 +346,8 @@ fn should_read_body_until_close(
     return false
   }
   current_body is Empty &&
-  headers.get("content-length") is None &&
-  headers.get("transfer-encoding") is None &&
+  headers.get("Content-Length") is None &&
+  headers.get("Transfer-Encoding") is None &&
   code >= 200 &&
   code != 204 &&
   code != 205 &&
@@ -371,9 +362,6 @@ fn should_read_body_until_close(
 ///
 /// After `read_response` successfully returned,
 /// the HTTP reader itself can be used to extract the body of the response.
-///
-/// HTTP header fields are case insensitive.
-/// In the result of `read_response`, all header fields will be in lower case.
 async fn Reader::read_response(
   self : Reader,
   auto_decompress~ : Bool,

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -16,7 +16,7 @@
 extend Reader with @io.Reader::{read_some, read_all}
 
 ///|
-fn log_headers(headers : Map[String, String], logger : &Logger) -> Unit {
+fn log_headers(headers : Headers, logger : &Logger) -> Unit {
   for k, v in headers {
     logger <+ "\{k}: \{v}\n"
   }
@@ -56,8 +56,8 @@ async test "read_request basic" {
     log.to_string(),
     content=(
       #|Get /
-      #|host: x.y.org
-      #|user-agent: MoonBit
+      #|Host: x.y.org
+      #|User-Agent: MoonBit
       #|
     ),
   )
@@ -87,9 +87,9 @@ async test "read_request fixed body" {
     log.to_string(),
     content=(
       #|Get /
-      #|host: x.y.org
-      #|user-agent: MoonBit
-      #|content-length: 7
+      #|Host: x.y.org
+      #|User-Agent: MoonBit
+      #|Content-Length: 7
       #|message
     ),
   )
@@ -148,9 +148,9 @@ async test "read_request chunked" {
     log.to_string(),
     content=(
       #|Get /
-      #|host: x.y.org
-      #|user-agent: MoonBit
-      #|transfer-encoding: chunked
+      #|Host: x.y.org
+      #|User-Agent: MoonBit
+      #|Transfer-Encoding: chunked
       #|abcdabcdefghijklmnop
     ),
   )
@@ -192,9 +192,9 @@ async test "read_request stream" {
     log.to_string(),
     content=(
       #|Get /
-      #|host: x.y.org
-      #|user-agent: MoonBit
-      #|transfer-encoding: chunked
+      #|Host: x.y.org
+      #|User-Agent: MoonBit
+      #|Transfer-Encoding: chunked
       #|writing data...
       #|received abcd from body
       #|writing data...
@@ -249,9 +249,9 @@ async test "multiple request" {
     log.to_string(),
     content=(
       #|Get /
-      #|host: x.y.org
-      #|user-agent: MoonBit
-      #|transfer-encoding: chunked
+      #|Host: x.y.org
+      #|User-Agent: MoonBit
+      #|Transfer-Encoding: chunked
       #|writing data...
       #|writing data...
       #|writing data...
@@ -260,9 +260,9 @@ async test "multiple request" {
       #|=========
       #|
       #|Get /
-      #|host: z.w.org
-      #|user-agent: MoonBit
-      #|content-length: 8
+      #|Host: z.w.org
+      #|User-Agent: MoonBit
+      #|Content-Length: 8
       #|message2
     ),
   )
@@ -293,7 +293,7 @@ async test "read_response basic" {
     log.to_string(),
     content=(
       #|200 OK
-      #|content-length: 7
+      #|Content-Length: 7
       #|message
     ),
   )
@@ -329,8 +329,8 @@ async test "read_response passthrough fallback (no length headers)" {
     log.to_string(),
     content=(
       #|200 OK
-      #|connection: close
-      #|content-type: text/plain
+      #|Connection: close
+      #|Content-Type: text/plain
       #|Hello, World!
     ),
   )
@@ -366,8 +366,8 @@ async test "read_response 204 No Content (no body)" {
     log.to_string(),
     content=(
       #|204 No Content
-      #|connection: keep-alive
-      #|date: Mon, 15 Feb 2026 00:00:00 GMT
+      #|Connection: keep-alive
+      #|Date: Mon, 15 Feb 2026 00:00:00 GMT
       #|body: 
     ),
   )
@@ -403,8 +403,8 @@ async test "read_response 205 Reset Content (no body)" {
     log.to_string(),
     content=(
       #|205 Reset Content
-      #|connection: keep-alive
-      #|date: Mon, 15 Feb 2026 00:00:00 GMT
+      #|Connection: keep-alive
+      #|Date: Mon, 15 Feb 2026 00:00:00 GMT
       #|body: 
     ),
   )
@@ -439,9 +439,9 @@ async test "read_response 304 Not Modified (no body)" {
     log.to_string(),
     content=(
       #|304 Not Modified
-      #|connection: keep-alive
-      #|etag: "abc123"
-      #|cache-control: max-age=3600
+      #|Connection: keep-alive
+      #|ETag: "abc123"
+      #|Cache-Control: max-age=3600
       #|body: 
     ),
   )
@@ -544,8 +544,8 @@ async test "read_response HEAD 200 (no body)" {
     log.to_string(),
     content=(
       #|200 OK
-      #|content-length: 1234
-      #|content-type: text/html
+      #|Content-Length: 1234
+      #|Content-Type: text/html
       #|body: 
     ),
   )
@@ -553,7 +553,7 @@ async test "read_response HEAD 200 (no body)" {
 
 ///|
 test "should_read_body_until_close - true cases" {
-  let headers_no_length : Map[String, String] = Map([])
+  let headers_no_length : Headers = Map([])
 
   // 200 OK with no length headers
   inspect(
@@ -605,7 +605,7 @@ test "should_read_body_until_close - true cases" {
 
 ///|
 test "should_read_body_until_close - false cases (bodyless status codes)" {
-  let headers_no_length : Map[String, String] = Map([])
+  let headers_no_length : Headers = Map([])
 
   // 1xx informational responses
   inspect(
@@ -645,23 +645,21 @@ test "should_read_body_until_close - false cases (bodyless status codes)" {
 ///|
 test "should_read_body_until_close - false cases (headers present)" {
   // Content-Length present
-  let headers_with_length : Map[String, String] = { "content-length": "42" }
+  let headers_with_length : Headers = { "content-length": "42" }
   inspect(
     should_read_body_until_close(200, headers_with_length, Empty, None),
     content="false",
   )
 
   // Transfer-Encoding present
-  let headers_with_transfer : Map[String, String] = {
-    "transfer-encoding": "chunked",
-  }
+  let headers_with_transfer : Headers = { "transfer-encoding": "chunked" }
   inspect(
     should_read_body_until_close(200, headers_with_transfer, Empty, None),
     content="false",
   )
 
   // Both present
-  let headers_with_both : Map[String, String] = {
+  let headers_with_both : Headers = {
     "content-length": "42",
     "transfer-encoding": "chunked",
   }
@@ -673,7 +671,7 @@ test "should_read_body_until_close - false cases (headers present)" {
 
 ///|
 test "should_read_body_until_close - false cases (body already determined)" {
-  let headers_no_length : Map[String, String] = Map([])
+  let headers_no_length : Headers = Map([])
 
   // Body is Fixed (already determined by Content-Length)
   inspect(
@@ -696,7 +694,7 @@ test "should_read_body_until_close - false cases (body already determined)" {
 
 ///|
 test "should_read_body_until_close - false cases (CONNECT requests)" {
-  let headers_no_length : Map[String, String] = Map([])
+  let headers_no_length : Headers = Map([])
 
   // Successful CONNECT (2xx) responses become tunnels with no HTTP body
   inspect(
@@ -729,7 +727,7 @@ test "should_read_body_until_close - false cases (CONNECT requests)" {
 
 ///|
 test "should_read_body_until_close - false cases (HEAD requests)" {
-  let headers_no_length : Map[String, String] = Map([])
+  let headers_no_length : Headers = Map([])
 
   // HEAD responses never have a message body, regardless of status code
   inspect(
@@ -748,7 +746,7 @@ test "should_read_body_until_close - false cases (HEAD requests)" {
   )
 
   // Even with Content-Length header, HEAD should not read body
-  let headers_with_length : Map[String, String] = { "content-length": "42" }
+  let headers_with_length : Headers = { "content-length": "42" }
   inspect(
     should_read_body_until_close(200, headers_with_length, Empty, Some(Head)),
     content="false",

--- a/src/http/pkg.generated.mbti
+++ b/src/http/pkg.generated.mbti
@@ -10,20 +10,20 @@ import {
 
 // Values
 #label_migration(body, fill=false, msg="`GET` request should not contain a body")
-pub async fn get(String, headers? : Map[String, String], body? : &@io.Data, proxy? : Client) -> (Response, &@io.Data)
+pub async fn get(String, headers? : Map[CaseInsensitiveString, String], body? : &@io.Data, proxy? : Client) -> (Response, &@io.Data)
 
 #label_migration(body, fill=false, msg="`GET` request should not contain a body")
-pub async fn get_stream(String, headers? : Map[String, String], body? : &@io.Data, proxy? : Client) -> (Response, Client)
+pub async fn get_stream(String, headers? : Map[CaseInsensitiveString, String], body? : &@io.Data, proxy? : Client) -> (Response, Client)
 
-pub async fn post(String, &@io.Data, headers? : Map[String, String], proxy? : Client) -> (Response, &@io.Data)
+pub async fn post(String, &@io.Data, headers? : Map[CaseInsensitiveString, String], proxy? : Client) -> (Response, &@io.Data)
 
-pub async fn post_stream(String, headers? : Map[String, String], proxy? : Client) -> Client
+pub async fn post_stream(String, headers? : Map[CaseInsensitiveString, String], proxy? : Client) -> Client
 
-pub async fn put(String, &@io.Data, headers? : Map[String, String], proxy? : Client) -> (Response, &@io.Data)
+pub async fn put(String, &@io.Data, headers? : Map[CaseInsensitiveString, String], proxy? : Client) -> (Response, &@io.Data)
 
-pub async fn put_stream(String, headers? : Map[String, String], proxy? : Client) -> Client
+pub async fn put_stream(String, headers? : Map[CaseInsensitiveString, String], proxy? : Client) -> Client
 
-pub async fn request(String, RequestMethod, Map[String, String], &@io.Data, proxy? : Client) -> (Response, &@io.Data)
+pub async fn request(String, RequestMethod, Map[CaseInsensitiveString, String], &@io.Data, proxy? : Client) -> (Response, &@io.Data)
 
 // Errors
 pub suberror HttpProtocolError {
@@ -50,19 +50,26 @@ pub suberror URIParseError {
 pub impl Show for URIParseError
 
 // Types and methods
+pub(all) struct CaseInsensitiveString(String) derive(ToJson)
+pub impl Compare for CaseInsensitiveString
+pub impl Eq for CaseInsensitiveString
+pub impl Hash for CaseInsensitiveString
+pub impl Show for CaseInsensitiveString
+pub impl @debug.Debug for CaseInsensitiveString
+
 type Client
 #alias(new, deprecated)
 #label_migration(verify, fill=false, msg="use `trust` instead")
-pub async fn Client::Client(String, headers? : Map[String, String], proxy? : Self, verify? : Bool, trust? : @tls.TrustedRoot) -> Self
+pub async fn Client::Client(String, headers? : Map[CaseInsensitiveString, String], proxy? : Self, verify? : Bool, trust? : @tls.TrustedRoot) -> Self
 pub fn Client::close(Self) -> Unit
 pub async fn Client::end_request(Self) -> Response
 pub async fn Client::enter_passthrough_mode(Self) -> Unit
 pub async fn Client::flush(Self) -> Unit
 #label_migration(body, fill=false, msg="`GET` request should not contain a body")
-pub async fn Client::get(Self, String, extra_headers? : Map[String, String], body? : &@io.Data) -> Response
-pub async fn Client::post(Self, String, &@io.Data, extra_headers? : Map[String, String]) -> Response
-pub async fn Client::put(Self, String, &@io.Data, extra_headers? : Map[String, String]) -> Response
-pub async fn Client::request(Self, RequestMethod, StringView, extra_headers? : Map[String, String]) -> Unit
+pub async fn Client::get(Self, String, extra_headers? : Map[CaseInsensitiveString, String], body? : &@io.Data) -> Response
+pub async fn Client::post(Self, String, &@io.Data, extra_headers? : Map[CaseInsensitiveString, String]) -> Response
+pub async fn Client::put(Self, String, &@io.Data, extra_headers? : Map[CaseInsensitiveString, String]) -> Response
+pub async fn Client::request(Self, RequestMethod, StringView, extra_headers? : Map[CaseInsensitiveString, String]) -> Unit
 pub async fn Client::skip_response_body(Self) -> Unit
 pub impl @io.Reader for Client
 pub impl @io.Writer for Client
@@ -92,7 +99,7 @@ pub impl Show for Protocol
 pub(all) struct Request {
   meth : RequestMethod
   path : String
-  headers : Map[String, String]
+  headers : Map[CaseInsensitiveString, String]
 } derive(ToJson, @debug.Debug)
 #deprecated
 pub impl Show for Request
@@ -114,7 +121,7 @@ pub impl Show for RequestMethod
 pub(all) struct Response {
   code : Int
   reason : String
-  headers : Map[String, String]
+  headers : Map[CaseInsensitiveString, String]
   cookies : Array[Cookie]
 } derive(ToJson, @debug.Debug)
 #deprecated
@@ -125,7 +132,7 @@ pub struct Server {
   // private fields
 }
 #alias(new, deprecated)
-pub async fn Server::Server(@socket.Addr, dual_stack? : Bool, reuse_addr? : Bool, headers? : Map[String, String]) -> Self
+pub async fn Server::Server(@socket.Addr, dual_stack? : Bool, reuse_addr? : Bool, headers? : Map[CaseInsensitiveString, String]) -> Self
 pub async fn Server::accept(Self) -> (ServerConnection, @socket.Addr)
 #deprecated
 pub fn Server::addr(Self) -> @socket.Addr
@@ -138,9 +145,9 @@ pub fn ServerConnection::close(Self) -> Unit
 pub async fn ServerConnection::end_response(Self) -> Unit
 pub async fn ServerConnection::enter_passthrough_mode(Self) -> Unit
 pub async fn ServerConnection::flush(Self) -> Unit
-pub fn ServerConnection::new(@socket.Tcp, headers? : Map[String, String]) -> Self
+pub fn ServerConnection::new(@socket.Tcp, headers? : Map[CaseInsensitiveString, String]) -> Self
 pub async fn ServerConnection::read_request(Self) -> Request
-pub async fn ServerConnection::send_response(Self, Int, String, extra_headers? : Map[String, String], cookies? : Array[Cookie]) -> Unit
+pub async fn ServerConnection::send_response(Self, Int, String, extra_headers? : Map[CaseInsensitiveString, String], cookies? : Array[Cookie]) -> Unit
 pub async fn ServerConnection::skip_request_body(Self) -> Unit
 pub async fn ServerConnection::write_string(Self, String) -> Unit
 pub async fn ServerConnection::write_string_interpolation(Self, &@io.Data) -> Unit
@@ -148,5 +155,6 @@ pub impl @io.Reader for ServerConnection
 pub impl @io.Writer for ServerConnection
 
 // Type aliases
+pub type Headers = Map[CaseInsensitiveString, String]
 
 // Traits

--- a/src/http/proxy_test.mbt
+++ b/src/http/proxy_test.mbt
@@ -218,7 +218,7 @@ async test "proxy error" {
         inspect(
           err,
           content=(
-            #|ProxyError({code: 407, reason: "ProxyAuthenticationRequired", headers: {"content-length": "0"}})
+            #|ProxyError({code: 407, reason: "ProxyAuthenticationRequired", headers: {"Content-Length": "0"}})
           ),
         )
     } noraise {

--- a/src/http/request.mbt
+++ b/src/http/request.mbt
@@ -84,7 +84,7 @@ fn resolve_host(
 pub async fn request(
   uri : String,
   meth : RequestMethod,
-  headers : Map[String, String],
+  headers : Headers,
   body : &@io.Data,
   proxy? : Client,
 ) -> (Response, &@io.Data) {
@@ -108,7 +108,7 @@ pub async fn request(
 #label_migration(body, fill=false, msg="`GET` request should not contain a body")
 pub async fn get(
   uri : String,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   body? : &@io.Data = b"",
   proxy? : Client,
 ) -> (Response, &@io.Data) {
@@ -120,7 +120,7 @@ pub async fn get(
 pub async fn put(
   uri : String,
   content : &@io.Data,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   proxy? : Client,
 ) -> (Response, &@io.Data) {
   request(uri, Put, headers, content, proxy?)
@@ -131,7 +131,7 @@ pub async fn put(
 pub async fn post(
   uri : String,
   content : &@io.Data,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   proxy? : Client,
 ) -> (Response, &@io.Data) {
   request(uri, Post, headers, content, proxy?)
@@ -150,7 +150,7 @@ pub async fn post(
 #label_migration(body, fill=false, msg="`GET` request should not contain a body")
 pub async fn get_stream(
   uri : String,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   body? : &@io.Data = b"",
   proxy? : Client,
 ) -> (Response, Client) {
@@ -182,7 +182,7 @@ pub async fn get_stream(
 /// to close the underlying connection used for the request.
 pub async fn put_stream(
   uri : String,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   proxy? : Client,
 ) -> Client {
   let (protocol, host, path) = resolve_url(uri)
@@ -212,7 +212,7 @@ pub async fn put_stream(
 /// to close the underlying connection used for the request.
 pub async fn post_stream(
   uri : String,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
   proxy? : Client,
 ) -> Client {
   let (protocol, host, path) = resolve_url(uri)

--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -34,8 +34,8 @@ priv struct Sender {
 }
 
 ///|
-let forbidden_headers : Set[String] = Set::from_array([
-  "content-length", "transfer-encoding",
+let forbidden_headers : Set[CaseInsensitiveString] = Set::from_array([
+  "Content-Length", "Transfer-Encoding",
 ])
 
 ///|
@@ -58,20 +58,16 @@ fn sanitize_header_value(s : String) -> String {
 }
 
 ///|
-fn[W : @io.Writer] Sender::new(
-  w : W,
-  headers? : Map[String, String] = Map([]),
-) -> Sender {
+fn[W : @io.Writer] Sender::new(w : W, headers? : Headers = Map([])) -> Sender {
   let header_text = Buffer()
   let mut has_accept_encoding = false
   for k, v in headers {
-    let k_lower = k.to_lower()
-    if !forbidden_headers.contains(k_lower) {
-      if k_lower is "accept-encoding" {
+    if !forbidden_headers.contains(k) {
+      if k == "Accept-Encoding" {
         has_accept_encoding = true
       }
       header_text
-      ..write_string_utf8(sanitize_header_value(k))
+      ..write_string_utf8(sanitize_header_value(k.0))
       ..write_bytes(b": ")
       ..write_string_utf8(sanitize_header_value(v))
       .write_bytes(b"\r\n")
@@ -285,22 +281,17 @@ async fn Sender::end_body(self : Sender) -> Unit {
 }
 
 ///|
-async fn Sender::send_headers(
-  self : Sender,
-  headers : Map[String, String],
-) -> Int64? {
+async fn Sender::send_headers(self : Sender, headers : Headers) -> Int64? {
   let mut content_length = None
-  for pair in headers.to_array() {
-    let (k, v) = pair
-    let k_lower = k.to_lower()
-    if k_lower is "content-length" {
+  for k, v in headers {
+    if k == "Content-Length" {
       let len = @string.parse_int64(v.trim(), base=10)
       content_length = Some(len)
-    } else if forbidden_headers.contains(k_lower) {
+    } else if forbidden_headers.contains(k) {
       continue
     }
     self
-    ..write(sanitize_header_value(k))
+    ..write(sanitize_header_value(k.0))
     ..write(b": ")
     ..write(sanitize_header_value(v))
     .write(b"\r\n")
@@ -314,7 +305,7 @@ async fn Sender::send_request(
   self : Sender,
   meth : RequestMethod,
   path : StringView,
-  extra_headers~ : Map[String, String],
+  extra_headers~ : Headers,
 ) -> Bool {
   guard! self.mode is SendingHeader
   self.should_have_empty_body = meth is (Get | Head | Delete | Trace)
@@ -335,8 +326,7 @@ async fn Sender::send_request(
     ..write(self.headers)
     .send_headers(extra_headers)
   let auto_decompress = !self.has_accept_encoding &&
-    extra_headers.keys().find_first(k => k.to_lower() is "accept-encoding")
-    is None
+    !extra_headers.contains("Accept-Encoding")
   if auto_decompress {
     self.write(b"Accept-Encoding: gzip,identity\r\n")
   }
@@ -354,7 +344,7 @@ async fn Sender::send_response(
   self : Sender,
   code : Int,
   reason : String,
-  extra_headers~ : Map[String, String],
+  extra_headers~ : Headers,
   cookies~ : Array[Cookie],
   request_method~ : RequestMethod,
 ) -> Unit {

--- a/src/http/server.mbt
+++ b/src/http/server.mbt
@@ -33,7 +33,7 @@ struct ServerConnection {
 /// - Content-Length, Transfer-Encoding
 pub fn ServerConnection::new(
   conn : @socket.Tcp,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
 ) -> ServerConnection {
   {
     reader: Reader::new(conn),
@@ -175,7 +175,7 @@ pub async fn ServerConnection::send_response(
   self : ServerConnection,
   code : Int,
   reason : String,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : Headers = Map([]),
   cookies? : Array[Cookie] = [],
 ) -> Unit {
   self.sender.send_response(
@@ -192,7 +192,7 @@ pub async fn ServerConnection::send_response(
 pub struct Server {
   addr : @socket.Addr
   priv server : @socket.TcpServer
-  priv headers : Map[String, String]
+  priv headers : Headers
 }
 
 ///|
@@ -208,7 +208,7 @@ pub async fn Server::Server(
   addr : @socket.Addr,
   dual_stack? : Bool,
   reuse_addr? : Bool,
-  headers? : Map[String, String] = Map([]),
+  headers? : Headers = Map([]),
 ) -> Server {
   let server = @socket.TcpServer(addr, dual_stack?, reuse_addr?)
   { addr: server.addr, server, headers }

--- a/src/http/types.mbt
+++ b/src/http/types.mbt
@@ -26,17 +26,28 @@ pub(all) enum RequestMethod {
 } derive(Debug, Eq, Compare, Hash, ToJson)
 
 ///|
+/// Type for HTTP headers. The names of headers are case insensitive.
+///
+/// The RFC requires that multiple header entries with the same name
+/// should be semantically equivalent to concatenating values with comma,
+/// so a `Map` with unique keys can be used to represent headers.
+///
+/// One important exception to the above rule is the `Set-Cookie` header,
+/// which is handled specially via the `Cookie` type.
+pub type Headers = Map[CaseInsensitiveString, String]
+
+///|
 pub(all) struct Request {
   meth : RequestMethod
   path : String
-  headers : Map[String, String]
+  headers : Headers
 } derive(Debug, ToJson)
 
 ///|
 pub(all) struct Response {
   code : Int
   reason : String
-  headers : Map[String, String]
+  headers : Headers
   /// The list of cookies specified in `Set-Cookie` headers.
   ///
   /// JS backend note: browsers forbid JS code from accessing raw cookie values,

--- a/src/websocket/client.mbt
+++ b/src/websocket/client.mbt
@@ -32,7 +32,7 @@
 pub async fn Conn::from_http_client(
   conn : @http.Client,
   path : StringView,
-  extra_headers? : Map[String, String] = Map([]),
+  extra_headers? : @http.Headers = Map([]),
 ) -> Conn {
   // Ref : https://datatracker.ietf.org/doc/html/rfc6455#section-4.1
   let seed = @tls.rand_bytes(32)
@@ -110,7 +110,7 @@ pub async fn Conn::from_http_client(
 #as_free_fn
 pub async fn Conn::connect(
   url : String,
-  headers? : Map[String, String] = Map([]),
+  headers? : @http.Headers = Map([]),
   proxy? : @http.Client,
 ) -> Conn {
   guard url.find("://") is Some(protocol_len) else {

--- a/src/websocket/pkg.generated.mbti
+++ b/src/websocket/pkg.generated.mbti
@@ -39,10 +39,10 @@ pub impl Show for CloseCode
 type Conn
 pub fn Conn::close(Self) -> Unit
 #as_free_fn
-pub async fn Conn::connect(String, headers? : Map[String, String], proxy? : @http.Client) -> Self
+pub async fn Conn::connect(String, headers? : Map[@http.CaseInsensitiveString, String], proxy? : @http.Client) -> Self
 pub async fn Conn::end_message(Self) -> Unit
 #as_free_fn
-pub async fn Conn::from_http_client(@http.Client, StringView, extra_headers? : Map[String, String]) -> Self
+pub async fn Conn::from_http_client(@http.Client, StringView, extra_headers? : Map[@http.CaseInsensitiveString, String]) -> Self
 #as_free_fn
 pub async fn Conn::from_http_server(@http.Request, @http.ServerConnection) -> Self
 pub async fn Conn::ping(Self, msg? : BytesView) -> Unit


### PR DESCRIPTION
This PR make HTTP header keys case insensitive everywhere, both sent and received. The trick is to introduce a newtype `pub(all) struct CaseInsensitiveString(String)`. This type is implicitly convertible from `String` and string literal, so existing code such as `headers["LiteralValue"]`, `extra_headers={ "XXX": "YYY" }` continue to work. The `Compare`, `Eq` and `Hash` implementation of `CaseInsensitiveString` is ASCII case insensitive, so case-insensitive deduplication and lookup work for free.

This PR is still breaking, because user code may have annotated `Map[String, String]` for the header map, and such type annotation will fail type checking after this PR. This PR provides a type alias `@http.Headers` to avoid the need for lengthy `Map[CaseInsensitiveString, String]`, users can use this alias to replace `Map[String, String]` during migration.