### PR TITLE
Runtime fixes: stdio shared file position, spawn orphan on pidfd_open failure, ws2_32 linkage

### DIFF
--- a/src/internal/event_loop/process.c
+++ b/src/internal/event_loop/process.c
@@ -117,7 +117,7 @@ HANDLE moonbitlang_async_open_pid_handle(int32_t pid) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
 
   int pidfd = syscall(SYS_pidfd_open, pid, 0);
-  if (pidfd < 0 && errno == ENOSYS || errno == EPERM)
+  if (pidfd < 0 && (errno == ENOSYS || errno == EPERM))
     // some container environments do not support `pidfd` even on Linux >= 5.3.0
     errno = 0;
 

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -93,17 +93,16 @@ fn setup_stdio(id : Int, context~ : String) -> IoHandle raise {
     // see the code for `read_job_worker`/`write_job_worker` in `thread_pool.c` for more details.
     is_async: false,
     read: Idle,
-    read_offset: if kind is Regular {
-      0
-    } else {
-      -1
-    },
+    // Even when a stdio channel is a regular file, its file description — and
+    // therefore its file position — is shared with the parent and possibly
+    // with sibling processes. Positioned I/O from a private offset would
+    // overwrite from the start of the file, ignore where the parent left the
+    // cursor, and bypass `O_APPEND`/`FILE_APPEND_DATA` on a channel that was
+    // redirected in append mode. Use the file description's own position
+    // instead, as ordinary processes do.
+    read_offset: -1,
     write: Idle,
-    write_offset: if kind is Regular {
-      0
-    } else {
-      -1
-    },
+    write_offset: -1,
   }
   stdio_handles[fd] = handle
   register_hook(

--- a/src/internal/event_loop/stdio.mbt
+++ b/src/internal/event_loop/stdio.mbt
@@ -93,13 +93,12 @@ fn setup_stdio(id : Int, context~ : String) -> IoHandle raise {
     // see the code for `read_job_worker`/`write_job_worker` in `thread_pool.c` for more details.
     is_async: false,
     read: Idle,
-    // Even when a stdio channel is a regular file, its file description — and
-    // therefore its file position — is shared with the parent and possibly
-    // with sibling processes. Positioned I/O from a private offset would
-    // overwrite from the start of the file, ignore where the parent left the
-    // cursor, and bypass `O_APPEND`/`FILE_APPEND_DATA` on a channel that was
-    // redirected in append mode. Use the file description's own position
-    // instead, as ordinary processes do.
+    // The tricky case here is regular file.
+    // When the user access a file via the `@fs.File` interface.
+    // we maintain independent private read/write offset etc. to provide better semantic.
+    // However, when the user is accessing a file via the `@stdio` interface,
+    // we should simply provide whatever the OS provides,
+    // respecting internal file pointer, append mode setting etc.
     read_offset: -1,
     write: Idle,
     write_offset: -1,

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -28,6 +28,11 @@
 #include <ws2tcpip.h>
 #include <stddef.h>
 
+/* This object uses winsock (`bind`, `GetAddrInfoW`, ...), so it must carry
+   its own default-library directive: a test binary may pull this object
+   without `io_windows.obj`, whose pragma otherwise supplied `ws2_32`. */
+#pragma comment(lib, "ws2_32.lib")
+
 #else
 
 #include <pthread.h>

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -28,9 +28,6 @@
 #include <ws2tcpip.h>
 #include <stddef.h>
 
-/* This object uses winsock (`bind`, `GetAddrInfoW`, ...), so it must carry
-   its own default-library directive: a test binary may pull this object
-   without `io_windows.obj`, whose pragma otherwise supplied `ws2_32`. */
 #pragma comment(lib, "ws2_32.lib")
 
 #else

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -1204,9 +1204,13 @@ int32_t spawn_job_worker(struct spawn_job *job, int32_t *err_out) {
 #ifdef __linux__
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
   if (!*err_out) {
+    /* A failed `pidfd_open` — `EMFILE` under descriptor pressure, or
+       `ENOSYS`/`EPERM` in some containers — must not turn a successful spawn
+       into an error: the child is already running, and reporting failure
+       here would let it escape ownership, unkilled and unreaped. Leave the
+       handle invalid instead; `wait_pid` falls back to a blocking `waitpid`
+       in a worker thread when there is no pidfd. */
     job->pidfd = syscall(SYS_pidfd_open, ret, 0);
-    if (job->pidfd < 0 && errno != ENOSYS && errno != EPERM)
-      *err_out = errno;
   }
 #endif // #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
 #endif // #ifdef __linux__


### PR DESCRIPTION
Extracts the uncontroversial runtime fixes from #570 into their own PR, per @Guest0x0's review there ("I'll open separated PR for those two later to keep things clean" — opening it from our side to save you the cherry-picking; the two questioned fixes stay in #570 for discussion). All three were found by #570's test suite; each commit message carries the full analysis.

1. **`setup_stdio`: use the shared file position for regular-file stdio channels.** Positioned writes from a private offset 0 overwrote from the start of the file, ignored the inherited cursor, and bypassed `O_APPEND` — any async MoonBit program with stdout redirected in append mode clobbered instead of appending. Position `-1` (the plain-write path append-mode `open()` already uses) restores ordinary shared-file-position semantics. Reproducible today with any published moonx tool: `moonx bobzhang/printf 'two\n' >> f` overwrites `f`, on both wasm and native builds, because those tools embed async 0.21.0.

2. **Spawn: don't orphan a running child when `pidfd_open` fails.** After a successful `posix_spawn`, a `pidfd_open` failure other than `ENOSYS`/`EPERM` (realistically `EMFILE`) was reported as a spawn error — but the child was already running, so it escaped its task group unkilled and unreaped. The handle is now simply left invalid; `wait_pid` already has a handle-less blocking-`waitpid` fallback that uses only the PID. Includes a parenthesization fix in `open_pid_handle` (`a && b || c` → intended grouping; no observable change with current callers).

3. **`thread_pool.c` declares its own `ws2_32` dependency.** It calls winsock functions but relied on the `#pragma comment(lib, ...)` in `io_windows.c`; a test binary whose selective link pulls `thread_pool.obj` without `io_windows.obj` fails with unresolved externals (reproduced by #570's whitebox tests on Windows).

Validation: `moon check` clean; full native suite 571/571 with `MOONBIT_ASYNC_CHECK_FD_LEAK=1`. Once this merges, #570 rebases and drops these commits from its diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6uYtEdLugFjzsqN2vQKex