### PR TITLE
perf(http): parse buffered headers without whole-line strings

### DIFF
--- a/src/http/moon.pkg
+++ b/src/http/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbitlang/core/cmp",
   "moonbitlang/core/string",
   "moonbitlang/core/buffer",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/async/io",
   "moonbitlang/async/socket",
   "moonbitlang/async/tls",

--- a/src/http/parser.mbt
+++ b/src/http/parser.mbt
@@ -233,26 +233,70 @@ impl @io.Reader for Reader with fn _get_internal_buffer(self) {
 extend Reader with @io.Reader::{_direct_read, _get_internal_buffer, drop}
 
 ///|
+fn parse_header_line(
+  header_line : String,
+) -> (CaseInsensitiveString, String) raise {
+  guard header_line.find(":") is Some(colon_index) else { raise BadRequest }
+  let key = CaseInsensitiveString(header_line[:colon_index].to_owned())
+  guard colon_index + 1 < header_line.length() else { raise BadRequest }
+  let value_start = if header_line.code_unit_at(colon_index + 1) == ' ' {
+    colon_index + 2
+  } else {
+    colon_index + 1
+  }
+  (key, header_line[value_start:].to_owned())
+}
+
+///|
+fn parse_ascii_header(
+  line : BytesView,
+) -> (CaseInsensitiveString, String)? raise {
+  let mut colon = -1
+  for i in 0..<line.length() {
+    let b = line[i]
+    if b >= b'\x80' {
+      return None
+    }
+    if b == b':' && colon < 0 {
+      colon = i
+    }
+  }
+  guard colon >= 0 && colon + 1 < line.length() else { raise BadRequest }
+  let value_start = if line[colon + 1] == b' ' { colon + 2 } else { colon + 1 }
+  Some(
+    (
+      CaseInsensitiveString(@utf8.decode(line[:colon])),
+      @utf8.decode(line[value_start:]),
+    ),
+  )
+}
+
+///|
 async fn Reader::read_headers(self : Reader) -> (Headers, Array[Cookie]) {
   let headers : Headers = Map([])
   let cookies = []
   for ;; {
-    guard self.transport.read_until("\r\n") is Some(header_line) else {
-      raise @io.ReaderClosed
-    }
-    if header_line is "" {
-      // empty line indicates end of header
-      break
-    }
-    guard header_line.find(":") is Some(colon_index) else { raise BadRequest }
-    let key = CaseInsensitiveString(header_line[:colon_index].to_owned())
-    guard colon_index + 1 < header_line.length() else { raise BadRequest }
-    let value_start = if header_line.code_unit_at(colon_index + 1) == ' ' {
-      colon_index + 2
+    let line = self.transport
+      ._get_internal_buffer()
+      .take_buffered_until(b"\r\n")
+    let (key, value) = if line is Some(line) {
+      if line.is_empty() {
+        break
+      }
+      if parse_ascii_header(line) is Some(fields) {
+        fields
+      } else {
+        parse_header_line(@utf8.decode(line))
+      }
     } else {
-      colon_index + 1
+      guard self.transport.read_until("\r\n") is Some(header_line) else {
+        raise @io.ReaderClosed
+      }
+      if header_line is "" {
+        break
+      }
+      parse_header_line(header_line)
     }
-    let value = header_line[value_start:].to_owned()
     if key == "Content-Length" {
       guard !(self.body is Fixed(_)) else { raise BadRequest }
       let len = @string.parse_int(value, base=10)

--- a/src/http/parser_wbtest.mbt
+++ b/src/http/parser_wbtest.mbt
@@ -911,3 +911,97 @@ async test "read_response parse cookie" {
     )
   }
 }
+
+///|
+test "buffered ASCII headers avoid a whole-line String" {
+  assert_eq(
+    parse_ascii_header(b"X-Test: a:b"),
+    Some((CaseInsensitiveString("X-Test"), "a:b")),
+  )
+  assert_eq(
+    parse_ascii_header(b"X-Test: "),
+    Some((CaseInsensitiveString("X-Test"), "")),
+  )
+  assert_eq(parse_ascii_header(@utf8.encode("X: 日本語")), None)
+}
+
+///|
+priv struct FragmentedHeaderReader {
+  data : Bytes
+  mut pos : Int
+  max_read : Int
+  buffer : @io.ReaderBuffer
+}
+
+///|
+impl @io.Reader for FragmentedHeaderReader with fn _get_internal_buffer(self) {
+  self.buffer
+}
+
+///|
+impl @io.Reader for FragmentedHeaderReader with fn _direct_read(
+  self,
+  dst,
+  offset~,
+  max_len~,
+) {
+  let n = @cmp.minimum(
+    @cmp.minimum(max_len, self.max_read),
+    self.data.length() - self.pos,
+  )
+  dst.blit_from_bytes(offset, self.data, self.pos, n)
+  self.pos += n
+  n
+}
+
+///|
+async test "buffered and fragmented headers preserve request boundaries" {
+  let data = @utf8.encode(
+    "GET /first HTTP/1.1\r\nX-Mixed: one\r\nx-MIXED: two\r\nX-Utf8: 日本語😀\r\nContent-Length: 3\r\n\r\nabcGET /second HTTP/1.1\r\nX-Empty: \r\n\r\n",
+  )
+  for max_read in [1, 7, 65536] {
+    let transport = FragmentedHeaderReader::{
+      data,
+      pos: 0,
+      max_read,
+      buffer: @io.ReaderBuffer::new(),
+    }
+    let reader = Reader::new(transport)
+    let request = reader.read_request()
+    assert_eq(request.path, "/first")
+    assert_eq(request.headers.get("x-mixed"), Some("one,two"))
+    assert_eq(request.headers.get("X-Utf8"), Some("日本語😀"))
+    assert_eq(reader.read_all().text(), "abc")
+    let request = reader.read_request()
+    assert_eq(request.path, "/second")
+    assert_eq(request.headers.get("X-Empty"), Some(""))
+  }
+}
+
+///|
+async test "buffered and fragmented malformed headers are rejected" {
+  for
+    header in [
+      b"NoColon", b"X:", b"X: \xff", b"Content-Length: 1\r\ncontent-length: 1", b"Transfer-Encoding: chunked\r\nTransfer-Encoding: chunked",
+    ] {
+    for max_read in [1, 65536] {
+      let b = Buffer()
+      b
+      ..write_bytes(b"GET / HTTP/1.1\r\n")
+      ..write_bytes(header)
+      .write_bytes(b"\r\n\r\n")
+      let transport = FragmentedHeaderReader::{
+        data: b.contents(),
+        pos: 0,
+        max_read,
+        buffer: @io.ReaderBuffer::new(),
+      }
+      let reader = Reader::new(transport)
+      try reader.read_request() catch {
+        _ => ()
+      } noraise {
+        _ => fail("expected malformed header to fail")
+      }
+    }
+  }
+}

--- a/src/http/unimplemented.mbt
+++ b/src/http/unimplemented.mbt
@@ -24,6 +24,7 @@ pub let unimplemented : Unit = {
   ignore(@tls.unimplemented)
   ignore(@io_buffer.new)
   ignore(@gzip.Decoder::is_finished)
+  ignore(@utf8.encode(""))
 }
 
 ///|

--- a/src/io/buffered_reader.mbt
+++ b/src/io/buffered_reader.mbt
@@ -66,3 +66,22 @@ async fn[R : Reader] ReaderBuffer::find_opt(
     continue len - target_len + 1
   }
 }
+
+///|
+/// Consume a complete buffered segment without entering the async reader.
+/// The returned view must be consumed before the next read mutates the buffer.
+#internal(internal, "internal buffered parser fast path")
+pub fn ReaderBuffer::take_buffered_until(
+  self : ReaderBuffer,
+  separator : Bytes,
+) -> BytesView? {
+  let available = self.buf.unsafe_reinterpret_as_bytes()[self.start:self.start +
+    self.len]
+  if available.find(separator) is Some(end) {
+    let line = available[:end]
+    self.0.drop(end + separator.length())
+    Some(line)
+  } else {
+    None
+  }
+}

--- a/src/io/pkg.generated.mbti
+++ b/src/io/pkg.generated.mbti
@@ -44,6 +44,7 @@ pub impl Writer for PipeWrite
 
 type ReaderBuffer
 pub fn ReaderBuffer::new() -> Self
+pub fn ReaderBuffer::take_buffered_until(Self, Bytes) -> BytesView?
 
 // Type aliases
 


### PR DESCRIPTION
Header lines already present in the transport buffer currently go through async `read_until` and a whole-line UTF-8 String before the field name and value are copied out. This adds per-header work even when no I/O is needed.

This change adds an internal `ReaderBuffer::take_buffered_until` helper and a synchronous ASCII header parser. Buffered ASCII lines decode only the name and value; incomplete lines and non-ASCII text retain the existing paths. The borrowed view is consumed before the next read can mutate its buffer. Request-line parsing, cookies, duplicate-header rules, and body framing remain unchanged.

I collected these measurements while benchmarking Mars, my web server implementation. See [this report](https://github.com/mizchi/mars.mbt/blob/4f8e98406068a11adf361e40651cd4d9e06a8b78/docs/async-header-followup.md#buffered-header-parser) for the methodology, tradeoffs, reproduction commands, harness, and raw data.

- Native Mars, 64 additional request headers: server instructions/request **593,563 → 415,189 (−30.1%)**. Standard request headers: **−5.8%**.
- Parsing 64 headers with 40-byte values: requested allocation **62,654 → 28,130 bytes (−55%)**, median time **17.313 → 10.669 µs**.
- With 7-byte input fragments, the fast-path check adds about **1% allocation** and was **2.4% slower** in the microbenchmark. The benefit is concentrated in already buffered lines.

Measurements use independent native release builds based on upstream `43e41261f99261f4030efbed1970388930229baa`, five timing/three allocation rounds and three network rounds. These are short runs on a shared developer machine, not a production throughput claim. This PR is independent of #603.

Validation on macOS:

- 115 native release tests across HTTP, io, read-buffer, coroutine, and event-loop packages; 104 native debug HTTP/io tests; 52 JS HTTP/io tests.
- Workspace-wide `moon check --deny-warn` passes for native, JS, Wasm, and Wasm-GC; formatting and generated interfaces updated.
- Tests cover fully buffered and 1/7-byte fragmented input, Unicode, invalid UTF-8, duplicate framing headers, repeated header names, and pipelined requests.
- Mars native tests: 92/92 on baseline and this patch; Mars JS suite: 331/331.
