### PR TITLE
Add `shell` package: a shell-free process EDSL for scripting

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     continue-on-error: false
-    timeout-minutes: 10
+    # The test suite cold-builds a few small `moonx` tool packages on every
+    # fresh runner; give the full-matrix build jobs headroom for that.
+    timeout-minutes: 15
     steps:
       - name: disable auto CRLF
         if: ${{ matrix.os == 'windows-latest' }}
@@ -70,7 +72,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     continue-on-error: false
-    timeout-minutes: 10
+    # The test suite cold-builds a few small `moonx` tool packages on every
+    # fresh runner; give the full-matrix build jobs headroom for that.
+    timeout-minutes: 15
     steps:
       - name: disable auto CRLF
         if: ${{ matrix.os == 'windows-latest' }}

--- a/src/process/redirect.mbt
+++ b/src/process/redirect.mbt
@@ -211,7 +211,28 @@ pub async fn redirect_from_file(path : String) -> &ProcessInput {
 /// An entity that can be used to redirect stdin of a process
 trait ProcessInput {
   fn fd(Self) -> @fd_util.Fd raise
+  /// Close the input channel.
+  /// May be called automatically via `after_spawn`, or manually via `.close()`
+  fn do_close(Self) -> Unit = _
   fn after_spawn(Self) -> Unit = _
+}
+
+///|
+/// Close an input channel that will not be passed to a child process.
+/// A channel is closed automatically once it is passed to a child process,
+/// so this is only needed when a channel has been created
+/// but spawning the process that would consume it fails or is abandoned.
+/// Closing is idempotent, and a no-op for channels that only borrow
+/// their file descriptor, such as `@stdio.stdin`.
+#doc(hidden)
+#deprecated
+pub fn &ProcessInput::close(self : &ProcessInput) -> Unit {
+  self.do_close()
+}
+
+///|
+impl ProcessInput with fn do_close(_) {
+  ()
 }
 
 ///|
@@ -316,11 +337,16 @@ impl ProcessInput for TempPipeRead with fn fd(self) {
 }
 
 ///|
-impl ProcessInput for TempPipeRead with fn after_spawn(self) {
+impl ProcessInput for TempPipeRead with fn do_close(self) {
   if !self.closed {
     self.closed = true
     self.pipe.close()
   }
+}
+
+///|
+impl ProcessInput for TempPipeRead with fn after_spawn(self) {
+  ProcessInput::do_close(self)
 }
 
 ///|
@@ -356,9 +382,14 @@ impl ProcessInput for RedirectToFile with fn fd(self) {
 }
 
 ///|
-impl ProcessInput for RedirectToFile with fn after_spawn(self) {
+impl ProcessInput for RedirectToFile with fn do_close(self) {
   if !self.closed {
     self.closed = true
     self.io.close()
   }
+}
+
+///|
+impl ProcessInput for RedirectToFile with fn after_spawn(self) {
+  ProcessInput::do_close(self)
 }

--- a/src/shell/README.mbt.md
+++ b/src/shell/README.mbt.md
@@ -1,0 +1,455 @@
+# Shell-Style Scripting (`@moonbitlang/async/shell`)
+
+`@shell` is a small, shell-free process EDSL: everything you use a shell for —
+running commands, pipes, redirects, exit-code logic, glob expansion — as a
+library, minus the shell itself. It is meant for scripts, sandboxed programs,
+and agents that need a familiar process API without receiving a shell as
+ambient authority.
+
+## The invariant
+
+`Cmd` never invokes a shell. The executable and argument vector stay separate,
+and every argument is passed literally. `|`, `>`, `&&`, `$()`, and `*` have no
+special meaning. Use `Pipeline` for pipes and ordinary MoonBit for control flow.
+Embedded NUL characters in process metadata are rejected before spawning rather
+than being truncated by an operating-system argv boundary.
+
+The package supports the `native` and `wasm` targets. On `wasm`, process
+creation is delegated through the host operations used by
+`moonbitlang/async/process`.
+
+## The whole API
+
+A process is described by one constructor and executed in one of four modes.
+There are no builder chains: a `Cmd` is written the way it is read.
+
+```moonbit nocheck
+///|
+Cmd(
+  program,                 // executable name or path
+  arguments,               // Array[String], each passed literally
+  cwd? : String,           // default: inherited working directory
+  env? : Map[String, String], // default: {}
+  inherit_env? : Bool,     // default: true
+  stdin? : Stdin,          // default: closed
+  stdout? : Redirect,      // default: Capture
+  stderr? : Redirect,      // default: Capture
+) -> Cmd
+
+Pipeline(commands : Array[Cmd]) -> Pipeline
+```
+
+```moonbit nocheck
+///|
+enum Stdin {
+  Text(String)
+  Binary(Bytes)
+  FromFile(String) // `< path`
+  Inherit
+}
+
+///|
+enum Redirect {
+  Capture
+  Inherit
+  ToFile(String) // `> path`
+  AppendToFile(String) // `>> path`
+  Discard // `> /dev/null`
+}
+```
+
+Execution: `output` collects the streams, `status` returns only the exit code,
+`run` is the checked form of `status` — quiet on success and raising on a
+non-zero exit — and `each_line` follows standard output as it is produced. All
+four exist on both `Cmd` and `Pipeline`.
+
+`Cmd` and `Pipeline` are abstract and immutable. Their derived `Debug`
+representations support logging and snapshot review without exposing one
+getter per constructor option. `Output` is abstract too; scripts consume it
+through `exit_code()`, `stdout()`, `stdout_bytes()`, and `stderr()`. Its
+`check() -> Unit raise` only checks an already completed result. `Stdin` and
+`Redirect` expose their variants because callers construct those choices.
+
+## 1. Run one command
+
+```mbt check
+///|
+async test {
+  let output = @shell.Cmd("moonx", ["bobzhang/printf@0.1.0", "hello"]).output()
+  assert_eq(output.exit_code(), 0)
+  assert_eq(output.stdout(), "hello")
+}
+```
+
+## 2. Pass shell characters literally
+
+This prints the characters; it does not execute `echo` and does not create a
+pipe.
+
+```mbt check
+///|
+async test {
+  let output = @shell.Cmd("moonx", [
+    "bobzhang/printf@0.1.0", "%s", "$(echo no) | *",
+  ]).output()
+  assert_eq(output.stdout(), "$(echo no) | *")
+}
+```
+
+## 3. Set cwd and environment
+
+Options are labelled arguments on the constructor, so the whole plan is one
+expression.
+
+```mbt check
+///|
+test {
+  let command = @shell.Cmd("moon", ["check"], cwd="workspace", env={
+    "NO_COLOR": "1",
+  })
+  debug_inspect(
+    command,
+    content=(
+      #|{
+      #|  program: "moon",
+      #|  arguments: ["check"],
+      #|  cwd: Some("workspace"),
+      #|  env: { "NO_COLOR": "1" },
+      #|  inherit_env: true,
+      #|  stdin: None,
+      #|  stdout: Capture,
+      #|  stderr: Capture,
+      #|}
+    ),
+  )
+}
+```
+
+Pass `inherit_env=false` to start from an empty environment instead of adding
+to the parent's.
+
+## 4. Inspect a plan before running it
+
+A plan can be logged, diffed, or snapshot-reviewed before anything is spawned.
+Because `Cmd` is immutable, the value shown by its derived `Debug`
+representation is the value that runs. Its fields stay private: inspection does
+not add another programmable API for every constructor option.
+
+```mbt check
+///|
+test {
+  let command = @shell.Cmd("rm", ["-rf", "/"])
+  debug_inspect(
+    command,
+    content=(
+      #|{
+      #|  program: "rm",
+      #|  arguments: ["-rf", "/"],
+      #|  cwd: None,
+      #|  env: {},
+      #|  inherit_env: true,
+      #|  stdin: None,
+      #|  stdout: Capture,
+      #|  stderr: Capture,
+      #|}
+    ),
+  )
+}
+```
+
+Building a command list is ordinary MoonBit; there is no builder to learn.
+
+```mbt check
+///|
+test {
+  let arguments = ["check"]
+  if true {
+    arguments.push("--target")
+    arguments.push("wasm")
+  }
+  let command = @shell.Cmd("moon", arguments)
+  debug_inspect(
+    command,
+    content=(
+      #|{
+      #|  program: "moon",
+      #|  arguments: ["check", "--target", "wasm"],
+      #|  cwd: None,
+      #|  env: {},
+      #|  inherit_env: true,
+      #|  stdin: None,
+      #|  stdout: Capture,
+      #|  stderr: Capture,
+      #|}
+    ),
+  )
+}
+```
+
+## 5. Pipe commands
+
+Every stage is separately visible to the process host, and all stages run
+concurrently in one structured task group. Adjacent children share one blocking
+operating-system pipe created by `@process.pipe()`: payload bytes stay in the
+host pipe rather than crossing this process through a relay task. Each end is
+owned by the spawn that receives it, so the parent does not keep an extra copy
+that could delay EOF.
+
+```mbt check
+///|
+async test {
+  let output = @shell.Pipeline([
+    Cmd("moonx", ["bobzhang/printf@0.1.0", "alpha\nbeta\n"]),
+    Cmd("moonx", ["bobzhang/tail@0.1.0", "-n", "1"]),
+    Cmd("moonx", ["bobzhang/tr@0.1.0", "a-z", "A-Z"]),
+  ]).output()
+  assert_eq(output.stdout(), "BETA\n")
+  assert_eq(output.exit_code(), 0)
+}
+```
+
+## 6. Supply standard input
+
+Standard input is closed by default, so non-interactive runs cannot
+accidentally wait on ambient input. `stdin` on the first stage also feeds a
+pipeline; giving it to a later stage is rejected.
+
+```mbt check
+///|
+async test {
+  let output = @shell.Pipeline([
+    Cmd("moonx", ["bobzhang/tr@0.1.0", "a-z", "A-Z"], stdin=Text("hello")),
+    Cmd("moonx", ["bobzhang/tr@0.1.0", "A-Z", "a-z"]),
+  ]).output()
+  assert_eq(output.stdout(), "hello")
+}
+```
+
+Use `Binary` when the input is not text:
+
+```mbt check
+///|
+async test {
+  let output = @shell.Cmd(
+    "moonx",
+    ["bobzhang/cat@0.1.0"],
+    stdin=Binary(b"\x00\xff"),
+  ).output()
+  assert_eq(output.stdout_bytes(), b"\x00\xff")
+}
+```
+
+## 7. Redirect to and from files
+
+`ToFile` and `AppendToFile` replace a shell's `> path` and `>> path`, and
+`FromFile` replaces `< path`. Without them the only shell-free option would be
+to capture in memory and write the file yourself.
+
+```mbt check
+///|
+#cfg(all(target="native", not(platform="windows")))
+async test {
+  let directory = @fs.tmpdir(prefix="shell-readme")
+  let path = "\{directory}/log.txt"
+  @shell.Cmd("printf", ["one\n"], stdout=ToFile(path)).run()
+  @shell.Cmd("printf", ["two\n"], stdout=AppendToFile(path)).run()
+  let back = @shell.Cmd("cat", [], stdin=FromFile(path)).output()
+  assert_eq(back.stdout(), "one\ntwo\n")
+  @fs.rmdir(directory, recursive=true)
+}
+```
+
+A redirected stream is not captured, so it arrives empty in `Output` and does
+not count against `max_output_bytes`. Use `Inherit` to hand a stream to the
+parent's own descriptor. Only the last stage of a pipeline may redirect stdout,
+since every earlier stage's stdout is the pipe.
+
+## 8. Follow output as it is produced
+
+`output` returns nothing until the command finishes. `each_line` delivers
+standard output line by line while the command runs, which is what a
+long-running build or test needs in order to report progress. Completed lines
+are not retained, so total output is unbounded; `max_line_bytes` (8 MiB by
+default) caps one line's content exactly, so a child that never emits a newline
+cannot exhaust memory. Both `\n` and `\r\n` are recognised as terminators, and
+a CRLF's CR does not count against the limit.
+
+```mbt check
+///|
+async test {
+  let seen = []
+  let code = @shell.Cmd("moonx", ["bobzhang/printf@0.1.0", "alpha\nbeta\n"]).each_line(line => {
+      seen.push(line)
+    },
+  )
+  assert_eq(code, 0)
+  assert_eq(seen, ["alpha", "beta"])
+}
+```
+
+`Pipeline::each_line` follows the last stage the same way.
+
+## 9. Run without capturing output
+
+Use `status` when stdout and stderr should be inherited by the current process.
+It returns only the exit code and has no capture limit. `run` is the same
+execution with failure checked: the common verb of a script that just wants
+the command to have worked.
+
+```mbt check
+///|
+async test {
+  assert_eq(@shell.Cmd("moonx", ["bobzhang/false@0.1.0"]).status(), 1)
+  @shell.Cmd("moonx", ["bobzhang/true@0.1.0"]).run()
+  try @shell.Cmd("moonx", ["bobzhang/false@0.1.0"]).run() catch {
+    _ => ()
+  } noraise {
+    _ => fail("expected a non-zero exit to raise")
+  }
+}
+```
+
+## 10. Inspect exit status
+
+`Cmd::output` does not turn a non-zero exit status into an exception. Use
+ordinary MoonBit control flow or call `check()` when failure should raise.
+
+```mbt check
+///|
+async test {
+  let output = @shell.Cmd("moonx", ["bobzhang/false@0.1.0"]).output()
+  if output.exit_code() != 0 {
+    assert_eq(output.exit_code(), 1)
+  }
+}
+```
+
+## 11. Pipeline status uses pipefail
+
+`exit_code` is the rightmost non-zero stage status, or zero when all stages
+succeed. This is the portable `pipefail` result for the pipeline as a whole.
+
+```mbt check
+///|
+async test {
+  let output = @shell.Pipeline([
+    Cmd("moonx", ["bobzhang/false@0.1.0"]),
+    Cmd("moonx", ["bobzhang/cat@0.1.0"]),
+  ]).output()
+  assert_eq(output.exit_code(), 1)
+}
+```
+
+## 12. Capture stderr
+
+For pipelines, `stderr` concatenates captured standard error in stage order.
+Text uses lossy UTF-8 decoding so arbitrary process output cannot cancel
+sibling stages; exact standard output remains available through
+`stdout_bytes`.
+
+```mbt check
+///|
+async test {
+  let output = @shell.Cmd(
+    "moonx",
+    ["bobzhang/jq@0.1.1", "."],
+    stdin=Text("not json"),
+  ).output()
+  assert_true(!output.stderr().is_empty())
+}
+```
+
+## 13. Add a timeout
+
+A timeout cancels the structured task and kills each direct child immediately:
+a sandboxed runtime never waits on an untrusted process. A timeout is not a
+process-tree deadline: descendants must be contained and reaped by the host's
+native process sandbox.
+
+```mbt check
+///|
+async test {
+  try
+    @shell.Cmd("moonx", ["bobzhang/sleep@0.1.0", "5"]).output(timeout_ms=100)
+  catch {
+    @async.TimeoutError => ()
+    _ => fail("expected TimeoutError")
+  } noraise {
+    _ => fail("expected TimeoutError")
+  }
+}
+```
+
+Captured stdout plus stderr is limited to 8 MiB by default, to keep an
+untrusted child from growing this process without bound. Override it when
+needed:
+
+```mbt nocheck
+///|
+let output = command.output(max_output_bytes=32 * 1024 * 1024)
+```
+
+If all captured streams together exceed the limit, execution raises and
+cancels the structured process group.
+
+## 14. Expand paths without a shell
+
+A shell expands `*.mbt` into arguments before the command ever runs. `glob` does
+the same expansion as an ordinary value, so the result can be inspected, and
+each match reaches the child as one literal argument — a filename containing a
+space, a quote, or a `*` cannot be re-split or re-expanded on the way.
+
+```mbt check
+///|
+async test {
+  let sources = @shell.glob("*.mbt", cwd="src/shell")
+  assert_true(sources.contains("execute.mbt"))
+  let output = @shell.Cmd(
+    "moonx",
+    ["bobzhang/wc@0.1.0", "-l", ..sources],
+    cwd="src/shell",
+  ).output()
+  assert_eq(output.exit_code(), 0)
+}
+```
+
+`*` and `?` stay within one path segment, `[a-z]` and `[!a-z]` match a character
+from a set, and `**` as a whole segment spans any number of segments. A leading
+`.` is matched only by a literal `.`, so neither `*` nor `**` reaches hidden
+entries. A trailing separator restricts the result to directories and is kept.
+Matches come back in code-unit order with no duplicates, and a pattern that
+matches nothing returns an empty array rather than the pattern itself.
+
+Paths are parsed into a root and a list of names, so the same code serves both
+platforms. `/` always separates. On Windows a backslash separates too, and a
+drive (`C:/x`, `C:\x`), a drive-relative prefix (`C:x`), and a share
+(`\\server\share\x`) are recognised as roots; on Unix, where a backslash is not
+a separator, it escapes the next character instead.
+
+Matching follows the platform's own rules: on Windows, where filesystems do not
+distinguish case, `*.TXT` matches `foo.txt`. Only ASCII case is folded — a
+name differing solely in the case of a non-ASCII letter matches exactly, as
+full Unicode case folding is deliberately out of scope.
+
+`**` does not descend symbolic links, which is what keeps a link pointing at an
+ancestor from looping forever; a component you name yourself resolves links
+normally. A wildcard never produces `.` or `..`, though a pattern may name them,
+so `../*` reaches the parent — confining an expansion to a subtree is the
+sandbox policy's job rather than this function's. A cancelled expansion stops
+rather than returning a partial result as though it were complete.
+
+For filtering names already in hand — without touching the disk — MoonBit's
+own `str =~ regex` is the more general tool, so this package deliberately does
+not export a second pattern-matching predicate.
+
+## Security boundary
+
+This package removes shell parsing and keeps each process invocation structured;
+it does not decide which executables or effects are safe. Because a `Cmd` is
+immutable and fully readable, a caller can apply its own policy to a plan
+before calling `output` or `status` — the description and the execution are
+separate steps.
+
+On `wasm`, the host still owns executable authorization and the native process
+sandbox. A strong deployment should grant each child only the filesystem,
+network, environment, and secret capabilities required for that invocation.

--- a/src/shell/README.md
+++ b/src/shell/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/src/shell/cmd.mbt
+++ b/src/shell/cmd.mbt
@@ -1,0 +1,127 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Where a child process's standard input comes from.
+///
+/// `Text` is encoded as UTF-8. `Binary` is written verbatim, which is what a
+/// child expecting a compressed or otherwise non-textual stream needs.
+/// `FromFile` is the structured form of a shell's `< path`; the file must
+/// already exist. `Inherit` hands the child the parent's own standard input,
+/// which is what an interactive command needs; without it, standard input is
+/// closed.
+pub(all) enum Stdin {
+  Text(String)
+  Binary(Bytes)
+  FromFile(String)
+  Inherit
+} derive(Debug)
+
+///|
+/// Where a child process's standard output or standard error goes.
+///
+/// `Capture` returns the stream to the caller: `output` collects it into
+/// `Output`, `each_line` delivers stdout line by line, and `status` has no
+/// return channel so it inherits instead. `Inherit` hands the stream to the
+/// parent's own descriptor.
+///
+/// `ToFile` and `AppendToFile` are the structured forms of a shell's `> path`
+/// and `>> path`. Both create the file if it is missing; `ToFile` truncates an
+/// existing one. `Discard` is the structured `> /dev/null`: the stream goes to
+/// the platform's null device. A redirected stream is absent from `Output`,
+/// where it appears as an empty string.
+pub(all) enum Redirect {
+  Capture
+  Inherit
+  ToFile(String)
+  AppendToFile(String)
+  Discard
+} derive(Debug)
+
+///|
+/// A shell-free process description.
+///
+/// `program` is an executable name or path. Every element of `arguments` is
+/// passed as one literal argument. Shell operators such as `|`, `>`, `&&`,
+/// `$()`, and `*` have no special meaning.
+///
+/// The representation is abstract and a `Cmd` is immutable once built. Its
+/// derived `Debug` representation can be logged or snapshot-tested before it
+/// runs.
+struct Cmd {
+  program : String
+  arguments : Array[String]
+  cwd : String?
+  env : Map[String, String]
+  inherit_env : Bool
+  stdin : Stdin?
+  stdout : Redirect
+  stderr : Redirect
+} derive(Debug)
+
+///|
+/// Describe one process.
+///
+/// Standard input is closed unless `stdin` is given, so a non-interactive run
+/// cannot accidentally wait on ambient input. `env` adds to the inherited
+/// environment; pass `inherit_env=false` to start from an empty one.
+///
+/// `stdout` and `stderr` default to `Capture`, so `output` collects them.
+///
+/// `arguments` and `env` are copied, so later changes to the caller's
+/// collections do not reach the command.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let cmd = @shell.Cmd("git", ["status", "--short"], cwd="workspace")
+///   debug_inspect(
+///     cmd,
+///     content=(
+///       #|{
+///       #|  program: "git",
+///       #|  arguments: ["status", "--short"],
+///       #|  cwd: Some("workspace"),
+///       #|  env: {},
+///       #|  inherit_env: true,
+///       #|  stdin: None,
+///       #|  stdout: Capture,
+///       #|  stderr: Capture,
+///       #|}
+///     ),
+///   )
+/// }
+/// ```
+pub fn Cmd::Cmd(
+  program : String,
+  arguments : Array[String],
+  cwd? : String,
+  env? : Map[String, String] = {},
+  inherit_env? : Bool = true,
+  stdin? : Stdin,
+  stdout? : Redirect = Capture,
+  stderr? : Redirect = Capture,
+) -> Cmd {
+  {
+    program,
+    arguments: arguments.copy(),
+    cwd,
+    env: env.copy(),
+    inherit_env,
+    stdin,
+    stdout,
+    stderr,
+  }
+}

--- a/src/shell/execute.mbt
+++ b/src/shell/execute.mbt
@@ -1,0 +1,662 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Default aggregate limit for captured stdout and stderr: 8 MiB.
+let default_max_output_bytes : Int = 8 * 1024 * 1024
+
+///|
+/// What the caller wants done with the streams a stage marks `Capture`.
+priv enum Sink {
+  /// Collect into `Output`, bounded by the given aggregate byte limit.
+  Buffer(Int)
+  /// Deliver final stdout one line at a time, holding at most one line of the
+  /// given size.
+  Lines(async (String) -> Unit, Int)
+  /// Capture nothing; a `Capture` stream falls back to the parent's
+  /// descriptor, as `status` and `run` have no channel to return it on.
+  Inherited
+}
+
+///|
+/// Execute this command and capture stdout and stderr.
+///
+/// Constructing a `Cmd` does not execute it. Captured stdout and stderr share
+/// `max_output_bytes`; streams sent elsewhere by `stdout` or `stderr` do not
+/// count against it and arrive empty in `Output`. When `timeout_ms` expires,
+/// each direct child is killed immediately; descendants require enforcement by
+/// the host's native process sandbox.
+///
+/// # Example
+/// ```mbt check
+/// async test {
+///   let output = @shell.Cmd("moonx", ["bobzhang/printf@0.1.0", "hello"]).output()
+///   assert_eq(output.stdout(), "hello")
+/// }
+/// ```
+pub async fn Cmd::output(
+  self : Cmd,
+  timeout_ms? : Int,
+  max_output_bytes? : Int = default_max_output_bytes,
+) -> Output {
+  validate_output_limit(max_output_bytes)
+  Pipeline::{ commands: [self] }.execute(Buffer(max_output_bytes), timeout_ms)
+}
+
+///|
+/// Execute this command without capturing stdout or stderr.
+///
+/// Streams left as `Capture` are inherited by the current process, because
+/// `status` has no channel to return them on; explicit `ToFile`,
+/// `AppendToFile`, and `Inherit` settings still apply. This method returns
+/// only the exit status and has no capture limit.
+///
+/// # Example
+/// ```mbt check
+/// async test {
+///   assert_eq(@shell.Cmd("moonx", ["bobzhang/false@0.1.0"]).status(), 1)
+/// }
+/// ```
+pub async fn Cmd::status(self : Cmd, timeout_ms? : Int) -> Int {
+  Pipeline::{ commands: [self] }.execute(Inherited, timeout_ms).exit_code
+}
+
+///|
+/// Execute this command and raise on a non-zero exit status.
+///
+/// This is the checked form of `status` and the common verb of a script:
+/// streams are inherited exactly as there, and a failure becomes an error
+/// instead of a status the caller might forget to look at. Use `status` when
+/// a non-zero exit is an answer rather than a failure.
+///
+/// # Example
+/// ```mbt check
+/// async test {
+///   @shell.Cmd("moonx", ["bobzhang/true@0.1.0"]).run()
+///   try @shell.Cmd("moonx", ["bobzhang/false@0.1.0"]).run() catch {
+///     _ => ()
+///   } noraise {
+///     _ => fail("expected a non-zero exit to raise")
+///   }
+/// }
+/// ```
+pub async fn Cmd::run(self : Cmd, timeout_ms? : Int) -> Unit {
+  Pipeline::{ commands: [self] }.execute(Inherited, timeout_ms).check()
+}
+
+///|
+/// Execute this command, delivering standard output one line at a time.
+///
+/// `on_line` receives each line without its terminator — `\n` or `\r\n` — as
+/// soon as the child flushes it, so a long-running command can report progress
+/// instead of arriving as one block at the end. A trailing fragment with no
+/// newline is delivered as a final line. Standard error follows the same rule
+/// as in `status`.
+///
+/// Completed lines are not retained, so total output is unbounded. One line is
+/// held while it is assembled, and `max_line_bytes` caps its content exactly:
+/// any single line longer than that raises, whether or not a newline ever
+/// arrives, so a child that emits no newline cannot exhaust memory. A CRLF
+/// terminator's CR is punctuation rather than content and does not consume the
+/// allowance.
+///
+/// Raises when `stdout` sends the stream elsewhere, since there would be
+/// nothing to read.
+///
+/// # Example
+/// ```mbt check
+/// async test {
+///   let seen = []
+///   let code = @shell.Cmd("moonx", ["bobzhang/printf@0.1.0", "a\nb\n"]).each_line(line => {
+///       seen.push(line)
+///     },
+///   )
+///   assert_eq(code, 0)
+///   assert_eq(seen, ["a", "b"])
+/// }
+/// ```
+pub async fn Cmd::each_line(
+  self : Cmd,
+  on_line : async (String) -> Unit,
+  timeout_ms? : Int,
+  max_line_bytes? : Int = default_max_output_bytes,
+) -> Int {
+  validate_output_limit(max_line_bytes)
+  Pipeline::{ commands: [self] }.execute(
+    Lines(on_line, max_line_bytes),
+    timeout_ms,
+  ).exit_code
+}
+
+///|
+/// Execute this pipeline and capture final stdout plus every stage's stderr.
+///
+/// Stages run concurrently in one structured task group. `timeout_ms`, when
+/// present, applies to the whole pipeline.
+///
+/// # Example
+/// ```mbt check
+/// async test {
+///   let output = @shell.Pipeline([
+///     Cmd("moonx", ["bobzhang/printf@0.1.0", "alpha\nbeta\n"]),
+///     Cmd("moonx", ["bobzhang/tail@0.1.0", "-n", "1"]),
+///   ]).output()
+///   assert_eq(output.stdout(), "beta\n")
+/// }
+/// ```
+pub async fn Pipeline::output(
+  self : Pipeline,
+  timeout_ms? : Int,
+  max_output_bytes? : Int = default_max_output_bytes,
+) -> Output {
+  validate_output_limit(max_output_bytes)
+  self.execute(Buffer(max_output_bytes), timeout_ms)
+}
+
+///|
+/// Execute this pipeline without capturing stdout or stderr.
+///
+/// The last stage's streams left as `Capture` are inherited by the current
+/// process, exactly as in `Cmd::status`; the earlier stages' stdout is the
+/// connecting pipe regardless. The returned status uses the same pipefail
+/// rule as `output`, and there is no capture limit.
+pub async fn Pipeline::status(self : Pipeline, timeout_ms? : Int) -> Int {
+  self.execute(Inherited, timeout_ms).exit_code
+}
+
+///|
+/// Execute this pipeline and raise when any stage fails.
+///
+/// The checked form of `Pipeline::status`: streams are inherited the same
+/// way, and the pipefail status becomes an error when it is non-zero.
+pub async fn Pipeline::run(self : Pipeline, timeout_ms? : Int) -> Unit {
+  self.execute(Inherited, timeout_ms).check()
+}
+
+///|
+/// Execute this pipeline, delivering the last stage's output one line at a
+/// time.
+///
+/// The returned status uses the same pipefail rule as `output`. See
+/// `Cmd::each_line` for how lines are delivered and bounded.
+///
+/// # Example
+/// ```mbt check
+/// async test {
+///   let seen = []
+///   @shell.Pipeline([
+///     Cmd("moonx", ["bobzhang/printf@0.1.0", "alpha\nbeta\n"]),
+///     Cmd("moonx", ["bobzhang/tail@0.1.0", "-n", "1"]),
+///   ]).each_line(line => seen.push(line))
+///   |> ignore
+///   assert_eq(seen, ["beta"])
+/// }
+/// ```
+pub async fn Pipeline::each_line(
+  self : Pipeline,
+  on_line : async (String) -> Unit,
+  timeout_ms? : Int,
+  max_line_bytes? : Int = default_max_output_bytes,
+) -> Int {
+  validate_output_limit(max_line_bytes)
+  self.execute(Lines(on_line, max_line_bytes), timeout_ms).exit_code
+}
+
+///|
+/// Validate the whole plan, then run it under an optional deadline.
+async fn Pipeline::execute(
+  self : Pipeline,
+  sink : Sink,
+  timeout_ms : Int?,
+) -> Output {
+  let count = self.commands.length()
+  if count == 0 {
+    raise ShellError::EmptyPipeline
+  }
+  for index, cmd in self.commands {
+    validate_cmd(cmd)
+    if index > 0 && cmd.stdin is Some(_) {
+      raise StdinOnNonFirstStage(index)
+    }
+    if index + 1 < count && !(cmd.stdout is Capture) {
+      raise RedirectOnNonFinalStage(index)
+    }
+  }
+  if sink is Lines(_, _) && !(self.commands[count - 1].stdout is Capture) {
+    raise StdoutNotCaptured
+  }
+  match timeout_ms {
+    None => run_pipeline(self, sink)
+    Some(milliseconds) =>
+      @async.with_timeout(milliseconds, () => run_pipeline(self, sink))
+  }
+}
+
+///|
+fn validate_cmd(cmd : Cmd) -> Unit raise ShellError {
+  if cmd.program.is_empty() {
+    raise EmptyProgram
+  }
+  if cmd.program.contains("\u{0000}") {
+    raise NulByte("program")
+  }
+  for index, argument in cmd.arguments {
+    if argument.contains("\u{0000}") {
+      raise NulByte("argument[\{index}]")
+    }
+  }
+  if cmd.cwd is Some(directory) && directory.contains("\u{0000}") {
+    raise NulByte("working directory")
+  }
+  if cmd.stdin is Some(FromFile(path)) && path.contains("\u{0000}") {
+    raise NulByte("standard input path")
+  }
+  validate_redirect(cmd.stdout, "standard output path")
+  validate_redirect(cmd.stderr, "standard error path")
+  for name, value in cmd.env {
+    if name.contains("\u{0000}") {
+      raise NulByte("environment name")
+    }
+    if name.is_empty() || name.contains("=") {
+      raise InvalidEnvironmentName(name)
+    }
+    if value.contains("\u{0000}") {
+      raise NulByte("environment value for \{name}")
+    }
+  }
+}
+
+///|
+fn validate_redirect(
+  redirect : Redirect,
+  location : String,
+) -> Unit raise ShellError {
+  if redirect is (ToFile(path) | AppendToFile(path)) &&
+    path.contains("\u{0000}") {
+    raise NulByte(location)
+  }
+}
+
+///|
+fn validate_output_limit(limit : Int) -> Unit raise ShellError {
+  if limit <= 0 {
+    raise InvalidOutputLimit(limit)
+  }
+}
+
+///|
+/// Turn a `Redirect` into the descriptor a child should receive.
+///
+/// `None` means the child inherits the parent's descriptor. `capture` is the
+/// descriptor this run reads from, and is absent when the caller keeps nothing.
+///
+/// A file opened here is recorded in `created`, so that if a later setup step
+/// fails before the spawn that would consume it, the handle is closed rather
+/// than leaked. The spawn itself closes it through `after_spawn`.
+async fn resolve_redirect(
+  redirect : Redirect,
+  capture : &@process.ProcessOutput?,
+  created : Array[&@process.ProcessOutput],
+) -> &@process.ProcessOutput? {
+  match redirect {
+    Capture => capture
+    Inherit => None
+    ToFile(path) => {
+      let file = @process.redirect_to_file(path, create_mode=CreateOrTruncate)
+      created.push(file)
+      Some(file)
+    }
+    AppendToFile(path) => {
+      let file = @process.redirect_to_file(
+        path,
+        append=true,
+        create_mode=OpenOrCreate,
+      )
+      created.push(file)
+      Some(file)
+    }
+    Discard => {
+      let file = @process.redirect_to_file(
+        null_device,
+        create_mode=OpenExisting,
+      )
+      created.push(file)
+      Some(file)
+    }
+  }
+}
+
+///|
+/// The platform's always-existing sink for unwanted output.
+let null_device : String = if @env_util.platform is Windows {
+  "NUL"
+} else {
+  "/dev/null"
+}
+
+///|
+async fn[X] spawn_stage(
+  group : @async.TaskGroup[X],
+  cmd : Cmd,
+  stdin : &@process.ProcessInput,
+  stdout : &@process.ProcessOutput?,
+  stderr : &@process.ProcessOutput?,
+) -> @process.Process {
+  @process.spawn(
+    group,
+    cmd.program,
+    cmd.arguments,
+    extra_env=cmd.env,
+    inherit_env=cmd.inherit_env,
+    stdin~,
+    stdout?,
+    stderr?,
+    cwd?=cmd.cwd.map(directory => directory[:]),
+    // Cancellation — a timeout, a capture limit, a failing sibling — kills the
+    // child immediately: a sandboxed runtime never waits on an untrusted
+    // process.
+    cancel_handler=@process.hard_cancel(),
+  )
+}
+
+///|
+async fn write_standard_input(
+  writer : @process.WriteToProcess,
+  input : Stdin?,
+) -> Unit {
+  defer writer.close()
+  match input {
+    Some(Text(text)) => writer.write(text)
+    Some(Binary(bytes)) => writer.write(bytes)
+    // `FromFile` and `Inherit` never reach here: those descriptors are handed
+    // to the child directly.
+    Some(FromFile(_) | Inherit) | None => ()
+  }
+}
+
+///|
+fn pipefail_exit_code(exit_codes : ArrayView[Int]) -> Int {
+  let mut result = 0
+  for code in exit_codes {
+    if code != 0 {
+      result = code
+    }
+  }
+  result
+}
+
+///|
+async fn read_bounded(
+  reader : @process.ReadFromProcess,
+  captured : Ref[Int],
+  limit : Int,
+  stream : String,
+) -> Bytes {
+  let buffer = @buffer.Buffer(size_hint=4096)
+  for ;; {
+    let remaining = limit - captured.val
+    let chunk_size = if remaining < 4096 { remaining + 1 } else { 4096 }
+    match reader.read_some(max_len=chunk_size) {
+      None => break
+      Some(chunk) => {
+        let next_total = captured.val + chunk.length()
+        if next_total > limit {
+          raise OutputLimitExceeded(stream~, limit~)
+        }
+        captured.val = next_total
+        buffer.write_bytes(chunk)
+      }
+    }
+  }
+  buffer.to_bytes()
+}
+
+///|
+/// Deliver every line the child writes, including a final unterminated one.
+///
+/// This splits `read_some` chunks itself rather than using the reader's
+/// `read_until`: that helper decodes strictly, so one invalid byte would abort
+/// the run, and it stops early once its internal buffer fills. Decoding here is
+/// lossy and per line, matching how `Output` treats captured text.
+///
+/// Only one line is held at a time, and `limit` caps that line's content
+/// exactly, so a child that never emits a newline cannot grow it without
+/// bound. A CRLF terminator's CR is punctuation, not content, and so does not
+/// consume the line's allowance.
+async fn read_lines(
+  reader : @process.ReadFromProcess,
+  on_line : async (String) -> Unit,
+  limit : Int,
+) -> Unit {
+  let pending = @buffer.Buffer(size_hint=4096)
+  while reader.read_some(max_len=4096) is Some(chunk) {
+    let mut start = 0
+    for index in 0..<chunk.length() {
+      if chunk[index] == b'\n' {
+        extend_line(pending, chunk[start:index], limit)
+        on_line(take_line(pending, terminated=true, limit))
+        start = index + 1
+      }
+    }
+    extend_line(pending, chunk[start:], limit)
+  }
+  if pending.length() > 0 {
+    on_line(take_line(pending, terminated=false, limit))
+  }
+}
+
+///|
+/// Append to the line being assembled, refusing to buffer more than one line.
+///
+/// `limit` counts line content, and the CR of a CRLF terminator is not content.
+/// Whether a trailing CR is a terminator is only known once the LF arrives, so
+/// one byte of headroom is allowed here and `take_line` makes the final ruling.
+fn extend_line(
+  pending : @buffer.Buffer,
+  view : BytesView,
+  limit : Int,
+) -> Unit raise ShellError {
+  let projected = pending.length() + view.length()
+  // Written this way rather than `projected > limit + 1` so that a caller
+  // passing a limit near `Int`'s maximum cannot overflow the comparison.
+  if projected > limit && projected - limit > 1 {
+    raise OutputLimitExceeded(stream="stdout line", limit~)
+  }
+  pending.write_bytesview(view)
+}
+
+///|
+/// Take the assembled line and reset the buffer.
+///
+/// The CR of a CRLF terminator is dropped, but only for a line that a newline
+/// actually terminated: a lone trailing CR in the final unterminated fragment
+/// is data, not punctuation. What remains is the line content, so this is where
+/// `limit` is decided.
+fn take_line(
+  pending : @buffer.Buffer,
+  terminated~ : Bool,
+  limit : Int,
+) -> String raise ShellError {
+  let raw = pending.to_bytes()
+  pending.reset()
+  let length = raw.length()
+  let bytes = if terminated && length > 0 && raw[length - 1] == b'\r' {
+    raw[:length - 1].to_owned()
+  } else {
+    raw
+  }
+  if bytes.length() > limit {
+    raise OutputLimitExceeded(stream="stdout line", limit~)
+  }
+  @utf8.decode_lossy(bytes)
+}
+
+///|
+#warnings("-deprecated")
+fn close_process_input(input : &@process.ProcessInput) -> Unit {
+  input.close()
+}
+
+///|
+async fn run_pipeline(pipeline : Pipeline, sink : Sink) -> Output {
+  let commands = pipeline.commands
+  let count = commands.length()
+  //
+  // Each adjacent pair of stages shares one process-owned operating-system
+  // pipe. Both ends are blocking in the children, so payload bytes stay in the
+  // host pipe rather than crossing this process through a relay task.
+  //
+  // Everything the parent itself reads or writes uses the process-owned pipes.
+  // `@pipe.pipe()` makes both ends non-blocking, and that flag survives into
+  // the child, so a child that outran us would get `EAGAIN` on its own write
+  // instead of blocking. `read_from_process` and `write_to_process` keep the
+  // child's end blocking, which is the whole point of using them here.
+  //
+  // Passing a process-owned end to `spawn` transfers that end: `after_spawn`
+  // closes the parent's copy on success or failure. A junction is created
+  // immediately before its producer is spawned, keeping any unconsumed input
+  // end local to that one junction if the producer itself fails to spawn.
+  let capture_stderr = sink is Buffer(_)
+  @async.with_task_group() <| group => {
+    let captured = Ref(0)
+    let limit = match sink {
+      Buffer(limit) => limit
+      _ => 0
+    }
+    let mut stdout_task : @async.Task[Bytes]? = None
+    let stderr_tasks : Array[@async.Task[Bytes]?] = []
+    //
+    // A child-side end exists before the spawn that consumes it, so a failing
+    // setup step — an output file that cannot be opened, a pipe that cannot
+    // be created — would otherwise leak every end already made. Closing an
+    // end is idempotent, and a no-op for a borrowed one such as the parent's
+    // own stdin, so the cleanup is simply: record every end ever created, and
+    // on failure close them all. Ends a spawn has consumed were already
+    // closed by its `after_spawn` hook — on success and on failure alike —
+    // and closing them again does nothing.
+    let created_inputs : Array[&@process.ProcessInput] = []
+    let created_outputs : Array[&@process.ProcessOutput] = []
+    errdefer {
+      for input in created_inputs {
+        close_process_input(input)
+      }
+      for output in created_outputs {
+        output.close()
+      }
+    }
+    //
+    // Standard input for the first stage: a file the child reads itself, the
+    // parent's own descriptor, or a pipe this task fills.
+    let first_input : &@process.ProcessInput = match commands[0].stdin {
+      Some(FromFile(path)) => @process.redirect_from_file(path)
+      Some(Inherit) => @stdio.stdin
+      input => {
+        let (child_end, writer) = @process.write_to_process()
+        group.spawn_bg(allow_failure=true, () => {
+          write_standard_input(writer, input)
+        })
+        child_end
+      }
+    }
+    created_inputs.push(first_input)
+    let processes : Array[@process.Process] = []
+    let mut next_stdin : &@process.ProcessInput? = None
+    for index, cmd in commands {
+      let stdin : &@process.ProcessInput = if index == 0 {
+        first_input
+      } else {
+        guard next_stdin is Some(input) else {
+          abort("a later stage always has a junction")
+        }
+        input
+      }
+      //
+      // The junction is built here rather than up front, so each end is handed
+      // directly to the child that owns it. A downstream stage that stops
+      // reading early closes the pipe in the ordinary operating-system way,
+      // and the producer observes the resulting broken pipe.
+      let stdout = if index + 1 < count {
+        let (child_stdin, child_stdout) = @process.pipe()
+        next_stdin = Some(child_stdin)
+        created_inputs.push(child_stdin)
+        created_outputs.push(child_stdout)
+        Some(child_stdout)
+      } else {
+        let final_capture = if !(sink is Inherited) && cmd.stdout is Capture {
+          let (reader, child_stdout) = @process.read_from_process()
+          created_outputs.push(child_stdout)
+          match sink {
+            Buffer(_) =>
+              stdout_task = Some(
+                group.spawn(() => {
+                  defer reader.close()
+                  read_bounded(reader, captured, limit, "stdout")
+                }),
+              )
+            Lines(on_line, line_limit) =>
+              group.spawn_bg(() => {
+                defer reader.close()
+                read_lines(reader, on_line, line_limit)
+              })
+            Inherited => ()
+          }
+          Some(child_stdout)
+        } else {
+          None
+        }
+        resolve_redirect(cmd.stdout, final_capture, created_outputs)
+      }
+      //
+      // Each reader starts before its child, so a full pipe never stalls one.
+      let stderr_capture = if capture_stderr && cmd.stderr is Capture {
+        let (reader, child_stderr) = @process.read_from_process()
+        created_outputs.push(child_stderr)
+        stderr_tasks.push(
+          Some(
+            group.spawn(() => {
+              defer reader.close()
+              read_bounded(reader, captured, limit, "stderr")
+            }),
+          ),
+        )
+        Some(child_stderr)
+      } else {
+        stderr_tasks.push(None)
+        None
+      }
+      let stderr = resolve_redirect(cmd.stderr, stderr_capture, created_outputs)
+      processes.push(spawn_stage(group, cmd, stdin, stdout, stderr))
+    }
+    let exit_codes = [ for child in processes => child.wait() ]
+    let stdout_bytes = match stdout_task {
+      Some(task) => task.wait()
+      None => b""
+    }
+    let stderr = StringBuilder()
+    for task in stderr_tasks {
+      let stage_bytes = match task {
+        Some(task) => task.wait()
+        None => b""
+      }
+      stderr.write_string(@utf8.decode_lossy(stage_bytes))
+    }
+    {
+      exit_code: pipefail_exit_code(exit_codes),
+      stdout: @utf8.decode_lossy(stdout_bytes),
+      stdout_bytes,
+      stderr: stderr.to_string(),
+    }
+  }
+}

--- a/src/shell/glob.mbt
+++ b/src/shell/glob.mbt
@@ -1,0 +1,791 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// One element of a single path segment's pattern.
+priv enum Item {
+  Literal(Char)
+  Any
+  Star
+  Class(Array[(Char, Char)], Bool)
+}
+
+///|
+/// Where a path starts.
+///
+/// Keeping the root apart from the segments is what lets one representation
+/// serve both platforms: everything after the root is just names, and only the
+/// root knows whether it came from `/`, a drive, or a share.
+priv enum Root {
+  Relative
+  Rooted(String)
+  /// A path that names a root it does not finish, such as `\\server` with no
+  /// share. It denotes no directory, so it matches nothing rather than being
+  /// quietly reinterpreted as some other root.
+  Incomplete
+  /// `C:` with no separator: relative to that drive's own working directory,
+  /// which is a different place from `C:/`. Its first name attaches with no
+  /// separator between.
+  DriveRelative(String)
+}
+
+///|
+/// True when running on Windows.
+///
+/// Path syntax is the one place the two platforms genuinely disagree, so the
+/// parser takes it as a parameter and the public entry points pass this. The
+/// platform is read from the runtime rather than the build, because a `wasm`
+/// binary runs unchanged on every host.
+let native_windows : Bool = @env_util.platform is Windows
+
+///|
+/// A parsed path: where it starts, its names, and whether it ended in a
+/// separator.
+///
+/// `windows` selects the platform's syntax rather than the host's, so the
+/// parser is testable for both from either. `escapes` is false for a candidate
+/// name, which carries no pattern syntax at all — a backslash in a name is one
+/// of its characters.
+fn parse_path(
+  text : String,
+  windows~ : Bool,
+  escapes~ : Bool,
+) -> (Root, Array[String], Bool) {
+  let (root, rest) = if windows && starts_incomplete_root(text) {
+    (Incomplete, "")
+  } else if windows {
+    match windows_root(text) {
+      Some((root, rest)) =>
+        if root.has_suffix("\u{0000}") {
+          (DriveRelative(root[:root.length() - 1].to_owned()), rest)
+        } else {
+          (Rooted(root), rest)
+        }
+      None => (Relative, text)
+    }
+  } else {
+    (Relative, text)
+  }
+  let raw = split_path(rest, windows~, escapes~)
+  // On Unix a leading separator is what makes a path absolute, including an
+  // escaped one, since the escape is gone by the time the name is resolved.
+  let root = match root {
+    Rooted(_) | DriveRelative(_) | Incomplete => root
+    Relative =>
+      if !text.is_empty() && raw is [first, ..] && first.is_empty() {
+        Rooted("/")
+      } else {
+        Relative
+      }
+  }
+  let only_separators = raw.iter().all(segment => segment.is_empty())
+  // A trailing separator asks for directories only. A path that is nothing but
+  // separators is just its root, with no such request attached.
+  let directories_only = !only_separators &&
+    raw.length() > 1 &&
+    raw[raw.length() - 1].is_empty()
+  let segments = []
+  for segment in raw {
+    if !segment.is_empty() {
+      segments.push(segment)
+    }
+  }
+  (root, segments, directories_only)
+}
+
+///|
+/// Whether the text opens a share that it never completes.
+///
+/// `\\server` names no directory. Falling through would let the leading
+/// separators be read as an ordinary root and turn it into `/server`, which is
+/// somewhere else entirely.
+fn starts_incomplete_root(text : String) -> Bool {
+  let chars = collect_chars(text)
+  fn separator(index : Int) -> Bool {
+    index < chars.length() && (chars[index] == '/' || chars[index] == '\\')
+  }
+
+  if !(separator(0) && separator(1)) {
+    return false
+  }
+  windows_root(text) is None
+}
+
+///|
+/// Recognise a Windows root: a drive, a drive-relative prefix, a UNC share, or
+/// a bare separator. Returns the root and the remainder.
+fn windows_root(text : String) -> (String, String)? {
+  let chars = collect_chars(text)
+  fn separator(index : Int) -> Bool {
+    index < chars.length() && (chars[index] == '/' || chars[index] == '\\')
+  }
+
+  fn from(index : Int) -> String {
+    let rest = StringBuilder()
+    for position in index..<chars.length() {
+      rest.write_char(chars[position])
+    }
+    rest.to_string()
+  }
+
+  // `\\server\share` — the share is part of the root, not a segment.
+  if separator(0) && separator(1) {
+    let mut index = 2
+    let server = StringBuilder()
+    while index < chars.length() && !separator(index) {
+      server.write_char(chars[index])
+      index = index + 1
+    }
+    // Redundant separators collapse inside a root too: `\\server\\share` is
+    // the same share as `\\server\share`, not an empty share name.
+    while separator(index) {
+      index = index + 1
+    }
+    let share = StringBuilder()
+    while index < chars.length() && !separator(index) {
+      share.write_char(chars[index])
+      index = index + 1
+    }
+    // A share needs both halves. `\\server` alone names no directory, so it is
+    // not a root; treating it as one would invent `//server//`.
+    if !server.to_string().is_empty() && !share.to_string().is_empty() {
+      return Some(("//\{server}/\{share}/", from(index)))
+    }
+    return None
+  }
+  // `C:/...` is rooted on that drive; a bare `C:` is relative to the drive's
+  // own working directory, which only the operating system knows.
+  if chars.length() >= 2 &&
+    chars[1] == ':' &&
+    (
+      (chars[0] >= 'A' && chars[0] <= 'Z') ||
+      (chars[0] >= 'a' && chars[0] <= 'z')
+    ) {
+    if separator(2) {
+      return Some(("\{chars[0]}:/", from(3)))
+    }
+    // Marked with a NUL, which cannot occur in a path, so the caller can tell
+    // the two drive forms apart.
+    return Some(("\{chars[0]}:\u{0000}", from(2)))
+  }
+  if separator(0) {
+    return Some(("/", from(1)))
+  }
+  None
+}
+
+///|
+/// Split on separators, leaving escapes intact for the segment parser.
+///
+/// `/` separates on both platforms. A backslash separates on Windows, where it
+/// is the native separator, and escapes on Unix, where it is not. An escaped
+/// separator is still a separator: a shell resolves `a\/b` as the path `a/b`,
+/// because the escape is gone by the time the name is looked up.
+fn split_path(path : String, windows~ : Bool, escapes~ : Bool) -> Array[String] {
+  let chars = collect_chars(path)
+  let segments = []
+  let current = StringBuilder()
+  let mut index = 0
+  while index < chars.length() {
+    let char = chars[index]
+    if char == '\\' && windows {
+      segments.push(current.to_string())
+      current.reset()
+      index = index + 1
+    } else if char == '\\' && escapes && index + 1 < chars.length() {
+      if chars[index + 1] == '/' {
+        segments.push(current.to_string())
+        current.reset()
+      } else {
+        // Keep the escape so the segment parser can resolve it.
+        current.write_char('\\')
+        current.write_char(chars[index + 1])
+      }
+      index = index + 2
+    } else if char == '/' {
+      segments.push(current.to_string())
+      current.reset()
+      index = index + 1
+    } else {
+      current.write_char(char)
+      index = index + 1
+    }
+  }
+  segments.push(current.to_string())
+  segments
+}
+
+///|
+/// Whether a directory entry is hidden from `*` and `**`.
+fn is_hidden(name : String) -> Bool {
+  name.has_prefix(".")
+}
+
+///|
+/// Match one path segment, where `*` and `?` cannot cross a `/`.
+fn match_segment(pattern : String, name : String) -> Bool {
+  let items = parse_segment(pattern)
+  // A leading `.` is only ever matched literally, so `*` skips hidden entries.
+  if is_hidden(name) && !(items is [Literal('.'), ..]) {
+    return false
+  }
+  match_items(items, collect_chars(name))
+}
+
+///|
+fn collect_chars(text : String) -> Array[Char] {
+  let chars = []
+  for char in text {
+    chars.push(char)
+  }
+  chars
+}
+
+///|
+/// Parse one segment into its elements, resolving escapes and classes once.
+fn parse_segment(pattern : String) -> Array[Item] {
+  let chars = collect_chars(pattern)
+  let items = []
+  let mut index = 0
+  while index < chars.length() {
+    match chars[index] {
+      '\\' =>
+        if index + 1 < chars.length() {
+          items.push(Literal(chars[index + 1]))
+          index = index + 2
+        } else {
+          // A trailing backslash is itself.
+          items.push(Literal('\\'))
+          index = index + 1
+        }
+      '?' => {
+        items.push(Any)
+        index = index + 1
+      }
+      '*' => {
+        // Collapse runs, so `***` costs no more than `*`.
+        if !(items is [.., Star]) {
+          items.push(Star)
+        }
+        index = index + 1
+      }
+      '[' =>
+        match parse_class(chars, index + 1) {
+          Some((members, negated, next)) => {
+            items.push(Class(members, negated))
+            index = next
+          }
+          // An unterminated `[` is a literal, as a shell treats it.
+          None => {
+            items.push(Literal('['))
+            index = index + 1
+          }
+        }
+      char => {
+        items.push(Literal(char))
+        index = index + 1
+      }
+    }
+  }
+  items
+}
+
+///|
+/// Read a `[...]` class starting just past the `[`, returning its members,
+/// whether it is negated, and the index after the closing `]`.
+fn parse_class(
+  chars : Array[Char],
+  start : Int,
+) -> (Array[(Char, Char)], Bool, Int)? {
+  let mut index = start
+  let negated = index < chars.length() &&
+    (chars[index] == '!' || chars[index] == '^')
+  if negated {
+    index = index + 1
+  }
+  let members = []
+  // A `]` in the first position is a literal member, not the terminator.
+  if index < chars.length() && chars[index] == ']' {
+    members.push((']', ']'))
+    index = index + 1
+  }
+  while index < chars.length() {
+    if chars[index] == ']' {
+      return Some((members, negated, index + 1))
+    }
+    // A backslash inside a class makes the next character a plain member, so
+    // `[a\-c]` is the three characters and not the range `a` to `c`.
+    let (low, after_low) = if chars[index] == '\\' && index + 1 < chars.length() {
+      (chars[index + 1], index + 2)
+    } else {
+      (chars[index], index + 1)
+    }
+    // Only an escaped `-` is prevented from forming a range; escaping an
+    // endpoint, as in `[\a-c]`, leaves the range intact, as a shell has it.
+    if after_low + 1 < chars.length() &&
+      chars[after_low] == '-' &&
+      chars[after_low + 1] != ']' {
+      let (high, after_high) = if chars[after_low + 1] == '\\' &&
+        after_low + 2 < chars.length() {
+        (chars[after_low + 2], after_low + 3)
+      } else {
+        (chars[after_low + 1], after_low + 2)
+      }
+      // A reversed range such as `[z-a]` matches nothing, as in a shell.
+      if low <= high {
+        members.push((low, high))
+      }
+      index = after_high
+    } else {
+      members.push((low, low))
+      index = after_low
+    }
+  }
+  None
+}
+
+///|
+/// Match a parsed segment against a name.
+///
+/// Iterative with one backtrack point, so `*a*a*…` against a long name stays
+/// quadratic in the worst case rather than exponential, and nothing recurses.
+fn match_items(items : Array[Item], name : Array[Char]) -> Bool {
+  let mut item_index = 0
+  let mut name_index = 0
+  let mut star = -1
+  let mut retry_at = 0
+  while name_index < name.length() {
+    if item_index < items.length() &&
+      item_matches(items[item_index], name[name_index]) {
+      item_index = item_index + 1
+      name_index = name_index + 1
+    } else if item_index < items.length() && items[item_index] is Star {
+      star = item_index
+      retry_at = name_index
+      item_index = item_index + 1
+    } else if star >= 0 {
+      retry_at = retry_at + 1
+      name_index = retry_at
+      item_index = star + 1
+    } else {
+      return false
+    }
+  }
+  while item_index < items.length() && items[item_index] is Star {
+    item_index = item_index + 1
+  }
+  item_index >= items.length()
+}
+
+///|
+fn item_matches(item : Item, candidate : Char) -> Bool {
+  match item {
+    Literal(char) => same_char(char, candidate)
+    Any => true
+    Star => false
+    // Negation applies once, to the answer: folding case around it would make
+    // `[!a-z]` match every letter, since one casing is always outside a range.
+    Class(members, negated) => in_members(members, candidate) != negated
+  }
+}
+
+///|
+/// Whether two characters are the same name character.
+///
+/// Windows filesystems do not distinguish case, so neither does matching there.
+/// Only ASCII is folded: the rest of Unicode needs real case folding, which
+/// this does not attempt.
+fn same_char(left : Char, right : Char) -> Bool {
+  left == right || (native_windows && flip_case(left) == right)
+}
+
+///|
+fn in_members(members : Array[(Char, Char)], candidate : Char) -> Bool {
+  if in_ranges(members, candidate) {
+    return true
+  }
+  if native_windows {
+    let flipped = flip_case(candidate)
+    if flipped != candidate && in_ranges(members, flipped) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn in_ranges(members : Array[(Char, Char)], candidate : Char) -> Bool {
+  for range in members {
+    if candidate >= range.0 && candidate <= range.1 {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Expand a glob pattern against the filesystem.
+///
+/// Returns the paths that exist and match, in code-unit order and without
+/// duplicates, spelled from the same root the pattern used: relative to `cwd`
+/// for a relative pattern, and from `/`, a drive, or a share for a rooted one.
+/// Redundant separators collapse, and a trailing separator is kept and
+/// restricts the result to directories, as a shell does. A pattern that matches
+/// nothing returns an empty array rather than the pattern itself, which is the
+/// one place this deliberately differs from a shell.
+///
+/// Hidden entries are reached only by a pattern with a literal leading `.`, and
+/// `.` and `..` are never produced by a wildcard — though a pattern may name
+/// them, so `../*` reaches the parent. Confining an expansion to a subtree is
+/// the sandbox policy's job, not this function's. A pattern or `cwd`
+/// containing an embedded NUL raises, exactly as `Cmd` rejects one in process
+/// metadata: no filename can contain it, and a C-string filesystem API would
+/// otherwise see a truncated path.
+///
+/// Symbolic links to directories are not descended by `**`, which is what keeps
+/// a link pointing at an ancestor from looping forever; a component named
+/// explicitly resolves links normally. A directory that cannot be read is
+/// skipped rather than failing the whole expansion — but cancellation is never
+/// mistaken for an unreadable directory, so a cancelled expansion stops instead
+/// of returning a partial result as though it were complete.
+///
+/// The pattern language is the one a shell uses for filenames, and nothing
+/// else: `*` matches any run of characters within one path segment, `?`
+/// matches one such character, `[abc]` and `[a-z]` match a character from a
+/// set, `[!abc]` and `[^abc]` match one outside it, and `**` as a whole
+/// segment matches any number of segments including none. Everything else is
+/// literal already. On Unix a backslash makes the next character literal; on
+/// Windows it is the path separator instead, and matching folds case the way
+/// the filesystem does — ASCII only, as full Unicode case folding is
+/// deliberately out of scope.
+///
+/// # Example
+/// ```mbt check
+/// async test {
+///   let sources = @shell.glob("*.mbt", cwd="src/shell")
+///   assert_true(sources.contains("glob.mbt"))
+///   assert_true(sources.contains("execute.mbt"))
+/// }
+/// ```
+pub async fn glob(pattern : String, cwd? : String = ".") -> Array[String] {
+  // No filename can contain a NUL, and a C-string filesystem API would see a
+  // truncated path — matching something the caller did not spell. Reject it
+  // up front, exactly as `Cmd` does for process metadata.
+  if pattern.contains("\u{0000}") {
+    raise ShellError::NulByte("glob pattern")
+  }
+  if cwd.contains("\u{0000}") {
+    raise ShellError::NulByte("glob working directory")
+  }
+  let (root, segments, directories_only) = parse_path(
+    pattern,
+    windows=native_windows,
+    escapes=!native_windows,
+  )
+  // A drive-relative root attaches its first name directly: `C:` and `x`
+  // together are `C:x`, which is not the same place as `C:/x`.
+  let (base, prefix, drive_relative) = match root {
+    Rooted(root) => (root, root, false)
+    DriveRelative(root) => (root, root, true)
+    Relative => (cwd, "", false)
+    // Nothing is under a root that was never finished.
+    Incomplete => return []
+  }
+  let found = []
+  let seen = Map([])
+  let visited = Map([])
+  expand(
+    base, prefix, segments, 0, directories_only, drive_relative, found, seen, visited,
+  )
+  checkpoint()
+  found.sort_by(compare_code_units)
+  found
+}
+
+///|
+/// Compare two strings by code unit, then by length.
+///
+/// `Array::sort` on strings orders by length first, which would list
+/// "plain.txt" before "od d*name.txt". A shell does not.
+fn compare_code_units(left : String, right : String) -> Int {
+  let shared = if left.length() < right.length() {
+    left.length()
+  } else {
+    right.length()
+  }
+  for index in 0..<shared {
+    if left[index] != right[index] {
+      return if left[index] < right[index] { -1 } else { 1 }
+    }
+  }
+  left.length() - right.length()
+}
+
+///|
+/// Walk one pattern segment at a time, reading only the directories a segment
+/// actually requires.
+///
+/// `base` is where to look on disk and `prefix` is how to spell what is found.
+/// They differ whenever `cwd` is not the process's own directory, so every
+/// filesystem call uses `base` and every recorded result `prefix`.
+async fn expand(
+  base : String,
+  prefix : String,
+  segments : Array[String],
+  index : Int,
+  directories_only : Bool,
+  attach_directly : Bool,
+  found : Array[String],
+  seen : Map[String, Unit],
+  visited : Map[String, Unit],
+) -> Unit {
+  // Cancellation has to stop the walk rather than be read as one more
+  // unreadable directory. Checking the flag is not enough on its own, because
+  // a filesystem call can also return normally while the run is cancelled.
+  checkpoint()
+  // Two `**` in one pattern can reach the same directory at the same point in
+  // the pattern by many different routes. Without this, `**/**/x` on a deep
+  // tree explores every way of splitting the path between the globstars, which
+  // is combinatorial even when nothing matches. A state is a place in the tree
+  // paired with a place in the pattern; visiting one twice can only repeat work.
+  let state = "\{index}\u{0000}\{base}"
+  if visited.contains(state) {
+    return
+  }
+  visited[state] = ()
+  if index >= segments.length() {
+    if !prefix.is_empty() &&
+      !seen.contains(prefix) &&
+      entry_exists(base) &&
+      (!directories_only || is_directory(base)) {
+      seen[prefix] = ()
+      found.push(if directories_only { prefix + "/" } else { prefix })
+    }
+    return
+  }
+  let segment = segments[index]
+  if segment == "**" {
+    // `**` matches no segments at all, then every visible entry in turn.
+    expand(
+      base,
+      prefix,
+      segments,
+      index + 1,
+      directories_only,
+      attach_directly,
+      found,
+      seen,
+      visited,
+    )
+    for entry in read_directory(base) {
+      // A large flat directory is a long stretch of pure computation, so the
+      // check belongs in the loop and not only between states.
+      checkpoint()
+      if !is_hidden(entry) {
+        let child_base = attach(base, entry, attach_directly)
+        let child_prefix = attach(prefix, entry, attach_directly)
+        if is_real_directory(child_base) {
+          expand(
+            child_base, child_prefix, segments, index, directories_only, false, found,
+            seen, visited,
+          )
+        } else if index + 1 == segments.length() {
+          // A trailing `**` may also end on something that is not a directory,
+          // so it yields ordinary files too.
+          expand(
+            child_base,
+            child_prefix,
+            segments,
+            index + 1,
+            directories_only,
+            false,
+            found,
+            seen,
+            visited,
+          )
+        }
+      }
+    }
+  } else if is_literal_segment(segment) {
+    // Nothing to search: descend directly and let the final check decide.
+    let literal = unescape(segment)
+    let child = attach(base, literal, attach_directly)
+    if index + 1 == segments.length() || is_directory(child) {
+      expand(
+        child,
+        attach(prefix, literal, attach_directly),
+        segments,
+        index + 1,
+        directories_only,
+        false,
+        found,
+        seen,
+        visited,
+      )
+    }
+  } else {
+    for entry in read_directory(base) {
+      checkpoint()
+      if match_segment(segment, entry) {
+        let child = attach(base, entry, attach_directly)
+        if index + 1 == segments.length() || is_directory(child) {
+          expand(
+            child,
+            attach(prefix, entry, attach_directly),
+            segments,
+            index + 1,
+            directories_only,
+            false,
+            found,
+            seen,
+            visited,
+          )
+        }
+      }
+    }
+  }
+}
+
+///|
+/// Stop the walk if the run has been cancelled.
+///
+/// `pause` is a suspension point, so a cancelled coroutine raises there rather
+/// than returning. That is how cancellation is surfaced without naming the
+/// runtime's private error type.
+async fn checkpoint() -> Unit {
+  if @async.is_being_cancelled() {
+    @async.pause()
+  }
+}
+
+///|
+/// Join a name onto a path, or attach it directly for a drive-relative root.
+fn attach(prefix : String, entry : String, directly : Bool) -> String {
+  if directly {
+    prefix + entry
+  } else {
+    join(prefix, entry)
+  }
+}
+
+///|
+fn join(prefix : String, entry : String) -> String {
+  if prefix.is_empty() || prefix.has_suffix("/") {
+    prefix + entry
+  } else {
+    prefix + "/" + entry
+  }
+}
+
+///|
+/// Whether a segment has no metacharacters, so it needs no directory listing.
+fn is_literal_segment(segment : String) -> Bool {
+  for item in parse_segment(segment) {
+    if !(item is Literal(_)) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// Resolve a literal segment's escapes to the name it actually denotes.
+fn unescape(segment : String) -> String {
+  let text = StringBuilder()
+  for item in parse_segment(segment) {
+    if item is Literal(char) {
+      text.write_char(char)
+    }
+  }
+  text.to_string()
+}
+
+///|
+/// List a directory, treating one that cannot be read as empty.
+///
+/// `.` and `..` are not produced: a wildcard should match names, not the two
+/// entries every directory has. A pattern may still name them.
+async fn read_directory(path : String) -> Array[String] {
+  @fs.readdir(path, include_hidden=true) catch {
+    // A cancelled walk must stop, not report an empty directory and carry on
+    // as though the expansion had completed.
+    error => if @async.is_cancellation_error(error) { raise error } else { [] }
+  }
+}
+
+///|
+/// Whether a directory entry exists, without resolving a symbolic link.
+///
+/// A glob matches the entry a directory holds, so a dangling link still
+/// matches, and a link pointing at itself must not raise `ELOOP` here.
+async fn entry_exists(path : String) -> Bool {
+  (@fs.kind(path, follow_symlink=false) catch {
+    error =>
+      if @async.is_cancellation_error(error) {
+        raise error
+      } else {
+        return false
+      }
+  })
+  is _
+}
+
+///|
+/// Whether the path is a directory and not a symbolic link to one.
+///
+/// Only `**` uses this. Declining to descend links is what stops a link
+/// pointing at an ancestor from making a recursive walk run forever, and it is
+/// what a shell's globstar does.
+async fn is_real_directory(path : String) -> Bool {
+  (@fs.kind(path, follow_symlink=false) catch {
+    error =>
+      if @async.is_cancellation_error(error) {
+        raise error
+      } else {
+        return false
+      }
+  })
+  is Directory
+}
+
+///|
+/// Whether the path is a directory, resolving a symbolic link to one.
+///
+/// This is what an explicitly named or wildcard-matched component uses: naming
+/// `/var/log/*` has to work where `/var` is a link, exactly as it does in a
+/// shell.
+async fn is_directory(path : String) -> Bool {
+  (@fs.kind(path) catch {
+    error =>
+      if @async.is_cancellation_error(error) {
+        raise error
+      } else {
+        return false
+      }
+  })
+  is Directory
+}
+
+///|
+/// Swap the case of an ASCII letter, leaving everything else alone.
+fn flip_case(candidate : Char) -> Char {
+  if candidate >= 'a' && candidate <= 'z' {
+    (candidate.to_int() - 32).unsafe_to_char()
+  } else if candidate >= 'A' && candidate <= 'Z' {
+    (candidate.to_int() + 32).unsafe_to_char()
+  } else {
+    candidate
+  }
+}

--- a/src/shell/glob_test.mbt
+++ b/src/shell/glob_test.mbt
@@ -1,0 +1,216 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Read from the runtime, not the build: glob's platform behaviour is a
+/// runtime question, because a `wasm` binary runs unchanged on every host.
+fn not_windows() -> Bool {
+  !(@env_util.platform is Windows)
+}
+
+///|
+/// Build a tree of real files and real directories under `root`.
+///
+/// Note the shape: creating `a.mbt` as a directory by accident would let a
+/// later existence check pass, so files are created as files and only their
+/// parents as directories.
+async fn make_tree(root : String, files : Array[String]) -> Unit {
+  for file in files {
+    if file.rev_find("/") is Some(index) {
+      let directory = "\{root}/\{file[:index].to_owned()}"
+      if !@fs.exists(directory) {
+        @fs.mkdir(directory, recursive=true)
+      }
+    }
+    @fs.write_file("\{root}/\{file}", b"")
+  }
+}
+
+///|
+async test "expansion finds what is on disk and nothing else" {
+  let root = @fs.tmpdir(prefix="shell-glob")
+  make_tree(root, [
+    "a.mbt", "b.mbt", "c.txt", ".hidden.mbt", "src/d.mbt", "src/e.txt", "src/deep/f.mbt",
+  ])
+  // One segment, and hidden entries stay hidden.
+  assert_eq(@shell.glob("*.mbt", cwd=root), ["a.mbt", "b.mbt"])
+  assert_eq(@shell.glob(".*.mbt", cwd=root), [".hidden.mbt"])
+  // A literal segment needs no search.
+  assert_eq(@shell.glob("src/d.mbt", cwd=root), ["src/d.mbt"])
+  assert_eq(@shell.glob("src/*.txt", cwd=root), ["src/e.txt"])
+  // `**` spans any number of directories, including none.
+  assert_eq(@shell.glob("**/*.mbt", cwd=root), [
+    "a.mbt", "b.mbt", "src/d.mbt", "src/deep/f.mbt",
+  ])
+  // A terminal `**` yields files as well as directories, and never repeats a
+  // path even when two globstars could both reach it.
+  assert_eq(@shell.glob("**", cwd=root), [
+    "a.mbt", "b.mbt", "c.txt", "src", "src/d.mbt", "src/deep", "src/deep/f.mbt",
+    "src/e.txt",
+  ])
+  assert_eq(@shell.glob("**/**/f.mbt", cwd=root), ["src/deep/f.mbt"])
+  // A trailing slash asks for directories only, and is kept.
+  assert_eq(@shell.glob("*/", cwd=root), ["src/"])
+  // Nothing matched is an empty result, not the pattern.
+  assert_eq(@shell.glob("*.rs", cwd=root), [])
+  assert_eq(@shell.glob("nope/*.mbt", cwd=root), [])
+  // An absolute pattern is spelled from its own root. The result uses `/`
+  // between segments on both platforms, so normalise the fixture root for
+  // the comparison.
+  let spelled_root = root.replace_all(old="\\", new="/")
+  assert_eq(@shell.glob("\{spelled_root}/*.txt"), ["\{spelled_root}/c.txt"])
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "matches come back in code-unit order, not by length" {
+  let root = @fs.tmpdir(prefix="shell-glob-order")
+  // No case differences here: macOS is case-insensitive by default, so
+  // "B.txt" and "b.txt" would be one file there and two on Linux.
+  make_tree(root, ["b.txt", "ab.txt", "aaa.txt"])
+  // `Array::sort` on strings orders by length first, which would have put
+  // "b.txt" first. A shell does not, and neither does this.
+  assert_eq(@shell.glob("*.txt", cwd=root), ["aaa.txt", "ab.txt", "b.txt"])
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "a name with spaces expands as one literal path" {
+  let root = @fs.tmpdir(prefix="shell-glob-space")
+  make_tree(root, ["od d.txt", "plain.txt"])
+  assert_eq(@shell.glob("*.txt", cwd=root), ["od d.txt", "plain.txt"])
+  assert_eq(@shell.glob("od *", cwd=root), ["od d.txt"])
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "adjacent globstars do not explode on a deep tree" {
+  let root = @fs.tmpdir(prefix="shell-glob-deep")
+  // Twenty nested directories. Exploring every way of splitting this path
+  // between the globstars would be combinatorial; visiting each place in the
+  // tree once per place in the pattern is not.
+  let deep = "a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a"
+  make_tree(root, ["\{deep}/target.mbt"])
+  assert_eq(@shell.glob("**/**/**/**/target.mbt", cwd=root), [
+    "\{deep}/target.mbt",
+  ])
+  // The same pattern for a name that is not there has to finish too.
+  assert_eq(@shell.glob("**/**/**/**/missing.mbt", cwd=root), [])
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "a symlink loop does not trap the walker" {
+  // Symbolic links are a Unix fixture: creating one on Windows needs a
+  // privilege ordinary CI runners do not hold.
+  if not_windows() {
+    let root = @fs.tmpdir(prefix="shell-glob-loop")
+    make_tree(root, ["deep/inner/target.mbt"])
+    // A link pointing back at an ancestor: following it would never terminate.
+    @fs.symlink(target=root, "\{root}/deep/loop")
+    assert_eq(@shell.glob("**/*.mbt", cwd=root), ["deep/inner/target.mbt"])
+    @fs.rmdir(root, recursive=true)
+  }
+}
+
+///|
+async test "a dangling or self-referential link still matches" {
+  if not_windows() {
+    let root = @fs.tmpdir(prefix="shell-glob-link")
+    make_tree(root, ["real.txt"])
+    @fs.symlink(target="nowhere.txt", "\{root}/dangling.txt")
+    @fs.symlink(target="self.txt", "\{root}/self.txt")
+    // A glob matches the directory entry, so a link that resolves to nothing
+    // is still a match, and one that points at itself must not raise `ELOOP`.
+    assert_eq(@shell.glob("*.txt", cwd=root), [
+      "dangling.txt", "real.txt", "self.txt",
+    ])
+    @fs.rmdir(root, recursive=true)
+  }
+}
+
+///|
+async test "windows expansion is case-insensitive and accepts backslashes" {
+  if !not_windows() {
+    let root = @fs.tmpdir(prefix="shell-glob-win")
+    make_tree(root, ["c.txt", "src/d.mbt"])
+    // The filesystem does not distinguish case, so neither does matching.
+    assert_eq(@shell.glob("*.TXT", cwd=root), ["c.txt"])
+    // A backslash separates; the result is spelled with `/`, from the
+    // pattern's own spelling of each matched segment.
+    assert_eq(@shell.glob("src\\*.mbt", cwd=root), ["src/d.mbt"])
+    @fs.rmdir(root, recursive=true)
+  }
+}
+
+///|
+async test "a pattern of only separators is the root" {
+  if not_windows() {
+    assert_eq(@shell.glob("/"), ["/"])
+    assert_eq(@shell.glob("//"), ["/"])
+    assert_eq(@shell.glob("///"), ["/"])
+  } else {
+    // On Windows, `//` opens a share it never completes — `\\server\share`
+    // territory — so it names no directory and expands to nothing.
+    assert_eq(@shell.glob("//"), [])
+    assert_eq(@shell.glob("///"), [])
+  }
+}
+
+///|
+async test "an empty pattern matches nothing and is not the root" {
+  assert_eq(@shell.glob(""), [])
+  assert_eq(@shell.glob("", cwd="src"), [])
+}
+
+///|
+async test "an embedded NUL is rejected, not truncated" {
+  // A C-string filesystem API would see only "moon.mod" — a file that
+  // exists — and report a name the caller never spelled.
+  try @shell.glob("moon.mod\u{0000}.bak") |> ignore catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|NulByte("glob pattern")
+        ),
+      )
+  } noraise {
+    _ => fail("expected an embedded NUL to raise")
+  }
+  try @shell.glob("*", cwd="src\u{0000}decoy") |> ignore catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|NulByte("glob working directory")
+        ),
+      )
+  } noraise {
+    _ => fail("expected an embedded NUL to raise")
+  }
+}
+
+///|
+async test "an escaped leading separator is still absolute" {
+  // Escapes exist only where a backslash is not the path separator.
+  if not_windows() {
+    let root = @fs.tmpdir(prefix="shell-glob-abs")
+    make_tree(root, ["tmp/decoy.txt"])
+    // `\/tmp` denotes `/tmp`, so this must not search `<root>/tmp`.
+    assert_false(@shell.glob("\\/tmp/*", cwd=root).contains("tmp/decoy.txt"))
+    @fs.rmdir(root, recursive=true)
+  }
+}

--- a/src/shell/glob_wbtest.mbt
+++ b/src/shell/glob_wbtest.mbt
@@ -1,0 +1,459 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// White-box tests for the path parser.
+///
+/// The parser takes the platform as an argument rather than reading it from
+/// the build, so Windows syntax can be checked from a Unix machine — which is
+/// the only way this gets tested at all, since every filesystem test in the
+/// suite is skipped on Windows.
+fn parsed(
+  text : String,
+  windows~ : Bool,
+  escapes? : Bool = true,
+) -> (String, Array[String], Bool) {
+  let (root, segments, directories_only) = parse_path(text, windows~, escapes~)
+  let shown = match root {
+    Relative => ""
+    Rooted(root) => root
+    // Shown with a trailing marker so the two drive forms are visibly
+    // different in these expectations.
+    DriveRelative(root) => root + "|drive-relative"
+    Incomplete => "|incomplete"
+  }
+  (shown, segments, directories_only)
+}
+
+///|
+test "unix paths" {
+  debug_inspect(
+    parsed("a/b.mbt", windows=false),
+    content=(
+      #|("", ["a", "b.mbt"], false)
+    ),
+  )
+  debug_inspect(
+    parsed("/a/b.mbt", windows=false),
+    content=(
+      #|("/", ["a", "b.mbt"], false)
+    ),
+  )
+  // Redundant separators collapse; a trailing one asks for directories.
+  debug_inspect(
+    parsed("a//b", windows=false),
+    content=(
+      #|("", ["a", "b"], false)
+    ),
+  )
+  debug_inspect(
+    parsed("a/b/", windows=false),
+    content=(
+      #|("", ["a", "b"], true)
+    ),
+  )
+  // A path that is only separators is its root, with nothing else asked for.
+  debug_inspect(
+    parsed("/", windows=false),
+    content=(
+      #|("/", [], false)
+    ),
+  )
+  debug_inspect(
+    parsed("//", windows=false),
+    content=(
+      #|("/", [], false)
+    ),
+  )
+  // An empty path is not the root.
+  debug_inspect(
+    parsed("", windows=false),
+    content=(
+      #|("", [], false)
+    ),
+  )
+  // On Unix a backslash escapes, and an escaped separator still separates.
+  debug_inspect(
+    parsed("a\\/b", windows=false),
+    content=(
+      #|("", ["a", "b"], false)
+    ),
+  )
+  debug_inspect(
+    parsed("\\/tmp/x", windows=false),
+    content=(
+      #|("/", ["tmp", "x"], false)
+    ),
+  )
+  debug_inspect(
+    parsed("a\\*b", windows=false),
+    content=(
+      #|("", ["a\\*b"], false)
+    ),
+  )
+  // A candidate name carries no pattern syntax: its backslash is a character.
+  debug_inspect(
+    parsed("a\\b", windows=false, escapes=false),
+    content=(
+      #|("", ["a\\b"], false)
+    ),
+  )
+}
+
+///|
+test "windows paths" {
+  // A drive is a root, whichever separator follows it.
+  debug_inspect(
+    parsed("C:/Windows/*", windows=true),
+    content=(
+      #|("C:/", ["Windows", "*"], false)
+    ),
+  )
+  debug_inspect(
+    parsed("C:\\Windows\\*", windows=true),
+    content=(
+      #|("C:/", ["Windows", "*"], false)
+    ),
+  )
+  debug_inspect(
+    parsed("c:/x", windows=true),
+    content=(
+      #|("c:/", ["x"], false)
+    ),
+  )
+  // A bare drive is relative to that drive's own working directory.
+  debug_inspect(
+    parsed("C:x/y", windows=true),
+    content=(
+      #|("C:|drive-relative", ["x", "y"], false)
+    ),
+  )
+  // A share is part of the root, not a pair of segments.
+  debug_inspect(
+    parsed("\\\\server\\share\\dir\\*", windows=true),
+    content=(
+      #|("//server/share/", ["dir", "*"], false)
+    ),
+  )
+  // Redundant separators collapse inside the root as well: this is the same
+  // share, not an empty share name.
+  debug_inspect(
+    parsed("\\\\server\\\\share\\dir", windows=true),
+    content=(
+      #|("//server/share/", ["dir"], false)
+    ),
+  )
+  debug_inspect(
+    parsed("//server/share/dir", windows=true),
+    content=(
+      #|("//server/share/", ["dir"], false)
+    ),
+  )
+  // A bare separator is rooted on the current drive.
+  debug_inspect(
+    parsed("\\Windows", windows=true),
+    content=(
+      #|("/", ["Windows"], false)
+    ),
+  )
+  // Relative paths still work, and a backslash is a separator rather than an
+  // escape, so it cannot smuggle a metacharacter through as a literal.
+  debug_inspect(
+    parsed("src\\*.mbt", windows=true),
+    content=(
+      #|("", ["src", "*.mbt"], false)
+    ),
+  )
+  debug_inspect(
+    parsed("a\\b\\", windows=true),
+    content=(
+      #|("", ["a", "b"], true)
+    ),
+  )
+}
+
+///|
+test "incomplete windows roots are not roots" {
+  // A share needs a server and a share name. Half of one names nowhere, and
+  // must not fall through to the current drive's root as `/server`.
+  debug_inspect(
+    parsed("\\\\server", windows=true),
+    content=(
+      #|("|incomplete", [], false)
+    ),
+  )
+  debug_inspect(
+    parsed("\\\\server\\", windows=true),
+    content=(
+      #|("|incomplete", [], false)
+    ),
+  )
+  // A drive letter is one letter followed by a colon, nothing else.
+  debug_inspect(
+    parsed("ab:/x", windows=true),
+    content=(
+      #|("", ["ab:", "x"], false)
+    ),
+  )
+}
+
+///|
+/// Match a pattern's segments against a name's segments.
+///
+/// `**` is the only segment that can consume more than one, so it is the only
+/// place alternatives arise. This walks them with a single backtrack point
+/// rather than recursing, so a pattern with many `**` cannot blow up: each
+/// mismatch resumes from the most recent `**` and advances it by one segment.
+fn match_segments(pattern : Array[String], name : Array[String]) -> Bool {
+  let mut pattern_index = 0
+  let mut name_index = 0
+  let mut star = -1
+  let mut retry_at = 0
+  for ;; {
+    if name_index < name.length() &&
+      pattern_index < pattern.length() &&
+      pattern[pattern_index] != "**" &&
+      match_segment(pattern[pattern_index], name[name_index]) {
+      pattern_index = pattern_index + 1
+      name_index = name_index + 1
+    } else if pattern_index < pattern.length() && pattern[pattern_index] == "**" {
+      star = pattern_index
+      retry_at = name_index
+      pattern_index = pattern_index + 1
+    } else if star >= 0 &&
+      retry_at < name.length() &&
+      // `**` never reaches a hidden segment either.
+      !is_hidden(name[retry_at]) {
+      retry_at = retry_at + 1
+      name_index = retry_at
+      pattern_index = star + 1
+    } else {
+      break
+    }
+    if name_index >= name.length() && pattern_index >= pattern.length() {
+      return true
+    }
+  }
+  // Trailing `**` may match nothing at all.
+  while pattern_index < pattern.length() && pattern[pattern_index] == "**" {
+    pattern_index = pattern_index + 1
+  }
+  pattern_index >= pattern.length() && name_index >= name.length()
+}
+
+///|
+/// Whether two roots name the same place.
+///
+/// Windows does not distinguish the case of a drive letter or a share name,
+/// so `C:/` and `c:/` are one root there. An incomplete root, such as
+/// `\\server` with no share, names no place at all, so it is the same as
+/// nothing — not even another incomplete root.
+fn same_root(left : Root, right : Root) -> Bool {
+  match (left, right) {
+    (Relative, Relative) => true
+    (Incomplete, _) | (_, Incomplete) => false
+    (Rooted(left), Rooted(right))
+    | (DriveRelative(left), DriveRelative(right)) =>
+      if native_windows {
+        // Compared code unit by code unit: only ASCII case is folded, and a
+        // surrogate half compares exactly, so a share name containing a
+        // non-BMP character is ordinary data rather than a crash.
+        left.length() == right.length() &&
+        (for index in 0..<left.length() {
+          if !same_code_unit(left[index], right[index]) {
+            break false
+          }
+        } nobreak {
+          true
+        })
+      } else {
+        left == right
+      }
+    _ => false
+  }
+}
+
+///|
+/// Whether two UTF-16 code units are the same root character, folding only
+/// ASCII case.
+fn same_code_unit(left : UInt16, right : UInt16) -> Bool {
+  left == right || flip_case_unit(left) == right
+}
+
+///|
+/// Swap the case of an ASCII letter code unit, leaving everything else alone.
+fn flip_case_unit(unit : UInt16) -> UInt16 {
+  let code = unit.to_int()
+  if code >= 'a' && code <= 'z' {
+    (code - 32).to_uint16()
+  } else if code >= 'A' && code <= 'Z' {
+    (code + 32).to_uint16()
+  } else {
+    unit
+  }
+}
+
+///|
+/// Whether `name` matches the glob `pattern`, comparing strings only.
+///
+/// This is `glob`'s pattern language as a pure predicate, kept for the
+/// matcher's own tests. It is deliberately not public: for filtering names
+/// already in hand, the language's `str =~ regex` is the more general tool,
+/// and a filesystem-independent glob predicate would belong in a dedicated
+/// pattern package rather than a process one.
+fn glob_matches(pattern : String, name : String) -> Bool {
+  let (pattern_root, pattern_segments, pattern_directory) = parse_path(
+    pattern,
+    windows=native_windows,
+    escapes=!native_windows,
+  )
+  let (name_root, name_segments, name_directory) = parse_path(
+    name,
+    windows=native_windows,
+    escapes=false,
+  )
+  // A trailing separator is part of what a path says: `a/` asks for a
+  // directory and `a` does not, so the two do not match each other.
+  same_root(pattern_root, name_root) &&
+  pattern_directory == name_directory &&
+  match_segments(pattern_segments, name_segments)
+}
+
+///|
+test "the matcher is a shell's filename language and nothing more" {
+  // `*` and `?` stay inside one segment.
+  assert_true(glob_matches("*.mbt", "cmd.mbt"))
+  assert_false(glob_matches("*.mbt", "cmd.mbti"))
+  assert_false(glob_matches("*.mbt", "src/cmd.mbt"))
+  assert_true(glob_matches("src/*.mbt", "src/cmd.mbt"))
+  assert_true(glob_matches("c?d.mbt", "cmd.mbt"))
+  assert_false(glob_matches("c?d.mbt", "cd.mbt"))
+  assert_false(glob_matches("?", "/"))
+  // Character classes, ranges, and negation.
+  assert_true(glob_matches("[abc].mbt", "b.mbt"))
+  assert_false(glob_matches("[abc].mbt", "d.mbt"))
+  assert_true(glob_matches("[a-z]*.mbt", "cmd.mbt"))
+  // Windows filesystems do not distinguish case, so this only holds elsewhere.
+  if !native_windows {
+    assert_false(glob_matches("[a-z]*.mbt", "Cmd.mbt"))
+  }
+  assert_true(glob_matches("[!0-9]*", "cmd"))
+  assert_false(glob_matches("[!0-9]*", "9cmd"))
+  // A negated class must stay negated: folding case around the negation
+  // instead of inside it would let every letter through, on either platform.
+  assert_false(glob_matches("[!a-z]", "q"))
+  assert_true(glob_matches("[!a-z]", "4"))
+  // `Q` is outside `a-z` only where case is significant. Windows CI checks the
+  // other half of this.
+  assert_eq(glob_matches("[!a-z]", "Q"), !native_windows)
+  assert_true(glob_matches("[^0-9]*", "cmd"))
+  // A `]` first in the class is a member; an unclosed `[` is a literal; a
+  // reversed range matches nothing.
+  assert_true(glob_matches("[]a]", "]"))
+  assert_true(glob_matches("[abc", "[abc"))
+  assert_false(glob_matches("[z-a]", "b"))
+  // A backslash makes the next character literal — on Unix. On Windows it is
+  // the path separator, so `\*` is a rooted pattern there rather than an
+  // escaped one, and none of this applies.
+  if !native_windows {
+    assert_true(glob_matches("\\*", "*"))
+    assert_false(glob_matches("\\*", "anything"))
+    assert_true(glob_matches("a\\?c", "a?c"))
+    assert_false(glob_matches("a\\?c", "abc"))
+    assert_true(glob_matches("\\[abc]", "[abc]"))
+  } else {
+    // A backslash separates, so this names a root and one segment.
+    assert_true(glob_matches("\\*", "/anything"))
+    // An unfinished share prefix names no directory at all, so it matches
+    // nothing — not even itself.
+    assert_false(glob_matches("\\\\server", "\\\\server"))
+    assert_false(glob_matches("\\\\server", "\\\\other"))
+  }
+  // Everything else is literal, including shell operators.
+  assert_true(glob_matches("a b.mbt", "a b.mbt"))
+  assert_true(glob_matches("$(echo x)", "$(echo x)"))
+}
+
+///|
+test "globstar spans segments, including none, and skips hidden ones" {
+  assert_true(glob_matches("src/**/*.mbt", "src/cmd.mbt"))
+  assert_true(glob_matches("src/**/*.mbt", "src/a/b/cmd.mbt"))
+  assert_true(glob_matches("**", "a/b/c"))
+  assert_true(glob_matches("**", "file"))
+  assert_true(glob_matches("**/x", "x"))
+  assert_true(glob_matches("**/x", "a/b/x"))
+  assert_false(glob_matches("src/**/*.mbt", "other/cmd.mbt"))
+  // Adjacent globstars are not an error and do not change the meaning.
+  assert_true(glob_matches("**/**/x", "a/x"))
+  assert_true(glob_matches("**/**/x", "x"))
+  // Hidden segments are out of reach of `**`, as they are of `*`.
+  assert_false(glob_matches("**", ".git"))
+  assert_false(glob_matches("**/*.mbt", ".git/cmd.mbt"))
+  assert_true(glob_matches(".*/**", ".git/objects"))
+}
+
+///|
+test "a pathological pattern does not take exponential time" {
+  // The classic blow-up for a naive matcher: many stars separated by a
+  // character that keeps forcing it to try another split.
+  let pattern = "*a*a*a*a*a*a*a*a*a*a*a*a*b"
+  let name = "a".repeat(200)
+  assert_false(glob_matches(pattern, name))
+  assert_true(glob_matches(pattern, name + "b"))
+}
+
+///|
+test "escapes survive splitting and character classes" {
+  // Escapes are a Unix-only idea: a backslash separates on Windows, so there
+  // is nothing there to escape with.
+  if !native_windows {
+    // An escaped separator is still a separator, as a shell resolves it.
+    assert_true(glob_matches("cmd\\/smoke/main.mbt", "cmd/smoke/main.mbt"))
+    // Inside a class, a backslash makes the next character a plain member, so
+    // this is the three characters and not the range `a` to `c`.
+    assert_true(glob_matches("[a\\-c]", "-"))
+    assert_true(glob_matches("[a\\-c]", "a"))
+    assert_true(glob_matches("[a\\-c]", "c"))
+    assert_false(glob_matches("[a\\-c]", "b"))
+    assert_true(glob_matches("[\\]]", "]"))
+  }
+  // An unescaped range behaves as one everywhere.
+  assert_true(glob_matches("[a-c]", "b"))
+}
+
+///|
+test "a candidate is a path, not a pattern" {
+  if !native_windows {
+    // The backslash in the name is one of its characters, so this name has a
+    // single component called `dir\file` and does not match two components.
+    assert_false(glob_matches("dir/file", "dir\\/file"))
+    assert_true(glob_matches("dir\\/file", "dir/file"))
+    // Escaping an endpoint leaves the range intact; escaping the `-` does not.
+    assert_true(glob_matches("[\\a-c]", "b"))
+    assert_false(glob_matches("[a\\-c]", "b"))
+  } else {
+    // On Windows the backslash separates, so both spellings are the same path.
+    assert_true(glob_matches("dir/file", "dir\\file"))
+  }
+}
+
+///|
+test "a trailing separator is part of what a path says" {
+  // `a/` asks for a directory and `a` does not, so neither matches the other.
+  assert_false(glob_matches("*/", "file"))
+  assert_false(glob_matches("a", "a/"))
+  assert_true(glob_matches("*/", "dir/"))
+  assert_true(glob_matches("a/", "a/"))
+}

--- a/src/shell/lines_test.mbt
+++ b/src/shell/lines_test.mbt
@@ -1,0 +1,102 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// `each_line`'s framing rules are exercised by echoing a chosen payload
+/// through the `cat` test program, so every byte of the child's output is
+/// under the test's control on every platform.
+async fn lines_of(payload : String, max_line_bytes? : Int) -> Array[String] {
+  let seen = []
+  let code = @shell.Cmd(cat_prog.wait(), [], stdin=Text(payload)).each_line(
+    line => seen.push(line),
+    max_line_bytes?,
+  )
+  assert_eq(code, 0)
+  seen
+}
+
+///|
+async test "each_line delivers stdout incrementally, tail included" {
+  // The unterminated trailing fragment is still a line.
+  assert_eq(lines_of("alpha\nbeta\ngamma"), ["alpha", "beta", "gamma"])
+}
+
+///|
+async test "CRLF terminates a line; a lone trailing CR is data" {
+  // "a\r\n" and "b\r\n" are CRLF lines; the final "c\r" was never terminated,
+  // so its CR is content rather than punctuation.
+  assert_eq(lines_of("a\r\nb\r\nc\r"), ["a", "b", "c\r"])
+}
+
+///|
+async test "the line cap counts content, not terminators" {
+  // One byte of content under a one-byte cap: the CRLF is free.
+  assert_eq(lines_of("a\r\n", max_line_bytes=1), ["a"])
+  // A line exactly at the cap is allowed.
+  assert_eq(lines_of("aaaaaaaa\n", max_line_bytes=8), ["aaaaaaaa"])
+  // One byte over — terminated or not, delivered lines keep the promise.
+  try lines_of("ab\r\n", max_line_bytes=1) |> ignore catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|OutputLimitExceeded(stream="stdout line", limit=1)
+        ),
+      )
+  } noraise {
+    _ => fail("expected the line limit to raise")
+  }
+  // A child that never emits a newline cannot grow the held line unboundedly.
+  try lines_of("a".repeat(1000), max_line_bytes=64) |> ignore catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|OutputLimitExceeded(stream="stdout line", limit=64)
+        ),
+      )
+  } noraise {
+    _ => fail("expected the line limit to raise")
+  }
+}
+
+///|
+async test "streaming is unbounded where capture is bounded" {
+  // 2000 lines of 30 bytes: far over the 1 KiB capture limit used below, yet
+  // each_line holds only one line at a time, so it delivers everything.
+  let payload = "\{"a".repeat(29)}\n".repeat(2000)
+  let lines = Ref(0)
+  let bytes = Ref(0)
+  let code = @shell.Cmd(cat_prog.wait(), [], stdin=Text(payload)).each_line(line => {
+    lines.val += 1
+    bytes.val += line.length()
+  })
+  inspect(code, content="0")
+  inspect(lines.val, content="2000")
+  inspect(bytes.val, content="58000")
+  try
+    @shell.Cmd(cat_prog.wait(), [], stdin=Text(payload)).output(
+      max_output_bytes=1024,
+    )
+  catch {
+    err => {
+      let diagnostic = "\{Repr(err)}"
+      assert_true(diagnostic.contains("OutputLimitExceeded"))
+      assert_true(diagnostic.contains("limit=1024"))
+    }
+  } noraise {
+    _ => fail("expected the output limit to raise")
+  }
+}

--- a/src/shell/moon.pkg
+++ b/src/shell/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/async",
   "moonbitlang/async/process",
+  "moonbitlang/async/fs",
   "moonbitlang/async/stdio",
   "moonbitlang/async/internal/env_util",
   "moonbitlang/core/buffer",
@@ -11,6 +12,7 @@ import {
 import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/async/internal/env_util",
   "moonbitlang/core/env",
   "moonbitlang/async/internal/test_util",
 } for "test"

--- a/src/shell/moon.pkg
+++ b/src/shell/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "moonbitlang/core/debug",
+}
+
+supported_targets = "native+wasm"
+
+options(
+  "max-concurrent-tests": 5,
+)

--- a/src/shell/moon.pkg
+++ b/src/shell/moon.pkg
@@ -1,6 +1,19 @@
 import {
+  "moonbitlang/async",
+  "moonbitlang/async/process",
+  "moonbitlang/async/stdio",
+  "moonbitlang/async/internal/env_util",
+  "moonbitlang/core/buffer",
   "moonbitlang/core/debug",
+  "moonbitlang/core/encoding/utf8",
 }
+
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/env",
+  "moonbitlang/async/internal/test_util",
+} for "test"
 
 supported_targets = "native+wasm"
 

--- a/src/shell/moonx_test.mbt
+++ b/src/shell/moonx_test.mbt
@@ -1,0 +1,35 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A published portable utility, run through `moonx`, joins a pipeline like
+/// any other program. `bobzhang/jq` is itself a MoonBit program, so the same
+/// stage runs on every platform — the test needs no host `jq`, `sed`, or
+/// `awk` — and the version is pinned so the run is reproducible. The first
+/// use fetches and builds the package; `moonx` caches it after that, so the
+/// generous timeout only covers a cold cache. The timeout stays well inside
+/// the CI job's own ten-minute budget, so a hung registry fails this test
+/// rather than the whole job.
+async test "a published tool runs as a pipeline stage via moonx" {
+  let record =
+    #|{"tool":"moonbit","tags":["async","shell"]}
+  let output = @shell.Pipeline([
+    Cmd(cat_prog.wait(), [], stdin=Text(record)),
+    Cmd("moonx", ["bobzhang/jq@0.1.1", "-r", ".tags[1]"]),
+  ]).output(timeout_ms=300_000)
+  inspect(output.stderr(), content="")
+  inspect(output.exit_code(), content="0")
+  inspect(output.stdout().replace_all(old="\r\n", new="\n"), content="shell\n")
+}

--- a/src/shell/output.mbt
+++ b/src/shell/output.mbt
@@ -1,0 +1,96 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// Captured output and exit status from a command or pipeline.
+///
+/// The representation is abstract; readers use the accessor methods. Text is
+/// decoded as lossy UTF-8 so arbitrary process output cannot cancel a run;
+/// `stdout_bytes` keeps standard output byte for byte.
+struct Output {
+  exit_code : Int
+  stdout : String
+  stdout_bytes : Bytes
+  stderr : String
+} derive(Debug)
+
+///|
+/// The exit status: for a pipeline, the rightmost non-zero stage status, or
+/// zero when every stage succeeded (pipefail).
+pub fn Output::exit_code(self : Output) -> Int {
+  self.exit_code
+}
+
+///|
+/// Captured standard output of the final stage, decoded as lossy UTF-8.
+pub fn Output::stdout(self : Output) -> String {
+  self.stdout
+}
+
+///|
+/// Captured standard output of the final stage, byte for byte.
+pub fn Output::stdout_bytes(self : Output) -> Bytes {
+  self.stdout_bytes
+}
+
+///|
+/// Every stage's captured standard error, concatenated in stage order and
+/// decoded as lossy UTF-8.
+pub fn Output::stderr(self : Output) -> String {
+  self.stderr
+}
+
+///|
+/// Raise when the command or pipeline did not succeed.
+///
+/// This does not execute anything: `output` has already waited for every
+/// process. It only checks `exit_code`.
+///
+/// # Example
+/// ```mbt check
+/// async test {
+///   let output = @shell.Cmd("moonx", ["bobzhang/false@0.1.0"]).output()
+///   inspect(output.exit_code(), content="1")
+///   try output.check() catch {
+///     _ => ()
+///   } noraise {
+///     _ => fail("expected a non-zero exit to raise")
+///   }
+/// }
+/// ```
+pub fn Output::check(self : Output) -> Unit raise {
+  if self.exit_code != 0 {
+    raise CommandFailed(self)
+  }
+}
+
+///|
+/// Errors reported internally by the process EDSL.
+///
+/// Callers choose between checked operations (`run` and `check`) and explicit
+/// status inspection (`status` and `exit_code`) rather than depending on these
+/// implementation-level categories.
+priv suberror ShellError {
+  EmptyProgram
+  EmptyPipeline
+  InvalidEnvironmentName(String)
+  InvalidOutputLimit(Int)
+  OutputLimitExceeded(stream~ : String, limit~ : Int)
+  NulByte(String)
+  StdinOnNonFirstStage(Int)
+  RedirectOnNonFinalStage(Int)
+  StdoutNotCaptured
+  CommandFailed(Output)
+} derive(Debug)

--- a/src/shell/pipeline.mbt
+++ b/src/shell/pipeline.mbt
@@ -1,0 +1,72 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A sequence of commands connected by operating-system pipes.
+///
+/// Every stage is separately visible to the process host, and an empty
+/// pipeline is rejected when execution is requested.
+struct Pipeline {
+  commands : Array[Cmd]
+} derive(Debug)
+
+///|
+/// Describe a pipeline whose stages are connected by real pipes.
+///
+/// Only the first stage may carry `stdin`; the rest read from the previous
+/// stage. `commands` is copied, so later changes to the caller's array do not
+/// reach the pipeline.
+///
+/// # Example
+/// ```mbt check
+/// test {
+///   let plan = @shell.Pipeline([
+///     Cmd("printf", ["alpha\nbeta\n"]),
+///     Cmd("grep", ["beta"]),
+///   ])
+///   debug_inspect(
+///     plan,
+///     content=(
+///       #|{
+///       #|  commands: [
+///       #|    {
+///       #|      program: "printf",
+///       #|      arguments: ["alpha\nbeta\n"],
+///       #|      cwd: None,
+///       #|      env: {},
+///       #|      inherit_env: true,
+///       #|      stdin: None,
+///       #|      stdout: Capture,
+///       #|      stderr: Capture,
+///       #|    },
+///       #|    {
+///       #|      program: "grep",
+///       #|      arguments: ["beta"],
+///       #|      cwd: None,
+///       #|      env: {},
+///       #|      inherit_env: true,
+///       #|      stdin: None,
+///       #|      stdout: Capture,
+///       #|      stderr: Capture,
+///       #|    },
+///       #|  ],
+///       #|}
+///     ),
+///   )
+/// }
+/// ```
+pub fn Pipeline::Pipeline(commands : Array[Cmd]) -> Pipeline {
+  { commands: commands.copy() }
+}

--- a/src/shell/pipeline_test.mbt
+++ b/src/shell/pipeline_test.mbt
@@ -1,0 +1,189 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "a pipeline is a plain, inspectable description" {
+  let plan = @shell.Pipeline([Cmd("cat", []), Cmd("sort", [])])
+  debug_inspect(
+    plan,
+    content=(
+      #|{
+      #|  commands: [
+      #|    {
+      #|      program: "cat",
+      #|      arguments: [],
+      #|      cwd: None,
+      #|      env: {},
+      #|      inherit_env: true,
+      #|      stdin: None,
+      #|      stdout: Capture,
+      #|      stderr: Capture,
+      #|    },
+      #|    {
+      #|      program: "sort",
+      #|      arguments: [],
+      #|      cwd: None,
+      #|      env: {},
+      #|      inherit_env: true,
+      #|      stdin: None,
+      #|      stdout: Capture,
+      #|      stderr: Capture,
+      #|    },
+      #|  ],
+      #|}
+    ),
+  )
+}
+
+///|
+async test "stages connect by real pipes" {
+  let filter = filter_prog.wait()
+  let output = @shell.Pipeline([
+    Cmd(cat_prog.wait(), [], stdin=Text("alpha\nbeta\ngamma\n")),
+    Cmd(filter, ["-keep", "beta"]),
+    Cmd(filter, ["-upper"]),
+  ]).output()
+  inspect(output.exit_code(), content="0")
+  inspect(output.stdout(), content="BETA\n")
+  inspect(output.stderr(), content="")
+}
+
+///|
+async test "the pipeline status uses pipefail" {
+  let failing = () => {
+    @shell.Pipeline([
+      Cmd(sleep_prog.wait(), ["0", "-exit-code", "7"]),
+      Cmd(cat_prog.wait(), []),
+    ])
+  }
+  let output = failing().output()
+  inspect(output.exit_code(), content="7")
+  // `status` reports the same rule without capturing anything, and `run` is
+  // its checked form.
+  inspect(failing().status(), content="7")
+  try failing().run() catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|CommandFailed({ exit_code: 7, stdout: "", stdout_bytes: <Bytes: []>, stderr: "" })
+        ),
+      )
+  } noraise {
+    _ => fail("expected a non-zero exit to raise")
+  }
+}
+
+///|
+async test "stderr is preserved from every stage" {
+  let filter = filter_prog.wait()
+  let output = @shell.Pipeline([
+    Cmd(
+      cat_prog.wait(),
+      ["-stderr"],
+      stdin=Text("first\nignored: stdout is closed downstream\n"),
+    ),
+    Cmd(filter, ["-stderr", "second"]),
+  ]).output()
+  // Stage one sent everything to stderr, so stage two saw no lines at all.
+  inspect(output.stdout(), content="")
+  inspect(
+    output.stderr(),
+    content="first\nignored: stdout is closed downstream\nsecond",
+  )
+}
+
+///|
+async test "a large distinct payload crosses every stage unchanged" {
+  let cat = cat_prog.wait()
+  let payload = distinct_lines(50000)
+  let piped = @shell.Pipeline([
+    Cmd(cat, [], stdin=Text(payload)),
+    Cmd(cat, []),
+    Cmd(cat, []),
+  ]).output(max_output_bytes=32 * 1024 * 1024)
+  // Byte-for-byte, not merely the same length.
+  assert_eq(piped.stdout(), payload)
+}
+
+///|
+async test "a stage may stop reading before its producer finishes" {
+  // The consumer takes one line and exits without draining its input. The
+  // producer, mid-way through a payload much larger than a pipe buffer, gets
+  // an ordinary broken pipe — the pipeline still completes and pipefail
+  // reports the cut-off stage.
+  let output = @shell.Pipeline([
+    Cmd(cat_prog.wait(), [], stdin=Text(distinct_lines(100000))),
+    Cmd(filter_prog.wait(), ["-head", "1"]),
+  ]).output(timeout_ms=30000)
+  inspect(output.stdout(), content="line-0\n")
+  assert_true(output.exit_code() != 0)
+}
+
+///|
+async test "a pipe stays open until its producer reaches EOF" {
+  // The producer emits only after a delay. If the runtime closed or leaked
+  // either pipe end, the consumer would see EOF early and lose the line, or
+  // never see EOF and time out.
+  let output = @shell.Pipeline([
+    Cmd(sleep_prog.wait(), ["100", "-print-after-sleep", "late line"]),
+    Cmd(cat_prog.wait(), []),
+  ]).output(timeout_ms=10000)
+  inspect(output.exit_code(), content="0")
+  inspect(output.stdout().trim(char_set="\r\n"), content="late line")
+}
+
+///|
+async test "a failing redirect closes every prepared pipe end" {
+  // By the time the final stage's stderr file fails to open, the junction,
+  // the stdout capture end, and the first stage's stdin all exist. The run
+  // must fail with the open error and close them — CI runs with
+  // MOONBIT_ASYNC_CHECK_FD_LEAK=1, which turns any leak here into a failure.
+  let cat = cat_prog.wait()
+  let directory = @fs.tmpdir(prefix="shell-leak")
+  let missing = "\{directory}/absent-dir/out.txt"
+  try
+    @shell.Pipeline([
+      Cmd(cat, [], stdin=Text("x\n")),
+      Cmd(cat, [], stderr=ToFile(missing)),
+    ]).output()
+    |> ignore
+  catch {
+    _ => ()
+  } noraise {
+    _ => fail("expected the redirect to fail")
+  }
+  // The single-command shape fails before any spawn at all.
+  try
+    @shell.Cmd(cat, [], stdin=Text("x\n"), stdout=ToFile(missing)).output()
+    |> ignore
+  catch {
+    _ => ()
+  } noraise {
+    _ => fail("expected the redirect to fail")
+  }
+  @fs.rmdir(directory, recursive=true)
+}
+
+///|
+async test "each_line follows the last stage of a pipeline" {
+  let seen = []
+  let code = @shell.Pipeline([
+    Cmd(cat_prog.wait(), [], stdin=Text("alpha\nbeta\ngamma\n")),
+    Cmd(filter_prog.wait(), ["-keep", "mm"]),
+  ]).each_line(line => seen.push(line))
+  inspect(code, content="0")
+  assert_eq(seen, ["gamma"])
+}

--- a/src/shell/pkg.generated.mbti
+++ b/src/shell/pkg.generated.mbti
@@ -12,9 +12,24 @@ import {
 // Types and methods
 type Cmd derive(@debug.Debug)
 pub fn Cmd::Cmd(String, Array[String], cwd? : String, env? : Map[String, String], inherit_env? : Bool, stdin? : Stdin, stdout? : Redirect, stderr? : Redirect) -> Self
+pub async fn Cmd::each_line(Self, async (String) -> Unit, timeout_ms? : Int, max_line_bytes? : Int) -> Int
+pub async fn Cmd::output(Self, timeout_ms? : Int, max_output_bytes? : Int) -> Output
+pub async fn Cmd::run(Self, timeout_ms? : Int) -> Unit
+pub async fn Cmd::status(Self, timeout_ms? : Int) -> Int
+
+type Output derive(@debug.Debug)
+pub fn Output::check(Self) -> Unit raise
+pub fn Output::exit_code(Self) -> Int
+pub fn Output::stderr(Self) -> String
+pub fn Output::stdout(Self) -> String
+pub fn Output::stdout_bytes(Self) -> Bytes
 
 type Pipeline derive(@debug.Debug)
 pub fn Pipeline::Pipeline(Array[Cmd]) -> Self
+pub async fn Pipeline::each_line(Self, async (String) -> Unit, timeout_ms? : Int, max_line_bytes? : Int) -> Int
+pub async fn Pipeline::output(Self, timeout_ms? : Int, max_output_bytes? : Int) -> Output
+pub async fn Pipeline::run(Self, timeout_ms? : Int) -> Unit
+pub async fn Pipeline::status(Self, timeout_ms? : Int) -> Int
 
 pub(all) enum Redirect {
   Capture

--- a/src/shell/pkg.generated.mbti
+++ b/src/shell/pkg.generated.mbti
@@ -6,6 +6,7 @@ import {
 }
 
 // Values
+pub async fn glob(String, cwd? : String) -> Array[String]
 
 // Errors
 

--- a/src/shell/pkg.generated.mbti
+++ b/src/shell/pkg.generated.mbti
@@ -1,0 +1,36 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/async/shell"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type Cmd derive(@debug.Debug)
+pub fn Cmd::Cmd(String, Array[String], cwd? : String, env? : Map[String, String], inherit_env? : Bool, stdin? : Stdin, stdout? : Redirect, stderr? : Redirect) -> Self
+
+type Pipeline derive(@debug.Debug)
+pub fn Pipeline::Pipeline(Array[Cmd]) -> Self
+
+pub(all) enum Redirect {
+  Capture
+  Inherit
+  ToFile(String)
+  AppendToFile(String)
+  Discard
+} derive(@debug.Debug)
+
+pub(all) enum Stdin {
+  Text(String)
+  Binary(Bytes)
+  FromFile(String)
+  Inherit
+} derive(@debug.Debug)
+
+// Type aliases
+
+// Traits

--- a/src/shell/plan_test.mbt
+++ b/src/shell/plan_test.mbt
@@ -1,0 +1,202 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+test "a command is a plain, inspectable description" {
+  let cmd = @shell.Cmd("git", ["status", "--short"], cwd="workspace", env={
+    "NO_COLOR": "1",
+  })
+  debug_inspect(
+    cmd,
+    content=(
+      #|{
+      #|  program: "git",
+      #|  arguments: ["status", "--short"],
+      #|  cwd: Some("workspace"),
+      #|  env: { "NO_COLOR": "1" },
+      #|  inherit_env: true,
+      #|  stdin: None,
+      #|  stdout: Capture,
+      #|  stderr: Capture,
+      #|}
+    ),
+  )
+}
+
+///|
+test "defaults keep a command closed and inherited" {
+  let cmd = @shell.Cmd("true", [])
+  debug_inspect(
+    cmd,
+    content=(
+      #|{
+      #|  program: "true",
+      #|  arguments: [],
+      #|  cwd: None,
+      #|  env: {},
+      #|  inherit_env: true,
+      #|  stdin: None,
+      #|  stdout: Capture,
+      #|  stderr: Capture,
+      #|}
+    ),
+  )
+}
+
+///|
+test "a command does not alias the caller's collections" {
+  let arguments = ["status"]
+  let env = { "NO_COLOR": "1" }
+  let cmd = @shell.Cmd("git", arguments, env~)
+  // Mutating what was passed in does not reach the command...
+  arguments.push("--short")
+  env["NO_COLOR"] = "0"
+  debug_inspect(
+    cmd,
+    content=(
+      #|{
+      #|  program: "git",
+      #|  arguments: ["status"],
+      #|  cwd: None,
+      #|  env: { "NO_COLOR": "1" },
+      #|  inherit_env: true,
+      #|  stdin: None,
+      #|  stdout: Capture,
+      #|  stderr: Capture,
+      #|}
+    ),
+  )
+}
+
+///|
+async test "invalid plans fail before spawning" {
+  try @shell.Cmd("", []).output() catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|EmptyProgram
+        ),
+      )
+  } noraise {
+    _ => fail("expected an empty program to raise")
+  }
+  try @shell.Pipeline([]).output() catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|EmptyPipeline
+        ),
+      )
+  } noraise {
+    _ => fail("expected an empty pipeline to raise")
+  }
+  try
+    @shell.Pipeline([
+      Cmd("first", []),
+      Cmd("second", [], stdin=Text("not allowed")),
+    ]).output()
+  catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|StdinOnNonFirstStage(1)
+        ),
+      )
+  } noraise {
+    _ => fail("expected stdin on a later stage to raise")
+  }
+  try
+    @shell.Pipeline([Cmd("first", [], stdout=ToFile("nope")), Cmd("second", [])]).output()
+  catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|RedirectOnNonFinalStage(0)
+        ),
+      )
+  } noraise {
+    _ => fail("expected a redirected intermediate stage to raise")
+  }
+  try @shell.Cmd("cat", [], stdout=Inherit).each_line(_line => ()) catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|StdoutNotCaptured
+        ),
+      )
+  } noraise {
+    _ => fail("expected uncaptured line output to raise")
+  }
+  try @shell.Cmd("cat", ["allowed\u{0000}truncated"]).output() catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|NulByte("argument[0]")
+        ),
+      )
+  } noraise {
+    _ => fail("expected a NUL argument to raise")
+  }
+  try @shell.Cmd("cat", [], stdout=ToFile("bad\u{0000}path")).output() catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|NulByte("standard output path")
+        ),
+      )
+  } noraise {
+    _ => fail("expected a NUL redirect path to raise")
+  }
+  try @shell.Cmd("cat", [], env={ "BAD=NAME": "value" }).output() catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|InvalidEnvironmentName("BAD=NAME")
+        ),
+      )
+  } noraise {
+    _ => fail("expected an environment name containing '=' to raise")
+  }
+  try @shell.Cmd("cat", [], env={ "": "value" }).output() catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|InvalidEnvironmentName("")
+        ),
+      )
+  } noraise {
+    _ => fail("expected an empty environment name to raise")
+  }
+  try @shell.Cmd("cat", []).output(max_output_bytes=0) catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|InvalidOutputLimit(0)
+        ),
+      )
+  } noraise {
+    _ => fail("expected a non-positive output limit to raise")
+  }
+}

--- a/src/shell/progs_for_test.mbt
+++ b/src/shell/progs_for_test.mbt
@@ -1,0 +1,66 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// The suite runs the portable programs from `test_programs/` instead of
+/// `printf`, `grep`, or `sh`, so every execution test exercises the same code
+/// path on every platform. Building them goes through `@shell.Cmd` itself.
+fn make_test_prog(name : String) -> @async.Lazy[String] {
+  Lazy() <| () => {
+    let code = @shell.Cmd("moon", [
+      "build",
+      "test_programs/\{name}",
+      "--debug",
+      "--target-dir",
+      "_build/test_programs",
+    ]).status()
+    if code != 0 {
+      fail("failed to build test program `\{name}`: \{code}")
+    }
+    // Absolute, so a command that sets `cwd` can still name the program.
+    guard @env.current_dir() is Some(module_root) else {
+      fail("no working directory")
+    }
+    "\{module_root}/_build/test_programs/native/debug/build/moonbitlang/async_test_programs/\{name}/\{name}.exe"
+  }
+}
+
+///|
+/// Copies stdin to stdout, or to stderr under `-stderr`.
+let cat_prog : @async.Lazy[String] = make_test_prog("cat")
+
+///|
+/// Sleeps, reports a graceful termination signal, and can swallow it or exit
+/// with a chosen code. See `test_programs/sleep`.
+let sleep_prog : @async.Lazy[String] = make_test_prog("sleep")
+
+///|
+/// Prints its whole environment, one `NAME=value` line each.
+let dump_env_prog : @async.Lazy[String] = make_test_prog("dump_env")
+
+///|
+/// Line-wise `grep`/`tr`/`head` stand-in. See `test_programs/filter`.
+let filter_prog : @async.Lazy[String] = make_test_prog("filter")
+
+///|
+/// A payload of distinct lines: loss, duplication, and reordering all change
+/// it, where a payload of identical lines would hide the latter two.
+fn distinct_lines(count : Int) -> String {
+  let text = StringBuilder()
+  for index in 0..<count {
+    text.write_string("line-\{index}\n")
+  }
+  text.to_string()
+}

--- a/src/shell/run_test.mbt
+++ b/src/shell/run_test.mbt
@@ -1,0 +1,259 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+async test "an argument reaches the child literally, without a shell" {
+  // The needle is full of shell syntax. It arrives as one argv element — on
+  // Windows through `@process`'s escaping — or the child cannot select the
+  // marker line.
+  let needle = "$(echo not-executed) | *"
+  let output = @shell.Cmd(
+    filter_prog.wait(),
+    ["-keep", needle],
+    stdin=Text("plain\n\{needle} marker\n"),
+  ).output()
+  inspect(output.exit_code(), content="0")
+  inspect(output.stdout(), content="$(echo not-executed) | * marker\n")
+  inspect(output.stderr(), content="")
+}
+
+///|
+async test "binary bytes cross stdin and capture unharmed" {
+  let output = @shell.Cmd(cat_prog.wait(), [], stdin=Binary(b"\x00\xff")).output()
+  inspect(output.exit_code(), content="0")
+  assert_eq(output.stdout_bytes(), b"\x00\xff")
+  // The text field decodes lossily instead of failing the run.
+  inspect(output.stdout(), content="\u{0000}�")
+}
+
+///|
+async test "status returns the exit code without capturing" {
+  let sleep = sleep_prog.wait()
+  inspect(@shell.Cmd(sleep, ["0"]).status(), content="0")
+  inspect(@shell.Cmd(sleep, ["0", "-exit-code", "3"]).status(), content="3")
+  // A non-zero exit is a result, not an error — until `check` makes it one.
+  let output = @shell.Cmd(sleep, ["0", "-exit-code", "1"]).output()
+  inspect(output.exit_code(), content="1")
+  try output.check() catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|CommandFailed({ exit_code: 1, stdout: "", stdout_bytes: <Bytes: []>, stderr: "" })
+        ),
+      )
+  } noraise {
+    _ => fail("expected a non-zero exit to raise")
+  }
+  // `run` is the checked form of `status`: quiet on success, an error on a
+  // non-zero exit.
+  @shell.Cmd(sleep, ["0"]).run()
+  try @shell.Cmd(sleep, ["0", "-exit-code", "9"]).run() catch {
+    err =>
+      debug_inspect(
+        err,
+        content=(
+          #|CommandFailed({ exit_code: 9, stdout: "", stdout_bytes: <Bytes: []>, stderr: "" })
+        ),
+      )
+  } noraise {
+    _ => fail("expected a non-zero exit to raise")
+  }
+}
+
+///|
+async test "stdin can be inherited and output discarded" {
+  // `Inherit` hands over the parent's own standard input. The child here
+  // ignores it, which keeps the test independent of what that input is.
+  inspect(
+    @shell.Cmd(sleep_prog.wait(), ["0"], stdin=Inherit).status(),
+    content="0",
+  )
+  // `Discard` gives the child a real, writable sink: the whole payload is
+  // accepted — a closed or broken descriptor would fail the child — and none
+  // of it reaches the capture.
+  let output = @shell.Cmd(
+    cat_prog.wait(),
+    [],
+    stdin=Text(distinct_lines(5000)),
+    stdout=Discard,
+  ).output()
+  inspect(output.exit_code(), content="0")
+  inspect(output.stdout(), content="")
+}
+
+///|
+async test "env entries add to, or replace, the inherited environment" {
+  let dump_env = dump_env_prog.wait()
+  let added = @shell.Cmd(dump_env, [], env={ "SHELL_TEST_MAGIC": "works" }).output()
+  assert_true(added.stdout().contains("SHELL_TEST_MAGIC=works"))
+  let clean = @shell.Cmd(
+    dump_env,
+    [],
+    env={ "SHELL_TEST_ONLY_1": "one", "SHELL_TEST_ONLY_2": "two" },
+    inherit_env=false,
+  ).output()
+  inspect(
+    clean.stdout().replace_all(old="\r\n", new="\n"),
+    content=(
+      #|SHELL_TEST_ONLY_1=one
+      #|SHELL_TEST_ONLY_2=two
+      #|
+    ),
+  )
+}
+
+///|
+async test "cwd changes where the child runs" {
+  let output = @shell.Cmd(
+    filter_prog.wait(),
+    ["-print-cwd"],
+    cwd="test_directory",
+  ).output()
+  inspect(output.exit_code(), content="0")
+  inspect(
+    output.stdout().trim(char_set="\r\n ").has_suffix("test_directory"),
+    content="true",
+  )
+}
+
+///|
+async test "stdout can be sent to a file, appended, and read back as stdin" {
+  let cat = cat_prog.wait()
+  let directory = @fs.tmpdir(prefix="shell-redirect")
+  let path = "\{directory}/log.txt"
+  @shell.Cmd(cat, [], stdin=Text("one\n"), stdout=ToFile(path)).status()
+  |> ignore
+  @shell.Cmd(cat, [], stdin=Text("two\n"), stdout=AppendToFile(path)).status()
+  |> ignore
+  inspect(@fs.read_file(path).text(), content="one\ntwo\n")
+  // `ToFile` truncates, so the appended line is gone again.
+  @shell.Cmd(cat, [], stdin=Text("three\n"), stdout=ToFile(path)).status()
+  |> ignore
+  inspect(@fs.read_file(path).text(), content="three\n")
+  // `FromFile` is the structured `< path`.
+  let back = @shell.Cmd(cat, [], stdin=FromFile(path)).output()
+  inspect(back.stdout(), content="three\n")
+  @fs.rmdir(directory, recursive=true)
+}
+
+///|
+async test "a redirected stream is absent from the captured output" {
+  let directory = @fs.tmpdir(prefix="shell-redirect-stderr")
+  let path = "\{directory}/errors.txt"
+  let output = @shell.Cmd(
+    cat_prog.wait(),
+    ["-stderr"],
+    stdin=Text("err\n"),
+    stderr=ToFile(path),
+  ).output()
+  inspect(output.stdout(), content="")
+  inspect(output.stderr(), content="")
+  inspect(@fs.read_file(path).text(), content="err\n")
+  @fs.rmdir(directory, recursive=true)
+}
+
+///|
+async test "a timeout cancels the run" {
+  let sleep = sleep_prog.wait()
+  try @shell.Cmd(sleep, ["10000"]).output(timeout_ms=50) catch {
+    @async.TimeoutError => ()
+    err => fail("unexpected error: \{err}")
+  } noraise {
+    _ => fail("expected TimeoutError")
+  }
+  try
+    @shell.Pipeline([Cmd(sleep, ["10000"]), Cmd(cat_prog.wait(), [])]).output(
+      timeout_ms=50,
+    )
+  catch {
+    @async.TimeoutError => ()
+    err => fail("unexpected error: \{err}")
+  } noraise {
+    _ => fail("expected TimeoutError")
+  }
+}
+
+///|
+async test "capture is bounded across stdout and stderr" {
+  let cat = cat_prog.wait()
+  let payload = "x".repeat(64)
+  try
+    @shell.Cmd(cat, [], stdin=Text(payload)).output(max_output_bytes=16)
+  catch {
+    err => {
+      let diagnostic = "\{Repr(err)}"
+      assert_true(diagnostic.contains("OutputLimitExceeded"))
+      assert_true(diagnostic.contains("limit=16"))
+    }
+  } noraise {
+    _ => fail("expected the output limit to raise")
+  }
+  // Standard error counts against the same aggregate limit.
+  try
+    @shell.Cmd(cat, ["-stderr"], stdin=Text(payload)).output(
+      max_output_bytes=16,
+    )
+  catch {
+    err => {
+      let diagnostic = "\{Repr(err)}"
+      assert_true(diagnostic.contains("OutputLimitExceeded"))
+      assert_true(diagnostic.contains("limit=16"))
+    }
+  } noraise {
+    _ => fail("expected the output limit to raise")
+  }
+  // The limit is genuinely aggregate: 12 bytes of stdout and 12 bytes of
+  // stderr each fit under 16 alone, and still trip it together.
+  try
+    @shell.Cmd(
+      filter_prog.wait(),
+      ["-stderr", "e".repeat(12)],
+      stdin=Text("\{"o".repeat(11)}\n"),
+    ).output(max_output_bytes=16)
+  catch {
+    err => {
+      let diagnostic = "\{Repr(err)}"
+      assert_true(diagnostic.contains("OutputLimitExceeded"))
+      assert_true(diagnostic.contains("limit=16"))
+    }
+  } noraise {
+    _ => fail("expected the aggregate output limit to raise")
+  }
+}
+
+///|
+async test "a child that never reads its stdin does not fail the run" {
+  // The writer hits a closed pipe as soon as the child exits; that belongs to
+  // the run's plumbing, not to its result.
+  let output = @shell.Cmd(
+    sleep_prog.wait(),
+    ["0"],
+    stdin=Text("x".repeat(1024 * 1024)),
+  ).output(timeout_ms=10000)
+  inspect(output.exit_code(), content="0")
+}
+
+///|
+async test "output larger than a pipe buffer survives intact" {
+  // Spans many operating-system pipe buffers; a child that outran a
+  // non-blocking reader would abort mid-way and leave a silent prefix.
+  let payload = distinct_lines(20000)
+  let output = @shell.Cmd(cat_prog.wait(), [], stdin=Text(payload)).output(
+    max_output_bytes=32 * 1024 * 1024,
+  )
+  inspect(output.exit_code(), content="0")
+  assert_eq(output.stdout(), payload)
+}

--- a/src/shell/setup_test.mbt
+++ b/src/shell/setup_test.mbt
@@ -1,0 +1,18 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+fn init {
+  @test_util.increase_current_thread_priority()
+}

--- a/test_programs/filter/main.mbt
+++ b/test_programs/filter/main.mbt
@@ -1,0 +1,92 @@
+///|
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+/// A portable stand-in for the small text tools a shell pipeline test needs
+/// (`grep`, `tr '[a-z]' '[A-Z]'`, `head`), so tests behave the same on every
+/// platform.
+///
+/// Reads stdin line by line and writes matching lines to stdout:
+///
+///   -upper           uppercase each emitted line
+///   -keep <substr>   only emit lines containing <substr>
+///   -head <n>        exit right after emitting <n> lines, without draining
+///                    stdin, so an upstream writer observes a closed pipe
+///   -stderr <msg>    write <msg> to stderr before exiting
+///   -exit-code <n>   exit with status <n>
+///   -print-cwd       print the working directory and exit; stdin is not read
+extern "C" fn exit(code : Int) = "exit"
+
+///|
+async fn main {
+  let mut upper = false
+  let mut keep = None
+  let mut head = None
+  let mut stderr_msg = None
+  let mut exit_code = 0
+  let mut print_cwd = false
+  for args = @env.args()[1:] {
+    match args {
+      [] => break
+      ["-upper", .. rest] => {
+        upper = true
+        continue rest
+      }
+      ["-keep", substr, .. rest] => {
+        keep = Some(substr)
+        continue rest
+      }
+      ["-head", n, .. rest] => {
+        head = Some(@string.parse_int(n))
+        continue rest
+      }
+      ["-stderr", msg, .. rest] => {
+        stderr_msg = Some(msg)
+        continue rest
+      }
+      ["-exit-code", n, .. rest] => {
+        exit_code = @string.parse_int(n)
+        continue rest
+      }
+      ["-print-cwd", .. rest] => {
+        print_cwd = true
+        continue rest
+      }
+      _ => fail("invalid arguments")
+    }
+  }
+  if print_cwd {
+    guard @env.current_dir() is Some(cwd) else { fail("no working directory") }
+    @stdio.stdout.write("\{cwd}\n")
+  } else {
+    let mut emitted = 0
+    while @stdio.stdin.read_until("\n") is Some(line) {
+      let line = line.trim_end(chars="\r").to_owned()
+      if keep is Some(substr) && !line.contains(substr) {
+        continue
+      }
+      let line = if upper { line.to_upper() } else { line }
+      @stdio.stdout.write("\{line}\n")
+      emitted += 1
+      if head is Some(limit) && emitted >= limit {
+        break
+      }
+    }
+  }
+  if stderr_msg is Some(msg) {
+    @stdio.stderr.write(msg)
+  }
+  exit(exit_code)
+}

--- a/test_programs/filter/moon.pkg
+++ b/test_programs/filter/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "moonbitlang/core/string",
+  "moonbitlang/core/env",
+  "moonbitlang/async",
+  "moonbitlang/async/stdio",
+}
+
+supported_targets = "-all+native"
+
+pkgtype(kind: "executable")

--- a/test_programs/filter/pkg.generated.mbti
+++ b/test_programs/filter/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/async_test_programs/filter"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits


### PR DESCRIPTION
Ports [`bobzhang/myshell@0.3.0`](https://github.com/bobzhang/myshell) into the async module as **`moonbitlang/async/shell`** — everything a shell is used for (commands, pipes, redirects, exit-code logic, glob expansion) as a library, without shell parsing.

## Design

- **`Cmd` never invokes a shell.** Program and argument vector stay separate; every argument is passed literally; NUL bytes are rejected before spawning. `Cmd`/`Pipeline` are immutable and fully readable, so a plan that has been inspected is the plan that runs.
- **Pipelines ride on async's low-level pipe support.** Adjacent stages share one blocking OS pipe from `@process.pipe()`; payload bytes stay in the kernel instead of being relayed through the parent. Everything the parent itself reads or writes goes through `@process.read_from_process` / `write_to_process`.
- **`glob`/`glob_matches`**: shell filename expansion as an ordinary value — segment-rooted path model covering Unix and Windows roots (drives, drive-relative, UNC shares), non-exponential matching, `**` that does not descend symlinks nor reach hidden entries.
- Renames relative to upstream: package `myshell` → `shell`, `ProcessError` → `ShellError`.

## Windows support via CI

Upstream myshell gated every execution test with `#cfg(not(platform="windows"))`, so its Windows behavior shipped untested. This port migrates the whole suite to the repo's portable `test_programs/` pattern (adding one program, `filter`: a line-wise `grep`/`tr`/`head` stand-in), and builds glob fixtures with `@fs` — so pipelines, redirects, stdin/env/cwd handling, capture limits, and graceful-vs-kill cancellation (observed deterministically through a redirect file plus timing buckets, same technique as `src/process/cancel_test.mbt`) now run on all three CI platforms. A new Windows-only test covers case-insensitive, backslash-separated expansion on a real filesystem.

## Bug found and fixed: stdio ignored the shared file position

The port's `AppendToFile` test exposed a real bug in `internal/event_loop`: `setup_stdio` gave regular-file stdio channels a private positioned offset starting at 0, so any async MoonBit program with stdout redirected to a file would overwrite from position 0 — bypassing `O_APPEND` (`pwrite` ignores it) and clobbering output that the parent or an earlier process had already written at the same descriptor. Fixed in the first commit by using the file description's own shared position (the `-1` plain-write path that append-mode `open()` already uses). The shell redirect tests now cover this end to end.

## Testing

- `moon test --target native`: 627/627 (whole repo)
- `moon test src/shell --target native` and `--target wasm`: 74/74 (including `README.mbt.md` doctests)
- `moon check --target all`: clean; `moon fmt` and `moon info` run, `pkg.generated.mbti` committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6uYtEdLugFjzsqN2vQKex