### PR TITLE
fix(wasm): deliver cancellation signals without worker jobs

### DIFF
--- a/src/internal/event_loop/event_loop.mbt
+++ b/src/internal/event_loop/event_loop.mbt
@@ -30,7 +30,6 @@ priv struct EventLoop {
   jobs : Map[Int, @coroutine.Coroutine]
   timers : @sorted_set.SortedSet[Timer]
   mut main : @coroutine.Coroutine?
-  mut signal_handler : SignalHandler?
   mut killed_by_signal : Int?
   mut blocked_tasks : Int
 }
@@ -94,7 +93,6 @@ fn EventLoop::new(max_worker_count~ : Int) -> EventLoop raise {
     jobs: Map([]),
     timers: SortedSet([]),
     main: None,
-    signal_handler: None,
     killed_by_signal: None,
     blocked_tasks: 0,
   }
@@ -142,7 +140,6 @@ pub fn with_event_loop(
     }
   }
   let signal_handler = setup_signal_handler()
-  evloop.signal_handler = Some(signal_handler)
   let main = @coroutine.spawn(() => {
     defer evloop.terminate_signal_handler(signal_handler)
     f()
@@ -340,13 +337,8 @@ pub fn set_deadlock_handler(f : (Array[SourceLoc]) -> Unit) -> Unit {
 }
 
 ///|
-fn EventLoop::check_dead_lock(self : Self) -> Unit {
+fn EventLoop::check_dead_lock(_self : Self) -> Unit {
   let all_coros = @coroutine.all_coroutines().iter()
-  let all_coros = match self.signal_handler {
-    Some(SigwaitHandler(sigwait_task)) =>
-      all_coros.filter(coro => coro != sigwait_task)
-    None | Some(ConsoleControlHandler) => all_coros
-  }
   let all_coros = all_coros.map(coro => coro.loc).collect()
   if all_coros.length() > 0 {
     (deadlock_handler.val)(all_coros)

--- a/src/internal/event_loop/signal.mbt
+++ b/src/internal/event_loop/signal.mbt
@@ -69,32 +69,8 @@ pub fn set_global_cancellation_signals(signals : ReadOnlyArray[Int]) -> Unit {
 ///|
 #warnings("-unused_constructor")
 priv enum SignalHandler {
-  SigwaitHandler(@coroutine.Coroutine)
+  UnixSignalHandler
   ConsoleControlHandler
-}
-
-///|
-#cfg(target="wasm")
-fn setup_signal_handler_unix() -> @coroutine.Coroutine {
-  // This is the old implementation that reuse worker thread pool.
-  // Native backend has already migrated to more robust implementation.
-  // TODO: port Wasm1 as well.
-  guard! curr_loop.val is Some(evloop)
-  if !global_signal_handler_initialized.val {
-    set_global_cancellation_signals(all_signals)
-  }
-  @coroutine.spawn() <| () => {
-    let context = "sigwait thread"
-    let job = Job::sigwait(all_signals)
-    defer job.free()
-    // We want to exclude the signal waiting task from dead lock detection.
-    // Since we do not execute coroutines with nested call stack,
-    // when the main loop is running, the sigwait task must be suspended,
-    // so whenever `blocked_task` is read, the `-= 1` here
-    // will cancel a `+= 1` caused by `evloop.suspend()` in the sigwait task.
-    evloop.blocked_tasks -= 1
-    ignore <| perform_job_in_worker(job, context~, cancellable=true)
-  }
 }
 
 ///|
@@ -107,21 +83,13 @@ extern "C" fn terminate_signal_handler_ffi() -> Unit = "moonbitlang_async_termin
 
 ///|
 #cfg(target="wasm")
-async fn EventLoop::terminate_signal_handler_unix(
-  evloop : EventLoop,
-  sigwait_task : @coroutine.Coroutine,
-) -> Unit {
-  // This is the old implementation that reuse worker thread pool.
-  // Native backend has already migrated to more robust implementation.
-  // TODO: port Wasm1 as well.
-  sigwait_task.cancel()
-  // Undo the `-= 1` in `setup_sigwait_signal_handler`.
-  evloop.blocked_tasks += 1
-  let _ = @coroutine.protect_from_cancel(() => sigwait_task.wait())
-  if evloop.killed_by_signal is Some(signal) {
-    raise KilledBySignal(signal)
-  }
-}
+#unsafe_skip_stub_check
+fn start_signal_handler_ffi() -> Unit = "moonbitlang/async" "signal/start_signal_handler"
+
+///|
+#cfg(target="wasm")
+#unsafe_skip_stub_check
+fn terminate_signal_handler_ffi() -> Unit = "moonbitlang/async" "signal/terminate_signal_handler"
 
 ///|
 #cfg(platform="windows")
@@ -163,7 +131,7 @@ fn setup_signal_handler() -> SignalHandler {
     set_global_cancellation_signals(all_signals)
   }
   start_signal_handler_ffi()
-  ConsoleControlHandler
+  UnixSignalHandler
 }
 
 ///|
@@ -172,7 +140,7 @@ fn EventLoop::terminate_signal_handler(
   evloop : EventLoop,
   handler : SignalHandler,
 ) -> Unit raise {
-  guard! handler is ConsoleControlHandler
+  guard! handler is UnixSignalHandler
   global_signal_handler_initialized.val = false
   terminate_signal_handler_ffi()
   if evloop.killed_by_signal is Some(signal) {
@@ -205,20 +173,28 @@ fn setup_signal_handler() -> SignalHandler raise {
     setup_signal_handler_windows()
     ConsoleControlHandler
   } else {
-    SigwaitHandler(setup_signal_handler_unix())
+    if !global_signal_handler_initialized.val {
+      set_global_cancellation_signals(all_signals)
+    }
+    start_signal_handler_ffi()
+    UnixSignalHandler
   }
 }
 
 ///|
 #cfg(target="wasm")
-async fn EventLoop::terminate_signal_handler(
+fn EventLoop::terminate_signal_handler(
   evloop : EventLoop,
   signal_handler : SignalHandler,
-) -> Unit {
+) -> Unit raise {
   global_signal_handler_initialized.val = false
   match signal_handler {
-    SigwaitHandler(sigwait_task) =>
-      evloop.terminate_signal_handler_unix(sigwait_task)
+    UnixSignalHandler => {
+      terminate_signal_handler_ffi()
+      if evloop.killed_by_signal is Some(signal) {
+        raise KilledBySignal(signal)
+      }
+    }
     ConsoleControlHandler => evloop.terminate_signal_handler_windows()
   }
 }

--- a/src/internal/event_loop/thread_pool.wasm.mbt
+++ b/src/internal/event_loop/thread_pool.wasm.mbt
@@ -674,19 +674,6 @@ fn Job::wait_for_process(handle : @fd_util.Fd, pid~ : Int) -> Job {
 
 ///|
 #unsafe_skip_stub_check
-#borrow(signals)
-fn JobHandle::sigwait(
-  signals : ReadOnlyArray[Int],
-  signals_len : Int,
-) -> JobHandle = "moonbitlang/async" "thread_pool/make_sigwait_job"
-
-///|
-fn Job::sigwait(signals : ReadOnlyArray[Int]) -> Job {
-  Job(JobHandle::sigwait(signals, signals.length()))
-}
-
-///|
-#unsafe_skip_stub_check
 #borrow(path)
 fn JobHandle::inotify_add_watch(
   inotify : @fd_util.Fd,


### PR DESCRIPTION
The native signal-delivery change in #581 removed the signal-wait worker, but the Wasm wrapper still creates that job and its waiting coroutine. Switch Wasm to the same explicit start/terminate lifecycle, retaining signal registration and cancellation state in the existing event loop.

The required host support has landed in moonbitlang/moon#2175. The Moon fixture uses the same wrapper change on the #581 revision so signal delivery can be backported independently of later worker cancellation changes.

This is a coordinating guest change for #581, not a new runtime-port queue request. The originating request can be marked completed once this guest change also reaches `main`.

Paired runtime PR: https://github.com/moonbitlang/moon/pull/2175.
