### PR TITLE
[breaking] refine `@async.proctect_from_cancel` semantic

### DIFF
--- a/src/async.mbt
+++ b/src/async.mbt
@@ -95,11 +95,10 @@ pub async fn[X] with_timeout_opt(time : Int, f : async () -> X) -> X? {
 /// Things waiting for current task, such as the task group,
 /// will also wait until `f` finish.
 ///
-/// If `resume_on_cancel` is `false` (`false` by default),
-/// cancellation will be delayed until `f` returns.
-/// If `resume_on_cancel` is `true`, the program will resume normally
-/// after `f` returns, even if current task is cancelled.
-/// The next unprotected async operation will still get cancelled, though.
+/// The program will resume normally after `f` returns,
+/// even if current task is cancelled.
+/// The task will remain in cancelled state, though.
+/// So the next unprotected async operation will get cancelled immediately.
 ///
 /// This function should be use with extra care and only when absolutely necessary,
 /// because it will break other abstraction such as `with_timeout`.

--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -172,9 +172,10 @@ pub fn Coroutine::check_error(coro : Coroutine) -> Unit raise {
 }
 
 ///|
+#label_migration(resume_on_cancel, fill=false, msg="`resume_on_cancel=false` is deprecated, because it may result in data loss")
 pub async fn[X] protect_from_cancel(
   f : async () -> X,
-  resume_on_cancel? : Bool = false,
+  resume_on_cancel? : Bool = true,
 ) -> X {
   guard! scheduler.curr_coro is Some(coro)
   if coro.shielded {

--- a/src/internal/coroutine/pkg.generated.mbti
+++ b/src/internal/coroutine/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub fn is_being_cancelled() -> Bool
 
 pub async fn pause() -> Unit
 
+#label_migration(resume_on_cancel, fill=false, msg="`resume_on_cancel=false` is deprecated, because it may result in data loss")
 pub async fn[X] protect_from_cancel(async () -> X, resume_on_cancel? : Bool) -> X
 
 pub fn reschedule() -> Unit

--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -485,10 +485,7 @@ async fn wait_for_cancellation(
     err => {
       // The cancellation operation itself failed.
       // Give up the cancellation and wait for completion normally.
-      @coroutine.protect_from_cancel(
-        () => evloop.suspend(),
-        resume_on_cancel=true,
-      )
+      @coroutine.protect_from_cancel(() => evloop.suspend())
       raise err
     }
   } noraise {
@@ -496,10 +493,7 @@ async fn wait_for_cancellation(
       // The cancellation operation has succeeded,
       // but the thread pool or OS may need some more time to finish all the cleanup.
       // So wait for the completion of the cleanup process here.
-      @coroutine.protect_from_cancel(
-        () => evloop.suspend(),
-        resume_on_cancel=true,
-      )
+      @coroutine.protect_from_cancel(() => evloop.suspend())
     NoWait =>
       // The cancellation operation has succeeded,
       // and the cancelled operation has already terminated.
@@ -508,7 +502,7 @@ async fn wait_for_cancellation(
     RetryLater => {
       // Due to some inherent race condition, the cancellaion attempt did not succeed.
       // Retry again after a small timeout.
-      @coroutine.protect_from_cancel(() => sleep(10), resume_on_cancel=true)
+      @coroutine.protect_from_cancel(() => sleep(10))
       wait_for_cancellation(cancel_func)
     }
   }
@@ -538,10 +532,7 @@ async fn EventLoop::wait_for_job(
         })
     }
   } else {
-    @coroutine.protect_from_cancel(
-      () => evloop.suspend(),
-      resume_on_cancel=true,
-    )
+    @coroutine.protect_from_cancel(() => evloop.suspend())
   }
 }
 

--- a/src/internal/event_loop/fs.mbt
+++ b/src/internal/event_loop/fs.mbt
@@ -477,7 +477,7 @@ pub async fn IoHandle::read_dir_changes(
   if n >= 0 {
     // The `pause` here prevent a busy loop from exhausting the whole program,
     // and give chance for other tasks to execute.
-    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+    @coroutine.protect_from_cancel(@coroutine.pause)
     n
   } else if @os_error.is_nonblocking_io_error() {
     handle.wait_read_result(result, context~)

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -77,7 +77,7 @@ async fn IoHandle::read_via_event_bus_unix(
   if ret >= 0 {
     // The `pause` here prevent a busy read loop from exhausting the whole program
     // and give chance for other tasks to execute.
-    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+    @coroutine.protect_from_cancel(@coroutine.pause)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {
@@ -138,7 +138,7 @@ async fn IoHandle::write_via_event_bus_unix(
   if ret >= 0 {
     // The `pause` here prevent a busy write loop from exhausting the whole program,
     // and give chance for other tasks to execute.
-    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+    @coroutine.protect_from_cancel(@coroutine.pause)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {

--- a/src/internal/event_loop/io_windows.mbt
+++ b/src/internal/event_loop/io_windows.mbt
@@ -119,7 +119,7 @@ async fn IoHandle::generic_read_windows(
   let n = if n >= 0 {
     // The `pause` here prevent a busy read loop from exhausting the whole program,
     // and give chance for other tasks to execute.
-    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+    @coroutine.protect_from_cancel(@coroutine.pause)
     // It is important to note that the logic here is correct
     // only if `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS` is set
     // via `SetFileCompletionNotificationModes`.
@@ -198,7 +198,7 @@ async fn IoHandle::generic_write_windows(
   if n >= 0 {
     // The `pause` here prevent a busy write loop from exhausting the whole program,
     // and give chance for other tasks to execute.
-    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+    @coroutine.protect_from_cancel(@coroutine.pause)
     // It is important to note that the logic here is correct
     // only if `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS` is set
     // via `SetFileCompletionNotificationModes`.

--- a/src/internal/event_loop/network_unix.mbt
+++ b/src/internal/event_loop/network_unix.mbt
@@ -60,7 +60,7 @@ async fn IoHandle::recvfrom_unix(
   if ret >= 0 {
     // The `pause` here prevent a busy loop from exhausting the whole program,
     // and give chance for other tasks to execute.
-    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+    @coroutine.protect_from_cancel(@coroutine.pause)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {
@@ -125,7 +125,7 @@ async fn IoHandle::sendto_unix(
 ) -> Int {
   let ret = sendto_unix_ffi(handle.fd, buf, offset~, len~, addr~)
   if ret >= 0 {
-    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+    @coroutine.protect_from_cancel(@coroutine.pause)
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {
@@ -242,7 +242,7 @@ pub async fn IoHandle::accept_unix(
   let conn = if @fd_util.fd_is_valid(conn) {
     // The `pause` here prevent a busy `accept` loop from exhausting the whole program,
     // and give chance for other tasks to execute.
-    @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+    @coroutine.protect_from_cancel(@coroutine.pause)
     conn
   } else if @os_error.is_nonblocking_io_error() {
     handle.wait_read()

--- a/src/internal/event_loop/worker_wbtest.mbt
+++ b/src/internal/event_loop/worker_wbtest.mbt
@@ -27,7 +27,7 @@ async fn perform_sleep_job(t : Int) -> Unit {
 ///|
 #cfg(target="js")
 async fn perform_sleep_job(t : Int) -> Unit {
-  @async.protect_from_cancel(() => @async.sleep(t), resume_on_cancel=true)
+  @async.protect_from_cancel(() => @async.sleep(t))
 }
 
 ///|

--- a/src/io/pipe.mbt
+++ b/src/io/pipe.mbt
@@ -121,7 +121,7 @@ pub impl Reader for PipeRead with fn _direct_read(self, dst, offset~, max_len~) 
       // The pause here is not cancellable,
       // because otherwise the writer cannot have correct knowledge on what is written,
       // making writing not cancellation safe.
-      @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+      @coroutine.protect_from_cancel(@coroutine.pause)
       len
     }
   }
@@ -182,7 +182,7 @@ pub impl Writer for PipeWrite with fn write_once(self, buf, offset~, len~) {
       // The pause here is not cancellable,
       // because otherwise the writer cannot have correct knowledge on what is written,
       // making writing not cancellation safe.
-      @coroutine.protect_from_cancel(@coroutine.pause, resume_on_cancel=true)
+      @coroutine.protect_from_cancel(@coroutine.pause)
       len
     }
   }

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -23,6 +23,7 @@ pub fn now() -> Int64
 
 pub async fn pause() -> Unit
 
+#label_migration(resume_on_cancel, fill=false, msg="`resume_on_cancel=false` is deprecated, because it may result in data loss")
 pub async fn[X] protect_from_cancel(async () -> X, resume_on_cancel? : Bool) -> X
 
 pub async fn[X] retry(RetryMethod, max_retry? : Int, fatal_error? : (Error) -> Bool, async () -> X) -> X

--- a/src/process/process.mbt
+++ b/src/process/process.mbt
@@ -149,13 +149,15 @@ pub async fn run(
   defer process.close()
   let pid = process.pid
   process.wait_pid(context~) catch {
-    _ if @coroutine.is_being_cancelled() =>
-      @async.protect_from_cancel() <| () => {
+    @coroutine.Cancelled as err => {
+      let _ = @async.protect_from_cancel() <| () => {
         @async.with_task_group() <| group => {
           group.spawn_bg(no_wait=true, () => cancel_handler(pid))
           process.wait_pid(context~)
         }
       }
+      raise err
+    }
     err => raise err
   }
 }
@@ -237,13 +239,15 @@ pub async fn[X] spawn(
   let result = group.spawn(no_wait?, () => {
     defer process.close()
     process.wait_pid(context~) catch {
-      _ if @coroutine.is_being_cancelled() =>
-        @async.protect_from_cancel() <| () => {
+      @coroutine.Cancelled as err => {
+        let _ = @async.protect_from_cancel() <| () => {
           @async.with_task_group() <| group => {
             group.spawn_bg(no_wait=true, () => cancel_handler(pid))
             process.wait_pid(context~)
           }
         }
+        raise err
+      }
       err => raise err
     }
   })

--- a/src/protect_from_cancel_test.mbt
+++ b/src/protect_from_cancel_test.mbt
@@ -17,15 +17,18 @@ async test "protect_from_cancel" {
   let log = StringBuilder::new()
   @async.with_task_group(root => {
     root.spawn_bg() <| () => {
-      @async.protect_from_cancel(() => {
-        @async.sleep(400) catch {
-          err => {
-            log.write_string("critial job cancelled with error \{err}\n")
-            raise err
+      try {
+        @async.protect_from_cancel <| () => {
+          @async.sleep(400) catch {
+            err => {
+              log.write_string("critial job cancelled with error \{err}\n")
+              raise err
+            }
           }
         }
         log <+ "critical job finished\n"
-      }) catch {
+        @coroutine.check_cancellation()
+      } catch {
         err => {
           log <+ "job cancelled after critical part\n"
           raise err

--- a/src/spawn_test.mbt
+++ b/src/spawn_test.mbt
@@ -70,10 +70,7 @@ async test "spawn after cancelled" {
           // emulate a non-cancellable job,
           // or a job that happens to be completed on cancellation,
           // such that discarding the result may lead to data loss
-          @async.protect_from_cancel(
-            () => @async.sleep(300),
-            resume_on_cancel=true,
-          )
+          @async.protect_from_cancel(() => @async.sleep(300))
           // even if control flow enters here normally,
           // current task and the whole group may be in a cancelled state
           group.spawn_bg(allow_failure=true) <| () => {

--- a/src/task_group.mbt
+++ b/src/task_group.mbt
@@ -254,7 +254,7 @@ pub async fn[X] with_task_group(
         for child in tg.children {
           child.cancel()
         }
-        protect_from_cancel(@coroutine.suspend, resume_on_cancel=true)
+        protect_from_cancel(@coroutine.suspend)
       }
     }
   }


### PR DESCRIPTION
Make `resume_on_cancel=true` the default for `protect_from_cancel` and deprecate `resume_on_cancel`. `resume_on_cancel=false` risks data loss or resource leak, if the return value of the protected function is tied to data transfer or resource. Meanwhile, swallowing the cancellation signal via `resume_on_cancel=true` is not really a problem, because it does not revert the cancelled state of the task.

Breaking due to default behavior change. Most users should not get affected.