### PR TITLE
Fix empty JavaScript HTTP response bodies

### DIFF
--- a/src/http/client.js.mbt
+++ b/src/http/client.js.mbt
@@ -54,7 +54,9 @@ extern "js" fn JsResponse::headers(response : JsResponse) -> JsHeaders =
 extern "js" fn JsResponse::body(
   response : JsResponse,
 ) -> @js_async.JsReadableStream =
-  #| (response) => response.body
+  #| (response) => response.body ?? new ReadableStream({
+  #|   start(controller) { controller.close() },
+  #| })
 
 ///|
 priv struct OngoingRequest {

--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -60,6 +60,26 @@ extern "js" fn Server::create(
   #|   const server = http.createServer()
   #|   server.on('request', (req, response) => {
   #|     logger(`server received request: ${req.method} ${req.url}\n`)
+  #|     if (req.url === '/no-content') {
+  #|       response.statusCode = 204
+  #|       response.end()
+  #|       return
+  #|     }
+  #|     if (req.url === '/reset-content') {
+  #|       response.statusCode = 205
+  #|       response.end()
+  #|       return
+  #|     }
+  #|     if (req.url === '/not-modified') {
+  #|       response.statusCode = 304
+  #|       response.end()
+  #|       return
+  #|     }
+  #|     if (req.method === 'HEAD') {
+  #|       response.statusCode = 200
+  #|       response.end()
+  #|       return
+  #|     }
   #|     req.on('data', (data) => {
   #|       logger(`server received: ${data}`)
   #|     })
@@ -87,6 +107,30 @@ async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
   let server = Server::create(msg => log.write_string(msg)).wait()
   group.add_defer(() => server.close())
   server.port()
+}
+
+///|
+#cfg(target="js")
+async test "responses with null Web API bodies are empty readable streams" {
+  let log = StringBuilder()
+  @async.with_task_group() <| group => {
+    let port = test_server(group, log)
+    let client = @http.Client("http://localhost:\{port}")
+    defer client.close()
+    for
+      request in [
+        (@http.Get, "/no-content", 204),
+        (@http.Get, "/reset-content", 205),
+        (@http.Get, "/not-modified", 304),
+        (@http.Head, "/head", 200),
+      ] {
+      let (meth, path, expected_status) = request
+      client.request(meth, path)
+      let response = client.end_request()
+      assert_eq(response.code, expected_status)
+      assert_eq(client.read_all().text(), "")
+    }
+  }
 }
 
 ///|


### PR DESCRIPTION
`Response.body` is `null` for null-body responses, including 204, 205, 304, and responses to HEAD requests. The JS HTTP client passed this value to `ReadableStream::from_js`, which expects a stream and calls `getReader()`.

Use a closed `ReadableStream` when `Response.body` is `null`. Callers then observe an empty response body and immediate EOF.

The regression test covers 204, 205, 304, and HEAD responses.

## Tests

- `moon check --target js --deny-warn`
- `moon test src/http/client_test.mbt --target js --filter "*null Web API bodies*"`
