### PR TITLE
fix http gzip decode wrong EOF detection

### DIFF
--- a/src/http/parser.mbt
+++ b/src/http/parser.mbt
@@ -139,7 +139,7 @@ impl @io.Reader for Reader with fn _direct_read(self, buf, offset~, max_len~) {
         max_len~,
         limit=remaining,
       )
-      if consumed is 0 {
+      if consumed is 0 && produced is 0 {
         raise @io.ReaderClosed
       }
       let remaining = remaining - consumed
@@ -152,7 +152,11 @@ impl @io.Reader for Reader with fn _direct_read(self, buf, offset~, max_len~) {
       } else {
         Fixed(remaining)
       }
-      produced
+      if produced == 0 && !(self.body is Empty) {
+        self._direct_read(buf, offset~, max_len~)
+      } else {
+        produced
+      }
     }
     Chunked(0) => {
       guard self.transport.read_until("\r\n") is Some(len_str) else {

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -794,6 +794,47 @@ async test "gzip split between chunks" {
 }
 
 ///|
+async test "fixed length gzip direct bytes one byte reads" {
+  // This gzip stream reaches a state where the decoder can emit one more
+  // byte from an already-decoded match copy without consuming new input.
+  let compressed : Bytes = [
+    // Gzip header (10 bytes) ends at 0x03.
+    0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+    // Deflate payload starts here. This fixed-Huffman block is the interesting
+    // part: it sets up a match copy that outlives the first 1-byte read.
+     0x4b, 0x4c, 0x4a, 0x4e, 0x24, 0x84, 0x00, 0xea, 0x16,
+    // Gzip trailer starts here: CRC32 little-endian.
+     0x01, 0xf1, 0x24,
+    // ISIZE little-endian.
+     0x00, 0x00, 0x00,
+  ]
+  let (r, w) = @io.pipe()
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
+      defer w.close()
+      w
+      ..write("HTTP/1.1 200 OK\r\n")
+      ..write("Content-Length: \{compressed.length()}\r\n")
+      ..write("Content-Encoding: gzip\r\n")
+      .write("\r\n")
+      w.write(compressed)
+    }
+    defer r.close()
+    let input = Reader::new(r)
+    let response = input.read_response(
+      request_method=None,
+      auto_decompress=true,
+    )
+    inspect(response.code, content="200")
+    let output = FixedArray::make(1, b'\x00')
+    while input._direct_read(output, offset=0, max_len=1) > 0 {
+
+    }
+    inspect(true, content="true")
+  }
+}
+
+///|
 async test "read_response parse cookie" {
   @async.with_task_group() <| group => {
     let (r, w) = @io.pipe()


### PR DESCRIPTION
closes #567

Previously, in the fixed length + auto gzip decode path of the HTTP message parser, EOF is detected via `consumed is 0`. But it is possible for the gzip decoder state machine to produce `(consumed = 0, produced > 0)`: if the last state transition produces multiple bytes at once but the output buffer is not large enough, the next `_direct_read` call may produce those bytes without consuming anything, and this is *not* EOF. When the above scenario is triggered, the HTTP parser will wrongly report early EOF via `@io.ReaderClosed`.

This PR fixes the issue by turning EOF condition into `consumed is 0 && produced is 0`. Since the contract of `_direct_read` uses `0` for EOF indication, in case `produced is 0`, `_direct_read` will retry immediately.