### PR TITLE
fix request cancellation test

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -249,7 +249,6 @@ jobs:
 
       - name: run test with address sanitizer
         run: |
-          export MOONBIT_ASYNC_TEST_SANITIZER_ENABLED=1
           moon test
 
   sanitizer-check-windows:
@@ -290,5 +289,4 @@ jobs:
       - name: run test with address sanitizer
         run: |
           $env:ASAN_OPTIONS='fast_unwind_on_malloc=0'
-          $env:MOONBIT_ASYNC_TEST_SANITIZER_ENABLED=1
           moon test

--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -18,6 +18,18 @@ async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
   let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever() <| ((request, body, conn) => {
+      match request.path {
+        "/no-response" => {
+          @async.sleep(10000)
+          return
+        }
+        "/no-response-body" => {
+          conn..send_response(200, "OK").flush()
+          @async.sleep(10000)
+          return
+        }
+        _ => ()
+      }
       let meth = @debug.to_string(request.meth).to_upper()
       log.write_string("server received request: \{meth} \{request.path}\n")
       while body.read_some() is Some(data) {
@@ -43,7 +55,10 @@ type Server
 ///|
 #cfg(target="js")
 extern "js" fn Server::close(server : Server) =
-  #| (server) => server.close()
+  #| (server) => {
+  #|   server.close()
+  #|   server.closeAllConnections()
+  #| }
 
 ///|
 #cfg(target="js")
@@ -78,6 +93,14 @@ extern "js" fn Server::create(
   #|     if (req.method === 'HEAD') {
   #|       response.statusCode = 200
   #|       response.end()
+  #|       return
+  #|     }
+  #|     if (req.url === '/no-response') {
+  #|       return
+  #|     }
+  #|     if (req.url === '/no-response-body') {
+  #|       response.statusCode = 200
+  #|       response.flushHeaders()
   #|       return
   #|     }
   #|     req.on('data', (data) => {

--- a/src/http/client_test.mbt
+++ b/src/http/client_test.mbt
@@ -13,126 +13,6 @@
 // limitations under the License.
 
 ///|
-#cfg(any(target="native", target="wasm"))
-async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever() <| ((request, body, conn) => {
-      match request.path {
-        "/no-response" => {
-          @async.sleep(10000)
-          return
-        }
-        "/no-response-body" => {
-          conn..send_response(200, "OK").flush()
-          @async.sleep(10000)
-          return
-        }
-        _ => ()
-      }
-      let meth = @debug.to_string(request.meth).to_upper()
-      log.write_string("server received request: \{meth} \{request.path}\n")
-      while body.read_some() is Some(data) {
-        let data = @utf8.decode(data)
-        log.write_string("server received: \{data}")
-      }
-      conn.send_response(200, "OK")
-      log.write_string("server: sending \{meth} response part 1\n")
-      conn..write("\{meth} response part 1\n").flush()
-      @async.sleep(100)
-      log.write_string("server: sending \{meth} response part 2\n")
-      conn.write("\{meth} response part 2\n")
-    })
-  }
-  server.addr.port()
-}
-
-///|
-#cfg(target="js")
-#external
-type Server
-
-///|
-#cfg(target="js")
-extern "js" fn Server::close(server : Server) =
-  #| (server) => {
-  #|   server.close()
-  #|   server.closeAllConnections()
-  #| }
-
-///|
-#cfg(target="js")
-extern "js" fn Server::port(server : Server) -> Int =
-  #| (server) => server.address().port
-
-///|
-#cfg(target="js")
-extern "js" fn Server::create(
-  logger : (String) -> Unit,
-) -> @js_async.Promise[Server] =
-  #| (logger) => {
-  #|   const http = require('node:http')
-  #|   const server = http.createServer()
-  #|   server.on('request', (req, response) => {
-  #|     logger(`server received request: ${req.method} ${req.url}\n`)
-  #|     if (req.url === '/no-content') {
-  #|       response.statusCode = 204
-  #|       response.end()
-  #|       return
-  #|     }
-  #|     if (req.url === '/reset-content') {
-  #|       response.statusCode = 205
-  #|       response.end()
-  #|       return
-  #|     }
-  #|     if (req.url === '/not-modified') {
-  #|       response.statusCode = 304
-  #|       response.end()
-  #|       return
-  #|     }
-  #|     if (req.method === 'HEAD') {
-  #|       response.statusCode = 200
-  #|       response.end()
-  #|       return
-  #|     }
-  #|     if (req.url === '/no-response') {
-  #|       return
-  #|     }
-  #|     if (req.url === '/no-response-body') {
-  #|       response.statusCode = 200
-  #|       response.flushHeaders()
-  #|       return
-  #|     }
-  #|     req.on('data', (data) => {
-  #|       logger(`server received: ${data}`)
-  #|     })
-  #|     req.on('end', () => {
-  #|       response.statusCode  = 200
-  #|       response.statusMessage = "OK"
-  #|       logger(`server: sending ${req.method} response part 1\n`)
-  #|       response.write(`${req.method} response part 1\n`, () => {
-  #|         setTimeout(() => {
-  #|           logger(`server: sending ${req.method} response part 2\n`)
-  #|           response.end(`${req.method} response part 2\n`)
-  #|         }, 100)
-  #|       })
-  #|     })
-  #|   })
-  #|   server.listen(0, '127.0.0.1')
-  #|   return new Promise((resolve) => {
-  #|     server.on('listening', () => resolve(server))
-  #|   })
-  #| }
-
-///|
-#cfg(target="js")
-async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
-  let server = Server::create(msg => log.write_string(msg)).wait()
-  group.add_defer(() => server.close())
-  server.port()
-}
-
-///|
 #cfg(target="js")
 async test "responses with null Web API bodies are empty readable streams" {
   let log = StringBuilder()
@@ -178,14 +58,16 @@ async test "request streaming" {
 
     {
       log <+ "client sending GET request\n"
-      let (response, client) = @http.get_stream("http://localhost:\{port}/get")
+      let (response, client) = @http.get_stream(
+        "http://localhost:\{port}/get-streaming",
+      )
       defer client.close()
       inspect(response.code, content="200")
       fetch_response(client)
     }
     {
       log <+ "client sending PUT request\n"
-      let client = @http.put_stream("http://localhost:\{port}/put")
+      let client = @http.put_stream("http://localhost:\{port}/put-streaming")
       defer client.close()
       @async.sleep(100)
       log <+ "client: sending PUT data part 1\n"
@@ -199,7 +81,7 @@ async test "request streaming" {
     }
     {
       log <+ "client sending POST request\n"
-      let client = @http.post_stream("http://localhost:\{port}/post")
+      let client = @http.post_stream("http://localhost:\{port}/post-streaming")
       defer client.close()
       @async.sleep(100)
       log <+ "client: sending POST data part 1\n"
@@ -223,7 +105,7 @@ async test "request streaming" {
       log,
       content=(
         #|client sending GET request
-        #|server received request: GET /get
+        #|server received request: GET /get-streaming
         #|server: sending GET response part 1
         #|client received: GET response part 1
         #|server: sending GET response part 2
@@ -231,7 +113,7 @@ async test "request streaming" {
         #|client sending PUT request
         #|client: sending PUT data part 1
         #|client: sending PUT data part 2
-        #|server received request: PUT /put
+        #|server received request: PUT /put-streaming
         #|server received: PUT data part 1
         #|PUT data part 2
         #|server: sending PUT response part 1
@@ -241,7 +123,7 @@ async test "request streaming" {
         #|client sending POST request
         #|client: sending POST data part 1
         #|client: sending POST data part 2
-        #|server received request: POST /post
+        #|server received request: POST /post-streaming
         #|server received: POST data part 1
         #|POST data part 2
         #|server: sending POST response part 1
@@ -256,14 +138,14 @@ async test "request streaming" {
       log,
       content=(
         #|client sending GET request
-        #|server received request: GET /get
+        #|server received request: GET /get-streaming
         #|server: sending GET response part 1
         #|client received: GET response part 1
         #|server: sending GET response part 2
         #|client received: GET response part 2
         #|client sending PUT request
         #|client: sending PUT data part 1
-        #|server received request: PUT /put
+        #|server received request: PUT /put-streaming
         #|server received: PUT data part 1
         #|client: sending PUT data part 2
         #|server received: PUT data part 2
@@ -273,7 +155,7 @@ async test "request streaming" {
         #|client received: PUT response part 2
         #|client sending POST request
         #|client: sending POST data part 1
-        #|server received request: POST /post
+        #|server received request: POST /post-streaming
         #|server received: POST data part 1
         #|client: sending POST data part 2
         #|server received: POST data part 2

--- a/src/http/moon.pkg
+++ b/src/http/moon.pkg
@@ -13,7 +13,6 @@ import {
 import {
   "moonbitlang/core/debug",
   "moonbitlang/core/encoding/utf8",
-  "moonbitlang/core/env",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/gzip" @gzip_stream,

--- a/src/http/request_test.mbt
+++ b/src/http/request_test.mbt
@@ -25,20 +25,40 @@ async test "http request" {
 }
 
 ///|
-async test "request cancel" {
-  let start = @async.now()
-  let result = @async.with_timeout_opt(200, () => {
-    @http.get(
-      "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz",
-    )
-  })
-  let end = @async.now()
-  assert_true(result is None)
-  if @env.get_env_var("MOONBIT_ASYNC_TEST_SANITIZER_ENABLED") is None {
-    let delta = end - start
-    if delta >= 300 {
-      raise Failure::Failure("request cancellation took too long: \{delta}ms")
+async test "request cancel handshake" {
+  @async.with_task_group() <| group => {
+    let port = non_responding_tcp_server(group)
+    let result = @async.with_timeout_opt(250) <| () => {
+      let (response, _) = @http.get("http://127.0.0.1:\{port}/")
+      response.code
     }
+    debug_inspect(result, content="None")
+  }
+}
+
+///|
+async test "request cancel wait response header" {
+  let log = StringBuilder()
+  @async.with_task_group() <| group => {
+    let port = test_server(group, log)
+    let result = @async.with_timeout_opt(250) <| () => {
+      let (response, _) = @http.get("http://127.0.0.1:\{port}/no-response")
+      response.code
+    }
+    debug_inspect(result, content="None")
+  }
+}
+
+///|
+async test "request cancel wait response body" {
+  let log = StringBuilder()
+  @async.with_task_group() <| group => {
+    let port = test_server(group, log)
+    let result = @async.with_timeout_opt(250) <| () => {
+      let (response, _) = @http.get("http://127.0.0.1:\{port}/no-response-body")
+      response.code
+    }
+    debug_inspect(result, content="None")
   }
 }
 

--- a/src/http/unimplemented_test.mbt
+++ b/src/http/unimplemented_test.mbt
@@ -18,7 +18,6 @@ let _ignore_unused_import : Unit = {
   ignore(@debug.to_string(0))
   ignore(@async.sleep)
   ignore(@utf8.encode(""))
-  ignore(@env.get_env_var)
   ignore((_ : @gzip_stream.Encoder[&@io.Writer]) => ())
   ignore(@fs.unimplemented)
 }

--- a/src/http/utils_for_test.mbt
+++ b/src/http/utils_for_test.mbt
@@ -1,0 +1,56 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+///|
+#cfg(any(target="native", target="wasm"))
+async fn non_responding_tcp_server(group : @async.TaskGroup[Unit]) -> Int {
+  let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
+  group.add_defer(() => server.close())
+  server.addr.port()
+}
+
+///|
+#cfg(target="js")
+#external
+type TcpServer
+
+///|
+#cfg(target="js")
+extern "js" fn TcpServer::create() -> @js_async.Promise[TcpServer] =
+  #| () => {
+  #|   const net = require('node:net')
+  #|   const server = net.createServer({})
+  #|   server.listen(0, "127.0.0.1")
+  #|   return new Promise((resolve) => {
+  #|     server.on('listening', () => resolve(server))
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn TcpServer::close(server : TcpServer) =
+  #| (server) => server.close()
+
+///|
+#cfg(target="js")
+extern "js" fn TcpServer::port(server : TcpServer) -> Int =
+  #| (server) => server.address().port
+
+///|
+#cfg(target="js")
+async fn non_responding_tcp_server(group : @async.TaskGroup[Unit]) -> Int {
+  let server = TcpServer::create().wait()
+  group.add_defer(() => server.close())
+  server.port()
+}

--- a/src/http/utils_for_test.mbt
+++ b/src/http/utils_for_test.mbt
@@ -54,3 +54,133 @@ async fn non_responding_tcp_server(group : @async.TaskGroup[Unit]) -> Int {
   group.add_defer(() => server.close())
   server.port()
 }
+
+///|
+#cfg(any(target="native", target="wasm"))
+async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever() <| ((request, body, conn) => {
+      match request.path {
+        "/no-response" => {
+          @async.sleep(10000)
+          return
+        }
+        "/no-response-body" => {
+          conn..send_response(200, "OK").flush()
+          @async.sleep(10000)
+          return
+        }
+        "/get-streaming" | "/put-streaming" | "/post-streaming" => {
+          let meth = @debug.to_string(request.meth).to_upper()
+          log.write_string("server received request: \{meth} \{request.path}\n")
+          while body.read_some() is Some(data) {
+            let data = @utf8.decode(data)
+            log.write_string("server received: \{data}")
+          }
+          conn.send_response(200, "OK")
+          log.write_string("server: sending \{meth} response part 1\n")
+          conn..write("\{meth} response part 1\n").flush()
+          @async.sleep(100)
+          log.write_string("server: sending \{meth} response part 2\n")
+          conn.write("\{meth} response part 2\n")
+        }
+        path => raise Failure("unknown request path: \{path}")
+      }
+    })
+  }
+  server.addr.port()
+}
+
+///|
+#cfg(target="js")
+#external
+type Server
+
+///|
+#cfg(target="js")
+extern "js" fn Server::close(server : Server) =
+  #| (server) => {
+  #|   server.close()
+  #|   server.closeAllConnections()
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn Server::port(server : Server) -> Int =
+  #| (server) => server.address().port
+
+///|
+#cfg(target="js")
+extern "js" fn Server::create(
+  logger : (String) -> Unit,
+) -> @js_async.Promise[Server] =
+  #| (logger) => {
+  #|   const http = require('node:http')
+  #|   const server = http.createServer()
+  #|   server.on('request', (req, response) => {
+  #|     logger(`server received request: ${req.method} ${req.url}\n`)
+  #|     if (req.url === '/no-content') {
+  #|       response.statusCode = 204
+  #|       response.end()
+  #|       return
+  #|     }
+  #|     if (req.url === '/reset-content') {
+  #|       response.statusCode = 205
+  #|       response.end()
+  #|       return
+  #|     }
+  #|     if (req.url === '/not-modified') {
+  #|       response.statusCode = 304
+  #|       response.end()
+  #|       return
+  #|     }
+  #|     if (req.method === 'HEAD') {
+  #|       response.statusCode = 200
+  #|       response.end()
+  #|       return
+  #|     }
+  #|     if (req.url === '/no-response') {
+  #|       return
+  #|     }
+  #|     if (req.url === '/no-response-body') {
+  #|       response.statusCode = 200
+  #|       response.flushHeaders()
+  #|       return
+  #|     }
+  #|     if (
+  #|       req.url === '/get-streaming'
+  #|       || req.url === '/put-streaming'
+  #|       || req.url === '/post-streaming'
+  #|     ) {
+  #|       req.on('data', (data) => {
+  #|         logger(`server received: ${data}`)
+  #|       })
+  #|       req.on('end', () => {
+  #|         response.statusCode  = 200
+  #|         response.statusMessage = "OK"
+  #|         logger(`server: sending ${req.method} response part 1\n`)
+  #|         response.write(`${req.method} response part 1\n`, () => {
+  #|           setTimeout(() => {
+  #|             logger(`server: sending ${req.method} response part 2\n`)
+  #|             response.end(`${req.method} response part 2\n`)
+  #|           }, 100)
+  #|         })
+  #|       })
+  #|       return
+  #|     }
+  #|     throw Error(`unknown request path: ${req.url}`)
+  #|   })
+  #|   server.listen(0, '127.0.0.1')
+  #|   return new Promise((resolve) => {
+  #|     server.on('listening', () => resolve(server))
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+async fn test_server(group : @async.TaskGroup[Unit], log : &Logger) -> Int {
+  let server = Server::create(msg => log.write_string(msg)).wait()
+  group.add_defer(() => server.close())
+  server.port()
+}

--- a/src/js_async/readable_stream.mbt
+++ b/src/js_async/readable_stream.mbt
@@ -90,6 +90,8 @@ extern "js" fn JsReadableStream::get_reader(stream : Self) -> StreamReader =
 struct ReadableStream {
   read_end : @io.PipeRead
   worker : @coroutine.Coroutine
+  stream : JsReadableStream
+  reader : StreamReader
 }
 
 ///|
@@ -99,20 +101,18 @@ struct ReadableStream {
 /// other code cannot read the stream anymore.
 pub fn ReadableStream::from_js(stream : JsReadableStream) -> ReadableStream {
   let (r, w) = @io.pipe()
+  let reader = stream.get_reader()
   // Here, we use a coroutine to copy the data,
   // because the `.read()` method of `StreamReader` is NOT cancellable.
   // It can only be cancelled by cancelling the whole stream.
   // So we use a `@io.pipe` in the middle to provide proper cancellation support.
   let worker = @coroutine.spawn(() => {
     defer w.close()
-    defer stream.cancel()
-    let reader = stream.get_reader()
-    defer reader.release_lock()
     while reader.read() is Some(chunk) {
       w.write(chunk)
     }
   })
-  { read_end: r, worker, }
+  { read_end: r, worker, stream, reader, }
 }
 
 ///|
@@ -120,6 +120,8 @@ pub fn ReadableStream::from_js(stream : JsReadableStream) -> ReadableStream {
 pub fn ReadableStream::close(self : ReadableStream) -> Unit {
   self.worker.cancel()
   self.read_end.close()
+  self.reader.release_lock()
+  self.stream.cancel()
 }
 
 ///|


### PR DESCRIPTION
The `request cancel` test has been a common failing case on CI, due to its use of timing to detect successful cancellation. This PR make the test for direct and robust by crafting artificial server that hang at different stages (TCP connection setup, sending response header, sending response body) to test request cancellation support of the HTTP client. This way, the program will simply hang if it fail to cancel successfully, so there is no need for timing based detection anymore.

The improved test reveal a bug in current JS readable stream implementation: `close()` does not cancel the internal data carrying worker properly. This problem is also fixed in this PR.