### PR TITLE
fix(windows): do not error on `@process.spawn` when there is no stdio

### DIFF
--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -870,10 +870,10 @@ int32_t spawn_job_worker(struct spawn_job *job, int32_t *err_out) {
     if (job->stdio[i] == INVALID_HANDLE_VALUE)
       job->stdio[i] = GetStdHandle(std_handle_values[i]);
 
-    if (job->stdio[i] == INVALID_HANDLE_VALUE) {
-      *err_out = GetLastError();
-      return 0;
-    }
+    if (job->stdio[i] == INVALID_HANDLE_VALUE || job->stdio[i] == NULL)
+      // On Windows, no stdio channel is a valid & common case
+      // for GUI applications.
+      goto handle_already_added;
 
     for (int j = 0; j < number_of_handles_to_inherit; ++j) {
       if (handles_to_inherit[j] == job->stdio[i])


### PR DESCRIPTION
By default, child process spawned by `@process.spawn` etc. inherit stdio channels of current process. On Windows, some programs such as GUI applications simply do not have stdio channel. Previously, `@process.spawn` will fail in this case, which is not desirable. This PR fixes the problem by tolerating stdio not present error when inheriting stdio channels in process spawning.