### PR TITLE
workaround Linux pidfd spurious wakeup

### DIFF
--- a/src/internal/event_loop/process_unix.mbt
+++ b/src/internal/event_loop/process_unix.mbt
@@ -79,16 +79,23 @@ pub async fn Process::wait_pid_unix(self : Process, context~ : String) -> Int {
 
   let ret = get_process_result(handle, self.pid, out)
   if ret < 0 {
-    if platform is MacOS {
-      // On MacOS, when `kevent` report `ESRCH`,
-      // there is a small window where `waitpid(.., WNOHANG)` may still return zero.
-      // Work around this race condition by waiting again after a small timeout.
-      while @os_error.is_nonblocking_io_error() {
-        sleep(10)
-        let ret = get_process_result(handle, self.pid, out)
-        if ret >= 0 {
-          return out.val
-        }
+    while @os_error.is_nonblocking_io_error() {
+      match @env_util.platform {
+        Linux if self.handle is Some(io) =>
+          // On Linux, if the child process is `ptrace`'ed,
+          // we may receive spurious wakeup message from the pidfd.
+          // Work around this by retrying wait.
+          io.wait_read()
+        MacOS =>
+          // On MacOS, when `kevent` report `ESRCH`,
+          // there is a small window where `waitpid(.., WNOHANG)` may still return zero.
+          // Work around this race condition by waiting again after a small timeout.
+          sleep(10)
+        Linux | Windows => break
+      }
+      let ret = get_process_result(handle, self.pid, out)
+      if ret >= 0 {
+        return out.val
       }
     }
     @os_error.check_errno(context)


### PR DESCRIPTION
When the child process is `ptrace`'ed, `pidfd` may report spurious read readiness event. Upon receiving these events, `waitid(.., WNOHANG)` cannot produce a result normally, leading to failure. This has also been observed in https://github.com/tokio-rs/tokio/issues/7144. Leak sanitizer seems to be performing `ptrace` operations on exit, resulting in recent CI failure in the Linux sanitizer check job.

This PR fixes the problem by adding retry for the "`waitid` not yet ready" case.