### PR TITLE
do not register `NOTE_EXTEND` in MacOS watcher to avoid spurious events

### DIFF
--- a/src/fs/watch_kqueue.c
+++ b/src/fs/watch_kqueue.c
@@ -72,9 +72,6 @@ int moonbitlang_async_kqueue_watcher_add_file(int kq, int fd, int32_t is_dir) {
 #ifdef __MACH__
   struct kevent event;
   int events_to_watch = NOTE_WRITE;
-  if (!is_dir) {
-    events_to_watch |= NOTE_EXTEND;
-  }
   EV_SET(
     &event,
     fd,


### PR DESCRIPTION
For regular files, `NOTE_EXTEND` is fired when the file is extended. A write + extend operation will simultaneously generate `NOTE_WRITE` + `NOTE_EXTEND` events, causing spurious wakeup in the watcher. `NOTE_WRITE` along is enough for our purpose, so there is no need to register `NOTE_EXTEND` in `kqueue` file system watcher. This seems to be the cost of recent random MacOS CI watcher test failure.