### PR TITLE
report fatal error in `async fn main` for JS backend

### DIFF
--- a/src/integration.mbt
+++ b/src/integration.mbt
@@ -62,8 +62,14 @@ extern "C" fn exit(code : Int) = "exit"
 #cfg(target="js")
 #doc(hidden)
 pub fn run_async_main(main : async () -> Unit) -> Unit {
-  ignore(@env_util.eprintln)
-  let _ = @coroutine.spawn(main)
+  let _ = @coroutine.spawn <| () => {
+    main() catch {
+      err => {
+        @env_util.eprintln(err.to_string())
+        panic()
+      }
+    }
+  }
   @event_loop.reschedule()
 }
 


### PR DESCRIPTION
closes #584

Let `async fn main` output the error message and `panic()` on fatal error in JS backend. `@js_async.Promise::from_async` is not affected.

On JS backend, we do not control the event loop, so we don't really know whether the end of the whole program is. Fortunately, since `moonbitlang/async` uses structured concurrency, we know that when the main task exits, the MoonBit part of the program must have been terminated. So we only need to report the error at the end of the main task.