### PR TITLE
Fix spawning without standard handles on Windows

### DIFF
--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -931,7 +931,11 @@ int32_t spawn_job_worker(struct spawn_job *job, int32_t *err_out) {
     return 0;
   }
 
+  // `UpdateProcThreadAttribute` rejects an empty handle list with
+  // `ERROR_BAD_LENGTH`. Having no standard handles is valid for GUI processes.
   if (
+    number_of_handles_to_inherit > 0
+    &&
     !UpdateProcThreadAttribute(
       startup_info.lpAttributeList,
       0, // reserved

--- a/src/process/wait_test.mbt
+++ b/src/process/wait_test.mbt
@@ -70,6 +70,17 @@ async test "wait_pid" {
 }
 
 ///|
+async test "spawn without standard handles on Windows" {
+  guard @event_loop.platform is Windows else {  }
+  let spawn = spawn_prog.wait()
+  let sleep = sleep_prog.wait()
+  inspect(
+    @process.run(spawn, ["-no-stdio", "-orphan", sleep, "0"]),
+    content="0",
+  )
+}
+
+///|
 async test "wait exitcode STILL_ACTIVE" {
   guard @event_loop.platform is Windows else {  }
   // `259` is the special value for `STILL_ACTIVE`,

--- a/test_programs/spawn/main.mbt
+++ b/test_programs/spawn/main.mbt
@@ -14,7 +14,14 @@
 
 ///|
 async fn main {
-  let (is_orphan, args) = match @env.args()[1:] {
+  let args = match @env.args()[1:] {
+    ["-no-stdio", .. rest] => {
+      remove_standard_handles()
+      rest
+    }
+    args => args
+  }
+  let (is_orphan, args) = match args {
     ["-orphan", .. rest] => (true, rest)
     args => (false, args)
   }
@@ -26,3 +33,6 @@ async fn main {
     ignore(@process.run(cmd, args))
   }
 }
+
+///|
+extern "C" fn remove_standard_handles() = "remove_standard_handles"

--- a/test_programs/spawn/moon.pkg
+++ b/test_programs/spawn/moon.pkg
@@ -7,3 +7,7 @@ import {
 supported_targets = "-all+native"
 
 pkgtype(kind: "executable")
+
+options(
+  "native-stub": [ "stub.c" ],
+)

--- a/test_programs/spawn/stub.c
+++ b/test_programs/spawn/stub.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <moonbit.h>
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+MOONBIT_FFI_EXPORT
+void remove_standard_handles(void) {
+  SetStdHandle(STD_INPUT_HANDLE, NULL);
+  SetStdHandle(STD_OUTPUT_HANDLE, NULL);
+  SetStdHandle(STD_ERROR_HANDLE, NULL);
+}
+
+#else
+
+void remove_standard_handles(void) {}
+
+#endif


### PR DESCRIPTION
 Windows GUI applications may have no standard handles. In that case,
  `UpdateProcThreadAttribute` receives an empty handle list and fails with
  `ERROR_BAD_LENGTH`.

  Skip setting `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` when there are no handles to
  inherit, and add a Windows regression test covering `spawn_orphan` without
  standard handles.

  Tested with:

  - `moon test src/process --target native` — 42 passed
  - The regression test reproduces `ERROR_BAD_LENGTH` before the fix and passes
    after it