### PR TITLE
enhance process redirection API

### DIFF
--- a/src/process/README.mbt.md
+++ b/src/process/README.mbt.md
@@ -420,15 +420,17 @@ Run multiple processes writing to the same pipe:
 #cfg(all(target="native", not(platform="windows")))
 async test "multiple processes to one pipe" {
   @async.with_task_group(root => {
-    let (reader, writer) = @pipe.pipe()
+    let (reader, writer) = @process.read_from_process(shared=true)
     root.spawn_bg(no_wait=true, () => {
       defer reader.close()
       let output = reader.read_all().text()
       inspect(output.contains("first"), content="true")
       inspect(output.contains("second"), content="true")
     })
-    defer writer.close()
     @async.with_task_group(group => {
+      // The write must be manually closed after all children process are spawned
+      // in the shared case
+      defer writer.close()
       @process.spawn(group, "echo", ["first"], stdout=writer) |> ignore
       @process.spawn(group, "echo", ["second"], stdout=writer) |> ignore
     })

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -31,7 +31,7 @@ pub async fn redirect_from_file(String) -> &ProcessInput
 
 #label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
 #label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
-pub async fn redirect_to_file(String, append? : Bool, create_mode? : @fs.CreateMode, permission? : Int, create? : Int, truncate? : Bool) -> &ProcessOutput
+pub async fn redirect_to_file(String, append? : Bool, create_mode? : @fs.CreateMode, permission? : Int, create? : Int, truncate? : Bool, shared? : Bool) -> &ProcessOutput
 
 pub async fn run(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : StringView, no_console_window? : Bool, cancel_handler? : CancellationHandler) -> Int
 

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -23,6 +23,8 @@ pub fn graceful_cancel(timeout~ : Int, signal? : @signal.Signal) -> Cancellation
 
 pub fn hard_cancel() -> CancellationHandler
 
+pub fn pipe() -> (&ProcessInput, &ProcessOutput) raise
+
 pub fn read_from_process() -> (ReadFromProcess, &ProcessOutput) raise
 
 pub async fn redirect_from_file(String) -> &ProcessInput

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -25,7 +25,7 @@ pub fn hard_cancel() -> CancellationHandler
 
 pub fn pipe() -> (&ProcessInput, &ProcessOutput) raise
 
-pub fn read_from_process() -> (ReadFromProcess, &ProcessOutput) raise
+pub fn read_from_process(shared? : Bool) -> (ReadFromProcess, &ProcessOutput) raise
 
 pub async fn redirect_from_file(String) -> &ProcessInput
 
@@ -68,9 +68,12 @@ pub impl @io.Writer for WriteToProcess
 
 // Traits
 trait ProcessInput
+#deprecated
 pub impl ProcessInput for @pipe.PipeRead
 pub impl ProcessInput for @stdio.Input
 
 trait ProcessOutput
+#deprecated
 pub impl ProcessOutput for @pipe.PipeWrite
 pub impl ProcessOutput for @stdio.Output
+pub fn &ProcessOutput::close(Self) -> Unit

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -64,6 +64,24 @@ pub fn write_to_process() -> (&ProcessInput, WriteToProcess) raise {
 }
 
 ///|
+/// Create a temporary pipe for connecting the output of
+/// one child process to the input of another child process.
+pub fn pipe() -> (&ProcessInput, &ProcessOutput) raise {
+  let context = "@process.pipe()"
+  let (r, w) = @fd_util.pipe(
+    read_end_is_async=false,
+    write_end_is_async=false,
+    context~,
+  )
+  let r = @event_loop.IoHandle::from_fd(r, kind=Pipe, is_async=false)
+  let w = @event_loop.IoHandle::from_fd(w, kind=Pipe, is_async=false)
+  (
+    TempPipeRead::{ pipe: r, closed: false },
+    TempPipeWrite::{ pipe: w, closed: false },
+  )
+}
+
+///|
 pub fn ReadFromProcess::close(self : ReadFromProcess) -> Unit {
   self.io.close()
 }

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -144,8 +144,22 @@ fn @fs.CreateMode::to_int(self : @fs.CreateMode) -> Int = "%identity"
 
 ///|
 /// Redirect the output of a process to the file at `path`.
+/// An output channel that should be passed to child process will be returned.
+///
 /// The meaning of `append`, `create_mode` and `permission` is the same as `@fs.open`,
 /// see the document of `@fs.open` for more details.
+///
+/// If `shared` is `false` (the default), the returned channel `w` is unique.
+/// In this case, `w` can only be passed to one child process
+/// (but it is ok to pass `w` to both stdout and stderr of the same process),
+/// and `w` will be closed automatically after the child process started.
+///
+/// If `shared` is `true`, the returned channel `w` is shared:
+/// it can be passed to multiple children process to merge and collect their output.
+/// In this case, `w` should be closed manually via `w.close()`
+/// after being passed to the last child process.
+/// Note that `w` can be closed immediately after the last child process *started*,
+/// there is no need to wait for the termination of the child process.
 #label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
 #label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
 pub async fn redirect_to_file(
@@ -155,6 +169,7 @@ pub async fn redirect_to_file(
   permission? : Int,
   create? : Int,
   truncate? : Bool = false,
+  shared? : Bool = false,
 ) -> &ProcessOutput {
   let create_mode = match create_mode {
     Some(mode) => mode
@@ -180,7 +195,7 @@ pub async fn redirect_to_file(
     mode=permission,
     context="@process.redirect_to_file()",
   )
-  RedirectToFile(file)
+  RedirectToFile::{ io: file, shared, closed: false }
 }
 
 ///|
@@ -195,7 +210,7 @@ pub async fn redirect_from_file(path : String) -> &ProcessInput {
     mode=0,
     context="@process.redirect_from_file()",
   )
-  RedirectToFile(file)
+  RedirectToFile::{ io: file, shared: false, closed: false }
 }
 
 ///|
@@ -315,24 +330,41 @@ impl ProcessInput for TempPipeRead with fn after_spawn(self) {
 }
 
 ///|
-priv struct RedirectToFile(@event_loop.IoHandle)
+priv struct RedirectToFile {
+  io : @event_loop.IoHandle
+  shared : Bool
+  mut closed : Bool
+}
 
 ///|
 impl ProcessOutput for RedirectToFile with fn fd(self) {
-  self.0.fd()
+  self.io.fd()
+}
+
+///|
+impl ProcessOutput for RedirectToFile with fn do_close(self) {
+  if !self.closed {
+    self.closed = true
+    self.io.close()
+  }
 }
 
 ///|
 impl ProcessOutput for RedirectToFile with fn after_spawn(self) {
-  self.0.close()
+  if !self.shared {
+    ProcessOutput::do_close(self)
+  }
 }
 
 ///|
 impl ProcessInput for RedirectToFile with fn fd(self) {
-  self.0.fd()
+  self.io.fd()
 }
 
 ///|
 impl ProcessInput for RedirectToFile with fn after_spawn(self) {
-  self.0.close()
+  if !self.closed {
+    self.closed = true
+    self.io.close()
+  }
 }

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -27,11 +27,27 @@ struct WriteToProcess(@event_loop.IoHandle)
 /// Create a temporary pipe for reading from stdout/stderr of a process.
 /// The return value is a pair `(r, w)`,
 /// where `r` is a temporary pipe that can be used to read process output,
-/// and `w` should be passed to `@process.run`.
+/// and `w` should be passed to `@process.run`, `@process.spawn` etc.
 ///
 /// `w` is temporary: it can only be passed to one `@process.run` call.
 /// However, it is safe to pass `w` to both `stdout` and `stderr` of the same process.
-pub fn read_from_process() -> (ReadFromProcess, &ProcessOutput) raise {
+///
+/// If `shared` is `false` (the default), the created pipe is unique.
+/// In this case, `w` can only be passed to one child process
+/// (but it is ok to pass `w` to both stdout and stderr of the same process),
+/// and `w` will be closed automatically after the child process started.
+///
+/// If `shared` is `true`, the created pipe is shared:
+/// `w` can be passed to multiple children process to merge and collect their output.
+/// In this case, `w` should be closed manually via `w.close()`
+/// after being passed to the last child process.
+/// Note that `w` can be closed immediately after the last child process *started*,
+/// there is no need to wait for the termination of the child process.
+/// If you forgot to close `w` or close it too late,
+/// the read end `r` will fail to observe EOF from children process.
+pub fn read_from_process(
+  shared? : Bool = false,
+) -> (ReadFromProcess, &ProcessOutput) raise {
   let context = "@process.read_from_process()"
   let (r, w) = @fd_util.pipe(
     read_end_is_async=true,
@@ -42,7 +58,7 @@ pub fn read_from_process() -> (ReadFromProcess, &ProcessOutput) raise {
   let w = @event_loop.IoHandle::from_fd(w, kind=Pipe, is_async=false)
   (
     { io: r, read_buf: @io.ReaderBuffer::new() },
-    TempPipeWrite::{ pipe: w, closed: false },
+    TempPipeWrite::{ pipe: w, shared, closed: false },
   )
 }
 
@@ -77,7 +93,7 @@ pub fn pipe() -> (&ProcessInput, &ProcessOutput) raise {
   let w = @event_loop.IoHandle::from_fd(w, kind=Pipe, is_async=false)
   (
     TempPipeRead::{ pipe: r, closed: false },
-    TempPipeWrite::{ pipe: w, closed: false },
+    TempPipeWrite::{ pipe: w, shared: false, closed: false },
   )
 }
 
@@ -195,6 +211,10 @@ impl ProcessInput with fn after_spawn(_) {
 }
 
 ///|
+#deprecated("use `@process.write_to_process()` or `@process.pipe()` instead")
+pub impl ProcessInput for @pipe.PipeRead
+
+///|
 pub impl ProcessInput for @pipe.PipeRead with fn fd(self) {
   self.fd()
 }
@@ -208,13 +228,35 @@ pub impl ProcessInput for @stdio.Input with fn fd(self) {
 /// An entity that can be used to redirect stdout/stderr of a process
 trait ProcessOutput {
   fn fd(Self) -> @fd_util.Fd raise
+  /// Close the output channel.
+  /// May be called automatically via `after_spawn`, or manually via `.close()`
+  fn do_close(Self) -> Unit = _
   fn after_spawn(Self) -> Unit = _
+}
+
+///|
+/// Close a shared channel for redirecting process output.
+/// Once closed, the channel can no longer be passed to child process.
+/// Note that unique channels are automatically closed after being passed to child process,
+/// so there is no need to manually call `.close()` on a unique channel.
+/// See `@process.read_from_process` for more details.
+pub fn &ProcessOutput::close(self : &ProcessOutput) -> Unit {
+  self.do_close()
+}
+
+///|
+impl ProcessOutput with fn do_close(_) {
+  ()
 }
 
 ///|
 impl ProcessOutput with fn after_spawn(_) {
   ()
 }
+
+///|
+#deprecated("use `@process.read_from_process(shared~)` or `@process.pipe()` instead")
+pub impl ProcessOutput for @pipe.PipeWrite
 
 ///|
 pub impl ProcessOutput for @pipe.PipeWrite with fn fd(self) {
@@ -235,6 +277,7 @@ priv struct TempPipeRead {
 ///|
 priv struct TempPipeWrite {
   pipe : @event_loop.IoHandle
+  shared : Bool
   mut closed : Bool
 }
 
@@ -244,10 +287,17 @@ impl ProcessOutput for TempPipeWrite with fn fd(self) {
 }
 
 ///|
-impl ProcessOutput for TempPipeWrite with fn after_spawn(self) {
+impl ProcessOutput for TempPipeWrite with fn do_close(self) {
   if !self.closed {
     self.closed = true
     self.pipe.close()
+  }
+}
+
+///|
+impl ProcessOutput for TempPipeWrite with fn after_spawn(self) {
+  if !self.shared {
+    ProcessOutput::do_close(self)
   }
 }
 

--- a/src/process/redirect_test.mbt
+++ b/src/process/redirect_test.mbt
@@ -76,3 +76,31 @@ async test "merge stdout and stderr" {
     inspect(r.read_all().text(), content="abcdefgh")
   }
 }
+
+///|
+async test "pipe" {
+  let log = []
+  @async.with_task_group() <| group => {
+    let cat = cat.wait()
+    let (r1, w1) = @process.write_to_process()
+    defer w1.close()
+    let (r2, w2) = @process.pipe()
+    let (r3, w3) = @process.read_from_process()
+    group.spawn_bg() <| () => {
+      defer r3.close()
+      while r3.read_some() is Some(msg) {
+        log.push("received: \{@utf8.decode(msg)}")
+      }
+    }
+    let _ = @process.spawn(group, cat, [], stdin=r1, stdout=w2)
+    let _ = @process.spawn(group, cat, [], stdin=r2, stdout=w3)
+    log.push("writing: abcd")
+    w1.write("abcd")
+    @async.sleep(150)
+    log.push("writing: xyzw")
+    w1.write("xyzw")
+  }
+  json_inspect(log, content=[
+    "writing: abcd", "received: abcd", "writing: xyzw", "received: xyzw",
+  ])
+}

--- a/src/process/redirect_test.mbt
+++ b/src/process/redirect_test.mbt
@@ -16,13 +16,13 @@
 ///|
 async test "merge multiple" {
   @async.with_task_group() <| root => {
-    let (r, w) = @pipe.pipe()
+    let (r, w) = @process.read_from_process(shared=true)
     root.spawn_bg(no_wait=true) <| () => {
       defer r.close()
       inspect(r.read_all().text(), content="abcdefgh")
     }
-    defer w.close()
     @async.with_task_group() <| group => {
+      defer w.close()
       @process.spawn(group, shell, ["-c", "\{write_stdout} abcd"], stdout=w, extra_env={
         "LANG": "en_US.UTF-8",
       })

--- a/src/process/redirect_test.mbt
+++ b/src/process/redirect_test.mbt
@@ -62,6 +62,42 @@ async test "redirect to file" {
 }
 
 ///|
+async test "merge multiple to file" {
+  @async.with_task_group() <| root => {
+    let output_file = "_build/process_redirect_merge_multiple_test_out.txt"
+    root.add_defer(() => @fs.remove(output_file))
+    let w = @process.redirect_to_file(
+      output_file,
+      shared=true,
+      create_mode=CreateOrTruncate,
+    )
+    @async.with_task_group <| group => {
+      defer w.close()
+      let _ = @process.spawn(
+        group,
+        shell,
+        ["-c", "\{write_stdout} abcd"],
+        stdout=w,
+        extra_env={ "LANG": "en_US.UTF-8" },
+      )
+      let _ = @process.spawn(
+        group,
+        shell,
+        ["-c", "sleep 1; \{write_stdout} efgh"],
+        stdout=w,
+        extra_env={ "LANG": "en_US.UTF-8" },
+      )
+    }
+    inspect(
+      @fs.read_file(output_file).text(),
+      content=(
+        #|abcdefgh
+      ),
+    )
+  }
+}
+
+///|
 async test "merge stdout and stderr" {
   @async.with_task_group() <| group => {
     let (r, w) = @process.read_from_process()
@@ -74,6 +110,27 @@ async test "merge stdout and stderr" {
       stderr=w,
     )
     inspect(r.read_all().text(), content="abcdefgh")
+  }
+}
+
+///|
+async test "merge stdout and stderr to file" {
+  @async.with_task_group() <| group => {
+    let output_file = "_build/process_redirect_merge_test_out.txt"
+    group.add_defer(() => @fs.remove(output_file))
+    let w = @process.redirect_to_file(output_file, create_mode=CreateOrTruncate)
+    let _ = @process.run(
+      shell,
+      ["-c", "\{write_stdout} abcd; \{write_stderr} efgh"],
+      stdout=w,
+      stderr=w,
+    )
+    inspect(
+      @fs.read_file(output_file).text(),
+      content=(
+        #|abcdefgh
+      ),
+    )
   }
 }
 


### PR DESCRIPTION
closes #553

- introduce `@process.pipe()` for redirecting output of one process to input of another process
- introduce new parameter `shared=true` for `@process.read_from_process` and `@process.redirect_to_file`:
    - when `shared=false` (the default & old behavior), the output channel will be automatically closed after being passed to child process
    - when `shared=true`, the output channel can be passed to multiple children process, but must be manually closed after the last child is spawned
- `@process.redirect_to_file` can now be used to merge stdout & stderr of the same process, regardless of the value of `shared`
- `impl @process.ProcesssInput for @pipe.PipeRead` and `impl @process.ProcessOutput for @pipe.PipeWrite` are deprecated, in favor of `@process.{read_from_process,write_to_process,pipe}`
- sharing the same channel for `stdin` of multiple processes is explicitly not supported, due to its racy and chaotic nature