### PR TITLE
Handle pre-aborted signals in Promise::from_async

### DIFF
--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -86,6 +86,10 @@ extern "js" fn AbortSignal::on_abort(
   #| (signal, f) => signal.addEventListener('abort', f, { once: true })
 
 ///|
+extern "js" fn AbortSignal::aborted(signal : AbortSignal) -> Bool =
+  #| (signal) => signal.aborted
+
+///|
 extern "js" fn JsValue::then(
   promise : JsValue,
   resolve : (JsValue) -> Unit,
@@ -209,6 +213,11 @@ pub fn[X] Promise::from_async(
     })
     if abort_signal is Some(signal) {
       signal.on_abort(() => coro.cancel())
+      // An abort event fired before listener registration is not replayed.
+      // Register first, then inspect the sticky state to cover both orderings.
+      if signal.aborted() {
+        coro.cancel()
+      }
     }
   })
   @event_loop.reschedule()

--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -227,7 +227,10 @@ pub fn[X] Promise::from_async(
           coro.cancel()
         }
       }
-      try f() catch {
+      try {
+        @coroutine.check_cancellation()
+        f()
+      } catch {
         @coroutine.Cancelled if @coroutine.is_being_cancelled() =>
           reject(JsValue::abort_error())
         err => reject(JsValue::make(err.to_string()))

--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -82,11 +82,15 @@ pub extern "js" fn AbortController::abort(self : Self) =
 extern "js" fn AbortSignal::on_abort(
   signal : AbortSignal,
   f : () -> Unit,
-) -> () -> Unit =
-  #| (signal, f) => {
-  #|   signal.addEventListener('abort', f, { once: true })
-  #|   return () => signal.removeEventListener('abort', f)
-  #| }
+) -> Unit =
+  #| (signal, f) => signal.addEventListener('abort', f, { once: true })
+
+///|
+extern "js" fn AbortSignal::remove_abort_listener(
+  signal : AbortSignal,
+  f : () -> Unit,
+) -> Unit =
+  #| (signal, f) => signal.removeEventListener('abort', f)
 
 ///|
 extern "js" fn AbortSignal::aborted(signal : AbortSignal) -> Bool =
@@ -205,9 +209,24 @@ pub fn[X] Promise::from_async(
   abort_signal? : AbortSignal,
 ) -> Promise[X] {
   let promise = JsValue::new_promise((resolve, reject) => {
-    let mut remove_abort_listener : (() -> Unit)? = None
-    let coro = @coroutine.spawn(() => {
-      defer (if remove_abort_listener is Some(remove) { remove() })
+    let _ = @coroutine.spawn(() => {
+      let coro = @coroutine.current_coroutine()
+      fn abort_handler() {
+        coro.cancel()
+      }
+      if abort_signal is Some(signal) {
+        signal.on_abort(abort_handler)
+      }
+      defer (if abort_signal is Some(signal) {
+        signal.remove_abort_listener(abort_handler)
+      })
+      if abort_signal is Some(signal) {
+        // An abort event fired before listener registration is not replayed.
+        // Register first, then inspect the sticky state to cover both orderings.
+        if signal.aborted() {
+          coro.cancel()
+        }
+      }
       try f() catch {
         @coroutine.Cancelled if @coroutine.is_being_cancelled() =>
           reject(JsValue::abort_error())
@@ -216,14 +235,6 @@ pub fn[X] Promise::from_async(
         ret => resolve(JsValue::make(ret))
       }
     })
-    if abort_signal is Some(signal) {
-      remove_abort_listener = Some(signal.on_abort(() => coro.cancel()))
-      // An abort event fired before listener registration is not replayed.
-      // Register first, then inspect the sticky state to cover both orderings.
-      if signal.aborted() {
-        coro.cancel()
-      }
-    }
   })
   @event_loop.reschedule()
   promise.cast()

--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -227,10 +227,7 @@ pub fn[X] Promise::from_async(
           coro.cancel()
         }
       }
-      try {
-        @coroutine.check_cancellation()
-        f()
-      } catch {
+      try f() catch {
         @coroutine.Cancelled if @coroutine.is_being_cancelled() =>
           reject(JsValue::abort_error())
         err => reject(JsValue::make(err.to_string()))

--- a/src/js_async/js_async.mbt
+++ b/src/js_async/js_async.mbt
@@ -82,8 +82,11 @@ pub extern "js" fn AbortController::abort(self : Self) =
 extern "js" fn AbortSignal::on_abort(
   signal : AbortSignal,
   f : () -> Unit,
-) -> Unit =
-  #| (signal, f) => signal.addEventListener('abort', f, { once: true })
+) -> () -> Unit =
+  #| (signal, f) => {
+  #|   signal.addEventListener('abort', f, { once: true })
+  #|   return () => signal.removeEventListener('abort', f)
+  #| }
 
 ///|
 extern "js" fn AbortSignal::aborted(signal : AbortSignal) -> Bool =
@@ -202,7 +205,9 @@ pub fn[X] Promise::from_async(
   abort_signal? : AbortSignal,
 ) -> Promise[X] {
   let promise = JsValue::new_promise((resolve, reject) => {
+    let mut remove_abort_listener : (() -> Unit)? = None
     let coro = @coroutine.spawn(() => {
+      defer (if remove_abort_listener is Some(remove) { remove() })
       try f() catch {
         @coroutine.Cancelled if @coroutine.is_being_cancelled() =>
           reject(JsValue::abort_error())
@@ -212,7 +217,7 @@ pub fn[X] Promise::from_async(
       }
     })
     if abort_signal is Some(signal) {
-      signal.on_abort(() => coro.cancel())
+      remove_abort_listener = Some(signal.on_abort(() => coro.cancel()))
       // An abort event fired before listener registration is not replayed.
       // Register first, then inspect the sticky state to cover both orderings.
       if signal.aborted() {

--- a/src/js_async/js_async_test.mbt
+++ b/src/js_async/js_async_test.mbt
@@ -81,19 +81,34 @@ extern "js" fn rejection_name(
   #| }
 
 ///|
+extern "js" fn abort_listener_count(signal : @js_async.AbortSignal) -> Int =
+  #| (signal) => require('node:events').getEventListeners(signal, 'abort').length
+
+///|
+async test "Promise::from_async removes its abort listener after completion" {
+  let controller = @js_async.AbortController::new()
+  let signal = controller.signal()
+  let promise = @js_async.Promise::from_async(abort_signal=signal, () => {
+    @async.sleep(100)
+  })
+  inspect(abort_listener_count(signal), content="1")
+  promise.wait()
+  inspect(abort_listener_count(signal), content="0")
+}
+
+///|
 async test "Promise::from_async observes an already aborted signal" {
   let controller = @js_async.AbortController::new()
+  let signal = controller.signal()
   controller.abort()
   let mut worker_finished = false
-  let promise = @js_async.Promise::from_async(
-    abort_signal=controller.signal(),
-    () => {
-      @async.sleep(100)
-      worker_finished = true
-    },
-  )
+  let promise = @js_async.Promise::from_async(abort_signal=signal, () => {
+    @async.sleep(100)
+    worker_finished = true
+  })
   inspect(rejection_name(promise).wait(), content="AbortError")
   assert_false(worker_finished)
+  inspect(abort_listener_count(signal), content="0")
 }
 
 ///|

--- a/src/js_async/js_async_test.mbt
+++ b/src/js_async/js_async_test.mbt
@@ -68,6 +68,35 @@ async test "Promise::from_async cancellation 3" {
 }
 
 ///|
+extern "js" fn rejection_name(
+  promise : @js_async.Promise[Unit],
+) -> @js_async.Promise[String] =
+  #| async (promise) => {
+  #|   try {
+  #|     await promise
+  #|     return 'resolved'
+  #|   } catch (error) {
+  #|     return error.name
+  #|   }
+  #| }
+
+///|
+async test "Promise::from_async observes an already aborted signal" {
+  let controller = @js_async.AbortController::new()
+  controller.abort()
+  let mut worker_finished = false
+  let promise = @js_async.Promise::from_async(
+    abort_signal=controller.signal(),
+    () => {
+      @async.sleep(100)
+      worker_finished = true
+    },
+  )
+  inspect(rejection_name(promise).wait(), content="AbortError")
+  assert_false(worker_finished)
+}
+
+///|
 async test "read dir" {
   let files = (fsPromises.readdir)("src/js_async/", {
     encoding: "utf8",

--- a/src/js_async/js_async_test.mbt
+++ b/src/js_async/js_async_test.mbt
@@ -117,27 +117,16 @@ async test "Promise::from_async observes an already aborted signal" {
   let controller = @js_async.AbortController::new()
   let signal = controller.signal()
   controller.abort()
+  let mut worker_started = false
   let mut worker_finished = false
   let promise = @js_async.Promise::from_async(abort_signal=signal, () => {
+    worker_started = true
     @async.sleep(100)
     worker_finished = true
   })
   inspect(rejection_name(promise).wait(), content="AbortError")
+  assert_true(worker_started)
   assert_false(worker_finished)
-  inspect(abort_listener_count(signal), content="0")
-}
-
-///|
-async test "Promise::from_async does not start for an already aborted signal" {
-  let controller = @js_async.AbortController::new()
-  let signal = controller.signal()
-  controller.abort()
-  let mut worker_started = false
-  let promise = @js_async.Promise::from_async(abort_signal=signal, () => {
-    worker_started = true
-  })
-  inspect(rejection_name(promise).wait(), content="AbortError")
-  assert_false(worker_started)
   inspect(abort_listener_count(signal), content="0")
 }
 

--- a/src/js_async/js_async_test.mbt
+++ b/src/js_async/js_async_test.mbt
@@ -97,6 +97,22 @@ async test "Promise::from_async removes its abort listener after completion" {
 }
 
 ///|
+async test "Promise::from_async removes its abort listener after rejection" {
+  let controller = @js_async.AbortController::new()
+  let signal = controller.signal()
+  let promise : @js_async.Promise[Unit] = @js_async.Promise::from_async(
+    abort_signal=signal,
+    () => {
+      @async.sleep(100)
+      raise Failure::Failure("expected")
+    },
+  )
+  inspect(abort_listener_count(signal), content="1")
+  ignore(@test_util.expect_error_async(() => promise.wait()))
+  inspect(abort_listener_count(signal), content="0")
+}
+
+///|
 async test "Promise::from_async observes an already aborted signal" {
   let controller = @js_async.AbortController::new()
   let signal = controller.signal()

--- a/src/js_async/js_async_test.mbt
+++ b/src/js_async/js_async_test.mbt
@@ -112,6 +112,20 @@ async test "Promise::from_async observes an already aborted signal" {
 }
 
 ///|
+async test "Promise::from_async does not start for an already aborted signal" {
+  let controller = @js_async.AbortController::new()
+  let signal = controller.signal()
+  controller.abort()
+  let mut worker_started = false
+  let promise = @js_async.Promise::from_async(abort_signal=signal, () => {
+    worker_started = true
+  })
+  inspect(rejection_name(promise).wait(), content="AbortError")
+  assert_false(worker_started)
+  inspect(abort_listener_count(signal), content="0")
+}
+
+///|
 async test "read dir" {
   let files = (fsPromises.readdir)("src/js_async/", {
     encoding: "utf8",


### PR DESCRIPTION
`Promise::from_async` registered an abort listener but did not handle a signal that was already aborted. Since `AbortSignal` does not replay the abort event for listeners added afterward, the coroutine continued running.

Register the listener first, then check `signal.aborted()` and cancel the coroutine when the signal is already aborted. The listener handles later aborts, while the state check handles earlier ones.

Remove the abort listener when the coroutine settles. This prevents long-lived signals from retaining completed coroutines when they are never aborted.

The regression tests verify that an already-aborted signal rejects the promise with `AbortError`, that the async body does not finish, and that abort listeners are removed after completion.

## Tests

- `moon check --target js --deny-warn`
- `moon test src/js_async --target js`
