### PR TITLE
[breaking] refine file creation API options

### DIFF
--- a/src/fs/README.mbt.md
+++ b/src/fs/README.mbt.md
@@ -33,7 +33,7 @@ The `open` function provides flexible file opening with various modes and option
 #cfg(target="native")
 async test "open file for reading" {
   let test_file = "_build/test_open_read.txt"
-  @fs.write_file(test_file, b"Hello, MoonBit!", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"Hello, MoonBit!")
   let file = @fs.open(test_file, mode=ReadOnly)
   defer file.close()
   let content = file.read_all().text()
@@ -56,7 +56,7 @@ async test "open file for writing" {
 async test "open with append mode" {
   let test_file = "_build/test_append.txt"
   // Create initial file
-  @fs.write_file(test_file, b"First line\n", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"First line\n")
 
   // Append to existing file
   let file = @fs.open(test_file, mode=WriteOnly, append=true)
@@ -98,7 +98,7 @@ Read entire files or read data in chunks:
 #cfg(target="native")
 async test "read_file - read entire file" {
   let test_file = "_build/test_read_file.txt"
-  @fs.write_file(test_file, b"Hello, MoonBit!", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"Hello, MoonBit!")
   let content = @fs.read_file(test_file)
   @fs.remove(test_file)
   inspect(content.text(), content="Hello, MoonBit!")
@@ -108,7 +108,7 @@ async test "read_file - read entire file" {
 #cfg(target="native")
 async test "read in chunks using File" {
   let test_file = "_build/test_chunk_read.txt"
-  @fs.write_file(test_file, b"0123456789", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"0123456789")
   let file = @fs.open(test_file, mode=ReadOnly)
   defer file.close()
   let buf = FixedArray::make(5, b'0')
@@ -122,7 +122,7 @@ async test "read in chunks using File" {
 #cfg(target="native")
 async test "read_all from file" {
   let test_file = "_build/test_read_all.txt"
-  @fs.write_file(test_file, b"Complete content", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"Complete content")
   let file = @fs.open(test_file, mode=ReadOnly)
   let data = file.read_all()
   file.close()
@@ -134,7 +134,7 @@ async test "read_all from file" {
 #cfg(target="native")
 async test "read_exactly specific bytes" {
   let test_file = "_build/test_read_exact.txt"
-  @fs.write_file(test_file, b"1234567890", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"1234567890")
   let file = @fs.open(test_file, mode=ReadOnly)
   let bytes = file.read_exactly(5)
   file.close()
@@ -155,7 +155,7 @@ Write data to files using various methods:
 #cfg(target="native")
 async test "write_file - write entire file" {
   let test_file = "_build/test_write.txt"
-  @fs.write_file(test_file, b"File content", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"File content")
   let content = @fs.read_file(test_file).text()
   @fs.remove(test_file)
   inspect(content, content="File content")
@@ -166,12 +166,7 @@ async test "write_file - write entire file" {
 async test "write with sync modes" {
   let test_file = "_build/test_sync.txt"
   // Write with data sync
-  @fs.write_file(
-    test_file,
-    b"Synced data",
-    sync=Data,
-    create_mode=CreateOrTruncate,
-  )
+  @fs.write_file(test_file, b"Synced data", sync=Data)
   let content = @fs.read_file(test_file).text()
   @fs.remove(test_file)
   inspect(content, content="Synced data")
@@ -217,7 +212,7 @@ Read and write file from specified position:
 #cfg(target="native")
 async test "read at specific position" {
   let test_file = "_build/read_at_test.txt"
-  @fs.write_file(test_file, b"0123456789", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"0123456789")
   {
     let file = @fs.open(test_file, mode=ReadOnly)
     defer file.close()
@@ -254,7 +249,7 @@ async test "write at specific position" {
 #cfg(target="native")
 async test "size - get file size" {
   let test_file = "_build/test_size.txt"
-  @fs.write_file(test_file, b"Hello", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"Hello")
   let file = @fs.open(test_file, mode=ReadOnly)
   let size = file.size()
   file.close()
@@ -304,8 +299,8 @@ async test "mkdir - create with custom permissions" {
 async test "readdir - read directory entries" {
   let dir_path = "_build/test_readdir"
   @fs.mkdir(dir_path, permission=0o755)
-  @fs.write_file("\{dir_path}/test1.txt", b"", create_mode=CreateOrTruncate)
-  @fs.write_file("\{dir_path}/test2.txt", b"", create_mode=CreateOrTruncate)
+  @fs.write_file("\{dir_path}/test1.txt", b"")
+  @fs.write_file("\{dir_path}/test2.txt", b"")
   let entries = @fs.readdir(
     dir_path,
     include_hidden=false,
@@ -322,9 +317,9 @@ async test "readdir - read directory entries" {
 async test "readdir with sorting" {
   let dir_path = "_build/test_readdir_sort"
   @fs.mkdir(dir_path, permission=0o755)
-  @fs.write_file("\{dir_path}/c.txt", b"", create_mode=CreateOrTruncate)
-  @fs.write_file("\{dir_path}/a.txt", b"", create_mode=CreateOrTruncate)
-  @fs.write_file("\{dir_path}/b.txt", b"", create_mode=CreateOrTruncate)
+  @fs.write_file("\{dir_path}/c.txt", b"")
+  @fs.write_file("\{dir_path}/a.txt", b"")
+  @fs.write_file("\{dir_path}/b.txt", b"")
   let entries = @fs.readdir(dir_path, sort=true)
   @fs.rmdir(dir_path, recursive=true)
   json_inspect(entries, content=["a.txt", "b.txt", "c.txt"])
@@ -335,8 +330,8 @@ async test "readdir with sorting" {
 async test "opendir and Directory::read_all" {
   let dir_path = "_build/test_opendir"
   @fs.mkdir(dir_path, permission=0o755)
-  @fs.write_file("\{dir_path}/file1.txt", b"test", create_mode=CreateOrTruncate)
-  @fs.write_file("\{dir_path}/file2.txt", b"test", create_mode=CreateOrTruncate)
+  @fs.write_file("\{dir_path}/file1.txt", b"test")
+  @fs.write_file("\{dir_path}/file2.txt", b"test")
   let dir = @fs.opendir(dir_path)
   let entries = dir
     .read_all(include_hidden=false, include_special=false)
@@ -359,8 +354,8 @@ async test "walk directory tree" {
   @fs.mkdir(base)
   @fs.mkdir("\{base}/sub1")
   @fs.mkdir("\{base}/sub2")
-  @fs.write_file("\{base}/file.txt", b"", create_mode=CreateOrTruncate)
-  @fs.write_file("\{base}/sub1/file1.txt", b"", create_mode=CreateOrTruncate)
+  @fs.write_file("\{base}/file.txt", b"")
+  @fs.write_file("\{base}/sub1/file1.txt", b"")
   let visited : Ref[Int] = Ref(0)
   @fs.walk(base, fn(_path, _files) { visited.val = visited.val + 1 })
   @fs.remove("\{base}/file.txt")
@@ -410,12 +405,8 @@ async test "rmdir recursive - remove directory tree" {
   let base = "_build/test_rmdir_recursive"
   @fs.mkdir(base)
   @fs.mkdir("\{base}/subdir")
-  @fs.write_file("\{base}/file.txt", b"test", create_mode=CreateOrTruncate)
-  @fs.write_file(
-    "\{base}/subdir/nested.txt",
-    b"test",
-    create_mode=CreateOrTruncate,
-  )
+  @fs.write_file("\{base}/file.txt", b"test")
+  @fs.write_file("\{base}/subdir/nested.txt", b"test")
   @fs.rmdir(base, recursive=true)
   let exists = @fs.exists(base)
   inspect(exists, content="false")
@@ -433,7 +424,7 @@ Determine the type of file system entries:
 #cfg(target="native")
 async test "kind - regular file" {
   let test_file = "_build/test_kind_file.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   let kind = @fs.kind(test_file)
   @fs.remove(test_file)
   debug_inspect(kind, content="Regular")
@@ -453,7 +444,7 @@ async test "kind - directory" {
 #cfg(target="native")
 async test "File::kind method" {
   let test_file = "_build/test_file_kind.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   let file = @fs.open(test_file, mode=ReadOnly)
   let kind = file.kind()
   file.close()
@@ -471,7 +462,7 @@ Access file timestamps (atime, mtime, ctime):
 #cfg(all(target="native", not(platform="windows")))
 async test "atime - access time" {
   let test_file = "_build/test_atime.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   let (seconds, nanoseconds) = @fs.atime(test_file)
   @fs.remove(test_file)
   inspect(seconds > 0, content="true")
@@ -482,7 +473,7 @@ async test "atime - access time" {
 #cfg(target="native")
 async test "mtime - modification time" {
   let test_file = "_build/test_mtime.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   let (seconds, nanoseconds) = @fs.mtime(test_file)
   @fs.remove(test_file)
   inspect(seconds > 0, content="true")
@@ -493,7 +484,7 @@ async test "mtime - modification time" {
 #cfg(target="native")
 async test "ctime - status change time" {
   let test_file = "_build/test_ctime.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   let (seconds, nanoseconds) = @fs.ctime(test_file)
   @fs.remove(test_file)
   inspect(seconds > 0, content="true")
@@ -504,7 +495,7 @@ async test "ctime - status change time" {
 #cfg(target="native")
 async test "File timestamp methods" {
   let test_file = "_build/test_file_times.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   let file = @fs.open(test_file, mode=ReadOnly)
   let (atime_s, _) = file.atime()
   let (mtime_s, _) = file.mtime()
@@ -526,7 +517,7 @@ Check file access permissions:
 #cfg(target="native")
 async test "exists - check file existence" {
   let test_file = "_build/test_exists.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   let exists = @fs.exists(test_file)
   @fs.remove(test_file)
   inspect(exists, content="true")
@@ -543,7 +534,7 @@ async test "exists - non-existent file" {
 #cfg(target="native")
 async test "can_read - check read permission" {
   let test_file = "_build/test_can_read.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   let can_read = @fs.can_read(test_file)
   @fs.remove(test_file)
   inspect(can_read, content="true")
@@ -553,7 +544,7 @@ async test "can_read - check read permission" {
 #cfg(target="native")
 async test "can_write - check write permission" {
   let test_file = "_build/test_can_write.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   let can_write = @fs.can_write(test_file)
   @fs.remove(test_file)
   inspect(can_write, content="true")
@@ -597,7 +588,7 @@ async test "realpath - resolve absolute path" {
 #cfg(target="native")
 async test "remove - delete file" {
   let test_file = "_build/test_remove.txt"
-  @fs.write_file(test_file, b"test", create_mode=CreateOrTruncate)
+  @fs.write_file(test_file, b"test")
   @fs.remove(test_file)
   let exists = @fs.exists(test_file)
   inspect(exists, content="false")

--- a/src/fs/create_test.mbt
+++ b/src/fs/create_test.mbt
@@ -64,7 +64,7 @@ async test "create or append" {
 ///|
 async test "wrapper test" {
   let path = "_build/fs_wrapper_test"
-  @fs.write_file(path, b"abcd", create_mode=CreateOrTruncate)
+  @fs.write_file(path, b"abcd")
   let result = @fs.read_file(path).text()
   @fs.remove(path)
   inspect(result, content="abcd")

--- a/src/fs/cursor_test.mbt
+++ b/src/fs/cursor_test.mbt
@@ -15,7 +15,7 @@
 ///|
 async test "sequential read/write have separated cursor" {
   let path = "_build/read_write_cursor_test"
-  @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
+  @fs.write_file(path, "abcd", sync=Full)
   let file = @fs.open(path, mode=ReadWrite)
   defer file.close()
   file.write(b"AB")
@@ -26,7 +26,7 @@ async test "sequential read/write have separated cursor" {
 ///|
 async test "append mode only affect writing" {
   let path = "_build/append_cursor_test"
-  @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
+  @fs.write_file(path, "abcd", sync=Full)
   let file = @fs.open(path, append=true, mode=ReadWrite)
   defer file.close()
   // the read cursor should not be affected by `append`
@@ -41,7 +41,7 @@ async test "append mode only affect writing" {
 ///|
 async test "append mode file does not support random access write" {
   let path = "_build/append_random_access_test"
-  @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
+  @fs.write_file(path, "abcd", sync=Full)
   let file = @fs.open(path, append=true, mode=ReadWrite)
   defer file.close()
   // random access read is not affected

--- a/src/fs/file.mbt
+++ b/src/fs/file.mbt
@@ -107,37 +107,18 @@ fn CreateMode::to_int(self : CreateMode) -> Int = "%identity"
 ///
 ///   The default value is `0o644` (anyone can read, only owner can write, not executable).
 ///   `permission` is currently ignored on Windows.
-#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
-#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
 pub async fn open(
   filename : StringView,
   mode~ : Mode,
   sync? : SyncMode = NoSync,
   append? : Bool = false,
-  create_mode? : CreateMode,
-  permission? : Int,
-  create? : Int,
-  truncate? : Bool = false,
+  create_mode? : CreateMode = OpenExisting,
+  permission? : Int = 0o644,
 ) -> File {
   let access = match mode {
     ReadOnly => 0
     WriteOnly => 1
     ReadWrite => 2
-  }
-  let create_mode = match create_mode {
-    Some(mode) => mode
-    None =>
-      match (create is Some(_), truncate) {
-        (true, true) => CreateOrTruncate
-        (true, false) => OpenOrCreate
-        (false, true) => TruncateExisting
-        (false, false) => OpenExisting
-      }
-  }
-  let permission = match permission {
-    Some(perm) => perm
-    None if create is Some(perm) => perm
-    None => 0o644
   }
   let sync = match sync {
     NoSync => 0
@@ -517,33 +498,14 @@ pub async fn read_file(
 /// The meaning of `sync`, `append`, `create_mode` and `permission`,
 /// is the same as `open`, except that `create_mode` is `TruncateExisting` by default.
 /// See `open` for more details.
-#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
-#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
 pub async fn write_file(
   path : StringView,
   content : &@io.Data,
-  create_mode? : CreateMode,
-  permission? : Int,
+  create_mode? : CreateMode = CreateOrTruncate,
+  permission? : Int = 0o644,
   sync? : SyncMode = Data,
   append? : Bool = false,
-  create? : Int,
-  truncate? : Bool = true,
 ) -> Unit {
-  let create_mode = match create_mode {
-    Some(mode) => mode
-    None =>
-      match (create is Some(_), truncate) {
-        (true, true) => CreateOrTruncate
-        (true, false) => OpenOrCreate
-        (false, true) => TruncateExisting
-        (false, false) => OpenExisting
-      }
-  }
-  let permission = match permission {
-    Some(perm) => perm
-    None if create is Some(perm) => perm
-    None => 0o644
-  }
   let file = open(
     path,
     mode=WriteOnly,

--- a/src/fs/lock_test.mbt
+++ b/src/fs/lock_test.mbt
@@ -329,7 +329,7 @@ async test "flock advisory" {
   let log = []
   let file_name = "_build/flock_advisory"
   @async.with_task_group() <| group => {
-    @fs.write_file(file_name, create_mode=CreateOrTruncate, "abcd")
+    @fs.write_file(file_name, "abcd")
     let file = @fs.open(file_name, mode=ReadWrite)
     defer file.close()
     group.add_defer(() => @fs.remove(file_name))

--- a/src/fs/mkdir_test.mbt
+++ b/src/fs/mkdir_test.mbt
@@ -16,7 +16,7 @@
 async test "mkdir" {
   let path = "_build/mkdir_test"
   @fs.mkdir(path)
-  @fs.write_file("\{path}/file", "", create_mode=CreateOrTruncate)
+  @fs.write_file("\{path}/file", "")
   let result = @fs.readdir(path, sort=true)
   @fs.remove("\{path}/file")
   @fs.rmdir(path)
@@ -28,9 +28,9 @@ async test "rmdir recursive" {
   guard! @env.current_dir() is Some(cwd)
   let path = "_build/rmdir_test"
   @fs.mkdir(path, permission=0o755)
-  @fs.write_file("\{path}/file", "", create_mode=CreateOrTruncate)
+  @fs.write_file("\{path}/file", "")
   @fs.mkdir("\{path}/inner")
-  @fs.write_file("\{path}/inner/file", "", create_mode=CreateOrTruncate)
+  @fs.write_file("\{path}/inner/file", "")
   @fs.symlink("\{path}/symlink", target="\{cwd}/_build")
   @test_util.assert_raise_async(() => @fs.rmdir(path))
   @fs.rmdir(path, recursive=true)

--- a/src/fs/pkg.generated.mbti
+++ b/src/fs/pkg.generated.mbti
@@ -29,9 +29,7 @@ pub async fn mkdir(StringView, permission? : Int, recursive? : Bool) -> Unit
 
 pub async fn mtime(StringView, follow_symlink? : Bool) -> (Int64, Int)
 
-#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
-#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
-pub async fn open(StringView, mode~ : Mode, sync? : SyncMode, append? : Bool, create_mode? : CreateMode, permission? : Int, create? : Int, truncate? : Bool) -> File
+pub async fn open(StringView, mode~ : Mode, sync? : SyncMode, append? : Bool, create_mode? : CreateMode, permission? : Int) -> File
 
 pub async fn opendir(StringView) -> Directory
 
@@ -53,9 +51,7 @@ pub async fn tmpdir(prefix~ : StringView) -> String
 
 pub async fn walk(StringView, async (String, Array[String]) -> Unit, exclude? : (String) -> Bool, max_concurrency? : Int, allow_failure? : Bool) -> Unit
 
-#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
-#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
-pub async fn write_file(StringView, &@io.Data, create_mode? : CreateMode, permission? : Int, sync? : SyncMode, append? : Bool, create? : Int, truncate? : Bool) -> Unit
+pub async fn write_file(StringView, &@io.Data, create_mode? : CreateMode, permission? : Int, sync? : SyncMode, append? : Bool) -> Unit
 
 // Errors
 

--- a/src/fs/random_access_test.mbt
+++ b/src/fs/random_access_test.mbt
@@ -16,7 +16,7 @@
 async test "write_at" {
   let path = "_build/write_at_test"
   // initialize
-  @fs.write_file(path, "abcdef", create_mode=CreateOrTruncate, sync=Full)
+  @fs.write_file(path, "abcdef", sync=Full)
   // first read
   inspect(@fs.read_file(path).text(), content="abcdef")
   // update content
@@ -39,7 +39,7 @@ async test "write_at" {
 ///|
 async test "read_at" {
   let path = "_build/read_at_test"
-  @fs.write_file(path, "abcdef", create_mode=CreateOrTruncate, sync=Full)
+  @fs.write_file(path, "abcdef", sync=Full)
   {
     let r = @fs.open(path, mode=ReadOnly)
     defer r.close()

--- a/src/fs/rename_test.mbt
+++ b/src/fs/rename_test.mbt
@@ -37,7 +37,7 @@ async test "rename basic" {
 async test "rename replace" {
   let old_path = "_build/rename_replace_test_old"
   let new_path = "_build/rename_replace_test_new"
-  @fs.write_file(new_path, "xyzw", create_mode=CreateOrTruncate)
+  @fs.write_file(new_path, "xyzw")
   let old_file = @fs.open(
     old_path,
     mode=WriteOnly,

--- a/src/fs/text_file_test.mbt
+++ b/src/fs/text_file_test.mbt
@@ -17,7 +17,7 @@ async test "text file" {
   @async.with_task_group() <| root => {
     let path = "_build/basic_text_file_test"
     root.add_defer(() => @fs.remove(path))
-    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate)
+    @fs.write_file(path, "abcd")
     inspect(@fs.read_file(path).text(), content="abcd")
   }
 }

--- a/src/fs/timestamp_test.mbt
+++ b/src/fs/timestamp_test.mbt
@@ -29,12 +29,12 @@ async test "timestamp for path" {
   }
   let path = "/tmp/timestamp_test"
   @async.with_task_group() <| group => {
-    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
+    @fs.write_file(path, "abcd", sync=Full)
     group.add_defer(() => @fs.remove(path))
     let mtime_1 = @fs.mtime(path)
     let ctime_1 = @fs.ctime(path)
     @async.sleep(600)
-    @fs.write_file(path, "1234", sync=Full)
+    @fs.write_file(path, "1234", create_mode=OpenExisting, sync=Full)
     let atime_2 = @fs.atime(path)
     let mtime_2 = @fs.mtime(path)
     let ctime_2 = @fs.ctime(path)
@@ -66,12 +66,12 @@ async test "mtime for path" {
   }
   let path = "_build/timestamp_test"
   @async.with_task_group() <| group => {
-    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
+    @fs.write_file(path, "abcd", sync=Full)
     group.add_defer(() => @fs.remove(path))
     let mtime_1 = @fs.mtime(path)
     let ctime_1 = @fs.ctime(path)
     @async.sleep(600)
-    @fs.write_file(path, "1234", sync=Full)
+    @fs.write_file(path, "1234", create_mode=OpenExisting, sync=Full)
     let mtime_2 = @fs.mtime(path)
     let ctime_2 = @fs.ctime(path)
     assert_true(diff_timestamp(mtime_2, mtime_1) > 500_000_000)
@@ -89,7 +89,7 @@ async test "timestamp for opened file" {
   }
   let path = "/tmp/opened_file_timestamp_test"
   @async.with_task_group() <| group => {
-    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
+    @fs.write_file(path, "abcd", sync=Full)
     group.add_defer(() => @fs.remove(path))
     let file = @fs.open(path, mode=ReadWrite, sync=Full)
     defer file.close()
@@ -129,7 +129,7 @@ async test "mtime for opened file" {
   }
   let path = "_build/opened_file_timestamp_test"
   @async.with_task_group() <| group => {
-    @fs.write_file(path, "abcd", create_mode=CreateOrTruncate, sync=Full)
+    @fs.write_file(path, "abcd", sync=Full)
     group.add_defer(() => @fs.remove(path))
     let file = @fs.open(path, mode=ReadWrite, sync=Full)
     defer file.close()

--- a/src/fs/watch_test.mbt
+++ b/src/fs/watch_test.mbt
@@ -21,7 +21,7 @@ enum TestFile {
 ///|
 async fn TestFile::instantiate(self : TestFile, path : String) -> Unit {
   match self {
-    File(content) => @fs.write_file(path, content, create_mode=CreateOrTruncate)
+    File(content) => @fs.write_file(path, content)
     Dir(files) => {
       @fs.mkdir(path)
       for name, file in files {
@@ -558,11 +558,11 @@ async fn watch_vertical_swap_test(
     let events = @async.with_timeout(1000, () => watcher.wait())
     log.push("watcher received change: \{Repr(events)}")
     log.push("modifying previous outer file")
-    @fs.write_file("\{path}/outer/inner/file", "ABCD")
+    @fs.write_file("\{path}/outer/inner/file", "ABCD", create_mode=OpenExisting)
     let events = @async.with_timeout(1000, () => watcher.wait())
     log.push("watcher received change: \{Repr(events)}")
     log.push("modifying previous inner file")
-    @fs.write_file("\{path}/outer/file", "EFGH")
+    @fs.write_file("\{path}/outer/file", "EFGH", create_mode=OpenExisting)
     let events = @async.with_timeout(1000, () => watcher.wait())
     log.push("watcher received change: \{Repr(events)}")
   })

--- a/src/process/README.mbt.md
+++ b/src/process/README.mbt.md
@@ -191,7 +191,7 @@ Use a file as process input:
 async test "redirect input from file" {
   @async.with_task_group(root => {
     let input_file = "_build/process_test_input.txt"
-    @fs.write_file(input_file, "file content", create_mode=CreateOrTruncate)
+    @fs.write_file(input_file, "file content")
     root.add_defer(() => @fs.remove(input_file))
     let (code, output) = @process.collect_stdout(
       "cat",
@@ -218,10 +218,7 @@ async test "redirect output to file" {
     let code = @process.run(
       "echo",
       ["test output"],
-      stdout=@process.redirect_to_file(
-        output_file,
-        create_mode=CreateOrTruncate,
-      ),
+      stdout=@process.redirect_to_file(output_file),
     )
     inspect(code, content="0")
     let content = @fs.read_file(output_file).text()
@@ -241,17 +238,14 @@ async test "file to file redirection" {
   @async.with_task_group(root => {
     let input_file = "_build/process_redirect_in.txt"
     let output_file = "_build/process_redirect_out.txt"
-    @fs.write_file(input_file, "redirect test", create_mode=CreateOrTruncate)
+    @fs.write_file(input_file, "redirect test")
     root.add_defer(() => @fs.remove(input_file))
     root.add_defer(() => @fs.remove(output_file))
     let _ = @process.run(
       "cat",
       [],
       stdin=@process.redirect_from_file(input_file),
-      stdout=@process.redirect_to_file(
-        output_file,
-        create_mode=CreateOrTruncate,
-      ),
+      stdout=@process.redirect_to_file(output_file),
     )
     inspect(@fs.read_file(output_file).text(), content="redirect test")
   })

--- a/src/process/pkg.generated.mbti
+++ b/src/process/pkg.generated.mbti
@@ -29,9 +29,7 @@ pub fn read_from_process(shared? : Bool) -> (ReadFromProcess, &ProcessOutput) ra
 
 pub async fn redirect_from_file(String) -> &ProcessInput
 
-#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
-#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
-pub async fn redirect_to_file(String, append? : Bool, create_mode? : @fs.CreateMode, permission? : Int, create? : Int, truncate? : Bool, shared? : Bool) -> &ProcessOutput
+pub async fn redirect_to_file(String, append? : Bool, create_mode? : @fs.CreateMode, permission? : Int, shared? : Bool) -> &ProcessOutput
 
 pub async fn run(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, stdin? : &ProcessInput, stdout? : &ProcessOutput, stderr? : &ProcessOutput, cwd? : StringView, no_console_window? : Bool, cancel_handler? : CancellationHandler) -> Int
 

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -160,32 +160,13 @@ fn @fs.CreateMode::to_int(self : @fs.CreateMode) -> Int = "%identity"
 /// after being passed to the last child process.
 /// Note that `w` can be closed immediately after the last child process *started*,
 /// there is no need to wait for the termination of the child process.
-#label_migration(create, fill=false, msg="the option `create` is deprecated, use `create_mode` and `permission` instead")
-#label_migration(truncate, fill=false, msg="the option `truncate` is deprecated, use `create_mode` instead")
 pub async fn redirect_to_file(
   path : String,
   append? : Bool = false,
-  create_mode? : @fs.CreateMode,
-  permission? : Int,
-  create? : Int,
-  truncate? : Bool = false,
+  create_mode? : @fs.CreateMode = CreateOrTruncate,
+  permission? : Int = 0o644,
   shared? : Bool = false,
 ) -> &ProcessOutput {
-  let create_mode = match create_mode {
-    Some(mode) => mode
-    None =>
-      match (create is Some(_), truncate) {
-        (true, true) => CreateOrTruncate
-        (true, false) => OpenOrCreate
-        (false, true) => TruncateExisting
-        (false, false) => OpenExisting
-      }
-  }
-  let permission = match permission {
-    Some(perm) => perm
-    None if create is Some(perm) => perm
-    None => 0o644
-  }
   let (file, _) = @event_loop.open(
     path,
     1, // write only

--- a/src/process/redirect_test.mbt
+++ b/src/process/redirect_test.mbt
@@ -47,15 +47,12 @@ async test "redirect to file" {
     let output_file = "_build/process_redirect_test_out.txt"
     root.add_defer(() => @fs.remove(input_file))
     root.add_defer(() => @fs.remove(output_file))
-    @fs.write_file(input_file, "abcd", create_mode=CreateOrTruncate)
+    @fs.write_file(input_file, "abcd")
     let _ = @process.run(
       cat,
       [],
       stdin=@process.redirect_from_file(input_file),
-      stdout=@process.redirect_to_file(
-        output_file,
-        create_mode=CreateOrTruncate,
-      ),
+      stdout=@process.redirect_to_file(output_file),
     )
     inspect(@fs.read_file(output_file).text(), content="abcd")
   }
@@ -66,11 +63,7 @@ async test "merge multiple to file" {
   @async.with_task_group() <| root => {
     let output_file = "_build/process_redirect_merge_multiple_test_out.txt"
     root.add_defer(() => @fs.remove(output_file))
-    let w = @process.redirect_to_file(
-      output_file,
-      shared=true,
-      create_mode=CreateOrTruncate,
-    )
+    let w = @process.redirect_to_file(output_file, shared=true)
     @async.with_task_group <| group => {
       defer w.close()
       let _ = @process.spawn(
@@ -118,7 +111,7 @@ async test "merge stdout and stderr to file" {
   @async.with_task_group() <| group => {
     let output_file = "_build/process_redirect_merge_test_out.txt"
     group.add_defer(() => @fs.remove(output_file))
-    let w = @process.redirect_to_file(output_file, create_mode=CreateOrTruncate)
+    let w = @process.redirect_to_file(output_file)
     let _ = @process.run(
       shell,
       ["-c", "\{write_stdout} abcd; \{write_stderr} efgh"],

--- a/src/stdio/stdio_test.mbt
+++ b/src/stdio/stdio_test.mbt
@@ -36,7 +36,7 @@ async test "redirect_file" {
     cat,
     [],
     stdin=@process.redirect_from_file("moon.mod"),
-    stdout=@process.redirect_to_file(out_file, create_mode=CreateOrTruncate),
+    stdout=@process.redirect_to_file(out_file),
   )
   inspect(code, content="0")
   assert_eq(@fs.read_file(out_file).text(), @fs.read_file("moon.mod").text())


### PR DESCRIPTION
- remove deprecated `create` and `truncate` flag from `@fs.open` etc.
- change the default create mode of `@fs.write_file`/`@process.redirect_to_file` from `OpenExisting` to `CreateOrTruncate`