### PR TITLE
perf(http): batch response heads within a fixed byte budget

### DIFF
--- a/src/http/send.mbt
+++ b/src/http/send.mbt
@@ -340,6 +340,39 @@ async fn Sender::send_request(
 }
 
 ///|
+// Bound the batch by both its own capacity and the available sender space, so
+// it cannot grow or retain a combined head across a blocked underlying write.
+fn Sender::can_batch_response_head(
+  self : Sender,
+  code_length : Int,
+  reason : String,
+  headers : Headers,
+) -> Bool {
+  // "HTTP/1.1 " + status code + " " + reason + CRLF.
+  let mut remaining = @cmp.minimum(256, self.send_buf.length() - self.send_len) -
+    12 -
+    code_length
+  guard remaining >= 0 && self.headers.length() <= remaining else { false }
+  remaining -= self.headers.length()
+  // A UTF-16 code unit needs at most three UTF-8 bytes, including unpaired
+  // surrogates. Check before multiplying to avoid overflow on large inputs.
+  guard reason.length() <= remaining / 3 else { false }
+  remaining -= reason.length() * 3
+  for k, v in headers {
+    if k != "Content-Length" && forbidden_headers.contains(k) {
+      continue
+    }
+    guard remaining >= 4 else { return false }
+    remaining -= 4 // ": " and CRLF
+    guard k.0.length() <= remaining / 3 else { return false }
+    remaining -= k.0.length() * 3
+    guard v.length() <= remaining / 3 else { return false }
+    remaining -= v.length() * 3
+  }
+  true
+}
+
+///|
 async fn Sender::send_response(
   self : Sender,
   code : Int,
@@ -354,14 +387,47 @@ async fn Sender::send_response(
     Connect => self.should_have_empty_body = code is (100..<300 | 304)
     _ => self.should_have_empty_body = code is (100..<200 | 204 | 205 | 304)
   }
-  let content_length = self
+  let code = encode_int(code, base=10)
+  let content_length = if self.can_batch_response_head(
+      code.length(),
+      reason,
+      extra_headers,
+    ) {
+    // Small heads cross the async writer boundary once. The preflight bound
+    // keeps this Buffer at 256 bytes and guarantees its copy fits in send_buf.
+    let head = Buffer(size_hint=256)
+    head
+    ..write_bytes(b"HTTP/1.1 ")
+    ..write_bytes(code)
+    ..write_byte(b' ')
+    ..write_string_utf8(sanitize_header_value(reason))
+    ..write_bytes(b"\r\n")
+    .write_bytes(self.headers)
+    let mut content_length = None
+    for k, v in extra_headers {
+      if k == "Content-Length" {
+        content_length = Some(@string.parse_int64(v.trim(), base=10))
+      } else if forbidden_headers.contains(k) {
+        continue
+      }
+      head
+      ..write_string_utf8(sanitize_header_value(k.0))
+      ..write_bytes(b": ")
+      ..write_string_utf8(sanitize_header_value(v))
+      .write_bytes(b"\r\n")
+    }
+    self.write(head.contents())
+    content_length
+  } else {
+    self
     ..write(b"HTTP/1.1 ")
-    ..write(encode_int(code, base=10))
+    ..write(code)
     ..write(b" ")
     ..write(sanitize_header_value(reason))
     ..write(b"\r\n")
     ..write(self.headers)
     .send_headers(extra_headers)
+  }
   for cookie in cookies {
     self.write(b"Set-Cookie: ")
     cookie.write_to(self)

--- a/src/http/send_wbtest.mbt
+++ b/src/http/send_wbtest.mbt
@@ -923,3 +923,92 @@ async test "HEAD response with non-empty body" {
     ignore(r.read_all().binary())
   }
 }
+
+///|
+async test "response header batching preserves long headers and persistent state" {
+  @async.with_task_group() <| group => {
+    let (r, w) = @io.pipe()
+    let value = "0123456789".repeat(300) + "日本語"
+    group.spawn_bg() <| () => {
+      defer w.close()
+      let sender = Sender::new(w, headers={ "Server": "MoonBit" })
+      sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={
+        "X-Long": value,
+        "Content-Length": "3",
+        "Transfer-Encoding": "forbidden",
+      })
+      sender..write(b"123").end_body()
+      sender.send_response(
+        204,
+        "No Content",
+        cookies=[],
+        request_method=Get,
+        extra_headers=Map([]),
+      )
+      sender.end_body()
+    }
+    defer r.close()
+    assert_eq(
+      r.read_all().text(),
+      "HTTP/1.1 200 OK\r\nServer: MoonBit\r\nX-Long: \{value}\r\nContent-Length: 3\r\n\r\n123HTTP/1.1 204 No Content\r\nServer: MoonBit\r\n\r\n",
+    )
+  }
+}
+
+///|
+test "response head batching stays within its byte budget" {
+  let (r, w) = @io.pipe()
+  defer r.close()
+  defer w.close()
+  let sender = Sender::new(w)
+  assert_true(sender.can_batch_response_head(3, "OK", Map([])))
+  // Three UTF-8 bytes per code unit: the upper bound is exactly 256 bytes.
+  assert_true(
+    sender.can_batch_response_head(3, "OK", { "X": "界".repeat(76) }),
+  )
+  assert_false(
+    sender.can_batch_response_head(3, "OK", { "X": "界".repeat(77) }),
+  )
+  assert_true(
+    sender.can_batch_response_head(3, "OK", { "X": "😀".repeat(38) }),
+  )
+  assert_false(
+    sender.can_batch_response_head(3, "OK", { "X": "😀".repeat(39) }),
+  )
+  assert_false(sender.can_batch_response_head(3, "x".repeat(100), Map([])))
+  assert_false(
+    sender.can_batch_response_head(3, "OK", { "X": "x".repeat(65536) }),
+  )
+  // Ignored headers do not consume the response-head budget.
+  assert_true(
+    sender.can_batch_response_head(3, "OK", {
+      "Transfer-Encoding": "x".repeat(65536),
+    }),
+  )
+  // A batched head must also fit in the space left in the sender's buffer.
+  sender.send_len = 1010
+  assert_false(sender.can_batch_response_head(3, "OK", Map([])))
+  let sender = Sender::new(w, headers={ "X": "x".repeat(256) })
+  assert_false(sender.can_batch_response_head(3, "OK", Map([])))
+}
+
+///|
+async test "response head batching preserves UTF-8 at the batch boundary" {
+  @async.with_task_group() <| group => {
+    let (r, w) = @io.pipe()
+    let value = "界".repeat(76)
+    group.spawn_bg() <| () => {
+      defer w.close()
+      let sender = Sender::new(w)
+      sender.send_response(200, "OK", cookies=[], request_method=Get, extra_headers={
+        "X": value,
+      })
+      sender.end_body()
+    }
+    defer r.close()
+    assert_eq(
+      r.read_all().text(),
+      "HTTP/1.1 200 OK\r\nX: \{value}\r\nContent-Length: 0\r\n\r\n",
+    )
+  }
+}


### PR DESCRIPTION
Small HTTP response heads currently cross the async writer boundary for each status/header fragment, allocating coroutine frames even when the complete head fits in Sender's existing buffer.

This batches eligible response heads into one write. A preflight uses a conservative UTF-8 size bound (at most three bytes per UTF-16 code unit) and requires the head to fit both a 256-byte batch and the remaining space in the existing 1,024-byte send buffer. Larger heads retain the incremental path. The batch therefore cannot grow or keep a combined head alive across a blocked underlying write. Some ASCII heads below 256 actual bytes deliberately use the fallback to keep the preflight cheap.

Cookie serialization, body framing, request sending, and public interfaces retain their existing code.

### Measurements

I collected these measurements while benchmarking Mars, my web server implementation. See [this report](https://github.com/mizchi/mars.mbt/blob/66277d49502626d8c2f477d63d7eb285d1ba5157/docs/async-response-head-pr.md) for the methodology, tradeoffs, reproduction steps, and raw data.

Five alternating native release runs of the same Mars HTTP response, against async v0.21.3:

| Median | Baseline | This change |
|---|---:|---:|
| Instructions/request | 96,013 | 85,521 (−10.9%) |
| User CPU µs/request | 4.217 | 3.692 (−12.5%) |
| User + system CPU µs/request | 7.870 | 7.494 (−4.8%) |

This is a shared Apple M5 development machine; throughput is exploratory. Both binaries use the same baseline and toolchain. The two files changed here are identical between v0.21.3 and the PR's upstream main base. [CPU samples and settings](https://github.com/mizchi/mars.mbt/blob/66277d49502626d8c2f477d63d7eb285d1ba5157/bench/results/profile-review-native-bounded.json).

A focused allocation probe, repeated in three fresh processes with identical results, found:

- One 40-byte header value: cumulative allocations fall from 4,139 to 1,853 bytes/response (−55.2%).
- One 64 KiB value: peak live memory is 66,317 → 66,329 bytes.
- 64 small headers on each of 64 blocked writers: retained memory is unchanged at 73,632 bytes.
- Fallback cases add 128–164 cumulative bytes/response in these tests. Empty heads have an 89-byte higher transient peak despite lower cumulative allocation traffic.

These are allocator-requested bytes, excluding existing Senders/input Strings and allocator rounding/RSS. [Raw memory results](https://github.com/mizchi/mars.mbt/blob/66277d49502626d8c2f477d63d7eb285d1ba5157/bench/results/buffer-memory-bounded.json). The size bound addresses the increased large-header and blocked-writer memory found in the [initial unbounded experiment](https://github.com/mizchi/mars.mbt/blob/66277d49502626d8c2f477d63d7eb285d1ba5157/docs/buffer-memory-2026-09-11.md).

### Validation

- All 61 native release HTTP tests pass on the PR branch.
- Native workspace check and HTTP Wasm check with `--deny-warn`; formatting and native interface generation pass.
- Added tests cover UTF-8/surrogate-pair size bounds, remaining sender space, persistent/ignored headers, an actual response at the batch boundary, and a long-header fallback followed by another response on the same sender.
- Mars `just release-check`: 331 JS tests pass. All 92 native tests in the root Mars package pass with the candidate dependency.
