### PR TITLE
improve cancellation handling of thread pool job

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -210,7 +210,18 @@ fn EventLoop::handle_completed_job(self : Self, job_id : Int) -> Unit {
     }
     self.killed_by_signal = Some(job_id ^ (1 << 31))
   }
-  guard! self.running_workers.get(job_id) is Some(worker)
+  guard self.running_workers.get(job_id) is Some(worker) else { return }
+  // Completion message for a job may receive in two cases:
+  //
+  // - the job indeed completed
+  // - the job is being cancelled, and we need to retry cancellation
+  //
+  // `check_cancellation_retry` check the second case and perform retry automatically.
+  // If the completion message is for retry, do not wake the waiter yet.
+  if worker.check_cancellation_retry() {
+    return
+  }
+
   self.running_workers.remove(job_id)
   match self.job_queue.iter().next() {
     None => {

--- a/src/internal/event_loop/fs.c
+++ b/src/internal/event_loop/fs.c
@@ -85,6 +85,10 @@ void *moonbitlang_async_make_job(
   (int32_t (*)(void*))cancel_handler\
 )
 
+void *moonbitlang_async_get_current_worker();
+int32_t moonbitlang_async_enter_cancellable_region(void *worker);
+void moonbitlang_async_leave_cancellable_region(void *worker);
+
 
 // ===== stat related helpers =====
 
@@ -934,6 +938,8 @@ HANDLE moonbitlang_async_open_sync(
   int32_t sync_mode,
   int32_t permission
 ) {
+  void *worker = moonbitlang_async_get_current_worker();
+
 #ifdef _WIN32
 
   static int access_flags[] = {
@@ -958,6 +964,11 @@ HANDLE moonbitlang_async_open_sync(
     access_flag = (access_flag ^ GENERIC_WRITE) | FILE_APPEND_DATA;
 
   while (1) {
+    if (moonbitlang_async_enter_cancellable_region(worker)) {
+      SetLastError(ERROR_OPERATION_ABORTED);
+      return INVALID_HANDLE_VALUE;
+    }
+
     HANDLE result = CreateFileW(
       filename,
       access_flag, // desired access
@@ -967,6 +978,7 @@ HANDLE moonbitlang_async_open_sync(
       flags, // flags and attributes. Note that we open files in synchronous mode
       NULL // template file
     );
+    moonbitlang_async_leave_cancellable_region(worker);
 
     if (result != INVALID_HANDLE_VALUE)
       return result;
@@ -979,7 +991,15 @@ HANDLE moonbitlang_async_open_sync(
     // We are trying to open a named pipe, but no pipe instance is available,
     // so wait until any instance is available.
     // This wait is cancellable via `CancelSynchronousIo`.
-    if (!WaitNamedPipeW(filename, NMPWAIT_WAIT_FOREVER))
+    if (moonbitlang_async_enter_cancellable_region(worker)) {
+      SetLastError(ERROR_OPERATION_ABORTED);
+      return INVALID_HANDLE_VALUE;
+    }
+
+    BOOL status = WaitNamedPipeW(filename, NMPWAIT_WAIT_FOREVER);
+    moonbitlang_async_leave_cancellable_region(worker);
+
+    if (!status)
       return INVALID_HANDLE_VALUE;
   }
 
@@ -1002,7 +1022,14 @@ HANDLE moonbitlang_async_open_sync(
     | create_modes[create_mode];
   if (append) flags |= O_APPEND;
 
-  return open(filename, flags | O_CLOEXEC, permission);
+  if (moonbitlang_async_enter_cancellable_region(worker)) {
+    errno = EINTR;
+    return -1;
+  }
+
+  int ret = open(filename, flags | O_CLOEXEC, permission);
+  moonbitlang_async_leave_cancellable_region(worker);
+  return ret;
 
 #endif
 }
@@ -1282,6 +1309,8 @@ struct fsync_job *moonbitlang_async_make_fsync_job(HANDLE fd, int only_data) {
 // ===== flock job, place advisory lock on a file =====
 static
 int32_t moonbitlang_async_flock_sync(HANDLE fd, int32_t exclusive) {
+  void *worker = moonbitlang_async_get_current_worker();
+
 #ifdef _WIN32
 
   OVERLAPPED overlapped;
@@ -1296,6 +1325,12 @@ int32_t moonbitlang_async_flock_sync(HANDLE fd, int32_t exclusive) {
   // as this region can almost never get touched by normal IO operations.
   overlapped.Offset = 0xfffffffe;
   overlapped.OffsetHigh = 0xffffffff;
+
+  if (moonbitlang_async_enter_cancellable_region(worker)) {
+    SetLastError(ERROR_OPERATION_ABORTED);
+    return -1;
+  }
+
   BOOL ret = LockFileEx(
     fd,
     exclusive ? LOCKFILE_EXCLUSIVE_LOCK : 0,
@@ -1304,12 +1339,21 @@ int32_t moonbitlang_async_flock_sync(HANDLE fd, int32_t exclusive) {
     0,
     &overlapped
   );
+  moonbitlang_async_leave_cancellable_region(worker);
 
   return ret ? 0 : -1;
 
 #else
 
-  return flock(fd, exclusive ? LOCK_EX : LOCK_SH);
+  if (moonbitlang_async_enter_cancellable_region(worker)) {
+    errno = EINTR;
+    return -1;
+  }
+
+  int ret = flock(fd, exclusive ? LOCK_EX : LOCK_SH);
+  moonbitlang_async_leave_cancellable_region(worker);
+
+  return ret;
 
 #endif
 }

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -392,9 +392,19 @@ int32_t moonbitlang_async_cancel_worker(struct worker *worker) {
 #else
 
   pthread_kill(worker->id, SIGUSR2);
-  return CANCELLATION_STATUS_RETRY_LATER;
+  return CANCELLATION_STATUS_NEED_WAIT;
 
 #endif
+}
+
+MOONBIT_FFI_EXPORT
+int32_t moonbitlang_async_worker_check_cancellation_retry(struct worker *worker) {
+  if (worker->state != Waiting) {
+    moonbitlang_async_cancel_worker(worker);
+    return 1;
+  } else {
+    return 0;
+  }
 }
 
 MOONBIT_FFI_EXPORT
@@ -420,7 +430,38 @@ void moonbitlang_async_free_worker(struct worker *worker) {
 
 #ifndef _WIN32
 static
-void nop_signal_handler(int signum) {}
+void cancellation_signal_handler(int signum) {
+  // `pthread_getspecific` is NOT async-signal-safe according to POSIX, however:
+  // - `glibc` explicitly guarantees async-signal-safety of `pthread_getspecific`
+  // - the implementation of `pthread_getspecific` in `musl` and MacOS
+  //   is just a simple TSD array indexing, which is async-signal-safe
+  // We deliberately rely on implementation specific behavior to simplify the logic.
+  // There is no POSIX-compilant way to access thread specific storage
+  // in signal handler without hack.
+  struct worker *worker = moonbitlang_async_get_current_worker();
+  if (!worker)
+    return;
+
+  if (worker->state == Cancelling && worker->inside_cancellable_region) {
+    // if the signal arrives with `inside_cancellable_region` set, there are three cases:
+    //
+    // 1. the signal arrives before entering the syscall
+    // 2. the signal interrupted the syscall
+    // 3. the signal arrives after the syscall completes normally
+    //
+    // In case (1), we cannot prevent the worker from entering the syscall,
+    // so we must send a retry request back to the main event loop.
+    int32_t data = worker->job_id;
+    // We should never do blocking `write` in signal handler.
+    // However, the number of items in the pipe is actually bounded here.
+    // Every worker can enqueue at most two items
+    // (one from this handler, one from normal completion) at the same time.
+    // So the max number of items in bounded by max worker count,
+    // which currently never exceed 1024 (not configurable by users).
+    // The default size of pipe buffer on Linux/MacOS is large enough to hold all items.
+    write(pool.notify_send, &data, sizeof(data));
+  }
+}
 
 int moonbitlang_async_event_bus_register(int event_bus, int fd, int32_t read_only);
 #endif
@@ -454,7 +495,7 @@ HANDLE moonbitlang_async_init_thread_pool(HANDLE event_bus) {
   // 1. the program won't get killed
   // 2. blocked syscall will be interrupted
   struct sigaction act;
-  act.sa_handler = nop_signal_handler;
+  act.sa_handler = cancellation_signal_handler;
   sigemptyset(&act.sa_mask);
   act.sa_flags = 0;
   sigaction(SIGUSR2, &act, NULL);

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -175,6 +175,12 @@ struct {
 #ifdef WAKEUP_METHOD_SIGNAL
   sigset_t wakeup_signal;
 #endif
+
+#ifdef _WIN32
+  DWORD current_worker;
+#else
+  pthread_key_t current_worker;
+#endif
 } pool;
 
 // The type for a worker thread
@@ -229,6 +235,12 @@ static
 thread_worker_result_t THREAD_PROC_CALLING_CONVENTION worker_loop(void *data) {
   int sig;
   struct worker *self = (struct worker*)data;
+
+#ifdef _WIN32
+  TlsSetValue(pool.current_worker, data);
+#else
+  pthread_setspecific(pool.current_worker, data);
+#endif
 
   int job_id = self->job_id;
   struct job *job = self->job;
@@ -292,6 +304,18 @@ void moonbitlang_async_wake_worker(
   worker->waiting = 0;
   pthread_cond_signal(&(worker->cond));
   pthread_mutex_unlock(&(worker->mutex));
+#endif
+}
+
+MOONBIT_FFI_EXPORT
+void *moonbitlang_async_get_current_worker() {
+  if (!pool.initialized)
+    return 0;
+
+#ifdef _WIN32
+  return TlsGetValue(pool.current_worker);
+#else
+  return pthread_getspecific(pool.current_worker);
 #endif
 }
 
@@ -433,6 +457,12 @@ HANDLE moonbitlang_async_init_thread_pool(HANDLE event_bus) {
 
 #endif
 
+#ifdef _WIN32
+  pool.current_worker = TlsAlloc();
+#else
+  pthread_key_create(&pool.current_worker, 0);
+#endif
+
   pool.initialized = 1;
   return pool.notify_recv;
 
@@ -455,6 +485,12 @@ void moonbitlang_async_destroy_thread_pool() {
   pthread_sigmask(SIG_SETMASK, &pool.old_sigmask, 0);
   close(pool.notify_recv);
   close(pool.notify_send);
+#endif
+
+#ifdef _WIN32
+  TlsFree(pool.current_worker);
+#else
+  pthread_key_delete(pool.current_worker);
 #endif
 }
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -174,7 +174,6 @@ struct {
   HANDLE notify_recv;
 
 #ifndef _WIN32
-  sigset_t worker_sigmask;
   sigset_t old_sigmask;
 #endif
 #ifdef WAKEUP_METHOD_SIGNAL
@@ -263,6 +262,13 @@ thread_worker_result_t THREAD_PROC_CALLING_CONVENTION worker_loop(void *data) {
 #elif defined(WAKEUP_METHOD_COND_VAR)
   pthread_mutex_init(&(self->mutex), 0);
   pthread_cond_init(&(self->cond), 0);
+#endif
+
+#ifndef _WIN32
+  sigset_t cancellation_signal;
+  sigemptyset(&cancellation_signal);
+  sigaddset(&cancellation_signal, SIGUSR2);
+  pthread_sigmask(SIG_UNBLOCK, &cancellation_signal, 0);
 #endif
 
   while (job) {
@@ -472,10 +478,6 @@ HANDLE moonbitlang_async_init_thread_pool(HANDLE event_bus) {
     abort();
 
 #ifndef _WIN32
-  sigfillset(&pool.worker_sigmask); 
-  // used for cancelling blocking IO in worker thread
-  sigdelset(&pool.worker_sigmask, SIGUSR2);
-
   sigset_t signals_to_block;
   sigemptyset(&signals_to_block);
   sigaddset(&signals_to_block, SIGCHLD);
@@ -603,8 +605,9 @@ struct worker *moonbitlang_async_spawn_worker(
 #endif
 
   // make sure the worker thread has correct sigmask immediately
-  sigset_t curr_sigmask;
-  pthread_sigmask(SIG_SETMASK, &pool.worker_sigmask, &curr_sigmask);
+  sigset_t all_signals, curr_sigmask;
+  sigfillset(&all_signals);
+  pthread_sigmask(SIG_SETMASK, &all_signals, &curr_sigmask);
 
   pthread_create(&(worker->id), &attr, &worker_loop, worker);
 

--- a/src/internal/event_loop/thread_pool.c
+++ b/src/internal/event_loop/thread_pool.c
@@ -30,6 +30,8 @@
 
 #pragma comment(lib, "ws2_32.lib")
 
+typedef volatile int32_t atomic_int32_t;
+
 #else
 
 #include <pthread.h>
@@ -38,6 +40,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <string.h>
+#include <stdatomic.h>
 #include <errno.h>
 #include <time.h>
 #if !defined(__ANDROID__) || __ANDROID_API__ >= 28
@@ -63,6 +66,8 @@ typedef int HANDLE;
 typedef int SOCKET;
 #define GetLastError() errno
 #define SetLastError(err) errno = err
+
+typedef _Atomic int32_t atomic_int32_t;
 
 #endif
 
@@ -183,6 +188,13 @@ struct {
 #endif
 } pool;
 
+enum WorkerState {
+  Running = 0,
+  Cancelling,
+  Cancelled,
+  Waiting
+};
+
 // The type for a worker thread
 struct worker {
 #ifdef _WIN32
@@ -198,7 +210,8 @@ struct worker {
   // the job currently being processed
   struct job *job;
 
-  int waiting;
+  atomic_int32_t state;
+  atomic_int32_t inside_cancellable_region;
 
 #ifdef WAKEUP_METHOD_EVENT
   HANDLE event;
@@ -256,7 +269,8 @@ thread_worker_result_t THREAD_PROC_CALLING_CONVENTION worker_loop(void *data) {
     job->err = 0;
     job->ret = job->worker(job->payload, &job->err);
 
-    self->waiting = 1;
+    self->state = Waiting;
+    self->inside_cancellable_region = 0;
 
     moonbitlang_async_notify_event_loop(job_id);
 
@@ -266,7 +280,7 @@ thread_worker_result_t THREAD_PROC_CALLING_CONVENTION worker_loop(void *data) {
     sigwait(&pool.wakeup_signal, &sig);
 #elif defined(WAKEUP_METHOD_COND_VAR)
     pthread_mutex_lock(&(self->mutex));
-    while (self->waiting) {
+    while (self->state == Waiting) {
 #ifdef __MACH__
       // There's a bug in the MacOS's `pthread_cond_wait`,
       // see https://github.com/graphia-app/graphia/issues/33
@@ -294,29 +308,48 @@ void moonbitlang_async_wake_worker(
   worker->job = job ? JOB_HEADER(job) : 0;
 
 #ifdef WAKEUP_METHOD_EVENT
-  worker->waiting = 0;
+  worker->state = Running;
   SetEvent(worker->event);
 #elif defined(WAKEUP_METHOD_SIGNAL)
-  worker->waiting = 0;
+  worker->state = Running;
   pthread_kill(worker->id, SIGUSR1);
 #elif defined(WAKEUP_METHOD_COND_VAR)
   pthread_mutex_lock(&(worker->mutex));
-  worker->waiting = 0;
+  worker->state = Running;
   pthread_cond_signal(&(worker->cond));
   pthread_mutex_unlock(&(worker->mutex));
 #endif
 }
 
-MOONBIT_FFI_EXPORT
-void *moonbitlang_async_get_current_worker() {
+struct worker *moonbitlang_async_get_current_worker() {
   if (!pool.initialized)
     return 0;
 
 #ifdef _WIN32
-  return TlsGetValue(pool.current_worker);
+  return (struct worker*)TlsGetValue(pool.current_worker);
 #else
-  return pthread_getspecific(pool.current_worker);
+  return (struct worker*)pthread_getspecific(pool.current_worker);
 #endif
+}
+
+int32_t moonbitlang_async_enter_cancellable_region(struct worker *worker) {
+  if (!worker)
+    return 0;
+
+  worker->inside_cancellable_region = 1;
+
+  if (worker->state == Cancelling) {
+    worker->state = Cancelled;
+    worker->inside_cancellable_region = 0;
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+void moonbitlang_async_leave_cancellable_region(struct worker *worker) {
+  if (worker)
+    worker->inside_cancellable_region = 0;
 }
 
 MOONBIT_FFI_EXPORT
@@ -331,8 +364,13 @@ enum {
 
 MOONBIT_FFI_EXPORT
 int32_t moonbitlang_async_cancel_worker(struct worker *worker) {
-  if (worker->waiting)
-    return 1;
+  switch (worker->state) {
+    case Cancelled:
+    case Waiting:
+      return CANCELLATION_STATUS_NEED_WAIT;
+    case Running:
+      worker->state = Cancelling;
+  }
 
   // invarint: `worker->job` is only manipulated in the main thread,
   // and must be non-NULL here.
@@ -502,7 +540,8 @@ struct worker *moonbitlang_async_spawn_worker(
   struct worker *worker = (struct worker*)malloc(sizeof(struct worker));
   worker->job_id = init_job_id;
   worker->job = JOB_HEADER(init_job);
-  worker->waiting = 0;
+  worker->state = Running;
+  worker->inside_cancellable_region = 0;
 
 #ifdef _WIN32
   worker->id = CreateThread(
@@ -639,6 +678,8 @@ void free_read_job(struct read_job *job) {
 
 static
 int32_t read_job_worker(struct read_job *job, int32_t *err_out) {
+  struct worker *worker = moonbitlang_async_get_current_worker();
+
 #ifdef _WIN32
 
    OVERLAPPED overlapped;
@@ -646,6 +687,11 @@ int32_t read_job_worker(struct read_job *job, int32_t *err_out) {
    if (job->position >= 0) {
      overlapped.Offset = job->position & 0xffffffff;
      overlapped.OffsetHigh = job->position >> 32;
+   }
+
+   if (moonbitlang_async_enter_cancellable_region(worker)) {
+     *err_out = ERROR_OPERATION_ABORTED;
+     return -1;
    }
 
    DWORD bytes_transferred;
@@ -656,6 +702,9 @@ int32_t read_job_worker(struct read_job *job, int32_t *err_out) {
      &bytes_transferred,
      job->position < 0 ? NULL : &overlapped
    );
+
+   moonbitlang_async_leave_cancellable_region(worker);
+
    if (result) {
      return bytes_transferred;
    } else {
@@ -673,7 +722,14 @@ int32_t read_job_worker(struct read_job *job, int32_t *err_out) {
   int32_t ret;
   if (job->position < 0) {
     while (1) {
+      if (moonbitlang_async_enter_cancellable_region(worker)) {
+        *err_out = EINTR;
+        return -1;
+      }
+
       ret = read(job->fd, job->buf + job->offset, job->len);
+      moonbitlang_async_leave_cancellable_region(worker);
+
       if (ret >= 0)
         break;
 
@@ -681,7 +737,15 @@ int32_t read_job_worker(struct read_job *job, int32_t *err_out) {
         break;
 
       struct pollfd pfd = { job->fd, POLL_IN, 0 };
-      if (poll(&pfd, 1, -1) < 0)
+      if (moonbitlang_async_enter_cancellable_region(worker)) {
+        *err_out = EINTR;
+        return -1;
+      }
+
+      ret = poll(&pfd, 1, -1);
+      moonbitlang_async_leave_cancellable_region(worker);
+
+      if (ret < 0)
         break;
     }
   } else {
@@ -734,6 +798,8 @@ void free_write_job(struct write_job *job) {
 
 static
 int32_t write_job_worker(struct write_job *job, int32_t *err_out) {
+  struct worker *worker = moonbitlang_async_get_current_worker();
+
 #ifdef _WIN32
 
    OVERLAPPED overlapped;
@@ -744,6 +810,11 @@ int32_t write_job_worker(struct write_job *job, int32_t *err_out) {
    }
 
    DWORD bytes_transferred;
+   if (moonbitlang_async_enter_cancellable_region(worker)) {
+     *err_out = ERROR_OPERATION_ABORTED;
+     return -1;
+   }
+
    BOOL result = WriteFile(
      job->fd,
      job->buf + job->offset,
@@ -751,6 +822,8 @@ int32_t write_job_worker(struct write_job *job, int32_t *err_out) {
      &bytes_transferred,
      job->position < 0 ? NULL : &overlapped
    );
+   moonbitlang_async_leave_cancellable_region(worker);
+
    if (result)
      return bytes_transferred;
    else {
@@ -763,7 +836,14 @@ int32_t write_job_worker(struct write_job *job, int32_t *err_out) {
   int32_t ret;
   if (job->position < 0) {
     while (1) {
+      if (moonbitlang_async_enter_cancellable_region(worker)) {
+        *err_out = EINTR;
+        return -1;
+      }
+
       ret = write(job->fd, job->buf + job->offset, job->len);
+      moonbitlang_async_leave_cancellable_region(worker);
+
       if (ret >= 0)
         break;
 
@@ -771,7 +851,15 @@ int32_t write_job_worker(struct write_job *job, int32_t *err_out) {
         break;
 
       struct pollfd pfd = { job->fd, POLL_OUT, 0 };
-      if (poll(&pfd, 1, -1) < 0)
+      if (moonbitlang_async_enter_cancellable_region(worker)) {
+        *err_out = EINTR;
+        return -1;
+      }
+
+      ret = poll(&pfd, 1, -1);
+      moonbitlang_async_leave_cancellable_region(worker);
+
+      if (ret < 0)
         break;
     }
   } else {
@@ -1307,8 +1395,17 @@ void free_wait_for_process_job(struct wait_for_process_job *job) {}
 
 static
 int32_t wait_for_process_job_worker(struct wait_for_process_job *job, int32_t *err_out) {
+  struct worker *worker = moonbitlang_async_get_current_worker();
+
   int status;
+  if (moonbitlang_async_enter_cancellable_region(worker)) {
+    *err_out = EINTR;
+    return -1;
+  }
+
   int ret = waitpid(job->pid, &status, 0);
+  moonbitlang_async_leave_cancellable_region(worker);
+
   if (ret == job->pid) {
     return WEXITSTATUS(status);
   } else {

--- a/src/internal/event_loop/thread_pool.mbt
+++ b/src/internal/event_loop/thread_pool.mbt
@@ -53,6 +53,9 @@ fn Worker::cancel(
 }
 
 ///|
+extern "C" fn Worker::check_cancellation_retry(worker : Worker) -> Bool = "moonbitlang_async_worker_check_cancellation_retry"
+
+///|
 #cfg(not(platform="windows"))
 #borrow(output)
 extern "C" fn fetch_completion_ffi(

--- a/src/internal/event_loop/thread_pool.wasm.mbt
+++ b/src/internal/event_loop/thread_pool.wasm.mbt
@@ -69,6 +69,11 @@ fn Worker::cancel(
 }
 
 ///|
+fn Worker::check_cancellation_retry(_worker : Worker) -> Bool {
+  false
+}
+
+///|
 #unsafe_skip_stub_check
 #borrow(output)
 fn fetch_completion_ffi(


### PR DESCRIPTION
Currently, `moonbitlang/async` allows cancellation of thread pool jobs when possible. There are cases where a cancellable operation that may potentially block forever still have to get dispatched to the thread pool. For example:

- `open` may block forever and can be interrupted if the destination is a named pipe
- `read`/`write` on stdio also have to run in the thread pool, because inherited stdio may be blocking

On Unix, cancellation of thread pool job is implemented by sending `SIGUSR2`. On Windows, cancellation is implemented through `CancelSynchronousIo`. One problem with current cancellation mechanism is that, we don't know whether cancellation has succeeded, so we can only blindly retry cancellation, until the job actually completes. This PR refactors and improves cancellation handling of thread pool jobs:

- various thread pool workers will now actively check and acknowledge cancellation, before entering a cancellable syscall
- when the main thread sees that the target thread has already acknowledged cancellation, it will no longer retry cancellation
- on Unix, instead of using a fixed 10ms delay, retrying is initiated by the cancellation signal handler on cancelled thread. If the handler is triggered inside cancellable region, it will ask the main thread to retry cancellation again via self-pipe