### PR TITLE
MacOS CI: set current thread as realtime

### DIFF
--- a/src/aqueue/setup_test.mbt
+++ b/src/aqueue/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/cond_var/setup_test.mbt
+++ b/src/cond_var/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/external_loop_integration/moon.pkg
+++ b/src/external_loop_integration/moon.pkg
@@ -5,4 +5,5 @@ import {
   "moonbitlang/async/internal/event_loop",
   "moonbitlang/async/external_loop_integration/internal/external_loop_test",
   "moonbitlang/async/pipe",
+  "moonbitlang/async/internal/test_util",
 } for "test"

--- a/src/external_loop_integration/setup_test.mbt
+++ b/src/external_loop_integration/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/fs/setup_test.mbt
+++ b/src/fs/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/gzip/moon.pkg
+++ b/src/gzip/moon.pkg
@@ -11,4 +11,5 @@ import {
   "moonbitlang/async/io",
   "moonbitlang/async/process",
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/async/internal/test_util",
 } for "test"

--- a/src/gzip/setup_test.mbt
+++ b/src/gzip/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/http/moon.pkg
+++ b/src/http/moon.pkg
@@ -17,6 +17,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/gzip" @gzip_stream,
+  "moonbitlang/async/internal/test_util",
 } for "test"
 
 import {

--- a/src/http/setup_test.mbt
+++ b/src/http/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/http/setup_wbtest.mbt
+++ b/src/http/setup_wbtest.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/internal/bytes_util/moon.pkg
+++ b/src/internal/bytes_util/moon.pkg
@@ -1,1 +1,3 @@
-
+import {
+  "moonbitlang/async/internal/test_util",
+} for "test"

--- a/src/internal/bytes_util/setup_test.mbt
+++ b/src/internal/bytes_util/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/internal/coroutine/moon.pkg
+++ b/src/internal/coroutine/moon.pkg
@@ -4,4 +4,5 @@ import {
 
 import {
   "moonbitlang/async",
+  "moonbitlang/async/internal/test_util",
 } for "test"

--- a/src/internal/coroutine/setup_test.mbt
+++ b/src/internal/coroutine/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/internal/event_loop/moon.pkg
+++ b/src/internal/event_loop/moon.pkg
@@ -20,10 +20,12 @@ import {
   "moonbitlang/async/pipe",
   "moonbitlang/async/fs",
   "moonbitlang/async/io",
+  "moonbitlang/async/internal/test_util",
 } for "test"
 
 import {
   "moonbitlang/async",
+  "moonbitlang/async/internal/test_util",
 } for "wbtest"
 
 options(

--- a/src/internal/event_loop/setup_test.mbt
+++ b/src/internal/event_loop/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/internal/event_loop/setup_wbtest.mbt
+++ b/src/internal/event_loop/setup_wbtest.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/internal/gzip_internal/moon.pkg
+++ b/src/internal/gzip_internal/moon.pkg
@@ -6,4 +6,5 @@ import {
   "moonbitlang/core/test",
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/async/internal/test_util",
 } for "test"

--- a/src/internal/gzip_internal/setup_test.mbt
+++ b/src/internal/gzip_internal/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/internal/os_string/moon.pkg
+++ b/src/internal/os_string/moon.pkg
@@ -3,6 +3,10 @@ import {
   "moonbitlang/async/internal/c_buffer",
 }
 
+import {
+  "moonbitlang/async/internal/test_util",
+} for "wbtest"
+
 options(
   "native-stub": [ "stub.c" ],
   targets: { "os_string.mbt": [ "native" ], "os_string.wasm.mbt": [ "wasm" ] },

--- a/src/internal/os_string/setup_wbtest.mbt
+++ b/src/internal/os_string/setup_wbtest.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/internal/test_util/moon.pkg
+++ b/src/internal/test_util/moon.pkg
@@ -1,1 +1,3 @@
-
+options(
+  "native-stub": [ "stub.c" ],
+)

--- a/src/internal/test_util/pkg.generated.mbti
+++ b/src/internal/test_util/pkg.generated.mbti
@@ -8,6 +8,8 @@ pub async fn[T, E : Error] assert_raise_async(async () -> T raise E, loc~ : Sour
 #callsite(autofill(loc))
 pub async fn[T, E : Error] expect_error_async(async () -> T raise E, loc~ : SourceLoc) -> E
 
+pub fn increase_current_thread_priority() -> Unit
+
 // Errors
 
 // Types and methods

--- a/src/internal/test_util/stub.c
+++ b/src/internal/test_util/stub.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef __MACH__
+
+#include <pthread.h>
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+
+_Noreturn void moonbit_panic();
+
+#endif
+
+#include "moonbit.h"
+
+MOONBIT_FFI_EXPORT
+void moonbitlang_async_increase_current_thread_priority() {
+#ifdef __MACH__
+  static int32_t already_processsed = 0;
+  if (already_processsed)
+    return;
+
+  already_processsed = 1;
+
+  // https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/KernelProgramming/scheduler/scheduler.html#//apple_ref/doc/uid/TP30000905-CH211-BABCHEEB
+
+  mach_timebase_info_data_t timebase_info;
+  mach_timebase_info(&timebase_info);
+
+  const uint64_t NANOS_PER_MSEC = 1000000ULL;
+  double clock2abs = ((double)timebase_info.denom / (double)timebase_info.numer) * NANOS_PER_MSEC;
+
+
+  thread_time_constraint_policy_data_t policy;
+  policy.period      = 0;
+  policy.computation = (uint32_t)(5 * clock2abs); // 5 ms of work
+  policy.constraint  = (uint32_t)(10 * clock2abs);
+  policy.preemptible = FALSE;
+
+  int kr = thread_policy_set(
+    pthread_mach_thread_np(pthread_self()),
+    THREAD_TIME_CONSTRAINT_POLICY,
+    (thread_policy_t)&policy,
+    THREAD_TIME_CONSTRAINT_POLICY_COUNT
+  );
+  if (kr != KERN_SUCCESS) {
+    mach_error("thread_policy_set:", kr);
+    moonbit_panic();
+  }
+#endif
+}

--- a/src/internal/test_util/test_util.mbt
+++ b/src/internal/test_util/test_util.mbt
@@ -37,3 +37,13 @@ pub async fn[T, E : Error] assert_raise_async(
     _ => fail("expected error, but no error is raised", loc~)
   }
 }
+
+///|
+#cfg(target="native")
+pub extern "C" fn increase_current_thread_priority() -> Unit = "moonbitlang_async_increase_current_thread_priority"
+
+///|
+#cfg(not(target="native"))
+pub fn increase_current_thread_priority() -> Unit {
+
+}

--- a/src/io/moon.pkg
+++ b/src/io/moon.pkg
@@ -10,6 +10,7 @@ import {
 import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/async/internal/test_util",
 } for "test"
 
 import {

--- a/src/io/setup_test.mbt
+++ b/src/io/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/os_error/setup_test.mbt
+++ b/src/os_error/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/pipe/setup_test.mbt
+++ b/src/pipe/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/process/moon.pkg
+++ b/src/process/moon.pkg
@@ -21,6 +21,10 @@ import {
   "moonbitlang/async/internal/test_util",
 } for "test"
 
+import {
+  "moonbitlang/async/internal/test_util",
+} for "wbtest"
+
 options(
   "max-concurrent-tests": 5,
   "native-stub": [ "unix.c", "windows.c" ],

--- a/src/process/setup_test.mbt
+++ b/src/process/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/process/setup_wbtest.mbt
+++ b/src/process/setup_wbtest.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/raw_fd/moon.pkg
+++ b/src/raw_fd/moon.pkg
@@ -10,6 +10,7 @@ import {
   "moonbitlang/async/fs",
   "moonbitlang/async/socket",
   "moonbitlang/async/os_error",
+  "moonbitlang/async/internal/test_util",
 } for "test"
 
 supported_targets = "-all+native"

--- a/src/raw_fd/setup_test.mbt
+++ b/src/raw_fd/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/semaphore/setup_test.mbt
+++ b/src/semaphore/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/setup_test.mbt
+++ b/src/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/signal/moon.pkg
+++ b/src/signal/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/async",
   "moonbitlang/async/process",
+  "moonbitlang/async/internal/test_util",
 } for "test"
 
 options(

--- a/src/signal/setup_test.mbt
+++ b/src/signal/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/socket/setup_test.mbt
+++ b/src/socket/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/stdio/moon.pkg
+++ b/src/stdio/moon.pkg
@@ -8,6 +8,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",
+  "moonbitlang/async/internal/test_util",
 } for "test"
 
 options(

--- a/src/stdio/setup_test.mbt
+++ b/src/stdio/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/tls/setup_test.mbt
+++ b/src/tls/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/websocket/moon.pkg
+++ b/src/websocket/moon.pkg
@@ -23,6 +23,7 @@ import {
 
 import {
   "moonbitlang/core/test",
+  "moonbitlang/async/internal/test_util",
 } for "wbtest"
 
 options(

--- a/src/websocket/setup_test.mbt
+++ b/src/websocket/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/src/websocket/setup_wbtest.mbt
+++ b/src/websocket/setup_wbtest.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}


### PR DESCRIPTION
Set current thread as realtime on MacOS tests to improve timer accuracy. Related: #502.

This is a CI-specific issue, so the internal helper for setting current thread priority is not exposed.