### PR TITLE
perf(unix): reduce allocation in post-I/O yields

### DIFF
--- a/src/internal/coroutine/coroutine.mbt
+++ b/src/internal/coroutine/coroutine.mbt
@@ -211,3 +211,22 @@ pub async fn[X] protect_from_cancel(f : async () -> X) -> X nocancel {
 pub async fn[X] handle_cancellation(f : async () -> X) -> X? {
   capture_cancellation(handler=() => None, () => Some(f()))
 }
+
+///|
+/// Yield after an I/O operation has made progress. Preserve cancellation for
+/// the caller's next cancellation point without losing the completed result.
+pub async fn pause_after_io() -> Unit noraise + nocancel {
+  guard! scheduler.curr_coro is Some(coro)
+  let shielded = coro.shielded
+  coro.shielded = true
+  defer {
+    coro.shielded = shielded
+  }
+  let result = async_suspend() <| cont => {
+    guard! coro.state is Running
+    coro.state = Suspend(cont)
+    coro.ready = true
+    scheduler.run_later.push_back(coro)
+  }
+  guard! result is Continue
+}

--- a/src/internal/coroutine/pause_wbtest.mbt
+++ b/src/internal/coroutine/pause_wbtest.mbt
@@ -1,3 +1,17 @@
+// Copyright 2025 International Digital Economy Academy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 ///|
 test "IO pause preserves round robin scheduling" {
   let log : Array[Int] = []

--- a/src/internal/coroutine/pause_wbtest.mbt
+++ b/src/internal/coroutine/pause_wbtest.mbt
@@ -1,0 +1,85 @@
+///|
+test "IO pause preserves round robin scheduling" {
+  let log : Array[Int] = []
+  let a = spawn(() => {
+    for _ in 0..<3 {
+      log.push(1)
+      pause_after_io()
+    }
+  })
+  let b = spawn(() => {
+    for _ in 0..<3 {
+      log.push(2)
+      pause_after_io()
+    }
+  })
+  while has_immediately_ready_task() {
+    reschedule()
+  }
+  guard! a.unwrap() is Continue
+  guard! b.unwrap() is Continue
+  assert_eq(log, [1, 2, 1, 2, 1, 2])
+}
+
+///|
+test "IO pause delivers completed IO then preserves cancellation" {
+  let log : Array[String] = []
+  let a = spawn(() => {
+    log.push("started")
+    pause_after_io()
+    log.push("delivered")
+    assert_false(current_coroutine().shielded)
+    check_cancellation()
+    log.push("unreachable")
+  })
+  a.cancel()
+  while has_immediately_ready_task() {
+    reschedule()
+  }
+  guard! a.unwrap() is Cancelled
+  assert_eq(log, ["started", "delivered"])
+}
+
+///|
+test "IO pause restores an enclosing cancellation shield" {
+  let log : Array[String] = []
+  let a = spawn(() => {
+    protect_from_cancel(() => {
+      current_coroutine().cancel()
+      pause_after_io()
+      assert_true(current_coroutine().shielded)
+      assert_true(current_coroutine().cancelled)
+      log.push("delivered")
+    })
+    assert_false(current_coroutine().shielded)
+    check_cancellation()
+    log.push("unreachable")
+  })
+  while has_immediately_ready_task() {
+    reschedule()
+  }
+  guard! a.unwrap() is Cancelled
+  assert_eq(log, ["delivered"])
+}
+
+///|
+test "IO pause delivers completed IO when cancelled during suspension" {
+  let log : Array[String] = []
+  let a = spawn(() => {
+    log.push("started")
+    pause_after_io()
+    log.push("delivered")
+    check_cancellation()
+    log.push("unreachable")
+  })
+  let b = spawn(() => {
+    assert_eq(log, ["started"])
+    a.cancel()
+  })
+  while has_immediately_ready_task() {
+    reschedule()
+  }
+  guard! a.unwrap() is Cancelled
+  guard! b.unwrap() is Continue
+  assert_eq(log, ["started", "delivered"])
+}

--- a/src/internal/coroutine/pkg.generated.mbti
+++ b/src/internal/coroutine/pkg.generated.mbti
@@ -20,6 +20,8 @@ pub fn is_being_cancelled() -> Bool
 
 pub async fn pause() -> Unit noraise
 
+pub async fn pause_after_io() -> Unit noraise + nocancel
+
 pub async fn[X] protect_from_cancel(async () -> X) -> X nocancel
 
 pub async fn[X] raise_cancellation_signal() -> X noraise

--- a/src/internal/event_loop/io_unix.mbt
+++ b/src/internal/event_loop/io_unix.mbt
@@ -77,7 +77,7 @@ async fn IoHandle::read_via_event_bus_unix(
   if ret >= 0 {
     // The `pause` here prevent a busy read loop from exhausting the whole program
     // and give chance for other tasks to execute.
-    @coroutine.protect_from_cancel(() => @coroutine.pause())
+    @coroutine.pause_after_io()
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {
@@ -138,7 +138,7 @@ async fn IoHandle::write_via_event_bus_unix(
   if ret >= 0 {
     // The `pause` here prevent a busy write loop from exhausting the whole program,
     // and give chance for other tasks to execute.
-    @coroutine.protect_from_cancel(() => @coroutine.pause())
+    @coroutine.pause_after_io()
     return ret
   }
   let ret = if @os_error.is_nonblocking_io_error() {


### PR DESCRIPTION
Successful Unix reads and writes yield through `protect_from_cancel(() => pause())` before returning their result. This adds an internal `pause_after_io` helper that performs the same protected yield without the generic higher-order cancellation wrapper, reducing allocation on this path.

The helper preserves every existing yield, queues the coroutine in the same order, and saves/restores its previous cancellation shield. Pending cancellation is delivered at the next cancellation point after returning the completed I/O result. The paths that wait for I/O readiness are unchanged. Four regression tests cover round-robin scheduling, cancellation pending before the yield, cancellation during suspension, and an enclosing cancellation shield.

I collected these measurements while benchmarking Mars, my web server implementation. The [detailed results, methodology, limitations, reproduction commands, and raw data are in Mars](https://github.com/mizchi/mars.mbt/blob/ff4485e0309a8532d03002eb588ab06dcd252848/docs/async-scheduler-followup.md). This standalone comparison uses async main at `43e41261f99261f4030efbed1970388930229baa`; it does not include #603 or #604.

| Metric | Main | This patch |
| --- | --- | --- |
| Requested allocation bytes per post-I/O yield | 404 | 296 (−26.7%) |
| Allocation requests per yield | 14 | 10 |
| Mars instructions per small-response request | 93,775 | 92,067 (−1.8%) |

These are native release measurements on macOS arm64. Separate binaries measure allocation and elapsed time; the yield-only microbenchmark's elapsed time is nearly unchanged. The real-server comparison uses six paired rounds with alternating order, a one-second warmup and five-second load, four wrk threads, and 64 connections. All six rounds reduce instructions/request by 1.65–2.20%. The allocation reduction is the primary motivation; these runs do not establish Linux performance or production throughput.

Local validation:

- Native release: 116 HTTP/io/buffer/coroutine/event-loop tests and 119 public async/socket tests pass.
- Native debug: 134 coroutine/event-loop/public async/socket tests pass; JS: all five coroutine tests pass.
- `moon check --deny-warn` passes for native, JS, Wasm, and Wasm-GC; `moon fmt` and `moon info` are clean.
- Mars's native root-package tests pass 92/92 against both variants; Mars's release checks pass, including 331 JS tests.

Linux native execution is covered by the upstream PR CI. This PR is based directly on main and is independent of #603 and #604.
